### PR TITLE
docs: restore framework-only install path entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ _Skills keep growing — but you don't need to manage them individually._
 |:---:|:---|:---|
 | **You get** | vibe runtime + full governance + all 340+ skills | vibe runtime + governance skeleton (no pre-loaded skills) |
 | **Best for** | Out-of-the-box use, extend as needed | Framework only, add skills selectively |
-| **Install** | [⚡ Prompt-based install (recommended)](./docs/install/one-click-install-release-copy.en.md) | [🔧 Framework-only install](./docs/install/framework-only-path.md) |
+| **Install** | [⚡ Prompt-based install (recommended)](./docs/install/one-click-install-release-copy.en.md) | [🔧 Framework-only install](./docs/install/framework-only-path.en.md) |
 
 </div>
 

--- a/docs/install/README.en.md
+++ b/docs/install/README.en.md
@@ -17,6 +17,7 @@ This directory contains the public install, upgrade, and custom-integration docs
 ### Reference Docs
 
 - [`one-click-install-release-copy.en.md`](./one-click-install-release-copy.en.md): default entrypoint with host/version selection and links to prompt files
+- [`framework-only-path.en.md`](./framework-only-path.en.md): framework-only path, kept as a compatibility entry
 - [`recommended-full-path.en.md`](./recommended-full-path.en.md): advanced host, lane, and command reference
 - [`manual-copy-install.en.md`](./manual-copy-install.en.md): manual copy path for offline or no-admin environments
 - [`installation-rules.en.md`](./installation-rules.en.md): truth-first rules every install assistant must follow

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -17,6 +17,7 @@
 ### 参考说明
 
 - [`one-click-install-release-copy.md`](./one-click-install-release-copy.md)：默认推荐入口，先看版本和宿主选择，再跳转到对应提示词
+- [`framework-only-path.md`](./framework-only-path.md)：仅核心框架路径，兼容旧入口名
 - [`recommended-full-path.md`](./recommended-full-path.md)：高级 host / lane / 命令参考
 - [`manual-copy-install.md`](./manual-copy-install.md)：离线或无管理员权限时的手动复制路径
 - [`installation-rules.md`](./installation-rules.md)：安装助手必须遵守的 truth-first 规则

--- a/docs/install/framework-only-path.en.md
+++ b/docs/install/framework-only-path.en.md
@@ -1,0 +1,24 @@
+# Install Path: Framework Only
+
+This page is a compatibility landing page for the older entry name.
+
+In the current repository, the real profile behind “Framework Only” is `minimal`, not the historical literal `framework-only` argument.
+
+## Where To Go
+
+- Use directly:
+  - [`minimal-path.en.md`](./minimal-path.en.md)
+- If you need prompt-based entrypoints:
+  - [`prompts/framework-only-install.en.md`](./prompts/framework-only-install.en.md)
+  - [`prompts/framework-only-update.en.md`](./prompts/framework-only-update.en.md)
+
+## Current Real Mapping
+
+- `Framework Only + Customizable Governance` -> `minimal`
+- `Full Version + Customizable Governance` -> `full`
+
+## Short Version
+
+- If you want the framework-only variant, follow [`minimal-path.en.md`](./minimal-path.en.md).
+- If you arrived here from an older README link, this is now the stable landing page.
+- Public wording may still say “Framework Only”, while execution maps it to `minimal`.

--- a/docs/install/framework-only-path.md
+++ b/docs/install/framework-only-path.md
@@ -1,0 +1,24 @@
+# 安装路径：仅核心框架
+
+这个页面是旧入口名的兼容页。
+
+当前仓库里，“仅核心框架” 的真实 profile 是 `minimal`，不再是历史上的 `framework-only` 字面参数。
+
+## 你应该看哪里
+
+- 直接使用：
+  - [`minimal-path.md`](./minimal-path.md)
+- 如果你需要提示词入口：
+  - [`prompts/framework-only-install.md`](./prompts/framework-only-install.md)
+  - [`prompts/framework-only-update.md`](./prompts/framework-only-update.md)
+
+## 当前真实映射
+
+- `仅核心框架 + 可自定义添加治理` -> `minimal`
+- `全量版本 + 可自定义添加治理` -> `full`
+
+## 最短说明
+
+- 如果你想装“仅核心框架”，优先按 [`minimal-path.md`](./minimal-path.md) 执行。
+- 如果你是从 README 的旧链接点进来，这就是新的稳定落点。
+- 公开文案可以继续写 “仅核心框架”，执行时统一映射到 `minimal`。

--- a/docs/plans/2026-03-26-framework-only-path-compat-fix-plan.md
+++ b/docs/plans/2026-03-26-framework-only-path-compat-fix-plan.md
@@ -1,0 +1,19 @@
+# Framework-Only Path 兼容入口修复计划
+
+**日期**: 2026-03-26
+**需求文档**: [2026-03-26-framework-only-path-compat-fix.md](../requirements/2026-03-26-framework-only-path-compat-fix.md)
+
+## 执行步骤
+
+1. 确认 `main` 上目标文件缺失且 README 仍在引用
+2. 新增中英文兼容落点页
+3. 修正英文 README 和安装索引入口
+4. 用全文检索验证引用闭环
+
+## 验证命令
+
+```bash
+rg -n "framework-only-path" README.md README.zh.md docs/install
+test -f docs/install/framework-only-path.md
+test -f docs/install/framework-only-path.en.md
+```

--- a/docs/requirements/2026-03-26-framework-only-path-compat-fix.md
+++ b/docs/requirements/2026-03-26-framework-only-path-compat-fix.md
@@ -1,0 +1,21 @@
+# Framework-Only Path 兼容入口修复需求文档
+
+**日期**: 2026-03-26
+**任务类型**: 文档入口修复
+**优先级**: 高
+
+## 目标
+
+修复 README 指向 `docs/install/framework-only-path.md` 时页面不存在的问题。
+
+## 交付物
+
+1. 可访问的 `framework-only-path.md`
+2. 可访问的 `framework-only-path.en.md`
+3. README / 安装索引中的正确入口链接
+
+## 验收标准
+
+1. 仓库内不再存在指向空页面的 `framework-only-path` 安装入口
+2. 中英文入口都能打开
+3. 文案明确 `framework-only` 的真实执行映射是 `minimal`


### PR DESCRIPTION
## Summary
- restore the missing `docs/install/framework-only-path.md` compatibility landing page
- add the English companion page `docs/install/framework-only-path.en.md`
- point the English README install entry to the English page
- add the compatibility entry to the install index docs
- document that public `framework-only` wording maps to the real `minimal` profile

## Verification
- `rg -n "framework-only-path" README.md README.zh.md docs/install`
- `test -f docs/install/framework-only-path.md`
- `test -f docs/install/framework-only-path.en.md`