### PR TITLE
docs: reduce framework-only install doc sprawl

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ _Skills keep growing — but you don't need to manage them individually._
 |:---:|:---|:---|
 | **You get** | vibe runtime + full governance + all 340+ skills | vibe runtime + governance skeleton (no pre-loaded skills) |
 | **Best for** | Out-of-the-box use, extend as needed | Framework only, add skills selectively |
-| **Install** | [⚡ Prompt-based install (recommended)](./docs/install/one-click-install-release-copy.en.md) | [🔧 Framework-only install](./docs/install/framework-only-path.en.md) |
+| **Install** | [⚡ Prompt-based install (recommended)](./docs/install/one-click-install-release-copy.en.md) | [🔧 Framework-only install](./docs/install/prompts/framework-only-install.en.md) |
 
 </div>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -488,7 +488,7 @@ _Skills 越积越多——但你不需要逐个管理它们。_
 |:---:|:---|:---|
 | **你会得到** | vibe runtime + 完整治理框架 + 340+ 技能全集 | vibe runtime + 治理骨架（无预装技能）|
 | **适合** | 直接开箱，后续持续扩展 | 只要框架，自己选择性接入技能 |
-| **安装入口** | [⚡ 提示词安装（推荐）](./docs/install/one-click-install-release-copy.md) | [🔧 仅框架安装](./docs/install/framework-only-path.md) |
+| **安装入口** | [⚡ 提示词安装（推荐）](./docs/install/one-click-install-release-copy.md) | [🔧 仅框架安装](./docs/install/prompts/framework-only-install.md) |
 
 </div>
 

--- a/docs/install/README.en.md
+++ b/docs/install/README.en.md
@@ -17,7 +17,6 @@ This directory contains the public install, upgrade, and custom-integration docs
 ### Reference Docs
 
 - [`one-click-install-release-copy.en.md`](./one-click-install-release-copy.en.md): default entrypoint with host/version selection and links to prompt files
-- [`framework-only-path.en.md`](./framework-only-path.en.md): framework-only path, kept as a compatibility entry
 - [`recommended-full-path.en.md`](./recommended-full-path.en.md): advanced host, lane, and command reference
 - [`manual-copy-install.en.md`](./manual-copy-install.en.md): manual copy path for offline or no-admin environments
 - [`installation-rules.en.md`](./installation-rules.en.md): truth-first rules every install assistant must follow

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -17,7 +17,6 @@
 ### 参考说明
 
 - [`one-click-install-release-copy.md`](./one-click-install-release-copy.md)：默认推荐入口，先看版本和宿主选择，再跳转到对应提示词
-- [`framework-only-path.md`](./framework-only-path.md)：仅核心框架路径，兼容旧入口名
 - [`recommended-full-path.md`](./recommended-full-path.md)：高级 host / lane / 命令参考
 - [`manual-copy-install.md`](./manual-copy-install.md)：离线或无管理员权限时的手动复制路径
 - [`installation-rules.md`](./installation-rules.md)：安装助手必须遵守的 truth-first 规则

--- a/docs/install/framework-only-path.en.md
+++ b/docs/install/framework-only-path.en.md
@@ -1,24 +1,8 @@
 # Install Path: Framework Only
 
-This page is a compatibility landing page for the older entry name.
+This is a compatibility landing page for the older entry name.
 
-In the current repository, the real profile behind “Framework Only” is `minimal`, not the historical literal `framework-only` argument.
+The real profile behind “Framework Only” is `minimal`.
 
-## Where To Go
-
-- Use directly:
-  - [`minimal-path.en.md`](./minimal-path.en.md)
-- If you need prompt-based entrypoints:
-  - [`prompts/framework-only-install.en.md`](./prompts/framework-only-install.en.md)
-  - [`prompts/framework-only-update.en.md`](./prompts/framework-only-update.en.md)
-
-## Current Real Mapping
-
-- `Framework Only + Customizable Governance` -> `minimal`
-- `Full Version + Customizable Governance` -> `full`
-
-## Short Version
-
-- If you want the framework-only variant, follow [`minimal-path.en.md`](./minimal-path.en.md).
-- If you arrived here from an older README link, this is now the stable landing page.
-- Public wording may still say “Framework Only”, while execution maps it to `minimal`.
+- Install directly: [`prompts/framework-only-install.en.md`](./prompts/framework-only-install.en.md)
+- See command boundaries: [`minimal-path.en.md`](./minimal-path.en.md)

--- a/docs/install/framework-only-path.md
+++ b/docs/install/framework-only-path.md
@@ -1,24 +1,8 @@
 # 安装路径：仅核心框架
 
-这个页面是旧入口名的兼容页。
+这是旧入口名的兼容页。
 
-当前仓库里，“仅核心框架” 的真实 profile 是 `minimal`，不再是历史上的 `framework-only` 字面参数。
+“仅核心框架” 的真实 profile 是 `minimal`。
 
-## 你应该看哪里
-
-- 直接使用：
-  - [`minimal-path.md`](./minimal-path.md)
-- 如果你需要提示词入口：
-  - [`prompts/framework-only-install.md`](./prompts/framework-only-install.md)
-  - [`prompts/framework-only-update.md`](./prompts/framework-only-update.md)
-
-## 当前真实映射
-
-- `仅核心框架 + 可自定义添加治理` -> `minimal`
-- `全量版本 + 可自定义添加治理` -> `full`
-
-## 最短说明
-
-- 如果你想装“仅核心框架”，优先按 [`minimal-path.md`](./minimal-path.md) 执行。
-- 如果你是从 README 的旧链接点进来，这就是新的稳定落点。
-- 公开文案可以继续写 “仅核心框架”，执行时统一映射到 `minimal`。
+- 直接安装：[`prompts/framework-only-install.md`](./prompts/framework-only-install.md)
+- 看命令边界：[`minimal-path.md`](./minimal-path.md)

--- a/docs/install/one-click-install-release-copy.en.md
+++ b/docs/install/one-click-install-release-copy.en.md
@@ -2,45 +2,31 @@
 
 This is the default public install entrypoint.
 
-## First confirm two things
+## Choose Two Things
 
 1. Confirm the host: `codex`, `claude-code`, `cursor`, `windsurf`, or `openclaw`
 2. Confirm the public version: `Full Version + Customizable Governance` or `Framework Only + Customizable Governance`
 
-The real profile mapping is:
+Public version maps to:
 
 - `Full Version + Customizable Governance` -> `full`
 - `Framework Only + Customizable Governance` -> `minimal`
 
-## Prompt files to copy directly
+## Copy One Prompt
 
 - [`prompts/full-version-install.en.md`](./prompts/full-version-install.en.md)
 - [`prompts/framework-only-install.en.md`](./prompts/framework-only-install.en.md)
 - [`prompts/full-version-update.en.md`](./prompts/full-version-update.en.md)
 - [`prompts/framework-only-update.en.md`](./prompts/framework-only-update.en.md)
 
+## Read Next Only If Needed
 
-## What AI should do in this flow
-
-The install assistant should:
-
-- ask for the host first, then the version
-- execute only on the five supported hosts
-- map the public versions only to `full` or `minimal`
-- choose `bash` or `pwsh` based on the operating system
-- never ask you to paste secrets into chat
-- distinguish “installed locally” from “online-ready”
-- end with a concise result summary plus manual follow-up
-
-## What to read next
-
-If you want to bring in your own workflows or skills afterward:
-
-- [`custom-workflow-onboarding.en.md`](./custom-workflow-onboarding.en.md)
-- [`custom-skill-governance-rules.en.md`](./custom-skill-governance-rules.en.md)
-
-If you want lower-level commands and boundary details:
-
-- [`recommended-full-path.en.md`](./recommended-full-path.en.md)
-- [`manual-copy-install.en.md`](./manual-copy-install.en.md)
-- [`host-plugin-policy.en.md`](./host-plugin-policy.en.md)
+- Framework-only command path:
+  - [`minimal-path.en.md`](./minimal-path.en.md)
+- Lower-level command and boundary docs:
+  - [`recommended-full-path.en.md`](./recommended-full-path.en.md)
+  - [`manual-copy-install.en.md`](./manual-copy-install.en.md)
+  - [`host-plugin-policy.en.md`](./host-plugin-policy.en.md)
+- If you want to bring in your own workflows or skills afterward:
+  - [`custom-workflow-onboarding.en.md`](./custom-workflow-onboarding.en.md)
+  - [`custom-skill-governance-rules.en.md`](./custom-skill-governance-rules.en.md)

--- a/docs/install/one-click-install-release-copy.md
+++ b/docs/install/one-click-install-release-copy.md
@@ -2,47 +2,31 @@
 
 这是当前默认推荐的公开安装入口。
 
-## 先做两件事
+## 先选两件事
 
 1. 先确认宿主：`codex`、`claude-code`、`cursor`、`windsurf`、`openclaw`
 2. 再确认版本：`全量版本 + 可自定义添加治理` 或 `仅核心框架 + 可自定义添加治理`
 
-对应的真实 profile 映射是：
+公开版本映射到：
 
 - `全量版本 + 可自定义添加治理` -> `full`
 - `仅核心框架 + 可自定义添加治理` -> `minimal`
 
-## 直接复制的提示词
+## 复制对应提示词
 
 - [`prompts/full-version-install.md`](./prompts/full-version-install.md)
 - [`prompts/framework-only-install.md`](./prompts/framework-only-install.md)
 - [`prompts/full-version-update.md`](./prompts/full-version-update.md)
 - [`prompts/framework-only-update.md`](./prompts/framework-only-update.md)
 
+## 需要时再继续看
 
-
-## 你应该期待 AI 怎么做
-
-AI 安装助手应当：
-
-- 先问宿主，再问版本
-- 只对五个已支持宿主执行安装
-- 只把两个公开版本映射到真实 profile：`full` 或 `minimal`
-- 按系统类型选择 `bash` 或 `pwsh`
-- 不要求你把密钥贴到聊天里
-- 区分“安装完成”和“在线能力就绪”
-- 安装后给出简洁结果摘要和手动后续动作
-
-
-## 安装完之后再做什么
-
-如果你后面还要接自己的 workflow / skill：
-
-- [`custom-workflow-onboarding.md`](./custom-workflow-onboarding.md)
-- [`custom-skill-governance-rules.md`](./custom-skill-governance-rules.md)
-
-如果你要看更底层的命令和边界：
-
-- [`recommended-full-path.md`](./recommended-full-path.md)
-- [`manual-copy-install.md`](./manual-copy-install.md)
-- [`host-plugin-policy.md`](./host-plugin-policy.md)
+- 仅核心框架命令路径：
+  - [`minimal-path.md`](./minimal-path.md)
+- 更底层的命令和边界：
+  - [`recommended-full-path.md`](./recommended-full-path.md)
+  - [`manual-copy-install.md`](./manual-copy-install.md)
+  - [`host-plugin-policy.md`](./host-plugin-policy.md)
+- 后续接自己的 workflow / skill：
+  - [`custom-workflow-onboarding.md`](./custom-workflow-onboarding.md)
+  - [`custom-skill-governance-rules.md`](./custom-skill-governance-rules.md)

--- a/docs/install/prompts/framework-only-install.en.md
+++ b/docs/install/prompts/framework-only-install.en.md
@@ -1,8 +1,6 @@
 # Framework-Version Install Prompt
 
-**Use case**: you want only the governance foundation first and plan to add workflows/skills yourself later.
-
-**Version mapping**: `Framework Only + Customizable Governance` -> `minimal`
+**Use case**: hand the framework-only variant to an install assistant.
 
 ```text
 You are now my VibeSkills installation assistant.
@@ -19,11 +17,8 @@ Rules:
 2. If I choose the framework version, map it to the real profile `minimal`.
 3. Detect the OS first; use `bash` on Linux/macOS and `pwsh` on Windows.
 4. Execute install and check with `--host <host> --profile minimal`.
-5. Describe `claude-code` and `cursor` as supported install-and-use paths.
-6. Describe `windsurf` as a supported install-and-use path with runtime-adapter integration and default root `~/.codeium/windsurf`.
-7. Describe `openclaw` with the `preview` / `runtime-core-preview` / `runtime-core` wording, default target root `OPENCLAW_HOME` or `~/.openclaw`, and the attach / copy / bundle paths.
-8. For `codex`, say clearly that hooks remain frozen and this is not an install failure.
-9. Never ask me to paste secrets, URLs, or model names into chat.
-10. Remind me that this gives me the governance foundation first, not the full default workflow-core experience.
-11. End with a concise report covering host, public version, real profile, commands executed, completed parts, and manual follow-up.
+5. For host wording, default roots, and truth-first boundaries, follow `docs/install/minimal-path.en.md` and `docs/install/installation-rules.en.md` instead of restating a second version here.
+6. Never ask me to paste secrets, URLs, or model names into chat.
+7. Remind me that this gives me the governance foundation first, not the full default workflow-core experience.
+8. End with a concise report covering host, public version, real profile, commands executed, completed parts, and manual follow-up.
 ```

--- a/docs/install/prompts/framework-only-install.md
+++ b/docs/install/prompts/framework-only-install.md
@@ -1,8 +1,6 @@
 # 框架版本安装提示词
 
-**适用场景**：只想先拿治理框架底座，后续自己逐步接 workflow / skill。
-
-**版本映射**：`仅核心框架 + 可自定义添加治理` -> `minimal`
+**适用场景**：需要把“仅核心框架”交给安装助手执行。
 
 ```text
 你现在是我的 VibeSkills 安装助手。
@@ -19,11 +17,8 @@
 2. 这次如果我选的是“仅核心框架+可自定义添加治理”，你必须把它映射到真实 profile：`minimal`。
 3. 先判断系统类型；Linux / macOS 用 `bash`，Windows 用 `pwsh`。
 4. 按我选择的宿主执行 `--host <host> --profile minimal` 的安装与检查命令。
-5. 对 `claude-code` 和 `cursor`，明确说明当前提供支持的安装与使用路径。
-6. 对 `windsurf`，明确说明当前提供支持的安装与使用路径，且已接入 runtime adapter，默认根目录是 `~/.codeium/windsurf`。
-7. 对 `openclaw`，明确说明当前按 `preview` / `runtime-core-preview` / `runtime-core` 路径接入，默认目标根目录是 `OPENCLAW_HOME` 或 `~/.openclaw`，并说明 attach / copy / bundle 三路径。
-8. 对 `codex`，明确说明 hook 仍冻结；这不是安装失败。
-9. 对五个宿主，都不要要求我把密钥、URL 或 model 粘贴到聊天里。
-10. 安装完成后，必须额外提醒我：当前拿到的是治理框架底座，不等于默认 workflow core 已齐备。
-11. 结果报告仍需包含：目标宿主、公开版本、实际 profile、实际命令、已完成部分、仍需手动处理的部分。
+5. 宿主支持边界、默认根目录和 truth-first 口径，统一遵循 `docs/install/minimal-path.md` 与 `docs/install/installation-rules.md`，不要在这里重复发明另一套说法。
+6. 不要要求我把密钥、URL 或 model 粘贴到聊天里。
+7. 安装完成后，必须额外提醒我：当前拿到的是治理框架底座，不等于默认 workflow core 已齐备。
+8. 结果报告仍需包含：目标宿主、公开版本、实际 profile、实际命令、已完成部分、仍需手动处理的部分。
 ```


### PR DESCRIPTION
## Summary
- make README point framework-only installs directly to the prompt entry
- stop using `framework-only-path*` as a main navigation hop
- keep `framework-only-path*` only as a minimal compatibility landing page
- trim `one-click-install-release-copy*` down to version selection and jumps
- trim `framework-only-install*` down to prompt rules and authoritative references

## Why
The previous install docs repeated the same framework-only mapping and host wording across multiple entry pages. This change narrows each document to one job and reduces entry-point sprawl.

## Verification
- `rg -n "framework-only-path|prompts/framework-only-install|one-click-install-release-copy" README.md README.zh.md docs/install`
- `rg -n "framework-only-path" README.md README.zh.md docs/install`
