### PR TITLE
docs: align readme host banner across languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If your AI supports skills, VibeSkills works. 340+ skills spanning coding, resea
 > Traditional skill repos answer: _"What tools do I have?"_
 > **VibeSkills tackles the core pain point of heavy AI users: _"How do I manage and invoke large numbers of Skills, and get work done efficiently and reliably?"_**
 
-<sub>Works with **Claude Code** · **Codex** · **Windsurf** · **OpenCode** · **Cursor** and any AI environment that supports the Skills protocol. Native **MCP** compatibility.</sub>
+<sub>Works with **Claude Code** · **Codex** · **Windsurf** · **OpenClaw** · **OpenCode** · **Cursor** and any AI environment that supports the Skills protocol. Native **MCP** compatibility.</sub>
 
 <br/>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -100,7 +100,7 @@
 > 传统的 Skills 仓库在回答：_"我这里有什么工具？"_
 > **VibeSkills 正面迎击的是重度 AI 用户的核心痛点：_"我该怎么管理调用大量 Skills，并且高效稳定地完成工作？"_**
 
-<sub>适用于 **Claude Code** · **Codex** · **Windsurf** · **OpenCode** · **Cursor** 及所有支持 Skills 协议的 AI 环境，原生兼容 **MCP**。</sub>
+<sub>适用于 **Claude Code** · **Codex** · **Windsurf** · **OpenClaw** · **OpenCode** · **Cursor** 及所有支持 Skills 协议的 AI 环境，原生兼容 **MCP**。</sub>
 
 <br/>
 

--- a/docs/plans/2026-03-26-readme-host-bilingual-parity-plan.md
+++ b/docs/plans/2026-03-26-readme-host-bilingual-parity-plan.md
@@ -1,0 +1,18 @@
+# README Host Bilingual Parity Plan
+
+## Scope
+
+Apply a narrow documentation correction for the top README host banner in English and Chinese.
+
+## Steps
+
+1. Locate the shared host-banner wording in [`README.md`](../../../README.md) and [`README.zh.md`](../../../README.zh.md).
+2. Add `OpenClaw` in the same position in both languages.
+3. Verify the resulting wording and search for the updated host banner.
+4. Commit and push the correction to the active PR branch.
+
+## Verification
+
+- `rg -n "OpenClaw" README.md README.zh.md`
+- `git diff --check`
+- `git diff -- README.md README.zh.md docs/requirements/2026-03-26-readme-host-bilingual-parity.md docs/plans/2026-03-26-readme-host-bilingual-parity-plan.md`

--- a/docs/requirements/2026-03-26-readme-host-bilingual-parity.md
+++ b/docs/requirements/2026-03-26-readme-host-bilingual-parity.md
@@ -1,0 +1,23 @@
+# README Host Bilingual Parity Requirement
+
+## Goal
+
+Align the top-level Chinese and English README host banner wording so both sides advertise the same supported host set.
+
+## Deliverable
+
+- updated [`README.md`](../../../README.md)
+- updated [`README.zh.md`](../../../README.zh.md)
+
+## Constraints
+
+- keep the existing banner style and sentence structure
+- add `OpenClaw` to the host list without changing the MCP claim
+- do not introduce absolute local paths into public docs
+
+## Acceptance Criteria
+
+1. The top README banner in English includes `OpenClaw`.
+2. The top README banner in Chinese includes `OpenClaw`.
+3. The English and Chinese host order matches.
+4. No other public wording is unintentionally changed.


### PR DESCRIPTION
## Summary
- add `OpenClaw` to the top README host banner in both English and Chinese
- keep the host order aligned across `README.md` and `README.zh.md`
- add lightweight requirement and plan docs for this bilingual parity correction

## Validation
- `git diff --check HEAD^ HEAD`
- `rg -n "Claude Code.*OpenClaw|适用于 .*OpenClaw" README.md README.zh.md`
- `git diff -- README.md README.zh.md docs/requirements/2026-03-26-readme-host-bilingual-parity.md docs/plans/2026-03-26-readme-host-bilingual-parity-plan.md`

## Notes
- this is a follow-up to the install-surface cleanup branch because repository rules blocked direct pushes to the existing PR branch
