### PR TITLE
docs: fix docs landing page mojibake

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,8 @@
 
 ### Runtime Entry
 
-- [`install/one-click-install-release-copy.md`](./install/one-click-install-release-copy.md)锛氶潰鍚戞櫘閫氱敤鎴风殑涓€閿畨瑁呭彂甯冩枃妗堜笌 AI 鍔╂墜澶嶅埗鎻愮ず璇?
-- [`install/one-click-install-release-copy.en.md`](./install/one-click-install-release-copy.en.md)锛歡rdinary-user public release copy and copy-paste onboarding prompt
+- [`install/one-click-install-release-copy.md`](./install/one-click-install-release-copy.md)：面向普通用户的一键安装发布文案与 AI 助手复制提示词
+- [`install/one-click-install-release-copy.en.md`](./install/one-click-install-release-copy.en.md)：ordinary-user public release copy and copy-paste onboarding prompt
 
 - [`status/README.md`](./status/README.md)：当前运行态、proof 入口与阶段回执总索引。
 - [`status/current-state.md`](./status/current-state.md)：当前 closure batch 的 runtime summary。

--- a/tests/runtime_neutral/test_docs_readme_encoding.py
+++ b/tests/runtime_neutral/test_docs_readme_encoding.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_README = REPO_ROOT / "docs" / "README.md"
+
+
+class DocsReadmeEncodingTests(unittest.TestCase):
+    def test_runtime_entry_copy_is_human_readable(self) -> None:
+        text = DOCS_README.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "- [`install/one-click-install-release-copy.md`](./install/one-click-install-release-copy.md)：面向普通用户的一键安装发布文案与 AI 助手复制提示词",
+            text,
+        )
+        self.assertIn(
+            "- [`install/one-click-install-release-copy.en.md`](./install/one-click-install-release-copy.en.md)：ordinary-user public release copy and copy-paste onboarding prompt",
+            text,
+        )
+        self.assertNotIn(
+            "锛氶潰鍚戞櫘閫氱敤鎴风殑涓€閿畨瑁呭彂甯冩枃妗堜笌 AI 鍔╂墜澶嶅埗鎻愮ず璇?",
+            text,
+        )
+        self.assertNotIn(
+            "锛歡rdinary-user public release copy and copy-paste onboarding prompt",
+            text,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix the mojibake text for the docs runtime entry install links in docs/README.md
- add a runtime-neutral unittest to prevent the broken copy from reappearing

## Test Plan
- python -m unittest tests.runtime_neutral.test_docs_readme_encoding tests.runtime_neutral.test_router_bridge tests.runtime_neutral.test_governed_runtime_bridge -q
- git -c safe.directory=D:/Desktop/Vibe-Skills diff --check -- docs/README.md
