### PR TITLE
Use Windows PowerShell as the default router gate command

### DIFF
--- a/docs/install/configuration-guide.en.md
+++ b/docs/install/configuration-guide.en.md
@@ -218,8 +218,10 @@ Typical states:
 Run:
 
 ```powershell
-pwsh -NoProfile -File .\scripts\verify\vibe-router-ai-connectivity-gate.ps1 -WriteArtifacts
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-router-ai-connectivity-gate.ps1 -WriteArtifacts
 ```
+
+If PowerShell 7 is already installed on your machine, you can use `pwsh` instead.
 
 Read outputs:
 - JSON: `outputs/verify/vibe-router-ai-connectivity-gate.json` (machine-readable status + next steps)

--- a/docs/install/configuration-guide.md
+++ b/docs/install/configuration-guide.md
@@ -218,8 +218,10 @@ bash ./check.sh --host claude-code --profile full --deep
 运行方式：
 
 ```powershell
-pwsh -NoProfile -File .\scripts\verify\vibe-router-ai-connectivity-gate.ps1 -WriteArtifacts
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-router-ai-connectivity-gate.ps1 -WriteArtifacts
 ```
+
+如果本机已经安装了 PowerShell 7，也可以改用 `pwsh`。
 
 结果读取：
 - JSON：`outputs/verify/vibe-router-ai-connectivity-gate.json`（机器可读，含状态与 next steps）

--- a/docs/install/one-click-install-release-copy.en.md
+++ b/docs/install/one-click-install-release-copy.en.md
@@ -55,9 +55,11 @@ Outside these four docs, the other pages no longer act as public install prompt 
 If you want to quickly confirm whether the router AI governance advice path is configured, run this from the repo root:
 
 - Windows:
-  - `pwsh -NoProfile -File .\scripts\verify\vibe-router-ai-connectivity-gate.ps1 -TargetRoot "<target host root>" -WriteArtifacts`
+  - `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-router-ai-connectivity-gate.ps1 -TargetRoot "<target host root>" -WriteArtifacts`
 - Linux / macOS:
   - `python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --target-root "<target host root>" --write-artifacts`
+
+If PowerShell 7 is already installed on your machine, you can replace `powershell.exe` with `pwsh`.
 
 Common default roots:
 

--- a/docs/install/one-click-install-release-copy.md
+++ b/docs/install/one-click-install-release-copy.md
@@ -55,9 +55,11 @@
 如果你想快速确认“路由里的 AI 治理 advice 是否已经配通”，可以在仓库根目录运行：
 
 - Windows：
-  - `pwsh -NoProfile -File .\scripts\verify\vibe-router-ai-connectivity-gate.ps1 -TargetRoot "<目标宿主根目录>" -WriteArtifacts`
+  - `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-router-ai-connectivity-gate.ps1 -TargetRoot "<目标宿主根目录>" -WriteArtifacts`
 - Linux / macOS：
   - `python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --target-root "<目标宿主根目录>" --write-artifacts`
+
+如果你本机已经装了 PowerShell 7，也可以把 `powershell.exe` 换成 `pwsh`。
 
 常见默认根目录：
 

--- a/docs/install/prompts/framework-only-install.en.md
+++ b/docs/install/prompts/framework-only-install.en.md
@@ -23,8 +23,9 @@ Rules:
 6. Never ask me to paste secrets, URLs, or model names into chat.
 7. Remind me that this gives me the governance foundation first, not the full default workflow-core experience.
 8. After installation, proactively give me one quick check command for “is AI governance configured?”:
-   - Windows: `pwsh -NoProfile -File .\\scripts\\verify\\vibe-router-ai-connectivity-gate.ps1 -TargetRoot "<resolved host root>" -WriteArtifacts`
+   - Windows: `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\verify\\vibe-router-ai-connectivity-gate.ps1 -TargetRoot "<resolved host root>" -WriteArtifacts`
    - Linux / macOS: `python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --target-root "<resolved host root>" --write-artifacts`
+   - if the user already has PowerShell 7, an equivalent `pwsh` command is acceptable, but `pwsh` must not be treated as the default prerequisite.
    - explain that this probe checks only AI governance advice connectivity, not full platform health.
 9. End with a concise report covering host, public version, real profile, commands executed, completed parts, and manual follow-up.
 ```

--- a/docs/install/prompts/framework-only-install.md
+++ b/docs/install/prompts/framework-only-install.md
@@ -23,8 +23,9 @@
 6. 不要要求我把密钥、URL 或 model 粘贴到聊天里。
 7. 安装完成后，必须额外提醒我：当前拿到的是治理框架底座，不等于默认 workflow core 已齐备。
 8. 安装完成后，主动给我一条“AI 治理是否配置好”的快速检查命令：
-   - Windows：`pwsh -NoProfile -File .\\scripts\\verify\\vibe-router-ai-connectivity-gate.ps1 -TargetRoot "<本次宿主根目录>" -WriteArtifacts`
+   - Windows：`powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\verify\\vibe-router-ai-connectivity-gate.ps1 -TargetRoot "<本次宿主根目录>" -WriteArtifacts`
    - Linux / macOS：`python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --target-root "<本次宿主根目录>" --write-artifacts`
+   - 如用户本机已安装 PowerShell 7，可接受等价的 `pwsh` 版本，但不要把 `pwsh` 当作默认前提。
    - 并说明：这个检查只看 AI 治理 advice 连通性，不等于整个平台总健康检查。
 9. 结果报告仍需包含：目标宿主、公开版本、实际 profile、实际命令、已完成部分、仍需手动处理的部分。
 ```

--- a/docs/install/prompts/full-version-install.en.md
+++ b/docs/install/prompts/full-version-install.en.md
@@ -31,8 +31,9 @@ Rules:
 10. Never ask me to paste secrets, URLs, or model names into chat.
 11. Distinguish “installed locally” from “online-ready”.
 12. After installation, proactively give me one quick check command for “is AI governance configured?”:
-   - Windows: `pwsh -NoProfile -File .\\scripts\\verify\\vibe-router-ai-connectivity-gate.ps1 -TargetRoot "<resolved host root>" -WriteArtifacts`
+   - Windows: `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\verify\\vibe-router-ai-connectivity-gate.ps1 -TargetRoot "<resolved host root>" -WriteArtifacts`
    - Linux / macOS: `python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --target-root "<resolved host root>" --write-artifacts`
+   - if the user already has PowerShell 7, an equivalent `pwsh` command is acceptable, but `pwsh` must not be treated as the default prerequisite.
    - also add one short sentence: `ok` means AI governance advice is online; `missing_credentials`, `missing_model`, or `provider_rejected_request` mean local or online readiness is still incomplete.
 13. End with a concise report covering host, public version, real profile, commands executed, completed parts, and manual follow-up.
 ```

--- a/docs/install/prompts/full-version-install.md
+++ b/docs/install/prompts/full-version-install.md
@@ -31,8 +31,9 @@
 10. 对六个宿主，都不要要求我把密钥、URL 或 model 粘贴到聊天里；只告诉我去本地 settings 或本地环境变量里配置。
 11. 区分“本地安装完成”和“在线能力就绪”。
 12. 安装完成后，主动给我一条“AI 治理是否配置好”的快速检查命令：
-   - Windows：`pwsh -NoProfile -File .\\scripts\\verify\\vibe-router-ai-connectivity-gate.ps1 -TargetRoot "<本次宿主根目录>" -WriteArtifacts`
+   - Windows：`powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\verify\\vibe-router-ai-connectivity-gate.ps1 -TargetRoot "<本次宿主根目录>" -WriteArtifacts`
    - Linux / macOS：`python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --target-root "<本次宿主根目录>" --write-artifacts`
+   - 如用户本机已安装 PowerShell 7，可接受等价的 `pwsh` 版本，但不要把 `pwsh` 当作默认前提。
    - 并用一句话说明：`ok` 表示 AI 治理 advice 已连通；`missing_credentials`、`missing_model`、`provider_rejected_request` 等表示本地或在线配置仍未就绪。
 13. 安装完成后，用简洁中文汇报：目标宿主、公开版本、实际 profile、实际命令、已完成部分、仍需我手动处理的部分。
 ```

--- a/scripts/verify/README.md
+++ b/scripts/verify/README.md
@@ -26,7 +26,7 @@ This probe targets only the router AI advice path (intent/advice layer). It is a
 Run:
 
 ```powershell
-pwsh -NoProfile -File .\vibe-router-ai-connectivity-gate.ps1 -WriteArtifacts
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\vibe-router-ai-connectivity-gate.ps1 -WriteArtifacts
 ```
 
 Typical states:


### PR DESCRIPTION
## Summary
- keep the router AI connectivity probe work from the previous branch
- switch public Windows examples from `pwsh` to `powershell.exe -ExecutionPolicy Bypass`
- update install entry, install prompts, and configuration guide so default Windows copy-paste works without requiring PowerShell 7
- keep `pwsh` documented as an optional equivalent when PowerShell 7 is already installed

## Why
Users on stock Windows may not have the `pwsh` command available. The `.ps1` gate itself can still run under the built-in Windows PowerShell, so the docs should default to the lowest-friction command.

## Verification
- `git diff --check`
- reviewed the updated public install docs and configuration guide for bilingual parity
