### PR TITLE
Add OpenCode preview adapter and refresh install docs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -19,7 +19,7 @@
     </a>
   </p>
   
-  
+
 
   <p align="center">
     <img src="https://komarev.com/ghpvc/?username=vibe-skills-foryourhealth&label=NODES%20ACTIVE&color=0078d7&style=flat-square" alt="Visitors">
@@ -43,34 +43,33 @@
 
 <br/>
 
-> [!IMPORTANT]
-> **🎯 Our core vision:**
+> [!IMPORTANT] > **🎯 Our core vision:**
 > Reduce the cognitive anxiety and high learning cost that come with every new technology wave. Here, whether or not you have a deep programming background, you can directly call on today's most advanced AI capabilities with an extremely low barrier to entry. **Let everyone enjoy the productivity leap that AI can bring.**
 
 ### 📊 Why is it so powerful?
 
 **VibeSkills** runs on **VCO**. It is not a one-off utility or a script that only knows how to patch code. It is a highly integrated and governed **super-capability network**:
 
-| 🧩 Skill Modules | 🌍 Ecosystem Integration | ⚖️ Governance Rules |
-| :---: | :---: | :---: |
+|                                                                 🧩 Skill Modules                                                                 |                                                           🌍 Ecosystem Integration                                                           |                                                                     ⚖️ Governance Rules                                                                     |
+| :----------------------------------------------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | <h2 align="center">340+</h2><div align="center">Directly callable Skills, covering the full chain from requirement planning to Execution. </div> | <h2 align="center">19+</h2><div align="center">High-value upstream open-source projects and best-practice sources absorbed and adapted</div> | <h2 align="center">129</h2><div align="center">Configuration-based policies and contracts to keep execution stable, traceable, and resistant to drift</div> |
+
 ---
 
 ## ✨ Why is it different?
 
-Traditional Skills repositories answer: *"What tools do I have here?"* VibeSkills goes straight after the core pain point of serious AI users: *"How do I finish work reliably?"*
+Traditional Skills repositories answer: _"What tools do I have here?"_ VibeSkills goes straight after the core pain point of serious AI users: _"How do I finish work reliably?"_
 
-| ❌ Traditional pain points you may have lived through | ✅ The VibeSkills answer we are building |
-| :--- | :--- |
-| **Sleeping skills**: hundreds of capabilities sit in the repo, but in real scenarios the AI does not remember to use them. Activation stays low. | **🧠 Intelligent routing**: the system figures out what to call based on context and logic, so you do not need to memorize a skill catalog. |
-| **Black-box sprinting**: the AI starts building before clarifying requirements. It looks fast, but the direction drifts, and the project slowly turns into a black box. | **🧭 Governed workflow**: the sequence is constrained on purpose. Clarification, verification, and traceability are folded into one unified flow, and every step stays auditable. |
-| **Conflicting components**: plugins and workflows fight each other, pollute the environment, or fall into loops because nobody is coordinating them. | **🧩 Global governance**: 129 contract rules define safety boundaries and rollback mechanisms, protecting the runtime's long-term stability. |
-| Messy Workspaces: AI workspaces often lack standardization. Over time, repositories become cluttered, hindering the next agent from taking over. Re-evaluating the architecture for a new agent leads to missed details and broken handoffs. |Semantic Directory Governance: Employs a standardized file storage architecture. It ensures that any work processed through this system is strictly organized, allowing the AI in subsequent sessions to instantly understand what files belong in which directories 👆. |
-| AI Quirks & Illusions: Deleting primary files by mistake when clearing backups; a bad habit of writing silent fallback mechanisms, then confidently claiming early success while the primary functionality is actually quite poor. | Built-in Guardrails: Includes strict rules, such as prohibiting bulk file deletion via commands (forcing one-by-one deletion to prevent accidents). Silent automated fallbacks are banned; any necessary fallback must trigger an explicit warning to the user 👆. |
-| High Cognitive Load: Users must rely on their own experience to regulate AI workflows, requiring steep learning curves and constant vigilance. | Guided Framework: The system actively guides the user through clarifying requirements, confirming execution plans, locking in workflow documents, and running concurrent multi-agents (allocating tasks and auto-invoking skills based on the plan), down to automated testing and iteration until the task is complete 👆. |
+| ❌ Traditional pain points you may have lived through                                                                                                                                                                                        | ✅ The VibeSkills answer we are building                                                                                                                                                                                                                                                                                    |
+| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Sleeping skills**: hundreds of capabilities sit in the repo, but in real scenarios the AI does not remember to use them. Activation stays low.                                                                                             | **🧠 Intelligent routing**: the system figures out what to call based on context and logic, so you do not need to memorize a skill catalog.                                                                                                                                                                                 |
+| **Black-box sprinting**: the AI starts building before clarifying requirements. It looks fast, but the direction drifts, and the project slowly turns into a black box.                                                                      | **🧭 Governed workflow**: the sequence is constrained on purpose. Clarification, verification, and traceability are folded into one unified flow, and every step stays auditable.                                                                                                                                           |
+| **Conflicting components**: plugins and workflows fight each other, pollute the environment, or fall into loops because nobody is coordinating them.                                                                                         | **🧩 Global governance**: 129 contract rules define safety boundaries and rollback mechanisms, protecting the runtime's long-term stability.                                                                                                                                                                                |
+| Messy Workspaces: AI workspaces often lack standardization. Over time, repositories become cluttered, hindering the next agent from taking over. Re-evaluating the architecture for a new agent leads to missed details and broken handoffs. | Semantic Directory Governance: Employs a standardized file storage architecture. It ensures that any work processed through this system is strictly organized, allowing the AI in subsequent sessions to instantly understand what files belong in which directories 👆.                                                    |
+| AI Quirks & Illusions: Deleting primary files by mistake when clearing backups; a bad habit of writing silent fallback mechanisms, then confidently claiming early success while the primary functionality is actually quite poor.           | Built-in Guardrails: Includes strict rules, such as prohibiting bulk file deletion via commands (forcing one-by-one deletion to prevent accidents). Silent automated fallbacks are banned; any necessary fallback must trigger an explicit warning to the user 👆.                                                          |
+| High Cognitive Load: Users must rely on their own experience to regulate AI workflows, requiring steep learning curves and constant vigilance.                                                                                               | Guided Framework: The system actively guides the user through clarifying requirements, confirming execution plans, locking in workflow documents, and running concurrent multi-agents (allocating tasks and auto-invoking skills based on the plan), down to automated testing and iteration until the task is complete 👆. |
 
-**With so many skills available, will the sheer number of options lead to a token explosion? Under the governance framework, this will certainly result in excessive token consumption, but not to the point of a token explosion. This is because routing doesn't provide the model with so many options; instead, it's triggered based on the user's task. The core logic is: user command - AI-assisted governance discovers keywords representing user intent - keywords trigger skill routing, and so on.**
----
+## **With so many skills available, will the sheer number of options lead to a token explosion? Under the governance framework, this will certainly result in excessive token consumption, but not to the point of a token explosion. This is because routing doesn't provide the model with so many options; instead, it's triggered based on the user's task. The core logic is: user command - AI-assisted governance discovers keywords representing user intent - keywords trigger skill routing, and so on.**
 
 ## ✦ Panoramic Capability Map: Your all-in-one workspace
 
@@ -92,6 +91,7 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 | **📐 Mathematics and professional computing** | Symbolic derivation, Bayesian modeling, multi-objective optimization, simulation, and even quantum computing. | `sympy`, `pymc-bayesian-modeling`, `qiskit` |
 | **🎨 Multimedia and presentation** | Interactive charts, scientific figures, image generation, speech synthesis, and video asset production. | `plotly`, `generate-image`, `video-studio` |
 <br/>
+
 <details>
 <summary><b>👉 Click to expand: Explore the full 340+ full-stack capability matrix of VibeSkills</b></summary>
 <br/>
@@ -100,6 +100,7 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 </blockquote>
 
 ### 🧠 Requirements, planning, and product management
+
 > **🎯 Make big ideas executable**: cover requirement insight, problem definition, sprint planning, task decomposition, and constraint collection. The goal is to make sure the direction is clear, the boundaries are explicit, and milestones are testable before the first line of code is written.
 
 `.system`, `aios-pm`, `aios-po`, `aios-sm`, `aios-squad-creator`, `aios-ux-design-expert`, `brainstorming`, `create-plan`, `designing-experiments`, `planning-with-files`, `shared-templates`, `speckit-analyze`, `speckit-checklist`, `speckit-clarify`, `speckit-constitution`, `speckit-plan`, `speckit-specify`, `speckit-tasks`, `speckit-taskstoissues`, `subagent-driven-development`, `think-harder`, `treatment-plans`, `ux-researcher-designer`, `writing-plans`
@@ -107,6 +108,7 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 ---
 
 ### 🛠️ Software engineering and architecture design
+
 > **🎯 A real engineering foundation**: from scaffolding, cross-file modification, and API design to microservice architecture evaluation. It does not just produce code. It also manages context memory, toolchain orchestration, and multi-stage collaboration among intelligent agents.
 
 `aios-architect`, `aios-dev`, `aios-master`, `architecture-patterns`, `autonomous-builder`, `cancel-ralph`, `coding-tutor`, `context-fundamentals`, `context-hunter`, `cs-foundations`, `deepagent-memory-fold`, `deepagent-toolchain-plan`, `evaluating-code-models`, `get-available-resources`, `hive-mind-advanced`, `local-vco-roles`, `node-zombie-guardian`, `nowait-reasoning-optimizer`, `prompt-lookup`, `ralph-loop`, `skill-creator`, `skill-lookup`, `spec-kit-vibe-compat`, `speckit-implement`, `superclaude-framework-compat`, `theme-factory`, `vibe`, `webthinker-deep-research`
@@ -114,6 +116,7 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 ---
 
 ### 🔧 Debugging, testing, and quality assurance
+
 > **🎯 Protect the lifeline of code and systems**: covers unit testing, root-cause analysis, dependency conflict resolution, security review, and a full TDD-style testing workflow so the system can get out of the "change it and it breaks" black-box state.
 
 `aios-qa`, `build-error-resolver`, `code-review`, `code-review-excellence`, `code-reviewer`, `data-quality-checker`, `data-quality-frameworks`, `debugging-strategies`, `deslop`, `detecting-performance-regressions`, `error-resolver`, `evals-context`, `experiment-failure-analysis`, `generating-test-reports`, `ml-data-leakage-guard`, `performance-testing`, `property-based-testing`, `providing-performance-optimization-advice`, `receiving-code-review`, `requesting-code-review`, `reviewing-code`, `security-best-practices`, `security-ownership-map`, `security-reviewer`, `security-threat-model`, `systematic-debugging`, `tdd-guide`, `verification-before-completion`, `verification-quality-assurance`, `windows-hook-debugging`
@@ -121,6 +124,7 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 ---
 
 ### 📊 Data analysis and statistical modeling
+
 > **🎯 Let data tell the facts**: provides a one-stop data-processing engine covering cleaning, missing-value handling, exploratory data analysis, advanced statistical testing, regression models, and time-series forecasting.
 
 `aios-data-engineer`, `anomaly-detector`, `correlation-analyzer`, `dask`, `data-artist`, `data-exploration-visualization`, `data-normalization-tool`, `detecting-data-anomalies`, `excel-analysis`, `exploratory-data-analysis`, `feature-importance-analyzer`, `geopandas`, `hypothesis-testing`, `metric-calculator`, `networkx`, `performing-causal-analysis`, `performing-regression-analysis`, `polars`, `preprocessing-data-with-automated-pipelines`, `regression-analysis-helper`, `running-clustering-algorithms`, `scientific-data-preprocessing`, `splitting-datasets`, `spreadsheet`, `statistical-analysis`, `statistics-math`, `statsmodels`, `usfiscaldata`, `vaex`, `xlsx`
@@ -128,6 +132,7 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 ---
 
 ### 🤖 Machine learning and AI engineering
+
 > **🎯 A full-stack AI model development stack**: goes far beyond calling APIs. It reaches into feature engineering, model training, fine-tuning, interpretability analysis, LLM evaluation, and reinforcement learning workflows.
 
 `LQF_Machine_Learning_Expert_Guide`, `aeon`, `datamol`, `deepchem`, `embedding-strategies`, `engineering-features-for-machine-learning`, `evaluating-llms-harness`, `evaluating-machine-learning-models`, `explaining-machine-learning-models`, `geniml`, `ml-pipeline-workflow`, `openai-knowledge`, `pufferlib`, `pytorch-lightning`, `scikit-learn`, `scikit-survival`, `senior-computer-vision`, `senior-data-scientist`, `senior-ml-engineer`, `senior-prompt-engineer`, `shap`, `similarity-search-patterns`, `sparse-autoencoder-training`, `stable-baselines3`, `tensorboard`, `timesfm-forecasting`, `torch-geometric`, `torch_geometric`, `torchdrug`, `training-machine-learning-models`, `transformer-lens-interpretability`, `transformers`, `umap-learn`, `unsloth`, `weights-and-biases`
@@ -135,6 +140,7 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 ---
 
 ### 🧬 Life sciences and bioinformatics computing
+
 > **🎯 A seriously powerful interdisciplinary toolset**: deeply integrates single-cell sequencing analysis, protein structure folding, drug molecule discovery, and genomics alignment, while connecting cleanly to many kinds of cloud biology lab systems.
 
 `adaptyv`, `alphafold-database`, `anndata`, `arboreto`, `benchling-integration`, `biopython`, `bioservices`, `cellxgene-census`, `cobrapy`, `deeptools`, `diffdock`, `dnanexus-integration`, `esm`, `etetoolkit`, `flowio`, `gene-database`, `gget`, `ginkgo-cloud-lab`, `gtars`, `histolab`, `imaging-data-commons`, `labarchive-integration`, `lamindb`, `latchbio-integration`, `matchms`, `medchem`, `molfeat`, `neurokit2`, `neuropixels-analysis`, `omero-integration`, `opentrons-integration`, `pathml`, `protocolsio-integration`, `pydeseq2`, `pydicom`, `pyhealth`, `pylabrobot`, `pyopenms`, `pysam`, `pytdc`, `rdkit`, `scanpy`, `scikit-bio`, `scvi-tools`, `tiledbvcf`
@@ -142,6 +148,7 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 ---
 
 ### 🔬 Scientific computing and mathematical logic
+
 > **🎯 Precise derivation and complex-system simulation**: provides symbolic mathematics, Bayesian probabilistic programming, quantum-computing simulation, multi-objective optimization, and rigorous propositional-logic and mathematical-proof assistance.
 
 `astropy`, `cirq`, `dialectic`, `fluidsim`, `gradient-methods`, `math`, `math-model-selector`, `math-tools`, `mathematical-logic-expert`, `matlab`, `pennylane`, `pymatgen`, `pymc`, `pymc-bayesian-modeling`, `pymoo`, `propositional-logic`, `qiskit`, `qutip`, `rowan`, `simpy`, `sympy`, `xan`
@@ -149,6 +156,7 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 ---
 
 ### 📚 Research literature and academic writing
+
 > **🎯 A high-speed lane for academic productivity**: spans precise search across dozens of scientific databases such as PubMed and arXiv, review-matrix organization, citation management, and a full publication workflow from drafting and revision to peer review.
 
 `bgpt-paper-search`, `biorxiv-database`, `brenda-database`, `chembl-database`, `citation-management`, `clinical-decision-support`, `clinical-reports`, `clinicaltrials-database`, `clinpgx-database`, `clinvar-database`, `comprehensive-research-agent`, `content-research-writer`, `cosmic-database`, `datacommons-client`, `documentation-lookup`, `drugbank-database`, `ena-database`, `ensembl-database`, `fda-database`, `geo-database`, `gwas-database`, `hmdb-database`, `hypothesis-generation`, `kegg-database`, `literature-matrix`, `literature-review`, `manuscript-as-code`, `market-research-reports`, `metabolomics-workbench-database`, `open-notebook`, `openalex-database`, `opentargets-database`, `paper-2-web`, `pdb-database`, `peer-review`, `pubchem-database`, `pubmed-database`, `pyzotero`, `reactome-database`, `research-grants`, `research-lookup`, `scholar-evaluation`, `scholarly-publishing`, `scientific-brainstorming`, `scientific-critical-thinking`, `scientific-reporting`, `scientific-writing`, `string-database`, `submission-checklist`, `uniprot-database`, `uspto-database`, `zinc-database`
@@ -156,6 +164,7 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 ---
 
 ### 🎨 Multimedia, visualization, and documents
+
 > **🎯 Make knowledge and data visible**: covers interactive chart generation, publication-grade scientific figures, slide creation, audio/video production, and deep read/write and parsing support for office documents such as Word and PDF.
 
 `algorithmic-art`, `creating-data-visualizations`, `data-storytelling`, `datavis`, `doc`, `docs-review`, `docs-write`, `document-skills`, `docx`, `docx-comment-reply`, `figma`, `figma-implement-design`, `file-organizer`, `g2-legend-expert`, `generate-image`, `imagegen`, `infographics`, `latex-posters`, `latex-submission-pipeline`, `markdown-mermaid-writing`, `markitdown`, `matplotlib`, `pdf`, `plotly`, `pptx-posters`, `report-generator`, `scientific-schematics`, `scientific-slides`, `scientific-visualization`, `screenshot`, `seaborn`, `slides-as-code`, `smart-file-writer`, `speech`, `structured-content-storage`, `transcribe`, `venue-templates`, `video-studio`, `visualization-best-practices`, `vscode-release-notes-writer`, `writing-docs`
@@ -163,6 +172,7 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 ---
 
 ### 🔌 External integrations, automation, and deployment
+
 > **🎯 Break through runtime boundaries**: connect to external browsers, design platforms, and cloud services through MCP and Playwright-style automation, while supporting CI/CD pipelines and one-click deployment.
 
 `aios-devops`, `alpha-vantage`, `claude-skills`, `commit-with-reflection`, `denario`, `digital-brain`, `edgartools`, `flashrag-evidence`, `fred-economic-data`, `geomaster`, `gh-address-comments`, `gh-fix-ci`, `hedgefundmonitor`, `hypogenic`, `iso-13485-certification`, `jupyter-notebook`, `knowledge-steward`, `mcp-integration`, `modal`, `modal-labs`, `netlify-deploy`, `openai-docs`, `perplexity-search`, `playwright`, `prowler-docs`, `scrapling`, `sentry`, `skypilot-multi-cloud-orchestration`, `vercel-deploy`
@@ -173,12 +183,12 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 
 ## 👥 Who is it for?
 
-* 🎯 **Everyday people who want stable delivery**: you want AI to be a reliable partner, not a runaway horse.
-* ⚡ **Advanced power users who rely heavily on AI and agents**: you need a unified foundation that can carry large workflows.
-* 🏢 **Small teams with stronger process requirements**: you want AI workflows that are easier to maintain and easier to pass on.
-* 😩 **Practitioners tired of "skill pileups"**: you are done hunting for tools and just want a solution that works out of the box.
+- 🎯 **Everyday people who want stable delivery**: you want AI to be a reliable partner, not a runaway horse.
+- ⚡ **Advanced power users who rely heavily on AI and agents**: you need a unified foundation that can carry large workflows.
+- 🏢 **Small teams with stronger process requirements**: you want AI workflows that are easier to maintain and easier to pass on.
+- 😩 **Practitioners tired of "skill pileups"**: you are done hunting for tools and just want a solution that works out of the box.
 
-*If all you want is one tiny script, this may be too much. But if you want to use AI more steadily, more smoothly, and for the long run, this becomes hard to replace.*
+_If all you want is one tiny script, this may be too much. But if you want to use AI more steadily, more smoothly, and for the long run, this becomes hard to replace._
 
 ---
 
@@ -186,12 +196,12 @@ If you unfold these 340 skills along real-world workflows, VibeSkills has alread
 
 The biggest advantage of VibeSkills is its **systematic governance and standardization**. This is not a pile of scattered skills. It is an upstream-to-downstream work chain with tight handoffs.
 
-* **🧩 Planning, architecture, and engineering implementation**
-    Start with requirement interviews and constraint collection, move through task breakdown and architecture selection, and land in precise cross-file changes. At the same time, quality gates stay enforced, covering root-cause-level refactors and maintainability-oriented review.
-* **🔗 Collaborative governance and capability activation**
-    Solve the "sleeping capability" problem. Through **intelligent routing** and **governed workflows**, the right MCP or plugin is activated at the right stage. The execution trail is fully recorded and can be turned into high-quality knowledge artifacts automatically.
-* **🔬 Data, research, and high-bar professional computing**
-    Go beyond ordinary coding. VibeSkills provides a complete **research and academic writing loop**, a deeply integrated **life-sciences toolchain**, and scientific-computing engines that support complex modeling.
+- **🧩 Planning, architecture, and engineering implementation**
+  Start with requirement interviews and constraint collection, move through task breakdown and architecture selection, and land in precise cross-file changes. At the same time, quality gates stay enforced, covering root-cause-level refactors and maintainability-oriented review.
+- **🔗 Collaborative governance and capability activation**
+  Solve the "sleeping capability" problem. Through **intelligent routing** and **governed workflows**, the right MCP or plugin is activated at the right stage. The execution trail is fully recorded and can be turned into high-quality knowledge artifacts automatically.
+- **🔬 Data, research, and high-bar professional computing**
+  Go beyond ordinary coding. VibeSkills provides a complete **research and academic writing loop**, a deeply integrated **life-sciences toolchain**, and scientific-computing engines that support complex modeling.
 
 We reject black-box execution. Vibe-Skills strictly follows a `clarify ➔ plan ➔ execute ➔ verify` directed acyclic graph (DAG) architecture.
 
@@ -205,7 +215,7 @@ graph LR
     E --> F[Execution Layer: 340+ Skills]
     F --> G[Automated QA Validation]
     G --> H((High-Quality Delivery))
-    
+
     style B fill:#2196F3,stroke:#fff,stroke-width:2px,color:#fff
     style C fill:#FF9800,stroke:#fff,stroke-width:2px,color:#fff
     style X fill:#F44336,stroke:#fff,stroke-width:2px,color:#fff
@@ -264,34 +274,115 @@ We know that building in isolation cannot keep up with the speed of the AI era. 
 >
 > `superpower` · `claude-scientific-skills` · `get-shit-done` · `aios-core` · `OpenSpec` · `ralph-claude-code` · `SuperClaude_Framework` · `spec-kit` · `Agent-S` · `mem0` · `scrapling` · `claude-flow` · `serena` · `everything-claude-code` · `DeepAgent` and more
 >
-> *Thank you to all of these authors for their generous work. Without those bright sources of inspiration, VibeSkills would not exist. While integrating strengths from many repositories, we have tried hard to handle attribution and redistribution responsibly. If anything has been missed, please raise it in an Issue and we will correct and supplement it as quickly as possible.*
+> _Thank you to all of these authors for their generous work. Without those bright sources of inspiration, VibeSkills would not exist. While integrating strengths from many repositories, we have tried hard to handle attribution and redistribution responsibly. If anything has been missed, please raise it in an Issue and we will correct and supplement it as quickly as possible._
 
 ---
 
 ## 🚀 Start your Vibe experience
 
-⚠️ **Invocation note**: to stay compatible with general-purpose agents, this project uses a **Skills-format architecture**. Please activate it through your host environment's Skills invocation flow. **Do not** run it directly as a standalone CLI program.
-* In **Claude Code**, type: `/vibe`
-* In **Codex**, type: `$vibe`
+If this is your first time landing in the repo, the most useful thing is not reading every document. It is figuring out how to start.
 
-### 📚 Navigation and guides
+### First, understand what it is in one sentence
 
-**Get familiar with the system quickly**
-* 📖 [Understand the system architecture and philosophy](./docs/quick-start.md)
-* 📜 [VibeSkills manifesto](./docs/manifesto.md)
+`VibeSkills` is not a standalone CLI, and it is not a single program you run directly after `git clone`.
 
-**Installation and configuration guide**
-* Current public support surface: **Claude Code and Codex only**
-* ⚡️ [Prompt-based install (recommended default)](./docs/install/one-click-install-release-copy.en.md)
-* 📁 [Manual copy install (offline / no-admin)](./docs/install/manual-copy-install.en.md)
+It is a **Skills runtime plus a governed workflow** that lives inside a supported host. You install it into that host, then activate it through the host's own skill invocation flow.
 
-**Advanced references**
-* 🛠 [Advanced host and lane reference](./docs/install/recommended-full-path.en.md)
-* 🧊 [Cold-start and other environment notes](./docs/cold-start-install-paths.en.md)
+### Which hosts are currently supported
+
+The current public install surface includes:
+
+- `Claude Code`
+- `Codex`
+- `OpenCode`
+
+Within that surface:
+
+- `Codex`: strongest current repo-governed path
+- `Claude Code`: preview guidance
+- `OpenCode`: preview adapter
+
+If you are using another host, the current version should not be described as already supported.
+
+### How you should start
+
+For most people, this path is enough:
+
+1. Confirm whether your target host is `Claude Code`, `Codex`, or `OpenCode`
+2. Start with [`Prompt-based install`](./docs/install/one-click-install-release-copy.en.md)
+3. If your target host is `OpenCode`, you can also go straight to [`OpenCode install path`](./docs/install/opencode-path.en.md)
+4. If you are offline, do not have admin rights, or only want to place files manually, use [`Manual copy install`](./docs/install/manual-copy-install.en.md)
+5. Fill the required values in your **local host configuration**
+6. Go back to the host, invoke `vibe`, and state your task directly
+
+### How to choose between the three install paths
+
+| Your situation                                                            | Recommended entry                                                                                   |
+| :------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------------- |
+| You want AI to choose the right supported host and run install checks     | [`Prompt-based install (recommended default)`](./docs/install/one-click-install-release-copy.en.md) |
+| Your target host is OpenCode and you want the direct preview adapter path | [`OpenCode install path`](./docs/install/opencode-path.en.md)                                       |
+| You do not want to run install scripts, or you are offline / no-admin     | [`Manual copy install`](./docs/install/manual-copy-install.en.md)                                   |
+
+### Boundaries you should know before installing
+
+- The current version does **not** support running VibeSkills as a standalone CLI
+- The current public install surface includes `Claude Code`, `Codex`, and `OpenCode`
+- The current version does **not** install hooks for either `Claude Code` or `Codex`
+- Hook installation is temporarily frozen because of compatibility issues
+- `OpenCode` is currently a preview adapter and does not take ownership of the real `opencode.json`, plugin installation, or MCP trust
+- Do not paste `url`, `apikey`, or `model` into chat; those values should be filled by the user in local settings or local environment variables
+- If those local provider values are still missing, the environment must not be described as online-ready
+
+### How you actually invoke it after installation
+
+After installation, you do not look for a new startup command. You go back to your host and invoke it there:
+
+- In **Claude Code**, type: `/vibe`
+- In **Codex**, type: `$vibe`
+- In **OpenCode**, type: `/vibe`
+
+Then state your task directly, for example:
+
+- "Help me plan a refactor for this repository"
+- "Help me fix this error and show the verification result"
+- "Help me produce a literature review in this area"
+
+### What happens after invocation
+
+`vibe` does not jump straight into black-box execution. It runs as a governed runtime, and it usually moves in this order:
+
+1. check the repository and runtime context
+2. clarify your goal, constraints, and acceptance criteria
+3. freeze a requirement document
+4. generate a plan document
+5. execute, verify, and leave traceable artifacts
+6. perform phase cleanup so the workspace does not decay
+
+That is the practical difference between VibeSkills and an ordinary skills repo: it is not only a pile of capabilities. It also makes the AI work through a governed process.
+
+### If you want to understand the project faster
+
+This reading order is the shortest path:
+
+1. [`Quick Start`](./docs/quick-start.md)
+2. [`Prompt-based install (recommended default)`](./docs/install/one-click-install-release-copy.en.md)
+3. [`VibeSkills manifesto`](./docs/manifesto.md)
+
+### If you are already a heavy user
+
+Continue with these fuller references:
+
+- [`Advanced host and lane reference`](./docs/install/recommended-full-path.en.md)
+- [`Cold-start and other environment notes`](./docs/cold-start-install-paths.en.md)
+- [`OpenCode install path`](./docs/install/opencode-path.en.md)
+
+Issues, discussions, and direct feedback are all useful if the current wording is still unclear.
 
 ---
+
 Welcome everyone to try it out and experience it for yourselves! I'd love to hear your thoughts, so please feel free to start discussions and share your feedback or suggestions. I know I'm far from perfect, so if you spot any issues or areas for improvement, please don't hesitate to point them out—I'm all ears and will definitely make the necessary fixes.
 If you like the project, please consider giving it a star! I'll be continuously updating it. Your support is the enriched U-235 to this nuclear-powered donkey!
+
 <div align="center">
   <p><i>Turn the most failure-prone parts of real work into a system that is more callable, more governable, and more maintainable over the long term.</i></p>
 </div>

--- a/README.md
+++ b/README.md
@@ -51,29 +51,29 @@
 
 **VibeSkills** 背后的运行时核心是 **VCO**。它绝不仅仅是一个单点工具或只会“补代码”的脚本，而是一个已经完成高度整合与治理的**超级能力网络**：
 
-| 🧩 技能模块 | 🌍 生态融合 | ⚖️ 治理规则 |
-| :---: | :---: | :---: |
+|                                                🧩 技能模块                                                |                                           🌍 生态融合                                           |                                                ⚖️ 治理规则                                                 |
+| :-------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------: |
 | <h2 align="center">340+</h2><div align="center">可直接调用的 Skills，覆盖从需求规划到执行的完整链路</div> | <h2 align="center">19+</h2><div align="center">吸收与借鉴高价值上游开源项目与最佳实践来源</div> | <h2 align="center">129 条</h2><div align="center">基于配置的策略与契约，确保执行稳定、可溯源、防发散</div> |
+
 ---
 
 ## ✨ 为什么它与众不同？
 
-传统的 Skills 仓库在回答：*“我这里有什么工具？”* 而 VibeSkills 正面迎击的是重度 AI 用户的核心痛点：*“我该怎么稳定地完成工作？”*
+传统的 Skills 仓库在回答：_“我这里有什么工具？”_ 而 VibeSkills 正面迎击的是重度 AI 用户的核心痛点：_“我该怎么稳定地完成工作？”_
 
-| ❌ 传统痛点（你可能经历过） | ✅ VibeSkills 解法（我们正在做） |
-| :--- | :--- |
-| **技能沉睡**：仓库里几百个能力，真实场景下 AI 根本想不起来用，激活率极低。 | **🧠 智能路由**：现在该调什么，系统会根据上下文和逻辑自动路由拉起，无需你翻背技能表。 |
-| **黑盒狂奔**：AI 不澄清需求就直接开做，速度快但方向偏，项目逐渐变成黑盒。 | **🧭 受管工作流**：先做什么再做什么被严格约束。将澄清、验证、留痕收进统一流程，每步可溯源。 |
-| **互相冲突**：不同插件和工作流之间缺乏统筹，导致环境污染或死循环。 | **🧩 全局治理**：通过 129 条契约规则，设定安全边界与回退机制，保障整个运行时的长期稳定性。 |
-| AI的工作区往往不够规范，工作久了之后仓库容易脏乱差，影响下一个agent接手工作区。在开一个新agent管理工作项目时，重新理解工作区的架构会遗漏一些项目细节，导致后面工作和前面工作衔接有问题 | 使用了一套文件目录语义治理。保证只要工作经过这个项目的治理，按固定化的架构存储文件，让下一个新的对话的AI明白什么什么目录下存储什么什么文件 |
-| AI诸多的小毛病：为删除备份，把主要文件删了；喜欢写静默的兜底机制，然后早早的自信满满的给你说做好了，实际上全是兜底机制在发力，主要功能实现度度很差 | 内置了一些治理，如上述的禁止按命令批量删除文件，只能一个文件一个文件的删除，防止误删文件。禁止写自动静默兜底机制，如果要写兜底机制，一定要显示有明确的警告用户|
-| 用户需要依据经验自己规范与AI的工作流，需要学习和保持警觉 | 框架会引导用户，从沟通好需求，沟通好落实计划，固定好工作步骤文件，多代理并发执行（同时会按照计划，不同的代理分配不同的工作，各自会自动调用相关的skills），自动测试迭代，直到任务完成|
+| ❌ 传统痛点（你可能经历过）                                                                                                                                                            | ✅ VibeSkills 解法（我们正在做）                                                                                                                                                     |
+| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **技能沉睡**：仓库里几百个能力，真实场景下 AI 根本想不起来用，激活率极低。                                                                                                             | **🧠 智能路由**：现在该调什么，系统会根据上下文和逻辑自动路由拉起，无需你翻背技能表。                                                                                                |
+| **黑盒狂奔**：AI 不澄清需求就直接开做，速度快但方向偏，项目逐渐变成黑盒。                                                                                                              | **🧭 受管工作流**：先做什么再做什么被严格约束。将澄清、验证、留痕收进统一流程，每步可溯源。                                                                                          |
+| **互相冲突**：不同插件和工作流之间缺乏统筹，导致环境污染或死循环。                                                                                                                     | **🧩 全局治理**：通过 129 条契约规则，设定安全边界与回退机制，保障整个运行时的长期稳定性。                                                                                           |
+| AI的工作区往往不够规范，工作久了之后仓库容易脏乱差，影响下一个agent接手工作区。在开一个新agent管理工作项目时，重新理解工作区的架构会遗漏一些项目细节，导致后面工作和前面工作衔接有问题 | 使用了一套文件目录语义治理。保证只要工作经过这个项目的治理，按固定化的架构存储文件，让下一个新的对话的AI明白什么什么目录下存储什么什么文件                                           |
+| AI诸多的小毛病：为删除备份，把主要文件删了；喜欢写静默的兜底机制，然后早早的自信满满的给你说做好了，实际上全是兜底机制在发力，主要功能实现度度很差                                     | 内置了一些治理，如上述的禁止按命令批量删除文件，只能一个文件一个文件的删除，防止误删文件。禁止写自动静默兜底机制，如果要写兜底机制，一定要显示有明确的警告用户                       |
+| 用户需要依据经验自己规范与AI的工作流，需要学习和保持警觉                                                                                                                               | 框架会引导用户，从沟通好需求，沟通好落实计划，固定好工作步骤文件，多代理并发执行（同时会按照计划，不同的代理分配不同的工作，各自会自动调用相关的skills），自动测试迭代，直到任务完成 |
 
 **集合了这么多skills，是否会因为选项过多导致token爆炸？
 在治理框架下肯定会导致多余的token消耗，但是不会至于token爆炸。因为路由不是给模型如此多的选项，而是依据用户的任务触发，核心是用户命令-ai辅助治理发掘用户意图的关键词-关键词触发技能路由，这样调用路由。**
 
 ---
-
 
 ## ✦ 全景能力地图：你的全能工作台
 
@@ -95,6 +95,7 @@
 | **📐 数学与专业计算** | 符号推导、贝叶斯建模、多目标优化、仿真乃至量子计算 | `sympy`, `pymc-bayesian-modeling`, `qiskit` |
 | **🎨 多媒体与展示** | 交互图表、科研绘图、图片生成、语音合成与视频素材生产 | `plotly`, `generate-image`, `video-studio` |
 <br/>
+
 <details>
 <summary><b>👉 点击展开：探索 VibeSkills 完整的 340+ 全栈能力矩阵详解</b></summary>
 <br/>
@@ -103,6 +104,7 @@
 </blockquote>
 
 ### 🧠 需求、规划与产品管理
+
 > **🎯 让大想法变得可落地**：负责需求洞察、问题定义、Sprint 规划、任务切分与约束收集。确保在写下第一行代码前，方向清晰、边界明确且具有可验收的里程碑。
 
 `.system`, `aios-pm`, `aios-po`, `aios-sm`, `aios-squad-creator`, `aios-ux-design-expert`, `brainstorming`, `create-plan`, `designing-experiments`, `planning-with-files`, `shared-templates`, `speckit-analyze`, `speckit-checklist`, `speckit-clarify`, `speckit-constitution`, `speckit-plan`, `speckit-specify`, `speckit-tasks`, `speckit-taskstoissues`, `subagent-driven-development`, `think-harder`, `treatment-plans`, `ux-researcher-designer`, `writing-plans`
@@ -110,6 +112,7 @@
 ---
 
 ### 🛠️ 软件工程与架构设计
+
 > **🎯 真正的工程化构建底座**：从脚手架搭建、跨文件修改、API 接口设计到微服务架构评估。不仅产出代码，更负责上下文记忆、工具链编排与智能 Agent 的多阶段协同执行。
 
 `aios-architect`, `aios-dev`, `aios-master`, `architecture-patterns`, `autonomous-builder`, `cancel-ralph`, `coding-tutor`, `context-fundamentals`, `context-hunter`, `cs-foundations`, `deepagent-memory-fold`, `deepagent-toolchain-plan`, `evaluating-code-models`, `get-available-resources`, `hive-mind-advanced`, `local-vco-roles`, `node-zombie-guardian`, `nowait-reasoning-optimizer`, `prompt-lookup`, `ralph-loop`, `skill-creator`, `skill-lookup`, `spec-kit-vibe-compat`, `speckit-implement`, `superclaude-framework-compat`, `theme-factory`, `vibe`, `webthinker-deep-research`
@@ -117,6 +120,7 @@
 ---
 
 ### 🔧 调试、测试与质量保证
+
 > **🎯 守住代码和系统的生命线**：涵盖单元测试、根因分析、依赖冲突解决、安全漏洞审查与全套 TDD 测试驱动指南，确保系统告别“改完就崩”的黑盒状态。
 
 `aios-qa`, `build-error-resolver`, `code-review`, `code-review-excellence`, `code-reviewer`, `data-quality-checker`, `data-quality-frameworks`, `debugging-strategies`, `deslop`, `detecting-performance-regressions`, `error-resolver`, `evals-context`, `experiment-failure-analysis`, `generating-test-reports`, `ml-data-leakage-guard`, `performance-testing`, `property-based-testing`, `providing-performance-optimization-advice`, `receiving-code-review`, `requesting-code-review`, `reviewing-code`, `security-best-practices`, `security-ownership-map`, `security-reviewer`, `security-threat-model`, `systematic-debugging`, `tdd-guide`, `verification-before-completion`, `verification-quality-assurance`, `windows-hook-debugging`
@@ -124,6 +128,7 @@
 ---
 
 ### 📊 数据分析与统计建模
+
 > **🎯 让数据讲述事实**：提供从数据清洗、缺失值处理、探索性分析（EDA）到高级统计检验、回归模型、时序预测的一站式数据处理引擎。
 
 `aios-data-engineer`, `anomaly-detector`, `correlation-analyzer`, `dask`, `data-artist`, `data-exploration-visualization`, `data-normalization-tool`, `detecting-data-anomalies`, `excel-analysis`, `exploratory-data-analysis`, `feature-importance-analyzer`, `geopandas`, `hypothesis-testing`, `metric-calculator`, `networkx`, `performing-causal-analysis`, `performing-regression-analysis`, `polars`, `preprocessing-data-with-automated-pipelines`, `regression-analysis-helper`, `running-clustering-algorithms`, `scientific-data-preprocessing`, `splitting-datasets`, `spreadsheet`, `statistical-analysis`, `statistics-math`, `statsmodels`, `usfiscaldata`, `vaex`, `xlsx`
@@ -131,6 +136,7 @@
 ---
 
 ### 🤖 机器学习与 AI 工程
+
 > **🎯 全链路 AI 模型开发栈**：不止于调用 API，更深入特征工程、模型训练、微调（Fine-tuning）、可解释性分析（SHAP）、大模型评估（Evals）与强化学习训练工作流。
 
 `LQF_Machine_Learning_Expert_Guide`, `aeon`, `datamol`, `deepchem`, `embedding-strategies`, `engineering-features-for-machine-learning`, `evaluating-llms-harness`, `evaluating-machine-learning-models`, `explaining-machine-learning-models`, `geniml`, `ml-pipeline-workflow`, `openai-knowledge`, `pufferlib`, `pytorch-lightning`, `scikit-learn`, `scikit-survival`, `senior-computer-vision`, `senior-data-scientist`, `senior-ml-engineer`, `senior-prompt-engineer`, `shap`, `similarity-search-patterns`, `sparse-autoencoder-training`, `stable-baselines3`, `tensorboard`, `timesfm-forecasting`, `torch-geometric`, `torch_geometric`, `torchdrug`, `training-machine-learning-models`, `transformer-lens-interpretability`, `transformers`, `umap-learn`, `unsloth`, `weights-and-biases`
@@ -138,6 +144,7 @@
 ---
 
 ### 🧬 生命科学与生信计算
+
 > **🎯 极其强悍的跨学科硬核利器**：深度集成单细胞测序分析、蛋白质结构折叠、药物分子发现、基因组学比对，并无缝对接各类云端生物实验室系统。
 
 `adaptyv`, `alphafold-database`, `anndata`, `arboreto`, `benchling-integration`, `biopython`, `bioservices`, `cellxgene-census`, `cobrapy`, `deeptools`, `diffdock`, `dnanexus-integration`, `esm`, `etetoolkit`, `flowio`, `gene-database`, `gget`, `ginkgo-cloud-lab`, `gtars`, `histolab`, `imaging-data-commons`, `labarchive-integration`, `lamindb`, `latchbio-integration`, `matchms`, `medchem`, `molfeat`, `neurokit2`, `neuropixels-analysis`, `omero-integration`, `opentrons-integration`, `pathml`, `protocolsio-integration`, `pydeseq2`, `pydicom`, `pyhealth`, `pylabrobot`, `pyopenms`, `pysam`, `pytdc`, `rdkit`, `scanpy`, `scikit-bio`, `scvi-tools`, `tiledbvcf`
@@ -145,6 +152,7 @@
 ---
 
 ### 🔬 科学计算与数学逻辑
+
 > **🎯 精确推导与复杂系统仿真**：提供符号数学演算、贝叶斯概率编程、量子计算模拟、多目标优化计算以及严格的命题逻辑与数理证明辅助。
 
 `astropy`, `cirq`, `dialectic`, `fluidsim`, `gradient-methods`, `math`, `math-model-selector`, `math-tools`, `mathematical-logic-expert`, `matlab`, `pennylane`, `pymatgen`, `pymc`, `pymc-bayesian-modeling`, `pymoo`, `propositional-logic`, `qiskit`, `qutip`, `rowan`, `simpy`, `sympy`, `xan`
@@ -152,6 +160,7 @@
 ---
 
 ### 📚 科研文献与学术写作
+
 > **🎯 学术生产力的高速公路**：横跨 PubMed/arXiv 等数十个科研数据库的精准检索、综述矩阵整理、引文管理系统，以及从论文起草、修改到同行评审的完整出版物流程。
 
 `bgpt-paper-search`, `biorxiv-database`, `brenda-database`, `chembl-database`, `citation-management`, `clinical-decision-support`, `clinical-reports`, `clinicaltrials-database`, `clinpgx-database`, `clinvar-database`, `comprehensive-research-agent`, `content-research-writer`, `cosmic-database`, `datacommons-client`, `documentation-lookup`, `drugbank-database`, `ena-database`, `ensembl-database`, `fda-database`, `geo-database`, `gwas-database`, `hmdb-database`, `hypothesis-generation`, `kegg-database`, `literature-matrix`, `literature-review`, `manuscript-as-code`, `market-research-reports`, `metabolomics-workbench-database`, `open-notebook`, `openalex-database`, `opentargets-database`, `paper-2-web`, `pdb-database`, `peer-review`, `pubchem-database`, `pubmed-database`, `pyzotero`, `reactome-database`, `research-grants`, `research-lookup`, `scholar-evaluation`, `scholarly-publishing`, `scientific-brainstorming`, `scientific-critical-thinking`, `scientific-reporting`, `scientific-writing`, `string-database`, `submission-checklist`, `uniprot-database`, `uspto-database`, `zinc-database`
@@ -159,6 +168,7 @@
 ---
 
 ### 🎨 多媒体、可视化与文档
+
 > **🎯 让知识与数据变得“可看见”**：涵盖交互式图表生成、科研出版级绘图、幻灯片生成、音视频生产，以及对 Word、PDF 等办公文档的深度读写与解析。
 
 `algorithmic-art`, `creating-data-visualizations`, `data-storytelling`, `datavis`, `doc`, `docs-review`, `docs-write`, `document-skills`, `docx`, `docx-comment-reply`, `figma`, `figma-implement-design`, `file-organizer`, `g2-legend-expert`, `generate-image`, `imagegen`, `infographics`, `latex-posters`, `latex-submission-pipeline`, `markdown-mermaid-writing`, `markitdown`, `matplotlib`, `pdf`, `plotly`, `pptx-posters`, `report-generator`, `scientific-schematics`, `scientific-slides`, `scientific-visualization`, `screenshot`, `seaborn`, `slides-as-code`, `smart-file-writer`, `speech`, `structured-content-storage`, `transcribe`, `venue-templates`, `video-studio`, `visualization-best-practices`, `vscode-release-notes-writer`, `writing-docs`
@@ -166,6 +176,7 @@
 ---
 
 ### 🔌 外部集成、自动化与部署
+
 > **🎯 打破运行时的局限**：通过 MCP 协议、Playwright 自动化框架无缝对接外部浏览器、设计平台与云端服务，并支持 CI/CD 流水线与一键自动化部署。
 
 `aios-devops`, `alpha-vantage`, `claude-skills`, `commit-with-reflection`, `denario`, `digital-brain`, `edgartools`, `flashrag-evidence`, `fred-economic-data`, `geomaster`, `gh-address-comments`, `gh-fix-ci`, `hedgefundmonitor`, `hypogenic`, `iso-13485-certification`, `jupyter-notebook`, `knowledge-steward`, `mcp-integration`, `modal`, `modal-labs`, `netlify-deploy`, `openai-docs`, `perplexity-search`, `playwright`, `prowler-docs`, `scrapling`, `sentry`, `skypilot-multi-cloud-orchestration`, `vercel-deploy`
@@ -176,12 +187,12 @@
 
 ## 👥 适用人群
 
-* 🎯 **追求稳定交付的普通用户**：想让 AI 成为可靠的帮手，而不是脱缰的野马。
-* ⚡ **重度依赖 AI/Agent 的进阶极客**：需要一个能承载庞大工作流的统一底座。
-* 🏢 **规范化要求高的小型团队**：希望把 AI 工作流变得更具可维护性和传承性。
-* 😩 **被“技能堆砌”折磨的实践者**：已经厌倦了找工具，只想要一套开箱即用的解决方案。
+- 🎯 **追求稳定交付的普通用户**：想让 AI 成为可靠的帮手，而不是脱缰的野马。
+- ⚡ **重度依赖 AI/Agent 的进阶极客**：需要一个能承载庞大工作流的统一底座。
+- 🏢 **规范化要求高的小型团队**：希望把 AI 工作流变得更具可维护性和传承性。
+- 😩 **被“技能堆砌”折磨的实践者**：已经厌倦了找工具，只想要一套开箱即用的解决方案。
 
-*如果你只想找个单一的小脚本，它可能过于庞大；但如果你想把 AI 用得更稳、更顺、更长远，它将是你不可或缺的利器。*
+_如果你只想找个单一的小脚本，它可能过于庞大；但如果你想把 AI 用得更稳、更顺、更长远，它将是你不可或缺的利器。_
 
 ---
 
@@ -189,15 +200,14 @@
 
 VibeSkills 最大的优势在于**系统性的治理与规范化**。这里不是零散技能的堆砌，而是紧密衔接的上下游工作链。
 
-* **🧩 规划、架构与工程实现**
-    从需求访谈、约束收集开始，经过 tasks 拆解与架构选型，最终落实到跨文件修改；同时严守质量门禁，涵盖根因级重构修复与长期可维护性代码评审。
-* **🔗 协作治理与能力激活**
-    解决“能力沉睡”痛点。通过**智能路由**与**受管工作流**，在正确阶段唤起正确的 MCP/插件。执行过程完整留痕，并自动沉淀为高质量知识文档。
-* **🔬 数据、科研与高门槛专业计算**
-    跨越常规编码边界，提供链路完整的**科研学术写作闭环**、深度集成的**生命科学工具链**，以及支撑复杂建模的科学计算引擎。
+- **🧩 规划、架构与工程实现**
+  从需求访谈、约束收集开始，经过 tasks 拆解与架构选型，最终落实到跨文件修改；同时严守质量门禁，涵盖根因级重构修复与长期可维护性代码评审。
+- **🔗 协作治理与能力激活**
+  解决“能力沉睡”痛点。通过**智能路由**与**受管工作流**，在正确阶段唤起正确的 MCP/插件。执行过程完整留痕，并自动沉淀为高质量知识文档。
+- **🔬 数据、科研与高门槛专业计算**
+  跨越常规编码边界，提供链路完整的**科研学术写作闭环**、深度集成的**生命科学工具链**，以及支撑复杂建模的科学计算引擎。
 
 我们拒绝“黑盒执行”。Vibe-Skills 严格执行 `澄清 ➔ 规划 ➔ 执行 ➔ 验证` 的有向无环图 (DAG) 架构。
-
 
 ```mermaid
 graph LR
@@ -209,7 +219,7 @@ graph LR
     E --> F[执行层: 340+ 技能]
     F --> G[QA 自动化验证]
     G --> H((高质量交付))
-    
+
     style B fill:#2196F3,stroke:#fff,stroke-width:2px,color:#fff
     style C fill:#FF9800,stroke:#fff,stroke-width:2px,color:#fff
     style X fill:#F44336,stroke:#fff,stroke-width:2px,color:#fff
@@ -257,7 +267,6 @@ graph LR
   **会拉起：** `scanpy`、`scvi-tools`、`anndata`、`scientific-visualization`
   **最终交付：** 一套分析流程、关键图形结果，以及能够继续深挖的初步结论。
 
-
 ---
 
 ## 📦 集众家之所长：资源整合与全量矩阵
@@ -265,40 +274,112 @@ graph LR
 我们深知，闭门造车无法适应飞速演进的 AI 时代。VibeSkills 的核心底气，来自于持续吸收开源社区最成熟的方法与架构，并将它们纳入同一套统一治理的调度系统中。
 
 > 🙏 **特别鸣谢与致敬** > 本项目持续整合、吸收并治理了以下优秀开源项目的核心优势：
-> 
+>
 > `superpower` · `claude-scientific-skills` · `get-shit-done` · `aios-core` · `OpenSpec` · `ralph-claude-code` · `SuperClaude_Framework` · `spec-kit` · `Agent-S` · `mem0` · `scrapling` · `claude-flow` · `serena` · `everything-claude-code` · `DeepAgent` 等等
-> 
-> *感谢各位作者的无私奉献，没有这些璀璨的星光，就没有 VibeSkills 的诞生。在吸纳众多优秀仓库的过程中，我们已竭尽全力做好版权的分发与署名。若百密一疏出现纰漏，请在 Issue 中向我们提出，我们将第一时间进行修正与补充！*
-
+>
+> _感谢各位作者的无私奉献，没有这些璀璨的星光，就没有 VibeSkills 的诞生。在吸纳众多优秀仓库的过程中，我们已竭尽全力做好版权的分发与署名。若百密一疏出现纰漏，请在 Issue 中向我们提出，我们将第一时间进行修正与补充！_
 
 ---
 
 ## 🚀 开启你的 Vibe 体验
 
-⚠️ **调用说明**：为保证通用代理的适配性，本项目采用 **Skills 格式架构**。请通过宿主环境的 Skills 调用方式唤起，**不要**将其作为独立命令行程序直接运行。
-* 在 **Claude Code** 中，输入：`/vibe`
-* 在 **Codex** 中，输入：`$vibe`
+如果你第一次来到这个仓库，最重要的不是把所有文档都读完，而是先判断自己应该怎么开始。
 
-### 📚 导航与指引
+### 先用一句话理解它是什么
 
-**快速了解系统**
-* 📖 [了解系统架构与理念](./docs/quick-start.md)
-* 📜 [VibeSkills 宣言](./docs/manifesto.md)
+`VibeSkills` 不是一个独立 CLI，也不是 `git clone` 之后直接运行的单体程序。
 
-**安装与配置指南**
-* 当前公开支持面：**仅支持 Claude Code 和 Codex**
-* ⚡️ [提示词安装（默认推荐）](./docs/install/one-click-install-release-copy.md)
-* 📁 [手动复制安装（离线 / 无管理员权限）](./docs/install/manual-copy-install.md)
+它是一套运行在宿主里的 **Skills runtime + governed workflow**。你需要把它安装到支持的宿主里，再通过宿主的技能调用方式唤起。
 
-**高级参考**
-* 🛠 [高级 host / lane 参考](./docs/install/recommended-full-path.md)
-* 🧊 [冷启动与其他环境说明](./docs/cold-start-install-paths.md)
+### 当前支持哪些宿主
 
-欢迎大家来尝试和体验啦 :heart_eyes:！欢迎大家讨论，并且向我提出建议和意见 :kissing_face_with_closed_eyes:。鄙人不才，可能有些地方有问题烦请大家指出，我一定会认真听取和修改。
+当前公开安装面覆盖三个宿主：
 
-如果您喜欢可以加个star :smiling_face_with_three_hearts:，我会持续更新这个项目的！您的支持也是我这个核动力驴的浓缩U-235 :blush:！
+- `Claude Code`
+- `Codex`
+- `OpenCode`
 
-感谢你的观看！
+其中：
+
+- `Codex`：当前最强的 repo-governed 路径
+- `Claude Code`：preview guidance
+- `OpenCode`：preview adapter
+
+如果你现在使用的不是这三个宿主，当前版本不要把它理解成“已经支持安装”。
+
+### 你应该怎么开始
+
+大多数人直接按下面这条顺序走就够了：
+
+1. 先确认你的目标宿主是 `Claude Code`、`Codex` 还是 `OpenCode`
+2. 默认先看 [`提示词安装`](./docs/install/one-click-install-release-copy.md)
+3. 如果你的目标是 `OpenCode`，也可以直接看 [`OpenCode 安装路径`](./docs/install/opencode-path.md)
+4. 如果你是离线环境、无管理员权限，或者只想自己拷文件，再看 [`手动复制安装`](./docs/install/manual-copy-install.md)
+5. 按文档要求，在**本地宿主配置**里补齐需要的设置
+6. 回到宿主里调用 `vibe`，再把你的任务直接告诉 AI
+
+### 三条安装路径怎么选
+
+| 你的情况                                             | 推荐入口                                                                     |
+| :--------------------------------------------------- | :--------------------------------------------------------------------------- |
+| 想让 AI 帮你判断该装到哪个宿主，并执行安装检查       | [`提示词安装（默认推荐）`](./docs/install/one-click-install-release-copy.md) |
+| 目标宿主就是 OpenCode，想直接走 preview adapter 安装 | [`OpenCode 安装路径`](./docs/install/opencode-path.md)                       |
+| 不想跑安装脚本，或者环境离线、无管理员权限           | [`手动复制安装`](./docs/install/manual-copy-install.md)                      |
+
+### 安装前一定要先知道的边界
+
+- 当前版本**不支持**把它当作独立 CLI 直接运行
+- 当前版本公开安装面包括 `Claude Code`、`Codex` 和 `OpenCode`
+- 当前版本对 `Claude Code` 和 `Codex` 都**不提供 hook 安装**
+- hook 目前因为兼容性问题，暂时被冻结
+- `OpenCode` 当前是 preview adapter，不接管真实 `opencode.json`、plugin 安装或 MCP 信任
+- 不要把 `url`、`apikey`、`model` 直接贴到聊天里；这些值应该由用户自己填到本地 settings 或本地环境变量里
+- 如果这些本地 provider 配置还没填好，就不能把环境描述成“已完成 online readiness”
+
+### 安装后你实际怎么调用
+
+安装完成后，不是再去找新的启动命令，而是回到你的宿主里直接调用：
+
+- 在 **Claude Code** 里输入：`/vibe`
+- 在 **Codex** 里输入：`$vibe`
+- 在 **OpenCode** 里输入：`/vibe`
+
+然后直接说你的任务，例如：
+
+- “帮我梳理这个仓库的重构计划”
+- “帮我修复这个报错，并给出验证结果”
+- “帮我做一份这个方向的文献综述”
+
+### 调用之后会发生什么
+
+`vibe` 不会一上来就黑盒开做。它背后是一个受管运行时，通常会按这个顺序推进：
+
+1. 先检查仓库和运行环境
+2. 澄清你的目标、约束和验收标准
+3. 冻结 requirement 文档
+4. 生成 plan 文档
+5. 执行、验证、留痕
+6. 做阶段清理，避免把工作区越做越乱
+
+如果你关心的是“它为什么和普通 skills 仓库不一样”，核心就在这里：它不只是给 AI 一堆能力，而是要求 AI 按治理流程工作。
+
+### 如果你想更快理解整个项目
+
+按这个顺序读最省时间：
+
+1. [`Quick Start`](./docs/quick-start.md)
+2. [`提示词安装（默认推荐）`](./docs/install/one-click-install-release-copy.md)
+3. [`VibeSkills 宣言`](./docs/manifesto.md)
+
+### 如果你已经是重度用户
+
+再继续看这些更完整的参考：
+
+- [`高级 host / lane 参考`](./docs/install/recommended-full-path.md)
+- [`冷启动与其他环境说明`](./docs/cold-start-install-paths.md)
+- [`OpenCode 安装路径`](./docs/install/opencode-path.md)
+
+欢迎继续提 issue、讨论区反馈，或者直接指出哪里还不够清楚。
 
 ---
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -13,7 +13,7 @@ Current adapter intent:
 
 - `codex/`: strongest current adapter because the repository already ships Codex-specific install, settings, and plugin guidance.
 - `claude-code/`: preview adapter derived from existing template and governance expectations.
-- `opencode/`: contract placeholder only; no runtime closure claim yet.
+- `opencode/`: preview adapter with host-native command/agent/example-config scaffolds, but still no full host closure claim.
 - `generic/`: lowest-common-denominator contract consumer, not an official runtime.
 
 The official runtime remains the canonical execution owner until replay, install isolation, and platform truth gates are passed.

--- a/adapters/index.json
+++ b/adapters/index.json
@@ -36,6 +36,22 @@
       "settings_map": "adapters/claude-code/settings-map.json",
       "closure": "adapters/claude-code/closure.json",
       "manifest": "dist/host-claude-code/manifest.json"
+    },
+    {
+      "id": "opencode",
+      "status": "preview",
+      "install_mode": "preview-guidance",
+      "check_mode": "preview-guidance",
+      "bootstrap_mode": "preview-guidance",
+      "default_target_root": {
+        "env": "OPENCODE_HOME",
+        "rel": ".config/opencode",
+        "kind": "host-home"
+      },
+      "host_profile": "adapters/opencode/host-profile.json",
+      "settings_map": "adapters/opencode/settings-map.json",
+      "closure": "adapters/opencode/closure.json",
+      "manifest": "dist/host-opencode/manifest.json"
     }
   ]
 }

--- a/adapters/opencode/closure.json
+++ b/adapters/opencode/closure.json
@@ -1,28 +1,34 @@
 {
   "adapter_id": "opencode",
-  "closure_level": "runtime-core-only-preview",
-  "install_mode": "runtime-core",
-  "check_mode": "runtime-core",
-  "bootstrap_mode": "runtime-core",
+  "closure_level": "preview-guidance",
+  "install_mode": "preview-guidance",
+  "check_mode": "preview-guidance",
+  "bootstrap_mode": "preview-guidance",
   "repo_managed_payload": [
+    "runtime core payload",
+    "OpenCode command wrappers under commands/** and command/**",
+    "OpenCode agent wrappers under agents/** and agent/**",
+    "OpenCode preview config example under opencode.json.example"
+  ],
+  "host_state_written": [
     "skills/**",
     "commands/**",
-    "config/upstream-lock.json",
-    "config/skills-lock.json",
-    "canonical vibe mirror under skills/vibe/**"
+    "command/**",
+    "agents/**",
+    "agent/**",
+    "opencode.json.example"
   ],
-  "host_state_written": [],
   "host_managed_boundaries": [
-    "all host settings",
+    "final opencode.json ownership",
     "plugin provisioning",
     "MCP registration",
     "provider credentials",
-    "runtime integration"
+    "runtime model/provider selection"
   ],
   "verification_contract": [
     "runtime freshness gate",
     "runtime BOM/frontmatter gate",
     "runtime coherence gate",
-    "runtime-core presence check"
+    "OpenCode preview smoke gate"
   ]
 }

--- a/adapters/opencode/host-profile.json
+++ b/adapters/opencode/host-profile.json
@@ -1,39 +1,50 @@
 {
   "adapter_id": "opencode",
   "host_name": "OpenCode",
-  "status": "not-yet-proven",
-  "runtime_role": "future-host-adapter",
+  "status": "preview",
+  "runtime_role": "host-adapter-preview",
   "source_evidence": [
-    "config/runtime-core-packaging.json",
+    "config/opencode/commands/vibe.md",
+    "config/opencode/agents/vibe-plan.md",
+    "config/opencode/opencode.json.example",
+    "docs/install/opencode-path.en.md",
     "adapters/opencode/closure.json",
     "install.ps1",
     "check.ps1"
   ],
   "settings_surface": {
-    "path": "neutral target root",
+    "path": "~/.config/opencode/opencode.json",
     "managed_by_repo": false,
-    "notes": "The repository currently supports only a neutral runtime-core lane for OpenCode-targeted experiments, not a host-native contract."
+    "notes": "The repository installs skills, commands, and agents into OpenCode roots, but the real opencode.json remains host-managed. The repo only ships an example config scaffold for preview guidance."
   },
   "host_managed_surfaces": [
-    "all plugin provisioning",
-    "all settings materialization",
-    "all MCP registration",
-    "all provider credential storage"
+    "final permission policy",
+    "provider credentials",
+    "plugin provisioning",
+    "MCP registration",
+    "model/provider selection"
   ],
   "capabilities": {
-    "fs.read": "unknown",
-    "fs.write": "unknown",
-    "shell.exec": "unknown",
-    "mcp.client": "unknown",
-    "settings.materialize": "runtime-core-only",
-    "plugin.provision": "unsupported",
-    "agent.spawn": "unknown",
-    "route.provider_call": "unknown",
-    "route.offline_fallback": "unknown",
-    "release.verify": "runtime-core-only"
+    "fs.read": "expected",
+    "fs.write": "expected",
+    "shell.exec": "expected",
+    "mcp.client": "supported-with-constraints",
+    "settings.materialize": "preview-guidance",
+    "plugin.provision": "manual-host-managed",
+    "agent.spawn": "expected",
+    "route.provider_call": "supported-with-constraints",
+    "route.offline_fallback": "not-yet-proven",
+    "release.verify": "preview-guidance"
   },
   "degrade_contract": {
-    "current_state": "not-yet-proven host; runtime-core-only neutral lane"
+    "missing_provider_credentials": "degraded-but-supported",
+    "missing_user_permission_policy": "degraded-but-supported",
+    "unverified_platform_lane": "not-yet-proven",
+    "skill_debug_surface_diverges_from_docs": "preview-guidance-only"
   },
-  "supported_platform_contracts": []
+  "supported_platform_contracts": [
+    "adapters/opencode/platform-windows.json",
+    "adapters/opencode/platform-linux.json",
+    "adapters/opencode/platform-macos.json"
+  ]
 }

--- a/adapters/opencode/platform-linux.json
+++ b/adapters/opencode/platform-linux.json
@@ -1,0 +1,18 @@
+{
+  "adapter_id": "opencode",
+  "platform": "linux",
+  "status": "not-yet-proven",
+  "install_surface": [
+    "install.sh --host opencode"
+  ],
+  "check_surface": [
+    "check.sh --host opencode"
+  ],
+  "doctor_surface": [
+    "scripts/verify/runtime_neutral/opencode_preview_smoke.py"
+  ],
+  "notes": [
+    "Linux preview payload can be installed into OpenCode roots, but replay-backed platform proof is still incomplete.",
+    "Local OpenCode CLI 1.2.27 shows unresolved skill discovery drift versus official docs, so the lane must remain below supported-with-constraints."
+  ]
+}

--- a/adapters/opencode/platform-macos.json
+++ b/adapters/opencode/platform-macos.json
@@ -1,0 +1,18 @@
+{
+  "adapter_id": "opencode",
+  "platform": "macos",
+  "status": "not-yet-proven",
+  "install_surface": [
+    "install.sh --host opencode"
+  ],
+  "check_surface": [
+    "check.sh --host opencode"
+  ],
+  "doctor_surface": [
+    "scripts/verify/runtime_neutral/opencode_preview_smoke.py"
+  ],
+  "notes": [
+    "The repository now exposes a preview OpenCode adapter contract, but macOS proof has not been frozen.",
+    "Do not market macOS OpenCode parity until replay-backed evidence exists."
+  ]
+}

--- a/adapters/opencode/platform-windows.json
+++ b/adapters/opencode/platform-windows.json
@@ -1,0 +1,18 @@
+{
+  "adapter_id": "opencode",
+  "platform": "windows",
+  "status": "not-yet-proven",
+  "install_surface": [
+    "install.ps1 --host opencode"
+  ],
+  "check_surface": [
+    "check.ps1 --host opencode"
+  ],
+  "doctor_surface": [
+    "scripts/verify/runtime_neutral/opencode_preview_smoke.py"
+  ],
+  "notes": [
+    "PowerShell entrypoints now understand OpenCode preview roots, but a Windows-specific proof bundle does not exist yet.",
+    "The preview lane writes only bounded wrapper payload and example config; it does not claim Windows host closure."
+  ]
+}

--- a/adapters/opencode/settings-map.json
+++ b/adapters/opencode/settings-map.json
@@ -1,9 +1,23 @@
 {
   "adapter_id": "opencode",
-  "template": null,
-  "target": null,
-  "semantics": {},
+  "template": "config/opencode/opencode.json.example",
+  "target": "~/.config/opencode/opencode.json",
+  "semantics": {
+    "vco.skill_root.global": "~/.config/opencode/skills",
+    "vco.skill_root.project": ".opencode/skills",
+    "vco.command_root.global": "~/.config/opencode/commands",
+    "vco.command_root.project": ".opencode/commands",
+    "vco.command_root.compat": "~/.config/opencode/command",
+    "vco.agent_root.global": "~/.config/opencode/agents",
+    "vco.agent_root.project": ".opencode/agents",
+    "vco.agent_root.compat": "~/.config/opencode/agent",
+    "permission.skill": "skill allow/ask rules for Vibe-Skills entrypoints",
+    "permission.external_directory": "needed only when the operator intentionally points OpenCode at compatibility roots outside the project or OpenCode config home",
+    "provider.*": "host-managed provider credentials and endpoint bindings"
+  },
   "notes": [
-    "OpenCode mapping is intentionally empty until a real host contract is implemented and verified."
+    "The repository does not overwrite the real opencode.json during preview installation.",
+    "Preview install writes markdown wrapper files into OpenCode command/agent roots and ships an example opencode.json scaffold only.",
+    "Both plural and singular command/agent subdirectories are mirrored during preview installation for compatibility with current doc/runtime drift."
   ]
 }

--- a/check.ps1
+++ b/check.ps1
@@ -1,7 +1,7 @@
 param(
   [ValidateSet("minimal", "full")]
   [string]$Profile = "full",
-  [ValidateSet("codex", "claude-code")]
+  [ValidateSet("codex", "claude-code", "opencode")]
   [string]$HostId = "codex",
   [string]$TargetRoot = '',
   [switch]$SkipRuntimeFreshnessGate,
@@ -92,6 +92,13 @@ function Check-Condition {
     }
     $script:fail++
   }
+}
+
+function Warn-Note {
+  param([string]$Message)
+
+  Write-Host "[WARN] $Message" -ForegroundColor Yellow
+  $script:warn++
 }
 
 function Get-JsonObject {
@@ -420,7 +427,11 @@ function Invoke-AdapterSpecificChecks {
     Check-Path -Label "settings.json" -Path (Join-Path $TargetRoot 'settings.json')
   }
   if ([string]$Adapter.check_mode -eq 'preview-guidance') {
-    Warn-Note -Message 'claude preview hook/settings scaffold is intentionally disabled because of current compatibility issues'
+    if ([string]$Adapter.id -eq 'claude-code') {
+      Warn-Note -Message 'claude preview hook/settings scaffold is intentionally disabled because of current compatibility issues'
+    } elseif ([string]$Adapter.id -eq 'opencode') {
+      Warn-Note -Message 'opencode preview keeps the real opencode.json host-managed; only skills, commands, agents, and an example config scaffold are verified'
+    }
   }
   if ([string]$Adapter.check_mode -eq 'governed') {
     Check-Path -Label "plugins manifest" -Path (Join-Path $TargetRoot 'config\plugins-manifest.codex.json')
@@ -478,6 +489,18 @@ function Invoke-AdapterSpecificChecks {
     foreach ($name in $optionalWorkflow) {
       Check-Path -Label "optional workflow skill/$name" -Path (Join-Path $TargetRoot "skills\$name\SKILL.md") -Required:$false
     }
+  }
+
+  if ([string]$Adapter.id -eq 'opencode') {
+    foreach ($name in @('vibe', 'vibe-implement', 'vibe-review')) {
+      Check-Path -Label "opencode command/$name" -Path (Join-Path $TargetRoot "commands\$name.md")
+      Check-Path -Label "opencode compat command/$name" -Path (Join-Path $TargetRoot "command\$name.md")
+    }
+    foreach ($name in @('vibe-plan', 'vibe-implement', 'vibe-review')) {
+      Check-Path -Label "opencode agent/$name" -Path (Join-Path $TargetRoot "agents\$name.md")
+      Check-Path -Label "opencode compat agent/$name" -Path (Join-Path $TargetRoot "agent\$name.md")
+    }
+    Check-Path -Label 'opencode preview config example' -Path (Join-Path $TargetRoot 'opencode.json.example')
   }
 }
 

--- a/check.sh
+++ b/check.sh
@@ -31,8 +31,9 @@ resolve_host_id() {
   case "${host_id}" in
     codex) printf '%s' 'codex' ;;
     claude|claude-code) printf '%s' 'claude-code' ;;
+    opencode) printf '%s' 'opencode' ;;
     *)
-      echo "[FAIL] Unsupported VCO host id: ${host_id}. Supported values: codex, claude-code" >&2
+      echo "[FAIL] Unsupported VCO host id: ${host_id}. Supported values: codex, claude-code, opencode" >&2
       exit 1
       ;;
   esac
@@ -43,6 +44,7 @@ resolve_default_target_root() {
   case "${host_id}" in
     codex) printf '%s' "${CODEX_HOME:-${HOME}/.codex}" ;;
     claude-code) printf '%s' "${CLAUDE_HOME:-${HOME}/.claude}" ;;
+    opencode) printf '%s' "${OPENCODE_HOME:-${HOME}/.config/opencode}" ;;
     *)
       echo "[FAIL] Unsupported VCO host id for target-root resolution: ${host_id}" >&2
       exit 1
@@ -54,16 +56,38 @@ assert_target_root_matches_host_intent() {
   local target_root="$1"
   local host_id="$2"
   local leaf
+  local normalized_root
   leaf="$(basename "${target_root}")"
   leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  normalized_root="$(printf '%s' "${target_root}" | tr '\\' '/' | sed 's#//*#/#g' | tr '[:upper:]' '[:lower:]')"
   if [[ "${host_id}" == "codex" && "${leaf}" == ".claude" ]]; then
     echo "[FAIL] Target root '${target_root}' looks like a Claude Code home, but host='codex'." >&2
     echo "[FAIL] Pass --host claude-code for preview guidance or use a Codex target root." >&2
     exit 1
   fi
+  if [[ "${host_id}" == "codex" && ( "${leaf}" == ".opencode" || "${normalized_root}" == */.config/opencode ) ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like an OpenCode root, but host='codex'." >&2
+    echo "[FAIL] Pass --host opencode for the OpenCode preview lane or use a Codex target root." >&2
+    exit 1
+  fi
   if [[ "${host_id}" == "claude-code" && "${leaf}" == ".codex" ]]; then
     echo "[FAIL] Target root '${target_root}' looks like a Codex home, but host='claude-code'." >&2
     echo "[FAIL] Use --host codex for the official closure lane or choose a Claude Code target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "claude-code" && ( "${leaf}" == ".opencode" || "${normalized_root}" == */.config/opencode ) ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like an OpenCode root, but host='claude-code'." >&2
+    echo "[FAIL] Use --host opencode for the OpenCode preview lane or choose a Claude Code target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "opencode" && "${leaf}" == ".codex" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Codex home, but host='opencode'." >&2
+    echo "[FAIL] Use --host codex for the official closure lane or choose an OpenCode target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "opencode" && "${leaf}" == ".claude" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Claude Code home, but host='opencode'." >&2
+    echo "[FAIL] Use --host claude-code for Claude preview guidance or choose an OpenCode target root." >&2
     exit 1
   fi
 }
@@ -534,7 +558,11 @@ if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   check_path "settings.json" "${TARGET_ROOT}/settings.json"
 fi
 if [[ "${ADAPTER_CHECK_MODE}" == "preview-guidance" ]]; then
-  warn_note "claude preview hook/settings scaffold is intentionally disabled because of current compatibility issues"
+  if [[ "${HOST_ID}" == "claude-code" ]]; then
+    warn_note "claude preview hook/settings scaffold is intentionally disabled because of current compatibility issues"
+  elif [[ "${HOST_ID}" == "opencode" ]]; then
+    warn_note "opencode preview keeps the real opencode.json host-managed; only skills, commands, agents, and an example config scaffold are verified"
+  fi
 fi
 if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   check_path "plugins manifest" "${TARGET_ROOT}/config/plugins-manifest.codex.json"
@@ -585,6 +613,17 @@ if [[ "${PROFILE}" == "full" ]]; then
   for n in requesting-code-review receiving-code-review verification-before-completion; do
     check_path "optional/${n}" "${TARGET_ROOT}/skills/${n}/SKILL.md" false
   done
+fi
+if [[ "${HOST_ID}" == "opencode" ]]; then
+  for n in vibe vibe-implement vibe-review; do
+    check_path "opencode command/${n}" "${TARGET_ROOT}/commands/${n}.md"
+    check_path "opencode compat command/${n}" "${TARGET_ROOT}/command/${n}.md"
+  done
+  for n in vibe-plan vibe-implement vibe-review; do
+    check_path "opencode agent/${n}" "${TARGET_ROOT}/agents/${n}.md"
+    check_path "opencode compat agent/${n}" "${TARGET_ROOT}/agent/${n}.md"
+  done
+  check_path "opencode preview config example" "${TARGET_ROOT}/opencode.json.example"
 fi
 if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   check_path "rules/common" "${TARGET_ROOT}/rules/common/agents.md"

--- a/config/opencode/agents/vibe-implement.md
+++ b/config/opencode/agents/vibe-implement.md
@@ -1,0 +1,12 @@
+---
+description: Implementation-first Vibe-Skills agent for approved designs and bounded execution.
+mode: primary
+---
+
+Use the `vibe` skill and execute with governed discipline.
+
+Priorities:
+1. Respect the frozen requirement and plan artifacts.
+2. Implement directly, but do not skip verification or cleanup.
+3. Keep host-managed boundaries explicit.
+4. Do not claim success without fresh evidence.

--- a/config/opencode/agents/vibe-plan.md
+++ b/config/opencode/agents/vibe-plan.md
@@ -1,0 +1,12 @@
+---
+description: Plan-first Vibe-Skills agent for requirements, architecture, rollout design, and bounded review.
+mode: primary
+---
+
+Use the `vibe` skill and follow its governed runtime contract.
+
+Priorities:
+1. Complete `skeleton_check`, `deep_interview`, `requirement_doc`, and `xl_plan` before implementation claims.
+2. Preserve single runtime authority and do not invent a second router.
+3. Prefer explicit constraints, acceptance criteria, and verification plans.
+4. Escalate ambiguous host/runtime truth instead of overclaiming support.

--- a/config/opencode/agents/vibe-review.md
+++ b/config/opencode/agents/vibe-review.md
@@ -1,0 +1,11 @@
+---
+description: Review-first Vibe-Skills agent focused on defects, regressions, and incomplete proof.
+mode: primary
+---
+
+Use the `vibe` skill and act as a review-first agent.
+
+Priorities:
+1. Find bugs, behavioral regressions, missing tests, and proof gaps before summarizing.
+2. Keep summaries brief and findings first.
+3. Treat weak evidence as a blocker for stronger support language.

--- a/config/opencode/commands/vibe-implement.md
+++ b/config/opencode/commands/vibe-implement.md
@@ -1,0 +1,9 @@
+---
+description: Run the governed Vibe-Skills runtime for implementation-first work after design approval.
+agent: vibe-implement
+---
+
+Use the `vibe` skill and treat this as an implementation-oriented pass, while still completing the governed stages `skeleton_check`, `deep_interview`, `requirement_doc`, `xl_plan`, `plan_execute`, and `phase_cleanup`.
+
+Execution target:
+$ARGUMENTS

--- a/config/opencode/commands/vibe-review.md
+++ b/config/opencode/commands/vibe-review.md
@@ -1,0 +1,14 @@
+---
+description: Run a governed review-first Vibe-Skills pass focused on bugs, regressions, and proof gaps.
+agent: vibe-review
+---
+
+Use the `vibe` skill and perform a review-first pass.
+
+Focus on:
+- bugs and behavioral regressions
+- missing tests or verification evidence
+- overclaim or host-truth mismatches
+
+Review target:
+$ARGUMENTS

--- a/config/opencode/commands/vibe.md
+++ b/config/opencode/commands/vibe.md
@@ -1,0 +1,9 @@
+---
+description: Run the governed Vibe-Skills runtime for planning-first work.
+agent: vibe-plan
+---
+
+Use the `vibe` skill and follow its governed runtime contract for this request.
+
+Request:
+$ARGUMENTS

--- a/config/opencode/opencode.json.example
+++ b/config/opencode/opencode.json.example
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "*": "ask",
+    "bash": {
+      "git *": "allow",
+      "rg *": "allow",
+      "fd *": "allow",
+      "ls *": "allow",
+      "*": "ask"
+    },
+    "skill": {
+      "*": "allow"
+    },
+    "edit": "ask",
+    "write": "ask"
+  },
+  "command": {
+    "vibe": {
+      "description": "Run the governed Vibe-Skills runtime",
+      "agent": "vibe-plan",
+      "template": "Use the `vibe` skill and follow its governed runtime contract for this request.\\n\\nRequest:\\n$ARGUMENTS"
+    }
+  }
+}

--- a/dist/README.md
+++ b/dist/README.md
@@ -28,7 +28,7 @@
 - `dist/manifests/vibeskills-core.json`：跨宿主可消费的 core contract（**不**做运行时承诺）
 - `dist/manifests/vibeskills-codex.json`：Codex lane（当前最强、但仍有 host-managed 与降级边界）
 - `dist/manifests/vibeskills-claude-code.json`：Claude Code lane（preview，不可宣传为 full）
-- `dist/manifests/vibeskills-opencode.json`：OpenCode lane（not-yet-proven，先冻结 truthful status）
+- `dist/manifests/vibeskills-opencode.json`：OpenCode lane（preview，仍保留 host-managed 边界与 proof blocker）
 - `dist/manifests/vibeskills-generic.json`：Generic lane（advisory-only，只能消费契约）
 
 每个 manifest 都必须与以下 truth sources **一致**：

--- a/dist/host-opencode/manifest.json
+++ b/dist/host-opencode/manifest.json
@@ -3,15 +3,15 @@
   "lane_id": "host-opencode",
   "lane_kind": "host-adapter",
   "host_id": "opencode",
-  "stability": "not-yet-proven",
+  "stability": "preview",
   "source_release": {
     "version": "2.3.47",
     "updated": "2026-03-15"
   },
-  "summary": "OpenCode host adapter target. The repo can install a neutral runtime-core payload for experimentation, but no host-native closure is promised yet.",
+  "summary": "OpenCode host adapter preview. The repo can install runtime-core plus OpenCode-native command and agent wrapper payload into OpenCode roots, but final host config and platform closure remain incomplete.",
   "runtime_ownership": {
-    "owner": "none",
-    "notes": "This lane exists to prevent overclaim. It freezes a truthful 'not-yet-proven' status until contract + replay proof exists."
+    "owner": "host_managed",
+    "notes": "This lane stays at preview because the repository does not take ownership of the real opencode.json, provider credentials, plugin provisioning, or unresolved runtime discovery gaps."
   },
   "entrypoints": {
     "install_primary": "install.ps1 --host opencode",
@@ -21,18 +21,39 @@
   },
   "capability_promises": [
     {
-      "id": "no_overclaim_until_proved",
+      "id": "opencode_preview_payload_exists",
       "promise_level": "promised",
       "evidence_paths": [
-        "docs/universalization/host-capability-matrix.md"
+        "config/opencode/commands/vibe.md",
+        "config/opencode/agents/vibe-plan.md",
+        "config/opencode/opencode.json.example"
+      ]
+    },
+    {
+      "id": "router_authority_remains_local",
+      "promise_level": "promised",
+      "evidence_paths": [
+        "docs/universalization/router-model-neutrality.md",
+        "scripts/router/resolve-pack-route.ps1"
+      ]
+    },
+    {
+      "id": "opencode_install_check_entrypoints_exist",
+      "promise_level": "promised",
+      "evidence_paths": [
+        "install.ps1",
+        "install.sh",
+        "check.ps1",
+        "check.sh",
+        "docs/install/opencode-path.en.md"
       ]
     }
   ],
   "non_goals": [
-    "official_runtime_install_entrypoints",
-    "official_runtime_check_entrypoints",
+    "full_opencode_json_ownership",
     "host_plugin_provisioning",
-    "cross_platform_parity_claims"
+    "cross_platform_parity_claims",
+    "supported-with-constraints_promotion"
   ],
   "docs": {
     "distribution_lanes": "docs/universalization/distribution-lanes.md",
@@ -49,7 +70,7 @@
     "host_support": {
       "truth_source": "docs/universalization/host-capability-matrix.md",
       "interpretation": "host_matrix_rating",
-      "rating": "not-yet-proven"
+      "rating": "preview"
     }
   }
 }

--- a/dist/manifests/vibeskills-opencode.json
+++ b/dist/manifests/vibeskills-opencode.json
@@ -2,36 +2,52 @@
   "manifest_kind": "vibeskills-distribution-manifest",
   "manifest_version": 1,
   "package_id": "vibeskills-opencode",
-  "package_name": "VibeSkills for OpenCode (Not Yet Proven)",
-  "status": "not-yet-proven",
-  "runtime_role": "future-host-adapter",
-  "summary": "OpenCode is a declared universalization target, but this repository does not currently provide a replay-backed runtime closure or governed install lane for it.",
+  "package_name": "VibeSkills for OpenCode (Preview)",
+  "status": "preview",
+  "runtime_role": "host-adapter-preview",
+  "summary": "OpenCode now has a truthful preview adapter lane with bounded install/check entrypoints, skills payload, and wrapper scaffolds, but the repository still avoids claiming full host closure or platform parity.",
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",
     "docs/universalization/platform-parity-contract.md",
     "adapters/opencode/host-profile.json",
-    "docs/plans/2026-03-13-universal-vibeskills-execution-program.md",
+    "adapters/opencode/platform-windows.json",
+    "adapters/opencode/platform-linux.json",
+    "adapters/opencode/platform-macos.json",
+    "docs/install/opencode-path.en.md",
     "README.md"
   ],
   "host_adapter_ref": "adapters/opencode/host-profile.json",
+  "platform_contracts": [
+    "adapters/opencode/platform-windows.json",
+    "adapters/opencode/platform-linux.json",
+    "adapters/opencode/platform-macos.json"
+  ],
   "install_entrypoints": {
-    "repo_provided": [],
+    "repo_provided": [
+      "install.ps1 --host opencode",
+      "install.sh --host opencode",
+      "config/opencode/commands/vibe.md",
+      "config/opencode/agents/vibe-plan.md",
+      "config/opencode/opencode.json.example"
+    ],
     "host_managed": [
-      "all settings materialization",
-      "all plugin provisioning",
-      "all MCP registration",
-      "all provider credential storage"
+      "final opencode.json ownership",
+      "plugin provisioning",
+      "MCP registration",
+      "provider credential storage"
     ],
     "notes": [
-      "OpenCode is frozen as a truthful migration target, not a governed runtime lane.",
-      "Do not market this package as supported until replay-backed proof exists."
+      "Preview means the repo can install a bounded OpenCode payload without taking ownership of final host config.",
+      "Do not market this package as supported-with-constraints until replay-backed proof closes the remaining runtime discovery gaps."
     ]
   },
   "degrade_states": {
-    "current_state": "not-yet-proven"
+    "unverified_platform_lane": "not-yet-proven",
+    "missing_provider_credentials": "degraded-but-supported",
+    "skill_debug_surface_diverges_from_docs": "preview-guidance-only"
   },
   "anti_overclaim": [
-    "No official runtime closure is implied for OpenCode.",
+    "Preview does not mean full host closure.",
     "No platform parity is claimed without host-specific proof and install isolation evidence."
   ]
 }

--- a/dist/official-runtime/manifest.json
+++ b/dist/official-runtime/manifest.json
@@ -92,7 +92,7 @@
       "ratings": {
         "codex": "supported-with-constraints",
         "claude_code": "preview",
-        "opencode": "not-yet-proven",
+        "opencode": "preview",
         "generic": "advisory-only"
       }
     }

--- a/docs/cold-start-install-paths.en.md
+++ b/docs/cold-start-install-paths.en.md
@@ -4,15 +4,17 @@ This document answers the only cold-start questions that matter right now: which
 
 ## One-Line Conclusion
 
-At the moment, only two hosts are supported:
+The current public install surface supports three hosts:
 
 - `codex`
 - `claude-code`
+- `opencode`
 
 Within that scope:
 
 - `codex`: recommended path
 - `claude-code`: preview guidance path
+- `opencode`: preview adapter path
 
 If you want another agent, the current version should be treated as unsupported rather than silently routed into a hidden lane.
 
@@ -80,6 +82,45 @@ What you do not get:
 - add `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` only when needed for the host connection
 - the current version no longer generates `settings.vibe.preview.json`
 - do not paste secrets into chat
+
+## Path 3: OpenCode
+
+Windows:
+
+```powershell
+pwsh -NoProfile -File .\install.ps1 -HostId opencode
+pwsh -NoProfile -File .\check.ps1 -HostId opencode
+```
+
+Linux / macOS:
+
+```bash
+bash ./install.sh --host opencode
+bash ./check.sh --host opencode
+```
+
+What you get:
+
+- runtime-core payload
+- VibeSkills skill payload
+- OpenCode command/agent wrappers
+- `opencode.json.example`
+
+What you do not get:
+
+- one-shot bootstrap
+- automatic overwrite of the real `opencode.json`
+- automatic plugin provisioning
+- automatic provider secret wiring
+- automatic MCP trust decisions
+
+## Correct Follow-Up For OpenCode
+
+- for a global install, the default target root is `OPENCODE_HOME`, otherwise `~/.config/opencode`
+- for project isolation, use `--target-root ./.opencode`
+- manage the real `opencode.json` locally
+- add provider credentials, plugin installation, and MCP trust locally
+- for the detailed path note, read [`install/opencode-path.en.md`](./install/opencode-path.en.md)
 
 ## Most Important Cold-Start Boundary
 

--- a/docs/cold-start-install-paths.md
+++ b/docs/cold-start-install-paths.md
@@ -4,15 +4,17 @@
 
 ## 一句话结论
 
-暂时只支持两个宿主：
+当前公开安装面支持三个宿主：
 
 - `codex`
 - `claude-code`
+- `opencode`
 
 其中：
 
 - `codex`：正式推荐路径
 - `claude-code`：预览指导路径
+- `opencode`：预览适配路径
 
 如果你要装到其他代理，当前版本应视为不支持，而不是改走隐藏 lane。
 
@@ -80,6 +82,45 @@ bash ./check.sh --host claude-code --profile full --deep
 - 如宿主连接需要，再补 `ANTHROPIC_BASE_URL`、`ANTHROPIC_AUTH_TOKEN`
 - 当前版本不会再生成 `settings.vibe.preview.json`
 - 不要把密钥贴到聊天里
+
+## 路径三：OpenCode
+
+Windows:
+
+```powershell
+pwsh -NoProfile -File .\install.ps1 -HostId opencode
+pwsh -NoProfile -File .\check.ps1 -HostId opencode
+```
+
+Linux / macOS:
+
+```bash
+bash ./install.sh --host opencode
+bash ./check.sh --host opencode
+```
+
+你会得到：
+
+- runtime-core payload
+- VibeSkills 技能载荷
+- OpenCode command/agent 包装器
+- `opencode.json.example`
+
+你不会得到：
+
+- one-shot bootstrap
+- 自动覆盖真实 `opencode.json`
+- 自动 plugin provision
+- 自动 provider secret 写入
+- 自动 MCP 信任决策
+
+## OpenCode 的正确后续动作
+
+- 需要全局安装时，默认目标根目录是 `OPENCODE_HOME`，否则是 `~/.config/opencode`
+- 需要项目隔离时，用 `--target-root ./.opencode`
+- 自己处理真实 `opencode.json`
+- 自己补 provider 凭据、plugin 安装和 MCP 信任
+- 细节看 [`install/opencode-path.md`](./install/opencode-path.md)
 
 ## 冷启动阶段最重要的边界
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,10 +7,11 @@
 
 ## Supported Hosts
 
-暂时只支持：
+当前公开安装面包括：
 
 - `codex`
 - `claude-code`
+- `opencode`
 
 `TargetRoot` 是文件路径。
 `HostId` / `--host` 才是宿主选择。
@@ -24,6 +25,8 @@ pwsh -File .\scripts\bootstrap\one-shot-setup.ps1 -HostId codex
 pwsh -File .\check.ps1 -HostId codex -Profile full -Deep
 pwsh -File .\scripts\bootstrap\one-shot-setup.ps1 -HostId claude-code
 pwsh -File .\check.ps1 -HostId claude-code -Profile full -Deep
+pwsh -NoProfile -File .\install.ps1 -HostId opencode
+pwsh -NoProfile -File .\check.ps1 -HostId opencode
 ```
 
 ### Linux / macOS
@@ -33,13 +36,17 @@ bash ./scripts/bootstrap/one-shot-setup.sh --host codex
 bash ./check.sh --host codex --profile full --deep
 bash ./scripts/bootstrap/one-shot-setup.sh --host claude-code
 bash ./check.sh --host claude-code --profile full --deep
+bash ./install.sh --host opencode
+bash ./check.sh --host opencode
 ```
 
 ## Truth Boundaries
 
 - `codex` 是当前最完整的 repo-governed 路径
 - `claude-code` 是 preview guidance，不是 full closure
+- `opencode` 是 preview adapter，不是 full closure，也不走 one-shot bootstrap
 - hook 当前因兼容性问题被冻结，`codex` / `claude-code` 都不提供 hook 安装
 - `claude-code` 不再写 `settings.vibe.preview.json`
+- `opencode` 只写 preview wrappers 和 `opencode.json.example`，不接管真实 `opencode.json`
 - provider 的 `url` / `apikey` / `model` 仍然是本地用户侧配置
 - 安装提示必须告诉用户去本地 settings 或本地环境变量里配置，不要让用户把密钥贴到聊天里

--- a/docs/install/enterprise-governed-path.md
+++ b/docs/install/enterprise-governed-path.md
@@ -7,6 +7,11 @@
 - `dist/manifests/vibeskills-codex.json`（Codex lane，supported-with-constraints）
 - `dist/manifests/vibeskills-core.json`（contract layer）
 
+补充说明：
+
+- `opencode` 现在已有 preview adapter lane，但还不属于这份 enterprise-governed 主路径
+- 如果组织要评估 OpenCode，请先从 [`opencode-path.md`](./opencode-path.md) 和对应 proof artifacts 开始，而不是把它当成 Codex 等价交付
+
 并且必须遵守 `docs/universalization/platform-parity-contract.md` 的反过度承诺规则。
 
 ## 适合谁
@@ -73,4 +78,3 @@ pwsh -File .\scripts\verify\vibe-version-packaging-gate.ps1
 - 出现 `core_install_incomplete`：立即停止推广
 - 版本一致性 / 离线闭包 / 打包治理 gate 失败：立即停止升级并回滚
 - 文档或对外口径把 `supported-with-constraints` / `preview` 说成 `full-authoritative`：立即撤回承诺并修订发布说明
-

--- a/docs/install/full-featured-install-prompts.en.md
+++ b/docs/install/full-featured-install-prompts.en.md
@@ -12,6 +12,7 @@ Boundary first:
 - Windows is the current strongest reference path
 - Linux only reaches the current authoritative full-featured lane when `pwsh` is available
 - Linux without `pwsh` can still install and run, but it is `degraded-but-supported`, not equivalent to the full Windows lane
+- `opencode` now has its own preview adapter install path, but it is outside the scope of these "full-featured" prompts; use [`opencode-path.en.md`](./opencode-path.en.md) instead.
 
 ## Universal Prompt
 
@@ -131,8 +132,6 @@ Requirements:
 > Reminder: AI governance layer values must be filled in by the user in local files or local environment variables. Do not ask the user to paste `url`, `apikey`, or `model` into chat.
 ```
 
-
-
 ## Suggested README / Community Framing
 
 If you want to place this into a README, issue template, or community post, add one sentence like this:
@@ -142,5 +141,6 @@ If you want to place this into a README, issue template, or community post, add 
 ## Related Docs
 
 - [`recommended-full-path.en.md`](./recommended-full-path.en.md)
+- [`opencode-path.en.md`](./opencode-path.en.md)
 - [`../one-shot-setup.md`](../one-shot-setup.md)
 - [`../cold-start-install-paths.en.md`](../cold-start-install-paths.en.md)

--- a/docs/install/full-featured-install-prompts.md
+++ b/docs/install/full-featured-install-prompts.md
@@ -9,6 +9,7 @@
 - Windows 是当前最强参考路径。
 - Linux 只有在宿主已具备 `pwsh` 时，才可进入当前权威满血路径。
 - Linux 如果没有 `pwsh`，仍可安装和使用，但属于 `degraded-but-supported`，不应被表述成等价满血。
+- `opencode` 已有单独的 preview adapter 安装路径，但它不属于这份“满血版”提示词范围；请改看 [`opencode-path.md`](./opencode-path.md)。
 
 ## 通用主提示词
 
@@ -104,7 +105,7 @@
 
 ```text
 请你把当前仓库按 Linux 推荐满血路径安装好，并先判断当前 Linux 是否具备 `pwsh`。
-仓库地址：https://github.com/foryourhealth111-pixel/Vibe-Skills 
+仓库地址：https://github.com/foryourhealth111-pixel/Vibe-Skills
 要求：
 
 1. 先检查 `pwsh` 是否可用。
@@ -126,7 +127,6 @@
 
 ```
 
-
 ## 给用户的话术建议
 
 如果你准备把这段发到 README、Issue 模板或社区帖子里，建议配一行说明：
@@ -136,5 +136,6 @@
 ## 相关文档
 
 - [`recommended-full-path.md`](./recommended-full-path.md)
+- [`opencode-path.md`](./opencode-path.md)
 - [`../one-shot-setup.md`](../one-shot-setup.md)
 - [`../cold-start-install-paths.md`](../cold-start-install-paths.md)

--- a/docs/install/host-plugin-policy.en.md
+++ b/docs/install/host-plugin-policy.en.md
@@ -9,12 +9,13 @@ This document answers only the questions that matter in the current version:
 
 ## Current Support Boundary
 
-The public support surface currently includes only:
+The public install surface currently includes:
 
 - `codex`
 - `claude-code`
+- `opencode`
 
-Anything outside those two hosts must not be described as "supported installation" in the current version.
+Anything outside those three hosts must not be described as "supported installation" in the current version.
 
 If someone wants to wire VibeSkills into another agent, the accurate wording is:
 
@@ -34,6 +35,7 @@ This is the part the repository owns, for example:
 - `commands/`
 - the `skills/vibe/` runtime mirror
 - install scripts, check scripts, and doctor / verification entrypoints
+- OpenCode preview command/agent wrappers
 
 This is the repo-governed surface.
 
@@ -43,8 +45,9 @@ This is the part the user still finishes locally, for example:
 
 - `~/.codex/settings.json`
 - `~/.claude/settings.json`
+- `~/.config/opencode/opencode.json`
 - local environment variables
-- host-side MCP registration
+- host-side MCP registration or trust decisions
 
 These are not part of "already completed automatically by the repo".
 
@@ -78,8 +81,6 @@ The public install story should no longer imply any of the following:
 - "install a bundle of host plugins first, then everything else"
 - "Codex normally requires a Claude-style hook/plugin stack"
 - "certain historical plugins are standard prerequisites for Codex"
-
-If any historical capability ever becomes part of a clearly verifiable and maintainable official integration path, that should be documented separately at that time. The current version should not describe it that way.
 
 ### How to talk about online capability
 
@@ -148,23 +149,69 @@ Again, none of those values should be requested in chat.
 
 If they are not configured locally yet, the environment must not be described as online-ready.
 
+## Default Policy For OpenCode
+
+For `opencode`, the right framing is preview adapter, not "another fully closed host lane."
+
+### Current real status
+
+`opencode` is currently:
+
+- a preview adapter
+- a host with real `install/check` entrypoints
+- a host where the repo writes skills, command/agent wrappers, and `opencode.json.example`
+- a host where the real `opencode.json`, provider credentials, plugin installation, and MCP trust stay host-managed
+
+### What the repository does
+
+Right now the repository:
+
+- installs runtime-core plus the VibeSkills payload
+- installs OpenCode command/agent wrappers
+- writes `opencode.json.example`
+- runs the matching preview checks
+
+### What the repository does not do
+
+Right now the repository does not automatically:
+
+- overwrite the real `opencode.json`
+- write production provider credentials
+- install host plugins
+- decide MCP trust for the user
+
+### What the user should do
+
+The correct host-side flow is:
+
+- install the preview payload into `OPENCODE_HOME`, `~/.config/opencode`, or project-local `./.opencode`
+- manage the real `opencode.json` locally
+- add provider credentials locally
+- make plugin and MCP trust decisions locally
+
+For the full path note, go straight to:
+
+- [`opencode-path.en.md`](./opencode-path.en.md)
+
 ## Current Policy Conclusion For Host Plugins
 
 For the current version, the public policy should hold these lines clearly:
 
 1. `codex` has no extra default host-plugin prerequisite.
 2. `claude-code` is not integrated by "adding a pile of host plugins". It is a preview guidance path plus local host configuration.
-3. Historical plugin names are not a reason to keep recommending them in current community docs.
-4. If a capability is not stably, publicly, and verifiably integrated by the repo, it should not be written as a standard install requirement.
+3. `opencode` is also not "repo takes over the whole host." It is a preview adapter plus host-managed final config.
+4. Historical plugin names are not a reason to keep recommending them in current community docs.
+5. If a capability is not stably, publicly, and verifiably integrated by the repo, it should not be written as a standard install requirement.
 
 ## Recommended Community Wording
 
 If you need to reference this policy in issues, README text, discussions, or install prompts, use language like this:
 
-- the current version supports only `codex` and `claude-code`
+- the current public install surface includes `codex`, `claude-code`, and `opencode`
 - `codex` follows a conservative path centered on local settings, MCP, and optional CLI enhancements
 - the current version does not install hooks for `codex` or `claude-code` because compatibility issues remain unresolved
 - `claude-code` follows a preview guidance path and does not overwrite the real `settings.json`
+- `opencode` follows a preview adapter path and does not overwrite the real `opencode.json`
 - provider `url` / `apikey` / `model` values are configured locally by the user, not pasted into chat
 - other agents are outside the current public support surface
 

--- a/docs/install/host-plugin-policy.md
+++ b/docs/install/host-plugin-policy.md
@@ -9,10 +9,11 @@
 
 ## 当前支持边界
 
-当前公开支持面只包括：
+当前公开安装面包括：
 
 - `codex`
 - `claude-code`
+- `opencode`
 
 除此之外的其他代理，当前版本都不应被描述成“已支持安装”。
 
@@ -34,6 +35,7 @@
 - `commands/`
 - `skills/vibe/` runtime mirror
 - 安装脚本、检查脚本、doctor / verify 入口
+- OpenCode preview command/agent 包装器
 
 这些内容属于 repo-governed surface。
 
@@ -43,8 +45,9 @@
 
 - `~/.codex/settings.json`
 - `~/.claude/settings.json`
+- `~/.config/opencode/opencode.json`
 - 本地环境变量
-- 宿主侧 MCP 注册
+- 宿主侧 MCP 注册或信任决策
 
 这些不属于“仓库已经自动完成”的范围。
 
@@ -78,8 +81,6 @@
 - “先把一串宿主插件全部装上再说”
 - “Codex 默认要补一套 Claude Code 风格 hook/plugin 面”
 - “某些历史插件是 Codex 标准安装前置”
-
-如果某些历史能力未来有明确、可验证、可维护的官方接入方式，再单独更新文档。当前版本不这么描述。
 
 ### 在线能力怎么处理
 
@@ -148,23 +149,69 @@
 
 如果本地还没配好这些值，也不能把环境描述成“已完成 online readiness”。
 
+## OpenCode 的默认策略
+
+对 `opencode`，当前口径应该描述成 preview adapter，而不是“又一个完整闭环宿主”。
+
+### 当前真实状态
+
+`opencode` 现在是：
+
+- preview adapter
+- 有真实的 `install/check` 入口
+- 仓库会写入 skills、command/agent 包装器和 `opencode.json.example`
+- 真正的 `opencode.json`、provider 凭据、plugin 安装与 MCP 信任仍由宿主管理
+
+### 仓库会做什么
+
+当前仓库会：
+
+- 安装 runtime-core + VibeSkills 技能载荷
+- 安装 OpenCode command/agent 包装器
+- 写入 `opencode.json.example`
+- 运行对应的 preview 检查
+
+### 仓库不会做什么
+
+当前仓库不会自动完成：
+
+- 覆盖真实 `opencode.json`
+- 写入生产 provider 凭据
+- 安装宿主 plugin
+- 替用户决定 MCP 信任
+
+### 用户应当怎么做
+
+正确方式是：
+
+- 把 preview payload 装到 `OPENCODE_HOME`、`~/.config/opencode` 或项目内 `./.opencode`
+- 自己处理真实 `opencode.json`
+- 自己补 provider 凭据
+- 自己决定 plugin 安装与 MCP 信任
+
+如果要看完整路径说明，直接看：
+
+- [`opencode-path.md`](./opencode-path.md)
+
 ## 宿主插件的当前政策结论
 
 如果只看当前版本，公开文档应该坚持下面这组结论：
 
 1. `codex` 没有额外的默认宿主插件前置要求。
-2. `claude-code` 也不是靠“补一堆宿主插件”来完成接入，而是靠 preview guidance + 用户本地配置补全。
-3. 历史上出现过的某些插件名，不等于当前社区文档还应该继续推荐它们。
-4. 只要某个能力没有被仓库稳定、公开、可验证地接入，就不该写成默认安装要求。
+2. `claude-code` 不是靠“补一堆宿主插件”来完成接入，而是靠 preview guidance + 用户本地配置补全。
+3. `opencode` 也不是“仓库接管整个宿主”，而是 preview adapter + host-managed 正式配置。
+4. 历史上出现过的某些插件名，不等于当前社区文档还应该继续推荐它们。
+5. 只要某个能力没有被仓库稳定、公开、可验证地接入，就不该写成默认安装要求。
 
 ## 推荐的社区表述
 
 如果你要在 issue、README、讨论区或安装提示词里引用这份策略，推荐用下面这种说法：
 
-- 当前版本只支持 `codex` 和 `claude-code`
+- 当前版本公开安装面包括 `codex`、`claude-code` 和 `opencode`
 - `codex` 走本地 settings + MCP + 可选 CLI 的保守增强路线
 - `codex` / `claude-code` 当前都不安装 hook，因为兼容性问题尚未解决
 - `claude-code` 走 preview guidance 路线，不覆盖真实 `settings.json`
+- `opencode` 走 preview adapter 路线，不覆盖真实 `opencode.json`
 - provider 的 `url` / `apikey` / `model` 由用户在本地配置，不在聊天里提供
 - 其他代理目前不在公开支持面内
 

--- a/docs/install/manual-copy-install.en.md
+++ b/docs/install/manual-copy-install.en.md
@@ -4,16 +4,17 @@ If you do not want to run the install scripts and only want to place the files m
 
 **copy the VibeSkills runtime directories into your target host root.**
 
-This path currently supports only two hosts:
+This path currently covers three public hosts:
 
 - `codex`
 - `claude-code`
+- `opencode`
 
-If your target is not one of those two, the current version should not be described as supported installation.
+If your target is not one of those three, the current version should not be described as supported installation.
 
 ## What To Copy
 
-Copy these items into the target host root:
+For `codex` and `claude-code`, copy these items into the target host root:
 
 - `skills/`
 - `commands/`
@@ -28,9 +29,30 @@ A simple way to think about them:
 - `config/*.json`: lock files and release-alignment metadata
 - `skills/vibe/`: the VCO runtime mirror
 
+### If your target is OpenCode
+
+For OpenCode preview manual copy, the relevant payload is:
+
+- `skills/`
+- `commands/*.md`
+- `command/*.md`
+- `agents/*.md`
+- `agent/*.md`
+- `config/opencode/opencode.json.example`
+
+The target root should be:
+
+- `OPENCODE_HOME`
+- or `~/.config/opencode`
+- or a project-local `./.opencode`
+
+If you are doing OpenCode manual copy, use the dedicated doc together with this page:
+
+- [`opencode-path.en.md`](./opencode-path.en.md)
+
 ## Where To Copy Them
 
-Copy them into your target host root.
+For `codex` and `claude-code`, copy them into your target host root.
 
 The target directory should end up containing paths like:
 
@@ -63,6 +85,17 @@ You still need to configure locally:
   - `ANTHROPIC_BASE_URL`
   - `ANTHROPIC_AUTH_TOKEN`
 
+### If you install into OpenCode
+
+You still need to handle:
+
+- the real `opencode.json`
+- provider credentials
+- plugin installation
+- MCP trust decisions
+
+The repository currently ships only `opencode.json.example` as a preview scaffold and does not take ownership of the final host config.
+
 ## What This Path Does Not Do Automatically
 
 Manual copy does not automatically complete:
@@ -71,11 +104,13 @@ Manual copy does not automatically complete:
 - MCP registration
 - provider credential wiring
 - edits to Claude Code's real `settings.json`
+- edits to OpenCode's real `opencode.json`
 
 The important current boundary is:
 
 - `codex` and `claude-code` currently do **not** install hooks
 - hook installation is temporarily frozen because of compatibility issues
+- `opencode` also keeps host plugins and final host config out of repo ownership
 
 ## Final Boundary
 
@@ -91,6 +126,7 @@ Do not use manual copy if you want:
 - the scripts to run install + check automatically
 - less host-local configuration work
 
-Use this instead:
+Use these instead:
 
 - [`one-click-install-release-copy.en.md`](./one-click-install-release-copy.en.md)
+- [`opencode-path.en.md`](./opencode-path.en.md)

--- a/docs/install/manual-copy-install.md
+++ b/docs/install/manual-copy-install.md
@@ -4,16 +4,17 @@
 
 **把 VibeSkills 的运行时目录复制到目标宿主目录里。**
 
-当前这条路径只面向两个宿主：
+当前这条路径面向三个公开宿主：
 
 - `codex`
 - `claude-code`
+- `opencode`
 
-如果你的目标不是这两个宿主，当前版本不应描述成“已支持安装”。
+如果你的目标不是这三个宿主，当前版本不应描述成“已支持安装”。
 
 ## 你要复制什么
 
-把下面这些内容复制到目标宿主目录中：
+对 `codex` / `claude-code`，把下面这些内容复制到目标宿主目录中：
 
 - `skills/`
 - `commands/`
@@ -28,9 +29,30 @@
 - `config/*.json`：锁文件和版本对齐信息
 - `skills/vibe/`：VCO 运行时镜像
 
+### 如果你的目标是 OpenCode
+
+OpenCode preview 手动复制需要的载荷是：
+
+- `skills/`
+- `commands/*.md`
+- `command/*.md`
+- `agents/*.md`
+- `agent/*.md`
+- `config/opencode/opencode.json.example`
+
+目标根目录应当是：
+
+- `OPENCODE_HOME`
+- 或 `~/.config/opencode`
+- 或项目内的 `./.opencode`
+
+如果你准备手动复制 OpenCode 载荷，优先结合这份专门文档一起做：
+
+- [`opencode-path.md`](./opencode-path.md)
+
 ## 复制到哪里
 
-复制到你的目标宿主根目录下。
+对 `codex` / `claude-code`，复制到你的目标宿主根目录下。
 
 也就是让目标目录里最终能看到这些路径：
 
@@ -63,6 +85,17 @@
   - `ANTHROPIC_BASE_URL`
   - `ANTHROPIC_AUTH_TOKEN`
 
+### 如果你装到 OpenCode
+
+你还需要自己处理：
+
+- 真正的 `opencode.json`
+- provider 凭据
+- plugin 安装
+- MCP 信任决策
+
+当前仓库只提供 `opencode.json.example` 作为 preview scaffold，不接管正式宿主配置。
+
 ## 当前不会自动帮你做什么
 
 手动复制安装不会自动完成这些事：
@@ -71,11 +104,13 @@
 - MCP 注册
 - provider 凭据写入
 - Claude Code 真实 `settings.json` 修改
+- OpenCode 真实 `opencode.json` 修改
 
 其中要特别注意：
 
 - `codex` / `claude-code` 当前都**不提供 hook 安装**
 - hook 目前因为兼容性问题，暂时被冻结
+- `opencode` 当前也不接管宿主 plugin 与正式配置
 
 ## 最后一个边界
 
@@ -94,3 +129,4 @@
 那就不要走手动复制，直接看：
 
 - [`one-click-install-release-copy.md`](./one-click-install-release-copy.md)
+- [`opencode-path.md`](./opencode-path.md)

--- a/docs/install/minimal-path.md
+++ b/docs/install/minimal-path.md
@@ -29,12 +29,17 @@
 - Linux **只有在安装了 `pwsh`** 并能跑 PowerShell gates 时，才接近权威路径；否则属于 **degraded**，不是“偷偷满血”
 - macOS 仍是 `not-yet-proven`
 
-### Claude Code / Generic Host
+### Claude Code / OpenCode / Generic Host
 
 - Claude Code：此仓库当前是 `preview`（模板与指导存在，但没有与 Codex 等价的 repo-governed install/check 闭环）
+- OpenCode：此仓库当前也是 `preview`，但有独立的 direct `install/check` 入口和专门安装说明
 - Generic Host：`advisory-only`（只能消费契约与文档，不做运行时承诺）
 
 如果你不是在 Codex 上运行，请把本路径理解为：**文档/契约消费 + 最小自检**，而不是“官方运行时安装”。
+
+如果你的目标是 OpenCode，请直接看：
+
+- [`opencode-path.md`](./opencode-path.md)
 
 ## 推荐命令（不接管主链）
 
@@ -68,4 +73,3 @@ bash ./check.sh
 
 - `docs/install/recommended-full-path.md`
 - `docs/install/enterprise-governed-path.md`
-

--- a/docs/install/one-click-install-release-copy.en.md
+++ b/docs/install/one-click-install-release-copy.en.md
@@ -2,10 +2,17 @@
 
 This is the default installation path.
 
-At the moment, only two target hosts are supported:
+The current public install surface covers three target hosts:
 
 - `codex`
 - `claude-code`
+- `opencode`
+
+Within that scope:
+
+- `codex`: strongest current repo-governed lane
+- `claude-code`: preview guidance lane
+- `opencode`: preview adapter lane that uses direct `install/check`, not one-shot bootstrap
 
 ## Prompt To Copy Into AI
 
@@ -14,51 +21,61 @@ You are now my VibeSkills installation assistant.
 Repository: https://github.com/foryourhealth111-pixel/Vibe-Skills
 
 Before running any install command, you must ask me:
-"Which host do you want to install VibeSkills into? Currently supported: codex or claude-code."
+"Which host do you want to install VibeSkills into? Currently supported: codex, claude-code, or opencode."
 
 Rules:
 1. Do not start installation until I explicitly answer which target host I want.
-2. If I answer with anything other than `codex` or `claude-code`, tell me clearly that this version does not support that host yet, and stop instead of pretending installation is complete.
+2. If I answer with anything other than `codex`, `claude-code`, or `opencode`, tell me clearly that this version does not support that host yet, and stop instead of pretending installation is complete.
 3. Detect whether the current system is Windows or Linux / macOS, and use the matching command format.
 4. If I choose `codex`:
    - on Linux / macOS, run `bash ./scripts/bootstrap/one-shot-setup.sh --host codex`
    - then run `bash ./check.sh --host codex --profile full --deep`
-   - on Windows, use the equivalent `pwsh` commands.
-   - explicitly tell me that the current version does not install any hook surface for Codex because of compatibility issues.
-   - keep Codex guidance limited to officially supportable local settings, MCP, and optional CLI dependencies.
-   - if online model access is needed, tell me to configure `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and related values in `~/.codex/settings.json` under `env` or in local environment variables, not in chat.
+   - on Windows, use the equivalent `pwsh` commands
+   - explicitly tell me that the current version does not install any hook surface for Codex because of compatibility issues
+   - keep Codex guidance limited to officially supportable local settings, MCP, and optional CLI dependencies
+   - if online model access is needed, tell me to configure `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and related values in `~/.codex/settings.json` under `env` or in local environment variables, not in chat
 5. If I choose `claude-code`:
    - on Linux / macOS, run `bash ./scripts/bootstrap/one-shot-setup.sh --host claude-code`
    - then run `bash ./check.sh --host claude-code --profile full --deep`
-   - on Windows, use the equivalent `pwsh` commands.
-   - explicitly tell me this is preview guidance, not full closure.
-   - explicitly tell me that because of compatibility issues, the current version does not install hooks for Claude Code and no longer writes `settings.vibe.preview.json`.
-   - do not ask me to paste API keys into chat.
-   - tell me to open `~/.claude/settings.json` and add only the required `env` fields while preserving my existing settings.
+   - on Windows, use the equivalent `pwsh` commands
+   - explicitly tell me this is preview guidance, not full closure
+   - explicitly tell me that because of compatibility issues, the current version does not install hooks for Claude Code and no longer writes `settings.vibe.preview.json`
+   - do not ask me to paste API keys into chat
+   - tell me to open `~/.claude/settings.json` and add only the required `env` fields while preserving my existing settings
    - if AI-governance online capability is needed, remind me to configure these fields locally:
      - `VCO_AI_PROVIDER_URL`
      - `VCO_AI_PROVIDER_API_KEY`
      - `VCO_AI_PROVIDER_MODEL`
-6. For both `codex` and `claude-code`, never ask me to paste secrets, URLs, or model values into chat. Only point me to local settings or local environment variables.
-7. If the required local provider fields are not configured yet, you must not describe the environment as online-ready.
-8. After installation, give me a concise English summary of:
+6. If I choose `opencode`:
+   - on Linux / macOS, run `./install.sh --host opencode` and then `./check.sh --host opencode`
+   - on Windows, run `pwsh -NoProfile -File ./install.ps1 -HostId opencode` and then `pwsh -NoProfile -File ./check.ps1 -HostId opencode`
+   - explicitly tell me that OpenCode is currently a preview adapter lane, not full closure
+   - explicitly tell me that the repo installs skills, command/agent wrappers, and `opencode.json.example`, but does not take ownership of the real `opencode.json`
+   - use `OPENCODE_HOME` as the default target root when it is set, otherwise `~/.config/opencode`
+   - if I want a project-local target, switch to `--target-root ./.opencode`
+   - do not pretend that plugin installation, provider credential wiring, or MCP trust decisions were completed automatically
+   - point me to `docs/install/opencode-path.en.md`
+7. For all three hosts, never ask me to paste secrets, URLs, or model values into chat. Only point me to local settings or local environment variables.
+8. If the required local provider fields are not configured yet, you must not describe the environment as online-ready.
+9. After installation, give me a concise English summary of:
    - the target host
    - the commands actually executed
    - what is complete
    - what I still need to do manually
-9. Do not pretend that host plugins, MCP registration, or provider credentials were completed automatically if they were not.
+10. Do not pretend that host plugins, MCP registration, or provider credentials were completed automatically if they were not.
 ```
 
 ## Who This Path Is For
 
-- users who want AI to choose between `codex` and `claude-code`
+- users who want AI to choose between `codex`, `claude-code`, and `opencode`
 - users who do not want to study the scripts first
 - users who want one truthful install pass plus a clear manual follow-up list
 
 ## What This Path Helps With
 
 - confirming the target host first
-- running the matching bootstrap + check flow
+- running the matching bootstrap + check flow for `codex` and `claude-code`
+- running the matching direct install + check flow for `opencode`
 - explaining what is still host-managed
 
 ## What It Does Not Pretend To Do
@@ -70,6 +87,7 @@ These may still remain host-side or user-side tasks:
 - waiting for hook compatibility work to resume
 - local `url` / `apikey` / `model` configuration
 - manual updates to Claude Code's real `settings.json`
+- OpenCode's real `opencode.json`, plugin installation, and MCP trust decisions
 
 ## Second Main Install Path
 
@@ -82,4 +100,5 @@ If you do not want AI to run installation, or the environment is offline or has 
 If you need the more detailed host boundaries, see:
 
 - [`recommended-full-path.en.md`](./recommended-full-path.en.md)
+- [`opencode-path.en.md`](./opencode-path.en.md)
 - [`../cold-start-install-paths.en.md`](../cold-start-install-paths.en.md)

--- a/docs/install/one-click-install-release-copy.md
+++ b/docs/install/one-click-install-release-copy.md
@@ -2,10 +2,17 @@
 
 这是当前默认安装方式。
 
-暂时只支持两个目标宿主：
+当前公开安装入口覆盖三个目标宿主：
 
 - `codex`
 - `claude-code`
+- `opencode`
+
+其中：
+
+- `codex`：当前最强的 repo-governed lane
+- `claude-code`：preview guidance lane
+- `opencode`：preview adapter lane，走直接 `install/check`，不走 one-shot bootstrap
 
 ## 复制给 AI 的提示词
 
@@ -14,11 +21,11 @@
 仓库地址：https://github.com/foryourhealth111-pixel/Vibe-Skills
 
 在执行任何安装命令前，你必须先问我：
-“你要把 VibeSkills 安装到哪个宿主里？当前只支持：codex 或 claude-code。”
+“你要把 VibeSkills 安装到哪个宿主里？当前支持：codex、claude-code、opencode。”
 
 规则：
 1. 在我明确回答目标宿主之前，不要开始安装。
-2. 如果我回答的不是 `codex` 或 `claude-code`，请直接告诉我：当前版本暂不支持该宿主安装，并停止继续伪装安装。
+2. 如果我回答的不是 `codex`、`claude-code` 或 `opencode`，请直接告诉我：当前版本暂不支持该宿主安装，并停止继续伪装安装。
 3. 先判断当前系统是 Windows 还是 Linux / macOS，并使用对应命令格式。
 4. 如果我选择 `codex`：
    - Linux / macOS 使用 `bash ./scripts/bootstrap/one-shot-setup.sh --host codex`
@@ -39,26 +46,36 @@
      - `VCO_AI_PROVIDER_URL`
      - `VCO_AI_PROVIDER_API_KEY`
      - `VCO_AI_PROVIDER_MODEL`
-6. 对 `codex` 和 `claude-code`，都不要要求我把密钥、URL 或 model 直接粘贴到聊天里；只告诉我去本地 settings 或本地环境变量里配置。
-7. 如果这些本地 provider 字段没有配置好，不能把环境描述成“已完成 online readiness”。
-8. 安装完成后，请用简洁中文告诉我：
+6. 如果我选择 `opencode`：
+   - Linux / macOS 使用 `./install.sh --host opencode`，然后执行 `./check.sh --host opencode`
+   - Windows 使用 `pwsh -NoProfile -File ./install.ps1 -HostId opencode`，然后执行 `pwsh -NoProfile -File ./check.ps1 -HostId opencode`
+   - 明确告诉我：OpenCode 当前是 preview adapter，不是 full closure。
+   - 明确告诉我：当前仓库会安装 skills、command/agent 包装器和 `opencode.json.example`，但不接管真正的 `opencode.json`。
+   - 默认目标根目录是 `OPENCODE_HOME`，否则是 `~/.config/opencode`。
+   - 如果我想把载荷装到项目内，请改用 `--target-root ./.opencode`。
+   - 不要伪装成已经自动完成 plugin 安装、provider 凭据写入或 MCP 信任决策。
+   - 提醒我查看 `docs/install/opencode-path.md`。
+7. 对三个宿主，都不要要求我把密钥、URL 或 model 直接粘贴到聊天里；只告诉我去本地 settings 或本地环境变量里配置。
+8. 如果这些本地 provider 字段没有配置好，不能把环境描述成“已完成 online readiness”。
+9. 安装完成后，请用简洁中文告诉我：
    - 目标宿主
    - 实际执行的命令
    - 已完成的部分
    - 仍需我手动处理的部分
-9. 不要把宿主插件、MCP 注册、provider 凭据伪装成已经自动完成。
+10. 不要把宿主插件、MCP 注册、provider 凭据伪装成已经自动完成。
 ```
 
 ## 这条路径适合谁
 
-- 想让 AI 先判断该走 `codex` 还是 `claude-code`
+- 想让 AI 帮你判断该走 `codex`、`claude-code` 还是 `opencode`
 - 不想自己先研究安装脚本的人
 - 想先完成一轮真实安装，再看剩余手动项的人
 
 ## 这条路径会帮你做到什么
 
 - 先确认目标宿主，避免装错 lane
-- 运行对应的 bootstrap + check
+- 对 `codex` / `claude-code` 运行对应的 bootstrap + check
+- 对 `opencode` 运行对应的 direct install + check
 - 诚实告诉你哪些仍然是宿主侧工作
 
 ## 它不会假装替你完成什么
@@ -70,6 +87,7 @@
 - hook 的后续兼容性等待
 - `url` / `apikey` / `model` 的本地填写
 - Claude Code 的真实 `settings.json` 人工补充
+- OpenCode 的真实 `opencode.json`、plugin 安装与 MCP 信任决策
 
 ## 第二条主路径
 
@@ -82,4 +100,5 @@
 如果你要看更细的宿主边界，再看：
 
 - [`recommended-full-path.md`](./recommended-full-path.md)
+- [`opencode-path.md`](./opencode-path.md)
 - [`../cold-start-install-paths.md`](../cold-start-install-paths.md)

--- a/docs/install/opencode-path.en.md
+++ b/docs/install/opencode-path.en.md
@@ -1,0 +1,108 @@
+# OpenCode Install Path
+
+## Scope
+
+This path is a truthful `preview` lane, not a claim of full OpenCode closure.
+
+The repository can install:
+
+- runtime-core payload
+- Vibe-Skills skill payload
+- OpenCode command wrappers
+- OpenCode agent wrappers
+- an example `opencode.json` scaffold
+
+The repository does **not** take ownership of:
+
+- the real `~/.config/opencode/opencode.json`
+- provider credentials
+- plugin installation
+- MCP trust decisions
+
+## Global Install
+
+Shell:
+
+```bash
+./install.sh --host opencode
+./check.sh --host opencode
+```
+
+PowerShell:
+
+```powershell
+pwsh -NoProfile -File ./install.ps1 -HostId opencode
+pwsh -NoProfile -File ./check.ps1 -HostId opencode
+```
+
+Default target root:
+
+- `OPENCODE_HOME` when set
+- otherwise `~/.config/opencode`
+
+## Project-Local Install
+
+Use a project-local OpenCode root when you want the preview payload to stay inside the repo:
+
+```bash
+./install.sh --host opencode --target-root ./.opencode
+./check.sh --host opencode --target-root ./.opencode
+```
+
+The same target can be used from PowerShell with `-TargetRoot .\.opencode`.
+
+## What Gets Written
+
+Preview install writes:
+
+- `skills/**`
+- `commands/*.md`
+- `command/*.md`
+- `agents/*.md`
+- `agent/*.md`
+- `opencode.json.example`
+
+Plural and singular command/agent directories are both materialized during preview because the current OpenCode docs and runtime ecosystem still show path drift.
+
+## How To Use
+
+After install, the intended entry surfaces are:
+
+- `/vibe`
+- `/vibe-implement`
+- `/vibe-review`
+
+You can also invoke the skill directly in chat, for example:
+
+- `Use the vibe skill to plan this change.`
+- `Use the vibe skill to implement the approved plan.`
+
+Custom agents installed by the preview payload:
+
+- `vibe-plan`
+- `vibe-implement`
+- `vibe-review`
+
+## Verification
+
+Use the shared repo health check first:
+
+```bash
+./check.sh --host opencode
+```
+
+The repository also ships a smoke verifier:
+
+```bash
+python3 ./scripts/verify/runtime_neutral/opencode_preview_smoke.py --repo-root . --write-artifacts
+```
+
+## Current Proof Note
+
+The committed preview smoke verifier now proves on local OpenCode CLI `1.2.27` that:
+
+- `opencode debug paths` resolves the isolated OpenCode root correctly
+- `opencode debug skill` detects the installed `vibe` skill
+- `opencode debug agent vibe-plan` detects the installed preview agent
+
+The lane still remains `preview` because command execution replay and platform-specific proof bundles are not yet frozen.

--- a/docs/install/opencode-path.md
+++ b/docs/install/opencode-path.md
@@ -1,0 +1,108 @@
+# OpenCode 安装路径
+
+## 适用范围
+
+这是一条真实的 `preview` 适配路径，不是“OpenCode 已经完全闭环”的声明。
+
+当前仓库可安装：
+
+- runtime-core 载荷
+- Vibe-Skills 技能载荷
+- OpenCode 命令包装器
+- OpenCode agent 包装器
+- `opencode.json` 示例配置
+
+当前仓库不接管：
+
+- 真正的 `~/.config/opencode/opencode.json`
+- provider 凭证
+- plugin 安装
+- MCP 信任决策
+
+## 全局安装
+
+Shell：
+
+```bash
+./install.sh --host opencode
+./check.sh --host opencode
+```
+
+PowerShell：
+
+```powershell
+pwsh -NoProfile -File ./install.ps1 -HostId opencode
+pwsh -NoProfile -File ./check.ps1 -HostId opencode
+```
+
+默认目标根目录：
+
+- 若设置了 `OPENCODE_HOME`，使用该目录
+- 否则使用 `~/.config/opencode`
+
+## 项目内安装
+
+如果希望把 preview 载荷隔离在项目内部：
+
+```bash
+./install.sh --host opencode --target-root ./.opencode
+./check.sh --host opencode --target-root ./.opencode
+```
+
+PowerShell 对应参数为 `-TargetRoot .\.opencode`。
+
+## 安装内容
+
+preview 安装会写入：
+
+- `skills/**`
+- `commands/*.md`
+- `command/*.md`
+- `agents/*.md`
+- `agent/*.md`
+- `opencode.json.example`
+
+当前 preview 会同时写入 plural 和 singular 的 command/agent 目录，因为 OpenCode 当前文档和运行时生态仍存在路径漂移。
+
+## 使用方式
+
+安装后的推荐入口：
+
+- `/vibe`
+- `/vibe-implement`
+- `/vibe-review`
+
+也可以直接在对话里显式要求：
+
+- `Use the vibe skill to plan this change.`
+- `Use the vibe skill to implement the approved plan.`
+
+preview 载荷安装的自定义 agent：
+
+- `vibe-plan`
+- `vibe-implement`
+- `vibe-review`
+
+## 验证方式
+
+先跑仓库自带健康检查：
+
+```bash
+./check.sh --host opencode
+```
+
+再跑专用 smoke verifier：
+
+```bash
+python3 ./scripts/verify/runtime_neutral/opencode_preview_smoke.py --repo-root . --write-artifacts
+```
+
+## 当前证明状态
+
+仓库内置的 preview smoke verifier 已经在本地 OpenCode CLI `1.2.27` 上证明：
+
+- `opencode debug paths` 能正确解析隔离的 OpenCode 根目录
+- `opencode debug skill` 能识别安装后的 `vibe` skill
+- `opencode debug agent vibe-plan` 能识别安装后的 preview agent
+
+该 lane 仍保持 `preview`，因为命令执行 replay 和平台级 proof bundle 还没有冻结完成。

--- a/docs/install/recommended-full-path.en.md
+++ b/docs/install/recommended-full-path.en.md
@@ -1,22 +1,26 @@
 # Install Path: Advanced Host / Lane Reference
 
-> Most users should start with the two main install paths:
+> Most users should start with the three main install paths:
+>
 > - [`one-click-install-release-copy.en.md`](./one-click-install-release-copy.en.md)
 > - [`manual-copy-install.en.md`](./manual-copy-install.en.md)
+> - [`opencode-path.en.md`](./opencode-path.en.md)
 
 This document exists to explain the current real support boundary.
 
 ## Current Supported Surface
 
-At the moment, only two hosts are supported:
+The current public install surface covers three hosts:
 
 - `codex`
 - `claude-code`
+- `opencode`
 
 Within that scope:
 
 - `codex`: recommended path
 - `claude-code`: preview guidance path
+- `opencode`: preview adapter path
 
 `TargetRoot` is only the install path.
 `HostId` / `--host` is what decides host semantics.
@@ -47,6 +51,20 @@ bash ./scripts/bootstrap/one-shot-setup.sh --host claude-code
 bash ./check.sh --host claude-code --profile full --deep
 ```
 
+### OpenCode
+
+```powershell
+pwsh -NoProfile -File .\install.ps1 -HostId opencode
+pwsh -NoProfile -File .\check.ps1 -HostId opencode
+```
+
+```bash
+bash ./install.sh --host opencode
+bash ./check.sh --host opencode
+```
+
+> OpenCode does not use `one-shot-setup` yet. This lane is currently a preview adapter reached through direct install + check.
+
 ## Boundaries That Must Stay Explicit
 
 ### Codex
@@ -70,8 +88,17 @@ bash ./check.sh --host claude-code --profile full --deep
 - add `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` only when needed for the host connection
 - do not ask users to paste secrets into chat
 
+### OpenCode
+
+- this is a preview adapter, not full closure
+- the repository writes skills, command/agent wrappers, and `opencode.json.example`
+- the default target root is `OPENCODE_HOME`, otherwise `~/.config/opencode`
+- if you want the preview payload isolated inside a project, use `--target-root ./.opencode`
+- the real `opencode.json`, provider credentials, plugin installation, and MCP trust remain host-managed
+- for detail, go straight to [`opencode-path.en.md`](./opencode-path.en.md)
+
 ## AI Governance Reminder
 
-For `claude-code`, if `url`, `apikey`, and `model` are not configured locally yet, the environment must not be described as online-ready.
+For `claude-code` and `opencode`, if `url`, `apikey`, `model`, or equivalent provider fields are not configured locally yet, the environment must not be described as online-ready.
 
 Those values must be filled by the user in local host settings or local environment variables.

--- a/docs/install/recommended-full-path.md
+++ b/docs/install/recommended-full-path.md
@@ -1,22 +1,26 @@
 # 安装路径：高级 host / lane 参考
 
-> 大多数用户先看两条主路径：
+> 大多数用户先看三条主路径：
+>
 > - [`one-click-install-release-copy.md`](./one-click-install-release-copy.md)
 > - [`manual-copy-install.md`](./manual-copy-install.md)
+> - [`opencode-path.md`](./opencode-path.md)
 
 这份文档只解释当前真实支持边界。
 
 ## 当前支持面
 
-暂时只支持两个宿主：
+当前公开安装面覆盖三个宿主：
 
 - `codex`
 - `claude-code`
+- `opencode`
 
 其中：
 
 - `codex`：正式推荐路径
 - `claude-code`：preview guidance 路径
+- `opencode`：preview adapter 路径
 
 `TargetRoot` 只是安装路径。
 `HostId` / `--host` 才决定宿主语义。
@@ -47,6 +51,20 @@ bash ./scripts/bootstrap/one-shot-setup.sh --host claude-code
 bash ./check.sh --host claude-code --profile full --deep
 ```
 
+### OpenCode
+
+```powershell
+pwsh -NoProfile -File .\install.ps1 -HostId opencode
+pwsh -NoProfile -File .\check.ps1 -HostId opencode
+```
+
+```bash
+bash ./install.sh --host opencode
+bash ./check.sh --host opencode
+```
+
+> OpenCode 当前不走 `one-shot-setup`。这条 lane 目前是 preview adapter，入口是 direct install + check。
+
 ## 必须说清楚的边界
 
 ### Codex
@@ -70,8 +88,17 @@ bash ./check.sh --host claude-code --profile full --deep
 - 如宿主连接需要，再补 `ANTHROPIC_BASE_URL`、`ANTHROPIC_AUTH_TOKEN`
 - 不要要求用户把密钥贴到聊天里
 
+### OpenCode
+
+- 这是 preview adapter，不是 full closure
+- 当前仓库会写 skills、command/agent 包装器以及 `opencode.json.example`
+- 默认目标根目录是 `OPENCODE_HOME`，否则是 `~/.config/opencode`
+- 如果你想把 preview 载荷隔离在项目目录，使用 `--target-root ./.opencode`
+- 真正的 `opencode.json`、provider 凭据、plugin 安装和 MCP 信任仍然是 host-managed
+- 如需细节，直接看 [`opencode-path.md`](./opencode-path.md)
+
 ## AI 治理层提示
 
-对 `claude-code`，如果本地还没配置好 `url`、`apikey`、`model`，就不能描述成“已完成 online readiness”。
+对 `claude-code` 和 `opencode`，如果本地还没配置好 `url`、`apikey`、`model` 或等价 provider 字段，就不能描述成“已完成 online readiness”。
 
 这些值必须由用户自己填进本地宿主配置或本地环境变量。

--- a/docs/one-shot-setup.md
+++ b/docs/one-shot-setup.md
@@ -2,6 +2,12 @@
 
 `vco-skills-codex` 现在提供一个面向支持宿主的单命令 bootstrap 入口，用来把 **仓库可自动化的部分** 一次性落地，并在最后给出一份深度 readiness 报告。
 
+这份文档当前只覆盖 `codex` 和 `claude-code` 的 one-shot bootstrap。
+
+如果你的目标宿主是 `opencode`，请改走 direct install/check 路径：
+
+- [`install/opencode-path.md`](./install/opencode-path.md)
+
 如果你还不知道自己应该走哪种安装方式，先看：
 
 - [`cold-start-install-paths.md`](./cold-start-install-paths.md)
@@ -143,9 +149,9 @@ bash ./check.sh --profile full --deep
 4. 再补官方支持的 MCP surfaces
 5. `Composio / Activepieces` 仅在你确实需要外部操作能力时再做 setup，并保持 confirm-gated
 
-1. 如果 `OPENAI_API_KEY` 仍是 `placeholder` 或 `missing`，先在本地配置 key，不要在聊天里粘贴。
-2. 如果是 Claude Code，打开 `~/.claude/settings.json`，只补充缺失的 `env` 字段；当前版本不会再生成 `settings.vibe.preview.json`。
-3. 如果 `manual_action_required` 的 MCP server 是 `stdio` 模式，先安装对应命令行依赖，再在 host 中注册。
+6. 如果 `OPENAI_API_KEY` 仍是 `placeholder` 或 `missing`，先在本地配置 key，不要在聊天里粘贴。
+7. 如果是 Claude Code，打开 `~/.claude/settings.json`，只补充缺失的 `env` 字段；当前版本不会再生成 `settings.vibe.preview.json`。
+8. 如果 `manual_action_required` 的 MCP server 是 `stdio` 模式，先安装对应命令行依赖，再在 host 中注册。
 
 当前 `full` profile 最重要的人工补齐项是：
 

--- a/docs/plans/2026-03-26-opencode-doc-refresh-plan.md
+++ b/docs/plans/2026-03-26-opencode-doc-refresh-plan.md
@@ -1,0 +1,64 @@
+# 2026-03-26 OpenCode Documentation Refresh Plan
+
+## Goal
+
+Refresh all installation-facing documentation so OpenCode preview support is represented consistently, accurately, and with the right proof boundaries.
+
+## Grade
+
+- Internal grade: L
+
+## Batches
+
+### Batch 1: Freeze and traceability
+
+- Create requirement doc
+- Create execution plan
+- Emit skeleton and intent receipts for the doc-refresh run
+
+### Batch 2: Public entrypoint docs
+
+- Update `README.md`
+- Update `README.en.md`
+- Update `docs/quick-start.md`
+- Update `docs/quick-start.en.md`
+- Update `docs/deployment.md`
+- Update `docs/cold-start-install-paths.md`
+- Update `docs/cold-start-install-paths.en.md`
+
+### Batch 3: Install policy and path docs
+
+- Update `docs/install/one-click-install-release-copy.md`
+- Update `docs/install/one-click-install-release-copy.en.md`
+- Update `docs/install/manual-copy-install.md`
+- Update `docs/install/manual-copy-install.en.md`
+- Update `docs/install/recommended-full-path.md`
+- Update `docs/install/recommended-full-path.en.md`
+- Update `docs/install/host-plugin-policy.md`
+- Update `docs/install/host-plugin-policy.en.md`
+- Add targeted OpenCode clarifications to related install docs where needed
+
+### Batch 4: Truth and release notes
+
+- Update `docs/universalization/host-capability-matrix.md`
+- Add a historical clarification note to `docs/releases/v2.3.36.md`
+
+### Batch 5: Verification and cleanup
+
+- Run formatting for edited markdown files
+- Run doc-safe verification commands
+- Emit phase execution receipt
+- Emit cleanup receipt
+
+## Verification Commands
+
+- `git diff --check`
+- `pwsh -NoProfile -File ./scripts/verify/vibe-host-adapter-contract-gate.ps1`
+- `pwsh -NoProfile -File ./scripts/verify/vibe-dist-manifest-gate.ps1 -WriteArtifacts`
+- `python3 ./scripts/verify/runtime_neutral/opencode_preview_smoke.py --repo-root . --write-artifacts`
+
+## Rollback Rules
+
+- If any doc change would imply one-shot bootstrap support for OpenCode, revert the wording and keep the doc on direct install/check only.
+- If a wording update conflicts with current manifests or proof artifacts, prefer the verified manifest/proof truth rather than polishing language.
+- If README changes conflict with unrelated user edits, narrow the patch to the specific install sections only.

--- a/docs/plans/2026-03-26-opencode-pr-delivery-plan.md
+++ b/docs/plans/2026-03-26-opencode-pr-delivery-plan.md
@@ -1,0 +1,57 @@
+# 2026-03-26 OpenCode PR Delivery Plan
+
+## Goal
+
+Re-verify the OpenCode compatibility work, isolate the intended file set, and submit a pull request with evidence-backed release notes.
+
+## Grade
+
+- Internal grade: L
+
+## Batches
+
+### Batch 1: Freeze and traceability
+- Create requirement doc
+- Create execution plan
+- Emit skeleton and intent receipts for this PR-delivery pass
+
+### Batch 2: Verification
+- Run `git diff --check`
+- Run adapter closure and target-root guard gates
+- Run host adapter and dist manifest gates
+- Run OpenCode preview smoke verification
+- Run direct shell and PowerShell install/check smoke against temp OpenCode roots
+
+### Batch 3: Commit boundary isolation
+- Enumerate task-relevant files
+- Create a branch for the OpenCode preview work
+- Stage only the OpenCode implementation, doc refresh, proof docs, and governed artifacts
+- Create a non-amended commit
+
+### Batch 4: Publish
+- Push the branch to `origin`
+- Open a PR against `main`
+- Include verification evidence and remaining preview limitations in the PR body
+
+### Batch 5: Cleanup
+- Emit phase execution and cleanup receipts
+- Leave unrelated worktree changes untouched
+
+## Verification Commands
+
+- `git diff --check`
+- `pwsh -NoProfile -File ./scripts/verify/vgo-adapter-closure-gate.ps1 -WriteArtifacts`
+- `pwsh -NoProfile -File ./scripts/verify/vgo-adapter-target-root-guard-gate.ps1 -WriteArtifacts`
+- `pwsh -NoProfile -File ./scripts/verify/vibe-host-adapter-contract-gate.ps1`
+- `pwsh -NoProfile -File ./scripts/verify/vibe-dist-manifest-gate.ps1 -WriteArtifacts`
+- `python3 ./scripts/verify/runtime_neutral/opencode_preview_smoke.py --repo-root . --write-artifacts`
+- `bash ./install.sh --host opencode --target-root <temp>`
+- `bash ./check.sh --host opencode --target-root <temp>`
+- `pwsh -NoProfile -File ./install.ps1 -HostId opencode -TargetRoot <temp>`
+- `pwsh -NoProfile -File ./check.ps1 -HostId opencode -TargetRoot <temp>`
+
+## Rollback Rules
+
+- If verification fails, do not create or update the PR until the failure is explained and resolved.
+- If a file cannot be cleanly attributed to this task, leave it unstaged.
+- If GitHub auth or push rights fail, stop after preparing the branch and report the blocker with the verified local state.

--- a/docs/plans/2026-03-26-opencode-preview-adapter-plan.md
+++ b/docs/plans/2026-03-26-opencode-preview-adapter-plan.md
@@ -1,0 +1,66 @@
+# 2026-03-26 OpenCode Preview Adapter Plan
+
+## Goal
+
+Land a truthful OpenCode preview adapter that installs bounded preview payload into OpenCode roots, updates distribution/docs truth, and proves the lane with fresh verification evidence.
+
+## Grade
+
+- Internal grade: L
+
+## Batches
+
+### Batch 1: Freeze and intent traceability
+- Create requirement doc
+- Create implementation plan
+- Emit skeleton and intent receipts for this governed pass
+- Anchor execution to the approved OpenCode design and proof framework
+
+### Batch 2: Adapter and distribution contracts
+- Activate `opencode` in `adapters/index.json`
+- Rewrite `adapters/opencode/host-profile.json`
+- Rewrite `adapters/opencode/settings-map.json`
+- Rewrite `adapters/opencode/closure.json`
+- Add `adapters/opencode/platform-linux.json`
+- Add `adapters/opencode/platform-macos.json`
+- Add `adapters/opencode/platform-windows.json`
+- Promote `dist/host-opencode/manifest.json`
+- Promote `dist/manifests/vibeskills-opencode.json`
+- Sync `dist/official-runtime/manifest.json` host support truth
+
+### Batch 3: Preview payload and entrypoints
+- Add OpenCode command wrapper templates
+- Add OpenCode agent wrapper templates
+- Add OpenCode example config scaffold
+- Update `install.sh` and `check.sh` for `--host opencode`
+- Update `install.ps1` and `check.ps1` for `--host opencode`
+- Update shared install/helper scripts to recognize OpenCode target roots and payload rules
+
+### Batch 4: Truth docs and proof surfaces
+- Update universalization matrices and adapter README/distribution README wording
+- Add dedicated OpenCode install docs in English and Chinese
+- Add OpenCode preview proof-bundle documentation
+- Add a runtime-neutral OpenCode preview smoke verification script
+- Update verification gates that still hard-code the old OpenCode placeholder state
+
+### Batch 5: Verification, receipts, cleanup
+- Run adapter closure, host adapter, target-root guard, and dist manifest gates
+- Run the OpenCode preview smoke verification
+- Run `git diff --check`
+- Emit phase execution receipt
+- Emit cleanup receipt with verification evidence and known remaining limitations
+
+## Verification Commands
+
+- `pwsh -NoProfile -File ./scripts/verify/vgo-adapter-closure-gate.ps1 -WriteArtifacts`
+- `pwsh -NoProfile -File ./scripts/verify/vgo-adapter-target-root-guard-gate.ps1 -WriteArtifacts`
+- `pwsh -NoProfile -File ./scripts/verify/vibe-host-adapter-contract-gate.ps1`
+- `pwsh -NoProfile -File ./scripts/verify/vibe-dist-manifest-gate.ps1 -WriteArtifacts`
+- `python3 ./scripts/verify/runtime_neutral/opencode_preview_smoke.py --repo-root . --write-artifacts`
+- `git diff --check`
+
+## Rollback Rules
+
+- If local OpenCode CLI behavior contradicts doc-based assumptions, keep the lane at `preview` and encode the limitation in proof artifacts rather than weakening Codex or overclaiming OpenCode closure.
+- If shared helper changes risk Codex/Claude regressions, block completion until regression gates pass or the helper delta is narrowed.
+- If command or agent wrapper discovery is unstable, preserve the skill payload and example config, but keep wrapper support explicitly provisional in docs and receipts.

--- a/docs/quick-start.en.md
+++ b/docs/quick-start.en.md
@@ -20,6 +20,10 @@ Go straight to:
 
 The main entry there is not a wall of commands. It is a prompt you can copy into your AI assistant.
 
+If your target host is OpenCode, you can also go straight to:
+
+- [`install/opencode-path.en.md`](./install/opencode-path.en.md)
+
 ## I want to understand why this project exists
 
 Read:
@@ -34,6 +38,7 @@ Read these:
 
 - [`install/recommended-full-path.en.md`](./install/recommended-full-path.en.md)
 - [`cold-start-install-paths.en.md`](./cold-start-install-paths.en.md)
+- [`install/opencode-path.en.md`](./install/opencode-path.en.md)
 
 They are more complete and more operator-oriented than the public entry pages.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -20,6 +20,10 @@
 
 这里的主入口不是一堆命令，而是一段可以直接复制给 AI 的安装提示词。
 
+如果你的目标宿主是 OpenCode，也可以直接看：
+
+- [`install/opencode-path.md`](./install/opencode-path.md)
+
 ## 我想理解这个项目为什么会做出来
 
 看：
@@ -34,6 +38,7 @@
 
 - [`install/recommended-full-path.md`](./install/recommended-full-path.md)
 - [`cold-start-install-paths.md`](./cold-start-install-paths.md)
+- [`install/opencode-path.md`](./install/opencode-path.md)
 
 它们比公开入口更完整，也更偏 operator / heavy-user 视角。
 

--- a/docs/releases/v2.3.36.md
+++ b/docs/releases/v2.3.36.md
@@ -19,4 +19,5 @@
 
 - No runtime contract was widened in this patch release. Official runtime ownership, host plugin ownership, and provider secret ownership remain unchanged.
 - Linux and macOS operators still need `pwsh` to obtain the authoritative freshness / coherence gate path. Without `pwsh`, installation remains supported but degraded, and some gates are warning-only.
-- Codex host usage remains `supported-with-constraints`; Claude Code remains `preview`; OpenCode remains `not-yet-proven`. This release improves disclosure and onboarding, not host-lane status.
+- At the time of this release on 2026-03-13, Codex remained `supported-with-constraints`, Claude Code remained `preview`, and OpenCode was still `not-yet-proven`.
+- Later work on 2026-03-26 promoted OpenCode to a truthful `preview` adapter lane with dedicated install/check docs and proof notes. Read the current status from `docs/install/opencode-path*.md` and `docs/universalization/host-capability-matrix.md`, not from this historical release note alone.

--- a/docs/requirements/2026-03-26-opencode-doc-refresh.md
+++ b/docs/requirements/2026-03-26-opencode-doc-refresh.md
@@ -1,0 +1,49 @@
+# 2026-03-26 OpenCode Documentation Refresh Requirement
+
+- Topic: refresh installation and onboarding documentation so OpenCode preview support is described truthfully and consistently across public entrypoints.
+- Mode: interactive_governed
+- Goal: update install, quick-start, deployment, README, and capability docs so they match the implemented OpenCode preview adapter and measured proof state.
+
+## Deliverable
+
+A documentation change set that:
+
+1. updates public install entry docs to include `opencode` as a documented preview lane
+2. keeps `codex` as the strongest current lane and `claude-code` / `opencode` as truthful preview lanes
+3. explains that OpenCode currently uses direct `install.*` / `check.*` entrypoints rather than one-shot bootstrap
+4. points OpenCode operators to the dedicated `docs/install/opencode-path*.md` pages
+5. aligns README, quick-start, deployment, install policy, and host capability wording with the current measured OpenCode proof
+6. records governed runtime receipts for this doc-refresh pass
+
+## Constraints
+
+- No false promotion above `preview`
+- No change to runtime code or support claims that verification cannot defend
+- Historical requirement and plan docs should remain historical records unless a clarification note is necessary
+- Existing unrelated user changes must remain untouched
+- Final completion language requires fresh verification evidence
+
+## Acceptance Criteria
+
+- Public install docs no longer say that only `codex` and `claude-code` are supported install targets
+- OpenCode docs consistently describe:
+  - preview lane status
+  - direct `install.* --host opencode` and `check.* --host opencode` usage
+  - default OpenCode target root behavior
+  - host-managed ownership of the real `opencode.json`, provider credentials, plugin provisioning, and MCP trust
+- README and quick-start entrypoints route OpenCode users to the correct doc
+- `docs/universalization/host-capability-matrix.md` matches the current measured proof note
+- Verification passes after the edits
+
+## Non-Goals
+
+- Promoting OpenCode to `supported-with-constraints`
+- Adding one-shot bootstrap support for OpenCode
+- Claiming full OpenCode host closure
+- Creating or discussing a PR in this pass
+
+## Inferred Assumptions
+
+- OpenCode preview install/check support landed before this doc refresh pass
+- The dedicated OpenCode install docs are already the most detailed source of truth and should be reused by broader entry docs
+- The local proof on OpenCode CLI `1.2.27` is strong enough to justify `preview`, but not strong enough to justify wider promotion

--- a/docs/requirements/2026-03-26-opencode-pr-delivery.md
+++ b/docs/requirements/2026-03-26-opencode-pr-delivery.md
@@ -1,0 +1,43 @@
+# 2026-03-26 OpenCode PR Delivery Requirement
+
+- Topic: verify the OpenCode compatibility work, isolate the task-relevant change set, and submit a pull request.
+- Mode: interactive_governed
+- Goal: turn the implemented OpenCode preview adapter and the refreshed documentation into a proof-backed PR without bundling unrelated worktree changes.
+
+## Deliverable
+
+A PR-ready change set that:
+
+1. re-verifies the OpenCode preview adapter and documentation truth against the current repo state
+2. keeps only the OpenCode compatibility and doc-refresh files inside the commit boundary
+3. preserves unrelated local changes outside the PR
+4. creates a branch, commit, and pull request with a concise proof-backed summary
+
+## Constraints
+
+- No regression to Codex or Claude Code truth surfaces
+- No false promotion above `preview`
+- Do not stage unrelated local changes or historical scratch docs outside the task scope
+- Do not amend old commits
+- Completion language must be backed by fresh verification output
+
+## Acceptance Criteria
+
+- OpenCode install/check entrypoints still pass on shell and PowerShell paths
+- OpenCode adapter/doc gates pass
+- OpenCode preview smoke passes
+- `git diff --check` passes before commit
+- The branch contains only the OpenCode implementation and documentation files plus governed artifacts for this task
+- A PR is opened against `main` with verification evidence in the body
+
+## Non-Goals
+
+- Rebasing or updating the local `main` branch
+- Cleaning unrelated historical requirement/plan notes from the repo
+- Promoting OpenCode to `supported-with-constraints`
+
+## Inferred Assumptions
+
+- The repository owner is the authenticated GitHub user or accessible with existing credentials
+- The current dirty worktree includes both task-relevant and unrelated local changes, so staging must be explicit
+- The current OpenCode proof bundle is sufficient for a truthful preview PR

--- a/docs/requirements/2026-03-26-opencode-preview-adapter.md
+++ b/docs/requirements/2026-03-26-opencode-preview-adapter.md
@@ -1,0 +1,51 @@
+# 2026-03-26 OpenCode Preview Adapter Requirement
+
+- Topic: promote OpenCode from placeholder to a truthful preview adapter.
+- Mode: interactive_governed
+- Goal: land a host-native OpenCode preview lane with bounded install/check behavior, wrapper payloads, proof notes, and no false closure claims.
+
+## Deliverable
+
+A working change that:
+
+1. activates `opencode` in `adapters/index.json`
+2. promotes the OpenCode host profile, closure contract, and dist manifests from placeholder to `preview`
+3. installs OpenCode-targeted preview payload into host-native roots without taking ownership of the real `opencode.json`
+4. adds OpenCode command and agent wrapper scaffolds for governed `vibe` usage
+5. updates install/check entrypoints so `--host opencode` works on both shell and PowerShell paths
+6. updates universalization docs so adapter, dist, and docs state the same truth
+7. adds replay/proof documentation and a runnable OpenCode preview smoke verification
+8. records phase execution and cleanup receipts for this governed pass
+
+## Constraints
+
+- No regression to Codex governed install/check behavior
+- No false promotion above `preview`
+- Real host config, provider credentials, plugin provisioning, and MCP trust remain host-managed
+- Existing unrelated repo changes must remain untouched
+- Verification must include fresh adapter/doc gates and an actual OpenCode CLI smoke pass when the local binary exists
+- Phase cleanup required before completion language
+
+## Acceptance Criteria
+
+- `install.* --host opencode` resolves to a host-native default root and writes only preview payload plus runtime-core payload
+- `check.* --host opencode` verifies the OpenCode preview payload truthfully
+- `adapters/opencode/*`, `dist/host-opencode/manifest.json`, and `dist/manifests/vibeskills-opencode.json` all agree on `preview`
+- `docs/universalization/*.md` and adapter manifests agree on OpenCode status and closure wording
+- OpenCode command wrappers exist for `vibe`, `vibe-implement`, and `vibe-review`
+- OpenCode agent wrappers exist for `vibe-plan`, `vibe-implement`, and `vibe-review`
+- A committed verification script can install/check the OpenCode preview lane in a temp workspace and emit machine-readable results
+- Existing core adapter closure and dist manifest gates still pass after the change
+
+## Non-Goals
+
+- Promoting OpenCode to `supported-with-constraints`
+- Automatic provider credential provisioning
+- Automatic plugin installation inside the OpenCode host
+- Claiming that `opencode debug skill` is authoritative if local runtime behavior disagrees with docs
+
+## Inferred Assumptions
+
+- OpenCode officially exposes host-native global and project roots for skills, commands, and agents.
+- The repository should prefer OpenCode-native roots over compatibility mirrors such as `.claude/skills` or `.agents/skills`.
+- Local OpenCode CLI behavior may lag or diverge from official docs, so preview proof must separate install truth from unresolved runtime discovery gaps.

--- a/docs/universalization/distribution-lanes.md
+++ b/docs/universalization/distribution-lanes.md
@@ -31,7 +31,7 @@ Dist manifests may point to these assets, but must not replace them.
 | `core` | universal contracts and schemas only | none | contract-only |
 | `host-codex` | strongest host adapter lane | governed-with-constraints | supported-with-constraints |
 | `host-claude-code` | preview host adapter lane | preview-scaffold via shared entrypoints | preview only |
-| `host-opencode` | future host adapter lane | runtime-core-only via neutral target root | not-yet-proven only |
+| `host-opencode` | preview host adapter lane | preview-scaffold via shared entrypoints | preview only |
 | `generic` | neutral contract consumer lane | runtime-core-only via neutral target root | advisory-only |
 
 ## Important Boundary
@@ -41,6 +41,11 @@ Dist manifests may point to these assets, but must not replace them.
 - the repo can install canonical skills, commands, locks, and mirrored `skills/vibe/**`
 - the repo does **not** claim host-native settings, plugin, MCP, or credential closure
 - target roots should remain neutral, not a fake `.codex` / `.claude` host home
+
+`preview-scaffold` means:
+
+- the repo may install bounded host-native payload such as wrapper files or example config
+- the repo still does not claim final host settings ownership or replay-backed platform parity
 
 ## Truth Sources
 

--- a/docs/universalization/host-capability-matrix.md
+++ b/docs/universalization/host-capability-matrix.md
@@ -15,21 +15,21 @@ It prevents the project from collapsing all hosts into a fake "one runtime fits 
 
 ## Status Vocabulary
 
-| Status | Meaning |
-| --- | --- |
-| `supported-with-constraints` | repo has real host evidence and a bounded support claim, but some surfaces remain host-managed |
-| `preview` | adapter contract exists and scaffold/check proof exists, but full host closure is still incomplete |
-| `not-yet-proven` | host is named in the migration target, but there is no verified host-native runtime contract yet |
-| `advisory-only` | host may consume canonical contracts or runtime-core payload, but the repo makes no host closure claim |
+| Status                       | Meaning                                                                                                |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `supported-with-constraints` | repo has real host evidence and a bounded support claim, but some surfaces remain host-managed         |
+| `preview`                    | adapter contract exists and scaffold/check proof exists, but full host closure is still incomplete     |
+| `not-yet-proven`             | host is named in the migration target, but there is no verified host-native runtime contract yet       |
+| `advisory-only`              | host may consume canonical contracts or runtime-core payload, but the repo makes no host closure claim |
 
 ## Host Matrix
 
-| Host | Status | Runtime Role | Settings Contract | Plugin/MCP Contract | Release Closure | Notes |
-| --- | --- | --- | --- | --- | --- | --- |
+| Host         | Status                       | Runtime Role             | Settings Contract                                                                  | Plugin/MCP Contract         | Release Closure        | Notes                                                                      |
+| ------------ | ---------------------------- | ------------------------ | ---------------------------------------------------------------------------------- | --------------------------- | ---------------------- | -------------------------------------------------------------------------- |
 | Codex | `supported-with-constraints` | official-runtime-adapter | repo template + materialization exist | host-managed but documented | strongest current path | current reference lane |
 | Claude Code | `preview` | host-adapter-preview | repo scaffold exists | mostly host-managed | preview-scaffold | install/check can scaffold and verify preview truth |
-| OpenCode | `not-yet-proven` | future-host-adapter | neutral runtime-core only | none yet | runtime-core-only | no host-native closure yet |
-| Generic Host | `advisory-only` | contract-consumer | neutral runtime-core only | host-defined | runtime-core-only | canonical skill truth can be consumed without host promise |
+| OpenCode | `preview` | host-adapter-preview | repo installs wrappers + example scaffold, real `opencode.json` stays host-managed | host-managed but documented | preview-scaffold | host-native roots are supported, but runtime discovery proof is incomplete |
+| Generic Host | `advisory-only`              | contract-consumer        | neutral runtime-core only                                                          | host-defined                | runtime-core-only      | canonical skill truth can be consumed without host promise                 |
 
 ## Capability Guidance
 
@@ -45,8 +45,10 @@ It prevents the project from collapsing all hosts into a fake "one runtime fits 
 
 ### OpenCode
 
-- The repo can only install neutral runtime-core payload into a non-host target root.
-- Host-native settings, plugin, and MCP semantics remain unproven.
+- The repo can install runtime-core plus command/agent wrapper scaffolds into OpenCode roots.
+- The real `opencode.json`, provider credentials, plugin provisioning, and MCP trust remain host-managed.
+- Local proof on OpenCode CLI `1.2.27` now confirms `opencode debug paths`, `opencode debug skill`, and `opencode debug agent vibe-plan` on the committed preview smoke path.
+- The lane still remains `preview` because command replay and platform-specific proof bundles are not yet frozen.
 
 ### Generic Host
 

--- a/docs/universalization/install-matrix.md
+++ b/docs/universalization/install-matrix.md
@@ -19,7 +19,7 @@ It does **not** promise that all host dependencies can be installed in one shot.
 | `host-codex` | `install.* --host codex` | `check.* --host codex` | governed-with-constraints | strongest current lane |
 | `host-claude-code` | `install.* --host claude-code` | `check.* --host claude-code` | preview-scaffold | writes truthful scaffold only |
 | `generic` | `install.* --host generic` | `check.* --host generic` | runtime-core-only | neutral target root only |
-| `host-opencode` | `install.* --host opencode` | `check.* --host opencode` | runtime-core-only | neutral target root only |
+| `host-opencode` | `install.* --host opencode` | `check.* --host opencode` | preview-scaffold | writes skills + command/agent wrappers + example config into OpenCode roots, but does not own the real `opencode.json` |
 | `core` | none | none | none | contracts only |
 
 ## Host-Managed Boundaries

--- a/docs/universalization/platform-install-matrix.md
+++ b/docs/universalization/platform-install-matrix.md
@@ -29,4 +29,5 @@ This document only maps that truth into the install entrypoints.
 ## Lane Applicability
 
 - `official-runtime` and `host-codex` inherit this platform matrix.
-- `core`, `host-claude-code`, and `host-opencode` do not claim a governed install closure lane yet.
+- `host-claude-code` and `host-opencode` expose preview scaffolds, but do not claim governed install closure.
+- `core` remains contract-only and does not claim a host-native install lane.

--- a/docs/universalization/platform-support-matrix.md
+++ b/docs/universalization/platform-support-matrix.md
@@ -60,6 +60,7 @@ Examples:
 
 - "Codex supported" is incomplete without saying whether the support claim is Windows-only, Linux-with-pwsh, or degraded.
 - "Linux supported" is incomplete without saying whether the lane is official runtime, host adapter preview, or heuristic-only.
+- "OpenCode preview install exists" is incomplete without saying which platform replay evidence has actually been frozen.
 
 The correct statement pattern is:
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,7 +1,7 @@
 param(
   [ValidateSet("minimal", "full")]
   [string]$Profile = "full",
-  [ValidateSet("codex", "claude-code")]
+  [ValidateSet("codex", "claude-code", "opencode")]
   [string]$HostId = "codex",
   [string]$TargetRoot = '',
   [switch]$InstallExternal,

--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,9 @@ resolve_host_id() {
   case "${host_id}" in
     codex) printf '%s' 'codex' ;;
     claude|claude-code) printf '%s' 'claude-code' ;;
+    opencode) printf '%s' 'opencode' ;;
     *)
-      echo "[FAIL] Unsupported VCO host id: ${host_id}. Supported values: codex, claude-code" >&2
+      echo "[FAIL] Unsupported VCO host id: ${host_id}. Supported values: codex, claude-code, opencode" >&2
       exit 1
       ;;
   esac
@@ -40,6 +41,7 @@ resolve_default_target_root() {
   case "${host_id}" in
     codex) printf '%s' "${CODEX_HOME:-${HOME}/.codex}" ;;
     claude-code) printf '%s' "${CLAUDE_HOME:-${HOME}/.claude}" ;;
+    opencode) printf '%s' "${OPENCODE_HOME:-${HOME}/.config/opencode}" ;;
     *)
       echo "[FAIL] Unsupported VCO host id for target-root resolution: ${host_id}" >&2
       exit 1
@@ -51,16 +53,38 @@ assert_target_root_matches_host_intent() {
   local target_root="$1"
   local host_id="$2"
   local leaf
+  local normalized_root
   leaf="$(basename "${target_root}")"
   leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  normalized_root="$(printf '%s' "${target_root}" | tr '\\' '/' | sed 's#//*#/#g' | tr '[:upper:]' '[:lower:]')"
   if [[ "${host_id}" == "codex" && "${leaf}" == ".claude" ]]; then
     echo "[FAIL] Target root '${target_root}' looks like a Claude Code home, but host='codex'." >&2
     echo "[FAIL] Pass --host claude-code for preview guidance or use a Codex target root." >&2
     exit 1
   fi
+  if [[ "${host_id}" == "codex" && ( "${leaf}" == ".opencode" || "${normalized_root}" == */.config/opencode ) ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like an OpenCode root, but host='codex'." >&2
+    echo "[FAIL] Pass --host opencode for the OpenCode preview lane or use a Codex target root." >&2
+    exit 1
+  fi
   if [[ "${host_id}" == "claude-code" && "${leaf}" == ".codex" ]]; then
     echo "[FAIL] Target root '${target_root}' looks like a Codex home, but host='claude-code'." >&2
     echo "[FAIL] Use --host codex for the official closure lane or choose a Claude Code target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "claude-code" && ( "${leaf}" == ".opencode" || "${normalized_root}" == */.config/opencode ) ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like an OpenCode root, but host='claude-code'." >&2
+    echo "[FAIL] Use --host opencode for the OpenCode preview lane or choose a Claude Code target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "opencode" && "${leaf}" == ".codex" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Codex home, but host='opencode'." >&2
+    echo "[FAIL] Use --host codex for the official closure lane or choose an OpenCode target root." >&2
+    exit 1
+  fi
+  if [[ "${host_id}" == "opencode" && "${leaf}" == ".claude" ]]; then
+    echo "[FAIL] Target root '${target_root}' looks like a Claude Code home, but host='opencode'." >&2
+    echo "[FAIL] Use --host claude-code for Claude preview guidance or choose an OpenCode target root." >&2
     exit 1
   fi
 }

--- a/references/proof-bundles/opencode-preview/README.md
+++ b/references/proof-bundles/opencode-preview/README.md
@@ -1,0 +1,51 @@
+# OpenCode Preview Proof Bundle
+
+## Scope
+
+This bundle defines what the repository must prove before OpenCode can honestly remain `preview` and what is still missing before any stronger promotion.
+
+## Required Evidence
+
+### Contract proof
+
+- `adapters/opencode/host-profile.json`
+- `adapters/opencode/settings-map.json`
+- `adapters/opencode/closure.json`
+- `dist/host-opencode/manifest.json`
+- `dist/manifests/vibeskills-opencode.json`
+- `docs/universalization/host-capability-matrix.md`
+- `docs/universalization/install-matrix.md`
+- `docs/universalization/distribution-lanes.md`
+
+### Install/check proof
+
+- `install.* --host opencode`
+- `check.* --host opencode`
+- temp-root install isolation evidence
+- runtime freshness/coherence receipts
+
+### Runtime discovery proof
+
+- OpenCode CLI path resolution evidence
+- agent wrapper discovery evidence
+- command wrapper file presence evidence
+- explicit note when `opencode debug skill` diverges from official docs
+
+## Current Measured State
+
+The committed smoke verifier currently proves on local `opencode 1.2.27` that:
+
+- isolated OpenCode path resolution works
+- the installed `vibe` skill is discovered
+- the installed `vibe-plan` agent is discovered
+
+This is enough for a truthful `preview` label.
+
+## Promotion Blockers
+
+OpenCode must not move above `preview` until all of these are true:
+
+1. command wrapper behavior is replay-backed, not only file-backed
+2. skill and agent discovery replay stays stable across repeated clean roots
+3. at least one platform-specific proof lane is frozen
+4. docs, adapter contracts, and proof outputs all stay in sync after reruns

--- a/scripts/common/vibe-governance-helpers.ps1
+++ b/scripts/common/vibe-governance-helpers.ps1
@@ -173,8 +173,10 @@ function Resolve-VgoHostId {
         'codex' { return 'codex' }
         'claude' { return 'claude-code' }
         'claude-code' { return 'claude-code' }
+        'opencode' { return 'opencode' }
+        'generic' { return 'generic' }
         default {
-            throw "Unsupported VCO host id: $resolved. Supported values: codex, claude-code"
+            throw "Unsupported VCO host id: $resolved. Supported values: codex, claude-code, opencode, generic"
         }
     }
 }
@@ -198,6 +200,15 @@ function Resolve-VgoDefaultTargetRoot {
                 return [System.IO.Path]::GetFullPath($env:CLAUDE_HOME)
             }
             return [System.IO.Path]::GetFullPath((Join-Path $homeDir '.claude'))
+        }
+        'opencode' {
+            if (-not [string]::IsNullOrWhiteSpace($env:OPENCODE_HOME)) {
+                return [System.IO.Path]::GetFullPath($env:OPENCODE_HOME)
+            }
+            return [System.IO.Path]::GetFullPath((Join-Path (Join-Path $homeDir '.config') 'opencode'))
+        }
+        'generic' {
+            return [System.IO.Path]::GetFullPath((Join-Path (Join-Path $homeDir '.vibe-skills') 'generic'))
         }
         default {
             throw "Unsupported VCO host id: $resolvedHostId"
@@ -239,8 +250,11 @@ function Assert-VgoTargetRootMatchesHostIntent {
     )
 
     $resolvedHostId = Resolve-VgoHostId -HostId $HostId
-    $leaf = Split-Path -Leaf ([System.IO.Path]::GetFullPath($TargetRoot))
+    $fullTargetRoot = [System.IO.Path]::GetFullPath($TargetRoot)
+    $leaf = Split-Path -Leaf $fullTargetRoot
     $normalizedLeaf = if ([string]::IsNullOrWhiteSpace($leaf)) { '' } else { $leaf.Trim().ToLowerInvariant() }
+    $normalizedPath = $fullTargetRoot.Trim().Replace('\', '/').ToLowerInvariant()
+    $looksLikeOpenCodeRoot = ($normalizedLeaf -eq '.opencode') -or $normalizedPath.EndsWith('/.config/opencode')
 
     switch ($resolvedHostId) {
         'codex' {
@@ -250,11 +264,45 @@ function Assert-VgoTargetRootMatchesHostIntent {
                     $TargetRoot
                 ))
             }
+            if ($looksLikeOpenCodeRoot) {
+                throw ([string]::Format(
+                    "TargetRoot '{0}' looks like an OpenCode root, but HostId resolved to 'codex'. Pass -HostId opencode for the OpenCode preview lane or use a Codex target root.",
+                    $TargetRoot
+                ))
+            }
         }
         'claude-code' {
             if ($normalizedLeaf -eq '.codex') {
                 throw ([string]::Format(
                     "TargetRoot '{0}' looks like a Codex home, but HostId resolved to 'claude-code'. Use -HostId codex for the official closure lane or choose a Claude Code target root.",
+                    $TargetRoot
+                ))
+            }
+            if ($looksLikeOpenCodeRoot) {
+                throw ([string]::Format(
+                    "TargetRoot '{0}' looks like an OpenCode root, but HostId resolved to 'claude-code'. Use -HostId opencode for the OpenCode preview lane or choose a Claude Code target root.",
+                    $TargetRoot
+                ))
+            }
+        }
+        'opencode' {
+            if ($normalizedLeaf -eq '.codex') {
+                throw ([string]::Format(
+                    "TargetRoot '{0}' looks like a Codex home, but HostId resolved to 'opencode'. Use -HostId codex for the official closure lane or choose an OpenCode target root.",
+                    $TargetRoot
+                ))
+            }
+            if ($normalizedLeaf -eq '.claude') {
+                throw ([string]::Format(
+                    "TargetRoot '{0}' looks like a Claude Code home, but HostId resolved to 'opencode'. Use -HostId claude-code for Claude preview guidance or choose an OpenCode target root.",
+                    $TargetRoot
+                ))
+            }
+        }
+        'generic' {
+            if ($normalizedLeaf -eq '.codex' -or $normalizedLeaf -eq '.claude' -or $looksLikeOpenCodeRoot) {
+                throw ([string]::Format(
+                    "TargetRoot '{0}' looks like a host-native root, but HostId resolved to 'generic'. Use a neutral generic target root instead.",
                     $TargetRoot
                 ))
             }

--- a/scripts/install/Install-VgoAdapter.ps1
+++ b/scripts/install/Install-VgoAdapter.ps1
@@ -201,11 +201,31 @@ function Install-ClaudeGuidancePayload {
     return
 }
 
+function Install-OpenCodeGuidancePayload {
+    Copy-DirContent -Source (Join-Path $RepoRoot 'config\opencode\commands') -Destination (Join-Path $TargetRoot 'commands')
+    Copy-DirContent -Source (Join-Path $RepoRoot 'config\opencode\commands') -Destination (Join-Path $TargetRoot 'command')
+    Copy-DirContent -Source (Join-Path $RepoRoot 'config\opencode\agents') -Destination (Join-Path $TargetRoot 'agents')
+    Copy-DirContent -Source (Join-Path $RepoRoot 'config\opencode\agents') -Destination (Join-Path $TargetRoot 'agent')
+
+    $exampleConfig = Join-Path $RepoRoot 'config\opencode\opencode.json.example'
+    if (Test-Path -LiteralPath $exampleConfig) {
+        Copy-Item -LiteralPath $exampleConfig -Destination (Join-Path $TargetRoot 'opencode.json.example') -Force
+    }
+}
+
 $adapter = Resolve-VgoAdapterDescriptor -RepoRoot $RepoRoot -HostId $HostId
 $result = Install-RuntimeCorePayload -Adapter $adapter
 switch ([string]$adapter.install_mode) {
     'governed' { Install-GovernedCodexPayload }
-    'preview-guidance' { Install-ClaudeGuidancePayload }
+    'preview-guidance' {
+        if ([string]$adapter.id -eq 'claude-code') {
+            Install-ClaudeGuidancePayload
+        } elseif ([string]$adapter.id -eq 'opencode') {
+            Install-OpenCodeGuidancePayload
+        } else {
+            throw "Unsupported preview-guidance adapter id: $($adapter.id)"
+        }
+    }
     'runtime-core' { }
     default { throw "Unsupported adapter install mode: $($adapter.install_mode)" }
 }

--- a/scripts/install/install_vgo_adapter.py
+++ b/scripts/install/install_vgo_adapter.py
@@ -193,6 +193,19 @@ def install_claude_guidance_payload(repo_root: Path, target_root: Path):
     return
 
 
+def install_opencode_guidance_payload(repo_root: Path, target_root: Path):
+    commands_root = repo_root / "config" / "opencode" / "commands"
+    agents_root = repo_root / "config" / "opencode" / "agents"
+    example_config = repo_root / "config" / "opencode" / "opencode.json.example"
+
+    copy_tree(commands_root, target_root / "commands")
+    copy_tree(commands_root, target_root / "command")
+    copy_tree(agents_root, target_root / "agents")
+    copy_tree(agents_root, target_root / "agent")
+    if example_config.exists():
+        copy_file(example_config, target_root / "opencode.json.example")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo-root", required=True)
@@ -211,7 +224,12 @@ def main():
     if mode == "governed":
         install_codex_payload(repo_root, target_root)
     elif mode == "preview-guidance":
-        install_claude_guidance_payload(repo_root, target_root)
+        if adapter["id"] == "claude-code":
+            install_claude_guidance_payload(repo_root, target_root)
+        elif adapter["id"] == "opencode":
+            install_opencode_guidance_payload(repo_root, target_root)
+        else:
+            raise SystemExit(f"Unsupported preview-guidance adapter id: {adapter['id']}")
     elif mode != "runtime-core":
         raise SystemExit(f"Unsupported adapter install mode: {mode}")
 

--- a/scripts/verify/runtime_neutral/opencode_preview_smoke.py
+++ b/scripts/verify/runtime_neutral/opencode_preview_smoke.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+EXPECTED_FILES = [
+    "skills/vibe/SKILL.md",
+    "skills/brainstorming/SKILL.md",
+    "commands/vibe.md",
+    "commands/vibe-implement.md",
+    "commands/vibe-review.md",
+    "command/vibe.md",
+    "command/vibe-implement.md",
+    "command/vibe-review.md",
+    "agents/vibe-plan.md",
+    "agents/vibe-implement.md",
+    "agents/vibe-review.md",
+    "agent/vibe-plan.md",
+    "agent/vibe-implement.md",
+    "agent/vibe-review.md",
+    "opencode.json.example",
+]
+
+
+def run(cmd, cwd, env=None):
+    completed = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    return {
+        "cmd": cmd,
+        "cwd": str(cwd),
+        "returncode": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+    }
+
+
+def write_json(path: Path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--write-artifacts", action="store_true")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    install_sh = repo_root / "install.sh"
+    check_sh = repo_root / "check.sh"
+    artifact_path = repo_root / "outputs" / "verify" / "opencode-preview-smoke.json"
+
+    failures = []
+    warnings = []
+
+    with tempfile.TemporaryDirectory(prefix="vgo-opencode-preview-") as tmp:
+        tmp_root = Path(tmp)
+        target_root = tmp_root / ".config" / "opencode"
+
+        install_result = run(
+            ["bash", str(install_sh), "--host", "opencode", "--target-root", str(target_root)],
+            cwd=repo_root,
+            env=os.environ.copy(),
+        )
+        if install_result["returncode"] != 0:
+            failures.append("install.sh --host opencode failed")
+
+        check_result = run(
+            ["bash", str(check_sh), "--host", "opencode", "--target-root", str(target_root)],
+            cwd=repo_root,
+            env=os.environ.copy(),
+        )
+        if check_result["returncode"] != 0:
+            failures.append("check.sh --host opencode failed")
+
+        missing_files = [rel for rel in EXPECTED_FILES if not (target_root / rel).exists()]
+        if missing_files:
+            failures.append("expected preview payload missing")
+
+        opencode_cli = shutil.which("opencode")
+        cli_probe = {
+            "present": bool(opencode_cli),
+            "binary": opencode_cli,
+            "debug_paths": None,
+            "debug_skill_detects_vibe": None,
+            "debug_agent_detects_vibe_plan": None,
+            "notes": [],
+        }
+
+        if opencode_cli:
+            env = os.environ.copy()
+            env["HOME"] = str(tmp_root)
+            env["XDG_CONFIG_HOME"] = str(tmp_root / ".config")
+            env["XDG_DATA_HOME"] = str(tmp_root / ".local" / "share")
+            env["XDG_STATE_HOME"] = str(tmp_root / ".local" / "state")
+            env["XDG_CACHE_HOME"] = str(tmp_root / ".cache")
+
+            debug_paths = run([opencode_cli, "debug", "paths"], cwd=repo_root, env=env)
+            cli_probe["debug_paths"] = debug_paths
+            if debug_paths["returncode"] != 0:
+                warnings.append("opencode debug paths failed in isolated env")
+
+            debug_skill = run([opencode_cli, "debug", "skill"], cwd=repo_root, env=env)
+            skill_hits = ("\"name\": \"vibe\"" in debug_skill["stdout"]) or ("skills/vibe/SKILL.md" in debug_skill["stdout"])
+            cli_probe["debug_skill_detects_vibe"] = skill_hits
+            if debug_skill["returncode"] != 0:
+                warnings.append("opencode debug skill failed in isolated env")
+            if not skill_hits:
+                warnings.append("opencode debug skill did not enumerate the installed vibe skill in the isolated OpenCode root")
+                cli_probe["notes"].append("This matches the known 1.2.27 discovery drift and is treated as a preview blocker, not a smoke failure.")
+
+            debug_agent = run([opencode_cli, "debug", "agent", "vibe-plan"], cwd=repo_root, env=env)
+            cli_probe["debug_agent_detects_vibe_plan"] = debug_agent["returncode"] == 0 and "vibe-plan" in (debug_agent["stdout"] + debug_agent["stderr"])
+            if not cli_probe["debug_agent_detects_vibe_plan"]:
+                failures.append("opencode debug agent vibe-plan did not recognize the installed preview agent")
+                cli_probe["notes"].append("Custom agent discovery is part of the preview wrapper contract and must work.")
+            cli_probe["debug_agent"] = debug_agent
+
+        result = "PASS" if not failures else "FAIL"
+        payload = {
+            "gate": "opencode-preview-smoke",
+            "result": result,
+            "repo_root": str(repo_root),
+            "target_root": str(target_root),
+            "expected_files": EXPECTED_FILES,
+            "missing_files": missing_files,
+            "install": install_result,
+            "check": check_result,
+            "opencode_cli": cli_probe,
+            "failures": failures,
+            "warnings": warnings,
+        }
+
+        if args.write_artifacts:
+            write_json(artifact_path, payload)
+
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        if failures:
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify/vgo-adapter-target-root-guard-gate.ps1
+++ b/scripts/verify/vgo-adapter-target-root-guard-gate.ps1
@@ -14,11 +14,14 @@ if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
 
 $cases = @(
     @{ host = 'codex'; target = 'C:\Users\demo\.claude'; should_throw = $true },
+    @{ host = 'codex'; target = 'C:\Users\demo\.config\opencode'; should_throw = $true },
     @{ host = 'claude-code'; target = 'C:\Users\demo\.codex'; should_throw = $true },
+    @{ host = 'claude-code'; target = 'C:\Users\demo\.config\opencode'; should_throw = $true },
     @{ host = 'generic'; target = 'C:\Users\demo\.codex'; should_throw = $true },
     @{ host = 'generic'; target = 'C:\Users\demo\.vibe-skills\generic'; should_throw = $false },
     @{ host = 'opencode'; target = 'C:\Users\demo\.claude'; should_throw = $true },
-    @{ host = 'opencode'; target = 'C:\Users\demo\.vibe-skills\opencode'; should_throw = $false }
+    @{ host = 'opencode'; target = 'C:\Users\demo\.config\opencode'; should_throw = $false },
+    @{ host = 'opencode'; target = 'C:\repo\.opencode'; should_throw = $false }
 )
 
 $failures = @()

--- a/scripts/verify/vibe-dist-manifest-gate.ps1
+++ b/scripts/verify/vibe-dist-manifest-gate.ps1
@@ -193,7 +193,7 @@ $requiredPublicManifests = @(
     [pscustomobject]@{ package_id = 'vibeskills-core'; path = 'dist/manifests/vibeskills-core.json'; expected_status = 'supported-with-constraints' },
     [pscustomobject]@{ package_id = 'vibeskills-codex'; path = 'dist/manifests/vibeskills-codex.json'; expected_status = 'supported-with-constraints' },
     [pscustomobject]@{ package_id = 'vibeskills-claude-code'; path = 'dist/manifests/vibeskills-claude-code.json'; expected_status = 'preview' },
-    [pscustomobject]@{ package_id = 'vibeskills-opencode'; path = 'dist/manifests/vibeskills-opencode.json'; expected_status = 'not-yet-proven' },
+    [pscustomobject]@{ package_id = 'vibeskills-opencode'; path = 'dist/manifests/vibeskills-opencode.json'; expected_status = 'preview' },
     [pscustomobject]@{ package_id = 'vibeskills-generic'; path = 'dist/manifests/vibeskills-generic.json'; expected_status = 'advisory-only' }
 )
 $results.dist.public_manifests = @($requiredPublicManifests | ForEach-Object { $_.path })
@@ -348,7 +348,7 @@ Add-Assertion -Collection $assertions -Condition (Test-ContentPattern -Path $doc
 
 $hostOpenCodeRow = Find-MarkdownTableRow -Path $docsHostCapabilityMatrix -RowStartsWith '| OpenCode |'
 Add-Assertion -Collection $assertions -Condition ($null -ne $hostOpenCodeRow) -Message '[truth] host capability row for OpenCode exists'
-Add-Assertion -Collection $assertions -Condition (Test-ContentPattern -Path $docsHostCapabilityMatrix -Pattern '| OpenCode | `not-yet-proven` |') -Message '[truth] OpenCode host status remains not-yet-proven in host capability matrix'
+Add-Assertion -Collection $assertions -Condition (Test-ContentPattern -Path $docsHostCapabilityMatrix -Pattern '| OpenCode | `preview` |') -Message '[truth] OpenCode host status remains preview in host capability matrix'
 
 $platformWindowsRow = Find-MarkdownTableRow -Path $docsPlatformSupportMatrix -RowStartsWith '| Windows |'
 Add-Assertion -Collection $assertions -Condition ($null -ne $platformWindowsRow) -Message '[truth] platform row for Windows exists'

--- a/scripts/verify/vibe-host-adapter-contract-gate.ps1
+++ b/scripts/verify/vibe-host-adapter-contract-gate.ps1
@@ -22,7 +22,10 @@ $checks = @(
     @{ Path = 'codex/platform-macos.json'; MustExist = $true },
     @{ Path = 'claude-code/platform-windows.json'; MustExist = $true },
     @{ Path = 'claude-code/platform-linux.json'; MustExist = $true },
-    @{ Path = 'claude-code/platform-macos.json'; MustExist = $true }
+    @{ Path = 'claude-code/platform-macos.json'; MustExist = $true },
+    @{ Path = 'opencode/platform-windows.json'; MustExist = $true },
+    @{ Path = 'opencode/platform-linux.json'; MustExist = $true },
+    @{ Path = 'opencode/platform-macos.json'; MustExist = $true }
 )
 
 foreach ($check in $checks) {
@@ -46,8 +49,11 @@ if (Test-Path -LiteralPath $codexProfilePath) {
 $openCodeProfilePath = Join-Path $adapterRoot 'opencode/host-profile.json'
 if (Test-Path -LiteralPath $openCodeProfilePath) {
     $opencode = Get-Content -LiteralPath $openCodeProfilePath -Raw -Encoding UTF8 | ConvertFrom-Json
-    if ($opencode.status -ne 'not-yet-proven') {
-        $failures += "opencode must remain not-yet-proven until a real adapter exists"
+    if ($opencode.status -ne 'preview') {
+        $failures += "opencode must now be preview"
+    }
+    if ($opencode.runtime_role -ne 'host-adapter-preview') {
+        $failures += "opencode runtime_role must be host-adapter-preview"
     }
 }
 


### PR DESCRIPTION
## Summary
- add an OpenCode preview adapter lane with host profile, platform profiles, settings map, and distribution manifests
- add `install` and `check` support for `--host opencode` and ship OpenCode command, agent, and example config payloads under `config/opencode/*`
- refresh README, quick-start, install, onboarding, deployment, and host capability docs so OpenCode is documented truthfully as `preview`
- add OpenCode proof and smoke verification surfaces, including `references/proof-bundles/opencode-preview/README.md` and `scripts/verify/runtime_neutral/opencode_preview_smoke.py`

## Verification
- `git diff --check`
- `pwsh -NoProfile -File ./scripts/verify/vgo-adapter-closure-gate.ps1 -WriteArtifacts`
- `pwsh -NoProfile -File ./scripts/verify/vgo-adapter-target-root-guard-gate.ps1 -WriteArtifacts`
- `pwsh -NoProfile -File ./scripts/verify/vibe-host-adapter-contract-gate.ps1`
- `pwsh -NoProfile -File ./scripts/verify/vibe-dist-manifest-gate.ps1 -WriteArtifacts`
- `python3 ./scripts/verify/runtime_neutral/opencode_preview_smoke.py --repo-root . --write-artifacts`
- `bash ./install.sh --host opencode --target-root <temp>`
- `bash ./check.sh --host opencode --target-root <temp>`
- `pwsh -NoProfile -File ./install.ps1 -HostId opencode -TargetRoot <temp>`
- `pwsh -NoProfile -File ./check.ps1 -HostId opencode -TargetRoot <temp>`
- staged-file scan for `/home/lqf`, `file://`, and `vscode://` returned no matches

## Notes
- OpenCode remains `preview`; this PR does not promote it above that status
- the real `opencode.json`, provider credentials, plugin install, and MCP trust remain host-managed boundaries
- unrelated historical local scratch docs were left out of the PR boundary