### PR TITLE
fix: dedupe installed runtime skill entrypoints

### DIFF
--- a/check.ps1
+++ b/check.ps1
@@ -473,6 +473,18 @@ function Check-Path {
   }
 }
 
+function Check-PathAbsent {
+  param([string]$Label, [string]$Path)
+
+  if (Test-Path -LiteralPath $Path) {
+    Write-Host "[FAIL] $Label -> $Path" -ForegroundColor Red
+    $script:fail++
+  } else {
+    Write-Host "[OK] $Label"
+    $script:pass++
+  }
+}
+
 function Invoke-AdapterSpecificChecks {
   param(
     [psobject]$Adapter,
@@ -547,6 +559,8 @@ function Invoke-AdapterSpecificChecks {
     Check-Path -Label "vibe bundled exploration intent profiles config" -Path (Join-Path $RuntimeNestedSkillRoot 'config\exploration-intent-profiles.json') -Required:$NestedBundledRequired
     Check-Path -Label "vibe bundled exploration domain map config" -Path (Join-Path $RuntimeNestedSkillRoot 'config\exploration-domain-map.json') -Required:$NestedBundledRequired
     Check-Path -Label "vibe bundled llm acceleration policy config" -Path (Join-Path $RuntimeNestedSkillRoot 'config\llm-acceleration-policy.json') -Required:$NestedBundledRequired
+    Check-PathAbsent -Label "vibe nested bundled skill entrypoint hidden" -Path (Join-Path $RuntimeNestedSkillRoot 'SKILL.md')
+    Check-Path -Label "vibe nested bundled skill runtime mirror" -Path (Join-Path $RuntimeNestedSkillRoot 'SKILL.runtime-mirror.md') -Required:$NestedBundledRequired
   } else {
     Write-Host ("[OK] vibe nested bundled config checks skipped (target absent; policy={0})" -f $NestedBundledPresencePolicy)
     $script:pass++

--- a/check.sh
+++ b/check.sh
@@ -281,6 +281,17 @@ check_path() {
   fi
 }
 
+check_absent_path() {
+  local label="$1"; local path="$2"
+  if [[ -e "$path" ]]; then
+    echo "[FAIL] $label -> $path"
+    FAIL=$((FAIL+1))
+  else
+    echo "[OK] $label"
+    PASS=$((PASS+1))
+  fi
+}
+
 check_condition() {
   local label="$1"; local condition="$2"; local detail="${3:-}"
   if [[ "$condition" == "true" ]]; then
@@ -781,6 +792,8 @@ if [[ -d "${runtime_nested_skill_root}" ]]; then
   check_path "vibe bundled exploration intent profiles config" "${runtime_nested_skill_root}/config/exploration-intent-profiles.json"
   check_path "vibe bundled exploration domain map config" "${runtime_nested_skill_root}/config/exploration-domain-map.json"
   check_path "vibe bundled llm acceleration policy config" "${runtime_nested_skill_root}/config/llm-acceleration-policy.json"
+  check_absent_path "vibe nested bundled skill entrypoint hidden" "${runtime_nested_skill_root}/SKILL.md"
+  check_path "vibe nested bundled skill runtime mirror" "${runtime_nested_skill_root}/SKILL.runtime-mirror.md"
 else
   echo "[OK] vibe nested bundled config checks skipped (target absent; policy=optional)"
   PASS=$((PASS+1))

--- a/docs/plans/2026-03-26-codex-vibe-dedupe-plan.md
+++ b/docs/plans/2026-03-26-codex-vibe-dedupe-plan.md
@@ -1,11 +1,13 @@
 # Plan: Codex `vibe` Duplicate Surface Fix
 
 - Internal grade: `M`
-- Scope: `install.sh`, `install.ps1`, `check.sh`, `check.ps1`, runtime-neutral install/check tests
+- Scope: `install.sh`, `install.ps1`, `check.sh`, `check.ps1`, adapter installers, runtime-neutral install/check tests
 
 ## Steps
 
 1. Detect the bounded duplicate candidate only for Codex default roots shaped like `.../.codex`.
 2. During install, quarantine legacy `.agents/skills/vibe` into `.agents/skills-disabled/`.
-3. During check, fail explicitly if the duplicate surface still exists.
-4. Verify with targeted runtime script tests and direct shell/PowerShell checks where available.
+3. During install, hide nested runtime-mirror `SKILL.md` entrypoints after materialization so hosts do not discover duplicate skills.
+4. Preserve bootstrap continuity by restoring `SKILL.md` when a sanitized runtime mirror is copied into a real top-level skill lane.
+5. During check, fail explicitly if the duplicate surface still exists or if nested runtime mirrors remain discoverable.
+6. Verify with targeted runtime script tests and direct shell/PowerShell checks where available.

--- a/docs/requirements/2026-03-26-codex-vibe-dedupe.md
+++ b/docs/requirements/2026-03-26-codex-vibe-dedupe.md
@@ -5,11 +5,15 @@
 
 ## Goal
 
-Prevent Codex from exposing two `vibe` skills when both `~/.codex/skills/vibe` and a legacy sibling copy under `~/.agents/skills/vibe` exist.
+Prevent Codex from exposing two `vibe` skills when either of these duplicate surfaces exist:
+
+- a legacy sibling copy under `~/.agents/skills/vibe`
+- a discoverable nested runtime mirror under `skills/vibe/bundled/skills/vibe/SKILL.md`
 
 ## Acceptance
 
 - Codex default-root install quarantines the legacy `.agents/skills/vibe` duplicate instead of leaving both surfaces discoverable.
+- Installed runtime payloads hide nested runtime-mirror `SKILL.md` entrypoints while preserving runtime configs and bootstrap behavior.
 - `check.sh` and `check.ps1` fail clearly when the duplicate surface still exists.
 - Non-default custom target roots are not mutated as part of this mitigation.
-- Automated tests cover shell install quarantine and shell health-check failure on duplicate reintroduction.
+- Automated tests cover shell/PowerShell install behavior, runtime bootstrap continuity, and duplicate-surface regression checks.

--- a/install.ps1
+++ b/install.ps1
@@ -239,7 +239,9 @@ function Ensure-SkillPresent {
       if ([string]::IsNullOrWhiteSpace($src)) { continue }
       if (Test-Path -LiteralPath $src) {
         Write-Warning "Using external fallback source for skill '$Name': $src"
-        Copy-DirContent -Source $src -Destination (Join-Path $TargetRoot ("skills\" + $Name))
+        $destination = Join-Path $TargetRoot ("skills\" + $Name)
+        Copy-DirContent -Source $src -Destination $destination
+        Restore-SkillEntryPointIfNeeded -SkillRoot $destination
         $ExternalFallbackUsed.Add($Name) | Out-Null
         break
       }
@@ -286,6 +288,44 @@ function Sync-VibeCanonicalToTarget {
     Copy-DirContent -Source $srcDir -Destination $dstDir
   }
 }
+
+function Hide-InstalledRuntimeMirrorSkillEntryPoints {
+  param([string]$TargetRoot)
+
+  $nestedSkillsRoot = Join-Path $TargetRoot 'skills\vibe\bundled\skills'
+  if (-not (Test-Path -LiteralPath $nestedSkillsRoot -PathType Container)) {
+    return
+  }
+
+  $renamed = 0
+  foreach ($skillDir in @(Get-ChildItem -LiteralPath $nestedSkillsRoot -Directory -ErrorAction SilentlyContinue)) {
+    $skillMd = Join-Path $skillDir.FullName 'SKILL.md'
+    if (-not (Test-Path -LiteralPath $skillMd -PathType Leaf)) {
+      continue
+    }
+
+    $mirrorPath = Join-Path $skillDir.FullName 'SKILL.runtime-mirror.md'
+    Move-Item -LiteralPath $skillMd -Destination $mirrorPath -Force
+    Write-Host ("[INFO] Hid nested runtime mirror skill entrypoint: {0} -> {1}" -f $skillMd, $mirrorPath)
+    $renamed++
+  }
+
+  if ($renamed -eq 0) {
+    Write-Host "[INFO] Nested runtime mirror skill entrypoints already sanitized."
+  }
+}
+
+function Restore-SkillEntryPointIfNeeded {
+  param([string]$SkillRoot)
+
+  $skillMd = Join-Path $SkillRoot 'SKILL.md'
+  $mirrorPath = Join-Path $SkillRoot 'SKILL.runtime-mirror.md'
+  if ((Test-Path -LiteralPath $skillMd -PathType Leaf) -or -not (Test-Path -LiteralPath $mirrorPath -PathType Leaf)) {
+    return
+  }
+
+  Move-Item -LiteralPath $mirrorPath -Destination $skillMd -Force
+}
 Write-Host "=== VCO Adapter Installer ===" -ForegroundColor Cyan
 Write-Host "Host   : $HostId"
 Write-Host "Mode   : $($Adapter.install_mode)"
@@ -322,6 +362,8 @@ if ($null -ne $adapterInstallReceipt -and $adapterInstallReceipt.PSObject.Proper
     }
   }
 }
+
+Hide-InstalledRuntimeMirrorSkillEntryPoints -TargetRoot $TargetRoot
 
 if ($InstallExternal) {
   if ($Adapter.install_mode -ne 'governed') {

--- a/install.sh
+++ b/install.sh
@@ -526,6 +526,34 @@ sync_vibe_canonical_to_target() {
   done
 }
 
+sanitize_installed_runtime_skill_entrypoints() {
+  local nested_skills_root="${TARGET_ROOT}/skills/vibe/bundled/skills"
+  [[ -d "${nested_skills_root}" ]] || return 0
+
+  local skill_md=""
+  local renamed=0
+  while IFS= read -r -d '' skill_md; do
+    local mirror_path="${skill_md%/SKILL.md}/SKILL.runtime-mirror.md"
+    mv "${skill_md}" "${mirror_path}"
+    echo "[INFO] Hid nested runtime mirror skill entrypoint: ${skill_md} -> ${mirror_path}"
+    renamed=$((renamed+1))
+  done < <(find "${nested_skills_root}" -mindepth 2 -maxdepth 2 -type f -name 'SKILL.md' -print0)
+
+  if [[ ${renamed} -eq 0 ]]; then
+    echo "[INFO] Nested runtime mirror skill entrypoints already sanitized."
+  fi
+}
+
+restore_skill_entrypoint_if_needed() {
+  local skill_root="$1"
+  local mirror_path="${skill_root}/SKILL.runtime-mirror.md"
+  local skill_md="${skill_root}/SKILL.md"
+  if [[ -f "${skill_md}" || ! -f "${mirror_path}" ]]; then
+    return 0
+  fi
+  mv "${mirror_path}" "${skill_md}"
+}
+
 ensure_skill_present() {
   local name="$1"
   local required="$2"
@@ -543,6 +571,7 @@ ensure_skill_present() {
       if [[ -d "${src}" ]]; then
         echo "[WARN] Using external fallback source for skill '${name}': ${src}"
         copy_dir_content "${src}" "${TARGET_ROOT}/skills/${name}"
+        restore_skill_entrypoint_if_needed "${TARGET_ROOT}/skills/${name}"
         EXTERNAL_FALLBACK_USED+=("${name}")
         break
       fi
@@ -587,6 +616,8 @@ ADAPTER_INSTALL_JSON="$("${PYTHON_BIN_FOR_ADAPTER}" "${ADAPTER_INSTALLER}" \
 if [[ -n "${ADAPTER_INSTALL_JSON}" ]]; then
   mapfile -t EXTERNAL_FALLBACK_USED < <(printf '%s\n' "${ADAPTER_INSTALL_JSON}" | "${PYTHON_BIN_FOR_ADAPTER}" -c 'import json,sys; data=json.load(sys.stdin); [print(x) for x in data.get("external_fallback_used", [])]')
 fi
+
+sanitize_installed_runtime_skill_entrypoints
 
 if [[ "${INSTALL_EXTERNAL}" == "true" ]]; then
   if [[ "${ADAPTER_INSTALL_MODE}" != "governed" ]]; then

--- a/scripts/install/Install-VgoAdapter.ps1
+++ b/scripts/install/Install-VgoAdapter.ps1
@@ -28,6 +28,18 @@ function Copy-DirContent {
     Copy-Item -Path (Join-Path $Source '*') -Destination $Destination -Recurse -Force
 }
 
+function Restore-SkillEntryPointIfNeeded {
+    param([string]$SkillRoot)
+
+    $skillMd = Join-Path $SkillRoot 'SKILL.md'
+    $mirrorPath = Join-Path $SkillRoot 'SKILL.runtime-mirror.md'
+    if ((Test-Path -LiteralPath $skillMd -PathType Leaf) -or -not (Test-Path -LiteralPath $mirrorPath -PathType Leaf)) {
+        return
+    }
+
+    Move-Item -LiteralPath $mirrorPath -Destination $skillMd -Force
+}
+
 function Ensure-SkillPresent {
     param(
         [string]$Name,
@@ -43,7 +55,9 @@ function Ensure-SkillPresent {
         foreach ($src in $FallbackSources) {
             if ([string]::IsNullOrWhiteSpace($src)) { continue }
             if (Test-Path -LiteralPath $src) {
-                Copy-DirContent -Source $src -Destination (Join-Path $TargetRoot ("skills\" + $Name))
+                $destination = Join-Path $TargetRoot ("skills\" + $Name)
+                Copy-DirContent -Source $src -Destination $destination
+                Restore-SkillEntryPointIfNeeded -SkillRoot $destination
                 $ExternalFallbackUsed.Add($Name) | Out-Null
                 break
             }
@@ -105,6 +119,11 @@ function Install-RuntimeCorePayload {
         $src = Join-Path $RepoRoot ([string]$entry.source)
         $dst = Join-Path $TargetRoot ([string]$entry.target)
         Copy-DirContent -Source $src -Destination $dst
+        if ([string]$entry.target -eq 'skills' -and (Test-Path -LiteralPath $dst -PathType Container)) {
+            foreach ($skillDir in @(Get-ChildItem -LiteralPath $dst -Directory -ErrorAction SilentlyContinue)) {
+                Restore-SkillEntryPointIfNeeded -SkillRoot $skillDir.FullName
+            }
+        }
     }
 
     foreach ($entry in @($packaging.copy_files)) {

--- a/scripts/install/install_vgo_adapter.py
+++ b/scripts/install/install_vgo_adapter.py
@@ -98,6 +98,14 @@ def copy_file(src: Path, dst: Path):
     shutil.copy2(src, dst)
 
 
+def restore_skill_entrypoint_if_needed(skill_root: Path):
+    skill_md = skill_root / "SKILL.md"
+    mirror_md = skill_root / "SKILL.runtime-mirror.md"
+    if skill_md.exists() or not mirror_md.exists():
+        return
+    mirror_md.rename(skill_md)
+
+
 def parent_dir(path: Path | None) -> Path | None:
     if path is None:
         return None
@@ -245,7 +253,9 @@ def ensure_skill_present(target_root: Path, name: str, required: bool, allow_fal
         for src in fallback_sources:
             src_path = Path(src)
             if src_path.exists():
-                copy_tree(src_path, target_root / "skills" / name)
+                destination = target_root / "skills" / name
+                copy_tree(src_path, destination)
+                restore_skill_entrypoint_if_needed(destination)
                 external_used.add(name)
                 break
     if required and not skill_md.exists():
@@ -258,6 +268,10 @@ def install_runtime_core(repo_root: Path, target_root: Path, profile: str, allow
         (target_root / rel).mkdir(parents=True, exist_ok=True)
     for entry in packaging["copy_directories"]:
         copy_tree(repo_root / entry["source"], target_root / entry["target"])
+        if entry["target"] == "skills":
+            for skill_dir in (target_root / "skills").iterdir():
+                if skill_dir.is_dir():
+                    restore_skill_entrypoint_if_needed(skill_dir)
     for entry in packaging["copy_files"]:
         src = repo_root / entry["source"]
         if not src.exists():

--- a/tests/runtime_neutral/test_installed_runtime_scripts.py
+++ b/tests/runtime_neutral/test_installed_runtime_scripts.py
@@ -34,6 +34,13 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         ]
         subprocess.run(cmd, capture_output=True, text=True, check=True)
 
+    def assert_nested_runtime_skill_entrypoints_sanitized(self, target_root: Path) -> None:
+        nested_skills_root = target_root / "skills" / "vibe" / "bundled" / "skills"
+        self.assertTrue(nested_skills_root.exists())
+        self.assertEqual([], sorted(nested_skills_root.glob("*/SKILL.md")))
+        for name in ("vibe", "ralph-loop", "cancel-ralph", "xan"):
+            self.assertTrue((nested_skills_root / name / "SKILL.runtime-mirror.md").exists())
+
     def test_shell_install_quarantines_legacy_agents_duplicate_for_default_codex_root(self) -> None:
         home_root = self.root / "home"
         target_root = home_root / ".codex"
@@ -143,6 +150,7 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
 
     def test_installed_shell_scripts_work_without_repo_level_adapter_registry(self) -> None:
         self.install_shell_runtime()
+        self.assert_nested_runtime_skill_entrypoints_sanitized(self.target_root)
 
         installed_root = self.target_root / "skills" / "vibe"
         check_cmd = [
@@ -203,6 +211,7 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
             str(self.target_root),
         ]
         subprocess.run(install_cmd, capture_output=True, text=True, check=True)
+        self.assert_nested_runtime_skill_entrypoints_sanitized(self.target_root)
 
         installed_root = self.target_root / "skills" / "vibe"
         check_cmd = [


### PR DESCRIPTION
## Summary
- quarantine legacy Codex `.agents/skills/vibe` duplicates and also hide discoverable nested runtime-mirror skill entrypoints after install
- preserve bootstrap/install continuity by restoring `SKILL.md` when a sanitized runtime mirror is copied into a real top-level skill lane
- extend shell and PowerShell health checks plus runtime-neutral tests so duplicate entrypoints regressions fail clearly

## Why
Codex duplicate `vibe` reports came from two separate surfaces:
- legacy sibling copies such as `~/.agents/skills/vibe`
- installed nested runtime mirrors such as `skills/vibe/bundled/skills/vibe/SKILL.md`

The previous fix only covered the first surface. This PR closes both.

## Validation
- `python3 -m pytest -q tests/runtime_neutral/test_installed_runtime_scripts.py` -> `8 passed`
- shell smoke install/check for `codex`
- shell smoke install + `one-shot-setup.sh` for `openclaw`

## Notes
- nested runtime mirror configs/scripts remain materialized; only discoverable `SKILL.md` entrypoints are hidden as `SKILL.runtime-mirror.md`
- top-level skills still keep normal `SKILL.md` entrypoints, so supported VibeSkills install and bootstrap flows remain functional