### PR TITLE
fix(vibe): make version consistency gate CRLF-safe

### DIFF
--- a/bundled/skills/vibe/scripts/verify/vibe-version-consistency-gate.ps1
+++ b/bundled/skills/vibe/scripts/verify/vibe-version-consistency-gate.ps1
@@ -84,7 +84,8 @@ $changelogHeadOk = $false
 if ($changelogExists) {
     $changelog = Read-Text -Path $changelogPath
     $expectedHeader = "## v$releaseVersion ($releaseUpdated)"
-    $changelogHeadOk = $changelog -match ("(?m)^" + [regex]::Escape($expectedHeader) + "$")
+    # Accept both LF and CRLF line endings to avoid false negatives across platforms.
+    $changelogHeadOk = $changelog -match ("(?m)^" + [regex]::Escape($expectedHeader) + "\r?$")
 }
 $assertions += Assert-True -Condition $changelogExists -Message "[changelog] exists"
 $assertions += Assert-True -Condition $changelogHeadOk -Message "[changelog] release header exists"

--- a/scripts/verify/vibe-version-consistency-gate.ps1
+++ b/scripts/verify/vibe-version-consistency-gate.ps1
@@ -84,7 +84,8 @@ $changelogHeadOk = $false
 if ($changelogExists) {
     $changelog = Read-Text -Path $changelogPath
     $expectedHeader = "## v$releaseVersion ($releaseUpdated)"
-    $changelogHeadOk = $changelog -match ("(?m)^" + [regex]::Escape($expectedHeader) + "$")
+    # Accept both LF and CRLF line endings to avoid false negatives across platforms.
+    $changelogHeadOk = $changelog -match ("(?m)^" + [regex]::Escape($expectedHeader) + "\r?$")
 }
 $assertions += Assert-True -Condition $changelogExists -Message "[changelog] exists"
 $assertions += Assert-True -Condition $changelogHeadOk -Message "[changelog] release header exists"


### PR DESCRIPTION
## Summary
- fix false negative in `vibe-version-consistency-gate` changelog header check on Windows CRLF files
- keep canonical and bundled gate scripts in parity

## Validation
- `scripts/verify/vibe-version-consistency-gate.ps1` PASS on CRLF changelog
- `scripts/verify/vibe-version-packaging-gate.ps1` PASS