### PR TITLE
feat: add cursor preview adapter support

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -13,6 +13,7 @@ Current adapter intent:
 
 - `codex/`: strongest current adapter because the repository already ships Codex-specific install, settings, and plugin guidance.
 - `claude-code/`: preview adapter derived from existing template and governance expectations.
+- `cursor/`: preview adapter with truthful host-managed boundaries; no full closure claim yet.
 - `opencode/`: contract placeholder only; no runtime closure claim yet.
 - `generic/`: lowest-common-denominator contract consumer, not an official runtime.
 

--- a/adapters/cursor/closure.json
+++ b/adapters/cursor/closure.json
@@ -1,0 +1,24 @@
+{
+  "adapter_id": "cursor",
+  "closure_level": "preview-guidance",
+  "install_mode": "preview-guidance",
+  "check_mode": "preview-guidance",
+  "bootstrap_mode": "preview-guidance",
+  "repo_managed_payload": [
+    "runtime core payload",
+    "canonical vibe mirror under skills/vibe/**"
+  ],
+  "host_state_written": [],
+  "host_managed_boundaries": [
+    "plugin provisioning",
+    "hook installation",
+    "MCP registration",
+    "provider credentials",
+    "final Cursor host configuration"
+  ],
+  "verification_contract": [
+    "runtime freshness gate",
+    "runtime BOM/frontmatter gate",
+    "runtime coherence gate"
+  ]
+}

--- a/adapters/cursor/host-profile.json
+++ b/adapters/cursor/host-profile.json
@@ -1,0 +1,44 @@
+{
+  "adapter_id": "cursor",
+  "host_name": "Cursor",
+  "status": "preview",
+  "runtime_role": "host-adapter-preview",
+  "source_evidence": [
+    "adapters/cursor/closure.json",
+    "install.ps1",
+    "check.ps1"
+  ],
+  "settings_surface": {
+    "path": "~/.cursor/settings.json",
+    "managed_by_repo": false,
+    "notes": "The repository currently provides preview guidance only. Real Cursor host settings remain host-managed."
+  },
+  "host_managed_surfaces": [
+    "plugin enablement",
+    "hook installation",
+    "MCP registration",
+    "provider credentials"
+  ],
+  "capabilities": {
+    "fs.read": "expected",
+    "fs.write": "expected",
+    "shell.exec": "expected",
+    "mcp.client": "supported-with-constraints",
+    "settings.materialize": "preview-guidance",
+    "plugin.provision": "manual-host-managed",
+    "agent.spawn": "supported-with-constraints",
+    "route.provider_call": "supported-with-constraints",
+    "route.offline_fallback": "expected",
+    "release.verify": "preview-guidance"
+  },
+  "degrade_contract": {
+    "missing_plugins": "degraded-but-supported",
+    "missing_provider_credentials": "degraded-but-supported",
+    "unverified_platform_lane": "not-yet-proven"
+  },
+  "supported_platform_contracts": [
+    "adapters/cursor/platform-windows.json",
+    "adapters/cursor/platform-linux.json",
+    "adapters/cursor/platform-macos.json"
+  ]
+}

--- a/adapters/cursor/platform-linux.json
+++ b/adapters/cursor/platform-linux.json
@@ -1,0 +1,17 @@
+{
+  "adapter_id": "cursor",
+  "platform": "linux",
+  "status": "not-yet-proven",
+  "install_surface": [
+    "template-only"
+  ],
+  "check_surface": [
+    "manual or host-native"
+  ],
+  "doctor_surface": [
+    "not yet frozen"
+  ],
+  "notes": [
+    "The repository has guidance surfaces, but no replay-backed proof lane yet."
+  ]
+}

--- a/adapters/cursor/platform-macos.json
+++ b/adapters/cursor/platform-macos.json
@@ -1,0 +1,17 @@
+{
+  "adapter_id": "cursor",
+  "platform": "macos",
+  "status": "not-yet-proven",
+  "install_surface": [
+    "template-only"
+  ],
+  "check_surface": [
+    "manual or host-native"
+  ],
+  "doctor_surface": [
+    "not yet frozen"
+  ],
+  "notes": [
+    "No governed proof lane exists yet."
+  ]
+}

--- a/adapters/cursor/platform-windows.json
+++ b/adapters/cursor/platform-windows.json
@@ -1,0 +1,17 @@
+{
+  "adapter_id": "cursor",
+  "platform": "windows",
+  "status": "not-yet-proven",
+  "install_surface": [
+    "template-only"
+  ],
+  "check_surface": [
+    "manual or host-native"
+  ],
+  "doctor_surface": [
+    "not yet frozen"
+  ],
+  "notes": [
+    "Windows support may be possible, but this repository does not yet provide a governed Cursor closure lane."
+  ]
+}

--- a/adapters/cursor/settings-map.json
+++ b/adapters/cursor/settings-map.json
@@ -1,0 +1,10 @@
+{
+  "adapter_id": "cursor",
+  "template": null,
+  "target": "~/.cursor/settings.json",
+  "semantics": {},
+  "notes": [
+    "Cursor mapping is currently guidance-only and host-managed.",
+    "No repository-managed hook installation is promised in this preview lane."
+  ]
+}

--- a/adapters/index.json
+++ b/adapters/index.json
@@ -36,6 +36,22 @@
       "settings_map": "adapters/claude-code/settings-map.json",
       "closure": "adapters/claude-code/closure.json",
       "manifest": "dist/host-claude-code/manifest.json"
+    },
+    {
+      "id": "cursor",
+      "status": "preview",
+      "install_mode": "preview-guidance",
+      "check_mode": "preview-guidance",
+      "bootstrap_mode": "preview-guidance",
+      "default_target_root": {
+        "env": "CURSOR_HOME",
+        "rel": ".cursor",
+        "kind": "host-home"
+      },
+      "host_profile": "adapters/cursor/host-profile.json",
+      "settings_map": "adapters/cursor/settings-map.json",
+      "closure": "adapters/cursor/closure.json",
+      "manifest": "dist/host-cursor/manifest.json"
     }
   ]
 }

--- a/check.ps1
+++ b/check.ps1
@@ -1,7 +1,7 @@
 param(
   [ValidateSet("minimal", "full")]
   [string]$Profile = "full",
-  [ValidateSet("codex", "claude-code")]
+  [ValidateSet("codex", "claude-code", "cursor")]
   [string]$HostId = "codex",
   [string]$TargetRoot = '',
   [switch]$SkipRuntimeFreshnessGate,

--- a/check.sh
+++ b/check.sh
@@ -31,8 +31,9 @@ resolve_host_id() {
   case "${host_id}" in
     codex) printf '%s' 'codex' ;;
     claude|claude-code) printf '%s' 'claude-code' ;;
+    cursor) printf '%s' 'cursor' ;;
     *)
-      echo "[FAIL] Unsupported VCO host id: ${host_id}. Supported values: codex, claude-code" >&2
+      echo "[FAIL] Unsupported VCO host id: ${host_id}. Supported values: codex, claude-code, cursor" >&2
       exit 1
       ;;
   esac
@@ -43,6 +44,7 @@ resolve_default_target_root() {
   case "${host_id}" in
     codex) printf '%s' "${CODEX_HOME:-${HOME}/.codex}" ;;
     claude-code) printf '%s' "${CLAUDE_HOME:-${HOME}/.claude}" ;;
+    cursor) printf '%s' "${CURSOR_HOME:-${HOME}/.cursor}" ;;
     *)
       echo "[FAIL] Unsupported VCO host id for target-root resolution: ${host_id}" >&2
       exit 1
@@ -82,9 +84,29 @@ assert_target_root_matches_host_intent() {
     echo "[FAIL] Pass --host claude-code for preview guidance or use a Codex target root." >&2
     exit 1
   fi
+  if [[ "${host_id}" == "codex" && "${leaf}" == ".cursor" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Cursor home, but host='codex'." >&2
+    echo "[FAIL] Pass --host cursor for preview guidance or use a Codex target root." >&2
+    exit 1
+  fi
   if [[ "${host_id}" == "claude-code" && "${leaf}" == ".codex" ]]; then
     echo "[FAIL] Target root '${target_root}' looks like a Codex home, but host='claude-code'." >&2
     echo "[FAIL] Use --host codex for the official closure lane or choose a Claude Code target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "claude-code" && "${leaf}" == ".cursor" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Cursor home, but host='claude-code'." >&2
+    echo "[FAIL] Pass --host cursor for Cursor preview guidance or choose a Claude Code target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "cursor" && "${leaf}" == ".codex" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Codex home, but host='cursor'." >&2
+    echo "[FAIL] Use --host codex for the official closure lane or choose a Cursor target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "cursor" && "${leaf}" == ".claude" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Claude Code home, but host='cursor'." >&2
+    echo "[FAIL] Pass --host claude-code for Claude preview guidance or choose a Cursor target root." >&2
     exit 1
   fi
 }
@@ -560,7 +582,7 @@ if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   check_path "settings.json" "${TARGET_ROOT}/settings.json"
 fi
 if [[ "${ADAPTER_CHECK_MODE}" == "preview-guidance" ]]; then
-  info_note "claude preview hook/settings scaffold remains intentionally unavailable while the author works through compatibility issues; this is a current product boundary, not an install failure"
+  info_note "${HOST_ID} preview hook/settings scaffold remains intentionally unavailable while the author works through compatibility issues; this is a current product boundary, not an install failure"
 fi
 if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   check_path "plugins manifest" "${TARGET_ROOT}/config/plugins-manifest.codex.json"

--- a/dist/host-cursor/manifest.json
+++ b/dist/host-cursor/manifest.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "lane_id": "host-cursor",
+  "lane_kind": "host-adapter",
+  "host_id": "cursor",
+  "stability": "preview",
+  "source_release": {
+    "version": "2.3.49",
+    "updated": "2026-03-24"
+  },
+  "summary": "Cursor host adapter preview. The repository can expose runtime-core payload and preview health checks, but does not claim full governed closure yet.",
+  "runtime_ownership": {
+    "owner": "host_managed",
+    "notes": "This lane must not claim official runtime closure. It only exposes configuration artifacts and truthful readiness boundaries."
+  },
+  "entrypoints": {
+    "install_primary": "install.ps1 --host cursor",
+    "install_secondary": "install.sh --host cursor",
+    "check_primary": "check.ps1 --host cursor",
+    "check_secondary": "check.sh --host cursor"
+  },
+  "capability_promises": [
+    {
+      "id": "cursor_preview_adapter_contract_exists",
+      "promise_level": "promised",
+      "evidence_paths": [
+        "adapters/cursor/host-profile.json",
+        "adapters/cursor/closure.json"
+      ]
+    },
+    {
+      "id": "router_authority_remains_local",
+      "promise_level": "promised",
+      "evidence_paths": [
+        "scripts/router/resolve-pack-route.ps1"
+      ]
+    }
+  ],
+  "non_goals": [
+    "official_runtime_install_entrypoints",
+    "official_runtime_check_entrypoints",
+    "host_plugin_provisioning",
+    "cross_platform_parity_claims"
+  ],
+  "docs": {
+    "distribution_lanes": "docs/universalization/distribution-lanes.md",
+    "install_matrix": "docs/universalization/install-matrix.md",
+    "platform_install_matrix": "docs/universalization/platform-install-matrix.md",
+    "platform_support_matrix": "docs/universalization/platform-support-matrix.md",
+    "host_capability_matrix": "docs/universalization/host-capability-matrix.md"
+  },
+  "support": {
+    "platform_support": {
+      "truth_source": "docs/universalization/platform-support-matrix.md",
+      "interpretation": "not_yet_proven_for_this_lane"
+    },
+    "host_support": {
+      "truth_source": "docs/universalization/host-capability-matrix.md",
+      "interpretation": "host_matrix_rating",
+      "rating": "preview"
+    }
+  }
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,6 +11,7 @@
 
 - `codex`
 - `claude-code`
+- `cursor`
 
 `TargetRoot` 是文件路径。
 `HostId` / `--host` 才是宿主选择。
@@ -24,6 +25,8 @@ pwsh -File .\scripts\bootstrap\one-shot-setup.ps1 -HostId codex
 pwsh -File .\check.ps1 -HostId codex -Profile full -Deep
 pwsh -File .\scripts\bootstrap\one-shot-setup.ps1 -HostId claude-code
 pwsh -File .\check.ps1 -HostId claude-code -Profile full -Deep
+pwsh -File .\scripts\bootstrap\one-shot-setup.ps1 -HostId cursor -TargetRoot "$env:USERPROFILE\.cursor"
+pwsh -File .\check.ps1 -HostId cursor -TargetRoot "$env:USERPROFILE\.cursor" -Profile full -Deep
 ```
 
 ### Linux / macOS
@@ -33,13 +36,16 @@ bash ./scripts/bootstrap/one-shot-setup.sh --host codex
 bash ./check.sh --host codex --profile full --deep
 bash ./scripts/bootstrap/one-shot-setup.sh --host claude-code
 bash ./check.sh --host claude-code --profile full --deep
+bash ./scripts/bootstrap/one-shot-setup.sh --host cursor --target-root "${HOME}/.cursor"
+bash ./check.sh --host cursor --target-root "${HOME}/.cursor" --profile full --deep
 ```
 
 ## Truth Boundaries
 
 - `codex` 是当前最完整的 repo-governed 路径
 - `claude-code` 是 preview guidance，不是 full closure
-- hook 当前因兼容性问题被冻结，`codex` / `claude-code` 都不提供 hook 安装
+- `cursor` 是 preview guidance，不是 full closure
+- hook 当前因兼容性问题被冻结，`codex` / `claude-code` / `cursor` 都不提供 hook 安装
 - `claude-code` 不再写 `settings.vibe.preview.json`
 - provider 的 `url` / `apikey` / `model` 仍然是本地用户侧配置
 - 安装提示必须告诉用户去本地 settings 或本地环境变量里配置，不要让用户把密钥贴到聊天里

--- a/install.ps1
+++ b/install.ps1
@@ -1,7 +1,7 @@
 param(
   [ValidateSet("minimal", "full")]
   [string]$Profile = "full",
-  [ValidateSet("codex", "claude-code")]
+  [ValidateSet("codex", "claude-code", "cursor")]
   [string]$HostId = "codex",
   [string]$TargetRoot = '',
   [switch]$InstallExternal,

--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,9 @@ resolve_host_id() {
   case "${host_id}" in
     codex) printf '%s' 'codex' ;;
     claude|claude-code) printf '%s' 'claude-code' ;;
+    cursor) printf '%s' 'cursor' ;;
     *)
-      echo "[FAIL] Unsupported VCO host id: ${host_id}. Supported values: codex, claude-code" >&2
+      echo "[FAIL] Unsupported VCO host id: ${host_id}. Supported values: codex, claude-code, cursor" >&2
       exit 1
       ;;
   esac
@@ -40,6 +41,7 @@ resolve_default_target_root() {
   case "${host_id}" in
     codex) printf '%s' "${CODEX_HOME:-${HOME}/.codex}" ;;
     claude-code) printf '%s' "${CLAUDE_HOME:-${HOME}/.claude}" ;;
+    cursor) printf '%s' "${CURSOR_HOME:-${HOME}/.cursor}" ;;
     *)
       echo "[FAIL] Unsupported VCO host id for target-root resolution: ${host_id}" >&2
       exit 1
@@ -90,9 +92,29 @@ assert_target_root_matches_host_intent() {
     echo "[FAIL] Pass --host claude-code for preview guidance or use a Codex target root." >&2
     exit 1
   fi
+  if [[ "${host_id}" == "codex" && "${leaf}" == ".cursor" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Cursor home, but host='codex'." >&2
+    echo "[FAIL] Pass --host cursor for preview guidance or use a Codex target root." >&2
+    exit 1
+  fi
   if [[ "${host_id}" == "claude-code" && "${leaf}" == ".codex" ]]; then
     echo "[FAIL] Target root '${target_root}' looks like a Codex home, but host='claude-code'." >&2
     echo "[FAIL] Use --host codex for the official closure lane or choose a Claude Code target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "claude-code" && "${leaf}" == ".cursor" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Cursor home, but host='claude-code'." >&2
+    echo "[FAIL] Pass --host cursor for Cursor preview guidance or choose a Claude Code target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "cursor" && "${leaf}" == ".codex" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Codex home, but host='cursor'." >&2
+    echo "[FAIL] Use --host codex for the official closure lane or choose a Cursor target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "cursor" && "${leaf}" == ".claude" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Claude Code home, but host='cursor'." >&2
+    echo "[FAIL] Pass --host claude-code for Claude preview guidance or choose a Cursor target root." >&2
     exit 1
   fi
 }

--- a/scripts/bootstrap/one-shot-setup.ps1
+++ b/scripts/bootstrap/one-shot-setup.ps1
@@ -33,7 +33,8 @@ function Prompt-VgoHostId {
         Write-Host 'Select the install target before bootstrap:'
         Write-Host '  1) codex        - strongest governed lane'
         Write-Host '  2) claude-code  - preview scaffold lane'
-        $choice = [string](Read-Host 'Install into which agent? [1-2]')
+        Write-Host '  3) cursor       - preview scaffold lane'
+        $choice = [string](Read-Host 'Install into which agent? [1-3]')
         $normalized = $choice.Trim().ToLowerInvariant()
         switch ($normalized) {
             '1' { return 'codex' }
@@ -41,7 +42,9 @@ function Prompt-VgoHostId {
             '2' { return 'claude-code' }
             'claude' { return 'claude-code' }
             'claude-code' { return 'claude-code' }
-            default { Write-Warning "Unsupported choice: $choice. Enter 1, 2, or a supported host name." }
+            '3' { return 'cursor' }
+            'cursor' { return 'cursor' }
+            default { Write-Warning "Unsupported choice: $choice. Enter 1, 2, 3, or a supported host name." }
         }
     }
 }
@@ -54,7 +57,7 @@ if (-not (Test-NonEmptyString -Value $HostId)) {
     } elseif (Test-IsInteractiveBootstrap) {
         $HostId = Prompt-VgoHostId
     } else {
-        throw 'No host was provided for one-shot bootstrap. Pass -HostId codex|claude-code when running non-interactively.'
+        throw 'No host was provided for one-shot bootstrap. Pass -HostId codex|claude-code|cursor when running non-interactively.'
     }
 }
 $HostId = Resolve-VgoHostId -HostId $HostId
@@ -174,10 +177,14 @@ switch ([string]$Adapter.bootstrap_mode) {
         & $checkPath -Profile $Profile -HostId $HostId -TargetRoot $TargetRoot -Deep
     }
     'preview-guidance' {
-        Write-Host '[2/5] Hook installation is frozen for Claude Code because of compatibility issues.' -ForegroundColor Yellow
-        & $claudeScaffoldPath -RepoRoot $repoRoot -TargetRoot $TargetRoot -Force | Out-Null
+        if ($HostId -eq 'claude-code') {
+            Write-Host '[2/5] Hook installation is frozen for Claude Code because of compatibility issues.' -ForegroundColor Yellow
+            & $claudeScaffoldPath -RepoRoot $repoRoot -TargetRoot $TargetRoot -Force | Out-Null
+        } else {
+            Write-Host ("[2/5] Host-specific preview scaffold is currently unavailable for '{0}'." -f $HostId) -ForegroundColor Yellow
+        }
         Write-Host '[3/5] No hook files or preview settings were installed into the target root.' -ForegroundColor DarkGray
-        Write-Host ("[4/5] Claude provider settings remain host-managed. Open {0} and add only the missing env fields there. Do not paste API keys into chat." -f (Join-Path $TargetRoot 'settings.json')) -ForegroundColor DarkGray
+        Write-Host ("[4/5] Provider settings remain host-managed for '{0}'. Configure the real host settings surface separately (for example, Cursor commonly uses ~/.cursor/settings.json). Do not paste API keys into chat." -f $HostId) -ForegroundColor DarkGray
         Write-Host '[5/5] Running preview guidance health check...' -ForegroundColor Yellow
         & $checkPath -Profile $Profile -HostId $HostId -TargetRoot $TargetRoot -Deep
     }

--- a/scripts/bootstrap/one-shot-setup.sh
+++ b/scripts/bootstrap/one-shot-setup.sh
@@ -40,8 +40,9 @@ resolve_host_id() {
   case "${host_id}" in
     codex) printf '%s' 'codex' ;;
     claude|claude-code) printf '%s' 'claude-code' ;;
+    cursor) printf '%s' 'cursor' ;;
     *)
-      echo "[FAIL] Unsupported VCO host id: ${host_id}. Supported values: codex, claude-code" >&2
+      echo "[FAIL] Unsupported VCO host id: ${host_id}. Supported values: codex, claude-code, cursor" >&2
       exit 1
       ;;
   esac
@@ -52,14 +53,16 @@ prompt_for_host_id() {
   echo "Select the install target before bootstrap:"
   echo "  1) codex        - strongest governed lane"
   echo "  2) claude-code  - preview scaffold lane"
+  echo "  3) cursor       - preview scaffold lane"
   while true; do
-    read -r -p "Install into which agent? [1-2]: " choice
+    read -r -p "Install into which agent? [1-3]: " choice
     normalized="$(printf '%s' "${choice}" | tr '[:upper:]' '[:lower:]' | xargs)"
     case "${normalized}" in
       1|codex) HOST_ID='codex'; return 0 ;;
       2|claude|claude-code) HOST_ID='claude-code'; return 0 ;;
+      3|cursor) HOST_ID='cursor'; return 0 ;;
       *)
-        echo "[WARN] Unsupported choice: ${choice}. Enter 1, 2, or a supported host name." >&2
+        echo "[WARN] Unsupported choice: ${choice}. Enter 1, 2, 3, or a supported host name." >&2
         ;;
     esac
   done
@@ -78,7 +81,7 @@ ensure_requested_host_id() {
     return 0
   fi
   echo "[FAIL] No host was provided for one-shot bootstrap." >&2
-  echo "[FAIL] Pass --host codex|claude-code when running non-interactively." >&2
+  echo "[FAIL] Pass --host codex|claude-code|cursor when running non-interactively." >&2
   return 1
 }
 
@@ -87,6 +90,7 @@ resolve_default_target_root() {
   case "${host_id}" in
     codex) printf '%s' "${CODEX_HOME:-${HOME}/.codex}" ;;
     claude-code) printf '%s' "${CLAUDE_HOME:-${HOME}/.claude}" ;;
+    cursor) printf '%s' "${CURSOR_HOME:-${HOME}/.cursor}" ;;
     *)
       echo "[FAIL] Unsupported VCO host id for target-root resolution: ${host_id}" >&2
       exit 1
@@ -105,9 +109,29 @@ assert_target_root_matches_host_intent() {
     echo "[FAIL] Pass --host claude-code for preview guidance or use a Codex target root." >&2
     exit 1
   fi
+  if [[ "${host_id}" == "codex" && "${leaf}" == ".cursor" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Cursor home, but host='codex'." >&2
+    echo "[FAIL] Pass --host cursor for preview guidance or use a Codex target root." >&2
+    exit 1
+  fi
   if [[ "${host_id}" == "claude-code" && "${leaf}" == ".codex" ]]; then
     echo "[FAIL] Target root '${target_root}' looks like a Codex home, but host='claude-code'." >&2
     echo "[FAIL] Use --host codex for the official closure lane or choose a Claude Code target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "claude-code" && "${leaf}" == ".cursor" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Cursor home, but host='claude-code'." >&2
+    echo "[FAIL] Pass --host cursor for Cursor preview guidance or choose a Claude Code target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "cursor" && "${leaf}" == ".codex" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Codex home, but host='cursor'." >&2
+    echo "[FAIL] Use --host codex for the official closure lane or choose a Cursor target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "cursor" && "${leaf}" == ".claude" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Claude Code home, but host='cursor'." >&2
+    echo "[FAIL] Pass --host claude-code for Claude preview guidance or choose a Cursor target root." >&2
     exit 1
   fi
 }
@@ -399,10 +423,14 @@ if [[ "${ADAPTER_BOOTSTRAP_MODE}" == "governed" ]]; then
   echo "[5/5] Running deep health check..."
   bash "${CHECK_SH}" --profile "${PROFILE}" --host "${HOST_ID}" --target-root "${TARGET_ROOT}" --deep
 elif [[ "${ADAPTER_BOOTSTRAP_MODE}" == "preview-guidance" ]]; then
-  echo "[2/5] Hook installation is frozen for Claude Code because of compatibility issues."
-  bash "${CLAUDE_SCAFFOLD_SH}" --repo-root "${REPO_ROOT}" --target-root "${TARGET_ROOT}" --force >/dev/null
+  if [[ "${HOST_ID}" == "claude-code" ]]; then
+    echo "[2/5] Hook installation is frozen for Claude Code because of compatibility issues."
+    bash "${CLAUDE_SCAFFOLD_SH}" --repo-root "${REPO_ROOT}" --target-root "${TARGET_ROOT}" --force >/dev/null
+  else
+    echo "[2/5] Host-specific preview scaffold is currently unavailable for '${HOST_ID}'."
+  fi
   echo "[3/5] No hook files or preview settings were installed into the target root."
-  echo "[4/5] Claude provider settings remain host-managed. Open ${TARGET_ROOT}/settings.json and add only the missing env fields there. Do not paste API keys into chat."
+  echo "[4/5] Provider settings remain host-managed for '${HOST_ID}'. Configure the real host settings surface separately (for example, Cursor commonly uses ~/.cursor/settings.json). Do not paste API keys into chat."
   echo "[5/5] Running preview guidance health check..."
   bash "${CHECK_SH}" --profile "${PROFILE}" --host "${HOST_ID}" --target-root "${TARGET_ROOT}" --deep
 else

--- a/scripts/common/Resolve-VgoAdapter.ps1
+++ b/scripts/common/Resolve-VgoAdapter.ps1
@@ -59,6 +59,22 @@ function Get-VgoEmbeddedAdapterRegistry {
                 settings_map = 'adapters/claude-code/settings-map.json'
                 closure = 'adapters/claude-code/closure.json'
                 manifest = 'dist/host-claude-code/manifest.json'
+            },
+            [pscustomobject]@{
+                id = 'cursor'
+                status = 'preview'
+                install_mode = 'preview-guidance'
+                check_mode = 'preview-guidance'
+                bootstrap_mode = 'preview-guidance'
+                default_target_root = [pscustomobject]@{
+                    env = 'CURSOR_HOME'
+                    rel = '.cursor'
+                    kind = 'host-home'
+                }
+                host_profile = 'adapters/cursor/host-profile.json'
+                settings_map = 'adapters/cursor/settings-map.json'
+                closure = 'adapters/cursor/closure.json'
+                manifest = 'dist/host-cursor/manifest.json'
             }
         )
     }

--- a/scripts/common/resolve_vgo_adapter.py
+++ b/scripts/common/resolve_vgo_adapter.py
@@ -40,6 +40,18 @@ def embedded_registry():
                 "closure": "adapters/claude-code/closure.json",
                 "manifest": "dist/host-claude-code/manifest.json",
             },
+            {
+                "id": "cursor",
+                "status": "preview",
+                "install_mode": "preview-guidance",
+                "check_mode": "preview-guidance",
+                "bootstrap_mode": "preview-guidance",
+                "default_target_root": {"env": "CURSOR_HOME", "rel": ".cursor", "kind": "host-home"},
+                "host_profile": "adapters/cursor/host-profile.json",
+                "settings_map": "adapters/cursor/settings-map.json",
+                "closure": "adapters/cursor/closure.json",
+                "manifest": "dist/host-cursor/manifest.json",
+            },
         ],
     }
 

--- a/scripts/common/vibe-governance-helpers.ps1
+++ b/scripts/common/vibe-governance-helpers.ps1
@@ -226,8 +226,9 @@ function Resolve-VgoHostId {
         'codex' { return 'codex' }
         'claude' { return 'claude-code' }
         'claude-code' { return 'claude-code' }
+        'cursor' { return 'cursor' }
         default {
-            throw "Unsupported VCO host id: $resolved. Supported values: codex, claude-code"
+            throw "Unsupported VCO host id: $resolved. Supported values: codex, claude-code, cursor"
         }
     }
 }
@@ -251,6 +252,12 @@ function Resolve-VgoDefaultTargetRoot {
                 return [System.IO.Path]::GetFullPath($env:CLAUDE_HOME)
             }
             return [System.IO.Path]::GetFullPath((Join-Path $homeDir '.claude'))
+        }
+        'cursor' {
+            if (-not [string]::IsNullOrWhiteSpace($env:CURSOR_HOME)) {
+                return [System.IO.Path]::GetFullPath($env:CURSOR_HOME)
+            }
+            return [System.IO.Path]::GetFullPath((Join-Path $homeDir '.cursor'))
         }
         default {
             throw "Unsupported VCO host id: $resolvedHostId"
@@ -303,11 +310,37 @@ function Assert-VgoTargetRootMatchesHostIntent {
                     $TargetRoot
                 ))
             }
+            if ($normalizedLeaf -eq '.cursor') {
+                throw ([string]::Format(
+                    "TargetRoot '{0}' looks like a Cursor home, but HostId resolved to 'codex'. Pass -HostId cursor for preview guidance or use a Codex target root.",
+                    $TargetRoot
+                ))
+            }
         }
         'claude-code' {
             if ($normalizedLeaf -eq '.codex') {
                 throw ([string]::Format(
                     "TargetRoot '{0}' looks like a Codex home, but HostId resolved to 'claude-code'. Use -HostId codex for the official closure lane or choose a Claude Code target root.",
+                    $TargetRoot
+                ))
+            }
+            if ($normalizedLeaf -eq '.cursor') {
+                throw ([string]::Format(
+                    "TargetRoot '{0}' looks like a Cursor home, but HostId resolved to 'claude-code'. Pass -HostId cursor for preview guidance or choose a Claude Code target root.",
+                    $TargetRoot
+                ))
+            }
+        }
+        'cursor' {
+            if ($normalizedLeaf -eq '.codex') {
+                throw ([string]::Format(
+                    "TargetRoot '{0}' looks like a Codex home, but HostId resolved to 'cursor'. Use -HostId codex for the official closure lane or choose a Cursor target root.",
+                    $TargetRoot
+                ))
+            }
+            if ($normalizedLeaf -eq '.claude') {
+                throw ([string]::Format(
+                    "TargetRoot '{0}' looks like a Claude Code home, but HostId resolved to 'cursor'. Use -HostId claude-code for Claude preview guidance or choose a Cursor target root.",
                     $TargetRoot
                 ))
             }

--- a/scripts/install/install_vgo_adapter.py
+++ b/scripts/install/install_vgo_adapter.py
@@ -113,6 +113,18 @@ def embedded_registry():
                 "closure": "adapters/claude-code/closure.json",
                 "manifest": "dist/host-claude-code/manifest.json",
             },
+            {
+                "id": "cursor",
+                "status": "preview",
+                "install_mode": "preview-guidance",
+                "check_mode": "preview-guidance",
+                "bootstrap_mode": "preview-guidance",
+                "default_target_root": {"env": "CURSOR_HOME", "rel": ".cursor", "kind": "host-home"},
+                "host_profile": "adapters/cursor/host-profile.json",
+                "settings_map": "adapters/cursor/settings-map.json",
+                "closure": "adapters/cursor/closure.json",
+                "manifest": "dist/host-cursor/manifest.json",
+            },
         ],
     }
 


### PR DESCRIPTION
## Summary

- Change class:
  - [ ] Docs-only (Class A)
  - [ ] Governance / policy (Class B)
  - [ ] Mirror / fixture / provenance / compliance (Class C)
  - [x] Runtime-affecting (Class D)
- Linked issue: #6
- Linked plan (`docs/plans/*.md`) if required:
  - `docs/plans/2026-03-13-post-upstream-governance-developer-entry-plan.md`

## Touched Zones

- [x] Z0 Frozen Control Plane
- [ ] Z1 Guarded Governance and Policy Surface
- [ ] Z2 Guarded Mirror, Fixture, Provenance, and Compliance Surface
- [x] Z3 Preferred Contribution Zones

## Frozen / Guarded Area Declaration

- Frozen or guarded area touched:
  - [ ] No
  - [x] Yes, Z0 touched
  - [ ] Yes, Z1 touched
  - [ ] Yes, Z2 touched
- If yes, explain why this could not stay additive in Z3:
  - Adding `cursor` support required updates to frozen install/check/bootstrap entrypoints and host-intent guard logic. Adapter metadata alone would not make the new host installable or verifiable.

## Proof Run

List the exact commands you ran and the result you observed. Use `Command -> Output -> Claim`.

| Command | Output | Claim |
| --- | --- | --- |
| `git diff --cached --check` | no output, exit 0 | no whitespace or patch formatting issues in the staged diff |
| `powershell -ExecutionPolicy Bypass -File .\install.ps1 -Profile minimal -HostId cursor -TargetRoot ".\.tmp_cursor_verify"` | completed successfully | `install.ps1` accepts `cursor` and can install the preview payload to a target root |
| `powershell -ExecutionPolicy Bypass -File .\check.ps1 -Profile minimal -HostId cursor -TargetRoot ".\.tmp_cursor_verify"` | completed with no failures | `check.ps1` accepts `cursor` and validates the preview-guidance lane |
| `powershell -ExecutionPolicy Bypass -File .\scripts\bootstrap\one-shot-setup.ps1 -Profile minimal -HostId cursor -TargetRoot "$env:USERPROFILE\.cursor" -SkipExternalInstall` | completed successfully | one-shot bootstrap works for the real Cursor target without routing into Claude-specific scaffold logic |
| `powershell -ExecutionPolicy Bypass -File .\check.ps1 -Profile minimal -HostId cursor -TargetRoot "$env:USERPROFILE\.cursor" -SkipRuntimeFreshnessGate` | completed with no failures | the installed Cursor-target preview lane is checkable in the real user target path |

## Escalation / Stop-Ship

- Escalation needed before merge:
  - [ ] No
  - [x] Yes, owner / maintainer review required
  - [ ] Yes, blocked until additional plan or proof is attached
- Stop-ship conditions triggered:
  - [x] None
  - [ ] Plan missing for Z0 or runtime-affecting change
  - [ ] Required proof bundle is incomplete
  - [ ] Frozen / guarded surface touched without explicit justification
  - [ ] Source-of-truth / mirror / provenance path is unclear
- Escalation details:
  - This PR touches Z0 runtime entrypoints (`install.*`, `check.*`, bootstrap scripts), so maintainer review is appropriate even though the change stays within preview-guidance scope and the proof commands above passed.

## Contributor Checklist

- [x] I identified the touched zone(s) before editing.
- [x] I did not treat `bundled/**`, `references/fixtures/**`, tracked `outputs/**`, or vendored material as source-of-truth unless explicitly governed by this PR.
- [x] If I touched Z0, Z1, or Z2, I linked the governing plan and attached the required proof.
- [x] If this PR changes contributor-facing governance, the template declarations above are complete and not left blank.
