### PR TITLE
[codex] add root-child vibe specialist governance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -70,6 +70,42 @@ Legacy compatibility alias only.
 If older callers still pass `benchmark_autonomous`, the runtime silently normalizes it to `interactive_governed`.
 It is not a separate execution plane and it must not create a second unattended control path.
 
+## Governor And Specialist Contract
+
+`vibe` owns runtime authority even when the canonical router surfaces a specialist skill.
+
+That means:
+
+- router-selected specialist skills may appear as bounded recommendations or route truth
+- runtime-selected skill remains `vibe` for governed entry
+- specialist help is allowed only as bounded native-mode assistance
+- specialist help must preserve the specialist skill's own workflow, inputs, outputs, and validation style
+- specialist help must not create a second requirement doc, second plan surface, or second runtime authority
+
+## Root/Child Governance Lanes
+
+For XL delegation, `vibe` runs with hierarchy semantics:
+
+- `root_governed`: the only lane that may freeze canonical requirement and plan surfaces and issue final completion claims
+- `child_governed`: subordinate execution lane that inherits frozen context and emits local receipts only
+
+Child-governed lanes must:
+
+- keep `$vibe` at prompt tail to preserve governed discipline
+- inherit frozen requirement and plan context from the root lane
+- stay within assigned ownership boundaries and write scopes
+
+Child-governed lanes must not:
+
+- create a second canonical requirement surface under `docs/requirements/`
+- create a second canonical plan surface under `docs/plans/`
+- publish final completion claims for the full root task
+
+Specialist dispatch under hierarchy:
+
+- `approved_dispatch`: root-approved specialist usage in the frozen plan
+- `local_suggestion`: child-detected specialist suggestion that stays advisory until root escalation approval
+
 ## Internal Execution Grades
 
 `M`, `L`, and `XL` remain active, but only as internal orchestration grades.
@@ -139,6 +175,8 @@ Execute the approved plan.
 
 If the work is parallelizable, prefer Codex-native XL orchestration.
 If subagents are spawned, their prompts must end with `$vibe`.
+If specialist skills are used, record them as bounded native dispatch under `vibe` governance rather than as a runtime handoff.
+If subagents run in child-governed lanes, they must inherit root-frozen context and must not reopen canonical requirement or plan truth surfaces.
 
 ### 6. `phase_cleanup`
 
@@ -232,6 +270,7 @@ The governed runtime should leave behind:
 - `docs/plans/YYYY-MM-DD-<topic>-execution-plan.md`
 - `outputs/runtime/vibe-sessions/<run-id>/phase-*.json`
 - `outputs/runtime/vibe-sessions/<run-id>/cleanup-receipt.json`
+- specialist recommendation and dispatch accounting when bounded specialist help is planned
 
 ## Known Boundaries
 

--- a/config/runtime-input-packet-policy.json
+++ b/config/runtime-input-packet-policy.json
@@ -9,16 +9,60 @@
   "shadow_only": true,
   "required_fields": [
     "run_id",
+    "governance_scope",
+    "hierarchy",
     "task",
     "runtime_mode",
     "internal_grade",
     "canonical_router",
     "route_snapshot",
+    "specialist_recommendations",
+    "specialist_dispatch",
     "overlay_decisions",
     "authority_flags",
     "divergence_shadow",
     "provenance"
   ],
+  "hierarchy_contract": {
+    "default_governance_scope": "root",
+    "child_receipt_only_stages": [
+      "requirement_doc",
+      "xl_plan"
+    ],
+    "root_authority_flags": {
+      "allow_requirement_freeze": true,
+      "allow_plan_freeze": true,
+      "allow_global_dispatch": true,
+      "allow_completion_claim": true
+    },
+    "child_authority_flags": {
+      "allow_requirement_freeze": false,
+      "allow_plan_freeze": false,
+      "allow_global_dispatch": false,
+      "allow_completion_claim": false
+    }
+  },
+  "specialist_dispatch_contract": {
+    "bounded_role": "specialist_assist",
+    "native_usage_required": true,
+    "must_preserve_workflow": true,
+    "required_inputs": [
+      "bounded specialist subtask contract",
+      "frozen requirement context",
+      "relevant source files or domain artifacts"
+    ],
+    "expected_outputs": [
+      "bounded specialist findings or code changes",
+      "verification notes aligned with the specialist skill"
+    ],
+    "verification_expectation": "Preserve the specialist skill's native workflow, boundaries, and validation style."
+  },
+  "child_specialist_suggestion_contract": {
+    "field_name": "local_specialist_suggestions",
+    "escalation_required": true,
+    "approval_owner": "root_vibe",
+    "status": "advisory_until_root_approval"
+  },
   "overlay_fields": [
     "openspec_advice",
     "gsd_overlay_advice",
@@ -42,5 +86,6 @@
     "llm_acceleration_advice",
     "heartbeat_advice"
   ],
+  "specialist_recommendation_limit": 4,
   "bounded_router_task_type_default": "planning"
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@
 
 - [`install/one-click-install-release-copy.md`](./install/one-click-install-release-copy.md)：面向普通用户的一键安装发布文案与 AI 助手复制提示词
 - [`install/one-click-install-release-copy.en.md`](./install/one-click-install-release-copy.en.md)：ordinary-user public release copy and copy-paste onboarding prompt
+- Governed runtime canonical surfaces live in [`../SKILL.md`](../SKILL.md), [`../protocols/runtime.md`](../protocols/runtime.md), and [`../protocols/team.md`](../protocols/team.md). Do not create a second runtime-governance truth document.
+- [`root-child-vibe-hierarchy-governance.md`](./root-child-vibe-hierarchy-governance.md)：稳定说明 root/child `vibe` 分层治理、批准式 specialist dispatch 与 child escalation 规则，避免递归顶层治理。
 
 - [`status/README.md`](./status/README.md)：当前运行态、proof 入口与阶段回执总索引。
 - [`status/current-state.md`](./status/current-state.md)：当前 closure batch 的 runtime summary。

--- a/docs/plans/2026-03-28-root-child-vibe-hierarchy-governance-plan.md
+++ b/docs/plans/2026-03-28-root-child-vibe-hierarchy-governance-plan.md
@@ -1,0 +1,184 @@
+# Root/Child Vibe Hierarchy Governance Plan
+
+## Execution Summary
+Land a hierarchy model for XL governed execution so one user task has one root `vibe` runtime, child agents inherit `vibe` as subordinate execution lanes, and specialist skills remain bounded assistants rather than recursive governance owners. The design must preserve current explicit `vibe` authority, prevent duplicate canonical surfaces, and produce proof that the new hierarchy is stable, usable, and intelligent under realistic task delegation flows.
+
+## Frozen Inputs
+- Requirement doc: /home/lqf/table/table5/workspace/issue-57-ai-governance/docs/requirements/2026-03-28-root-child-vibe-hierarchy-governance.md
+- Problem statement: recursive child-agent `vibe` use currently risks layered governance, repeated specialist dispatch, and ambiguous completion authority
+- Existing authority invariants:
+  - canonical router keeps route authority
+  - explicit `vibe` remains runtime owner
+  - no second requirement truth
+  - no second execution-plan truth
+
+## Internal Grade Decision
+- Grade: XL
+- The change spans runtime packet policy, execution topology, manifests, protocol docs, and proof gates.
+- Parallel implementation is justified, but final authority semantics must be integrated and verified as one coherent contract.
+
+## Design Overview
+
+### Target Model
+- `root_governed`: the only runtime allowed to freeze canonical requirement and plan surfaces and make final completion claims
+- `child_governed`: a subordinate `vibe` lane that inherits frozen context, keeps verification/cleanup discipline, and emits local receipts only
+- `specialist_native`: a bounded helper execution style that can be root-approved for direct use or child-suggested for escalation
+
+### Runtime Packet Additions
+- `governance_scope`: `root` or `child`
+- `root_run_id`
+- `parent_run_id`
+- `parent_unit_id`
+- `inherited_requirement_doc_path`
+- `inherited_execution_plan_path`
+- `allow_requirement_freeze`
+- `allow_plan_freeze`
+- `allow_global_dispatch`
+- `allow_completion_claim`
+- `approved_specialist_dispatch`
+- `local_specialist_suggestions`
+- `escalation_required`
+
+### Authority Split
+- Root owns:
+  - requirement freeze
+  - plan freeze
+  - global specialist approval
+  - overall completion claim
+  - root execution manifest
+- Child owns:
+  - bounded execution inside assigned scope
+  - local receipts and proof
+  - escalation requests when approved specialist coverage is insufficient
+- Specialists own:
+  - native workflow execution only
+  - skill-specific validation notes and outputs
+  - no runtime ownership and no top-level completion claims
+
+## Wave Plan
+
+### Wave 1: Contract Freeze
+- Update requirement, plan, and stable governance docs to define the hierarchy model.
+- Freeze naming for root versus child governance scope and approved dispatch versus local suggestion surfaces.
+- Confirm which existing runtime packet fields can be extended without breaking current proofs.
+
+### Wave 2: Runtime Packet and Policy
+- Extend `config/runtime-input-packet-policy.json` with hierarchy fields and scope-specific authority flags.
+- Update `scripts/runtime/Freeze-RuntimeInputPacket.ps1` to emit root or child packets.
+- Ensure explicit `vibe` authority remains the runtime-selected skill for both scopes.
+
+### Wave 3: Execution Topology and Artifact Boundaries
+- Update `scripts/runtime/Invoke-PlanExecute.ps1` to spawn child lanes as subordinate runs instead of fresh top-level governed runs.
+- Ensure child lanes inherit frozen requirement/plan paths and cannot write canonical docs.
+- Add child receipt and escalation artifact surfaces under root-owned runtime outputs.
+
+### Wave 4: Specialist Dispatch Semantics
+- Split specialist data into:
+  - root-approved dispatch
+  - child-local suggestion
+- Prevent child lanes from activating new global specialists without escalation approval.
+- Preserve native specialist workflow, inputs, outputs, and verification expectations.
+
+### Wave 5: Protocol and Operator Documentation
+- Update `SKILL.md`, `protocols/runtime.md`, and `protocols/team.md` with root/child hierarchy semantics.
+- Add a stable governance explainer for operator use and future implementation alignment.
+- Clarify the user-facing mental model: child `$vibe` keeps discipline, not recursive top-level governance.
+
+### Wave 6: Verification, Simulation, and Proof
+- Add runtime-neutral tests for root/child packet semantics and child escalation behavior.
+- Add governed gates for:
+  - no duplicate canonical requirement surface
+  - no duplicate canonical execution-plan surface
+  - child cannot issue final completion claim
+  - specialist suggestions remain advisory until root approval
+- Run realistic delegation simulations:
+  - root `vibe` planning task with child ML lane
+  - root `vibe` debug task with child systematic-debugging lane
+  - child requesting an extra specialist not pre-approved by root
+
+### Wave 7: Rollout and Cleanup
+- Re-run targeted gates after integration.
+- Remove temporary artifacts and stale test scratch space.
+- Audit for zombie node residue.
+- Leave only intended source/docs/test changes and generated proof artifacts.
+
+## Ownership Boundaries
+- Runtime packet contract: `config/runtime-input-packet-policy.json`, `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+- Execution topology and child-lane handoff: `scripts/runtime/Invoke-PlanExecute.ps1`
+- Requirement/plan write restrictions: `scripts/runtime/Write-RequirementDoc.ps1`, `scripts/runtime/Write-XlPlan.ps1`
+- Runtime authority docs: `SKILL.md`, `protocols/runtime.md`, `protocols/team.md`
+- Stable explanatory doc: `docs/root-child-vibe-hierarchy-governance.md`
+- Verification: `tests/runtime_neutral/*`, `scripts/verify/*`
+
+## Implementation Steps
+1. Freeze the new requirement and plan.
+2. Add the stable governance explainer doc and wire it into docs navigation.
+3. Extend runtime packet policy and packet emission for root/child scope.
+4. Restrict canonical requirement/plan writes to root scope only.
+5. Add approved specialist dispatch versus local suggestion semantics.
+6. Update plan-execute so child lanes inherit context and emit subordinate receipts.
+7. Update protocol docs and public-facing authority wording.
+8. Add tests and governed gates for hierarchy invariants.
+9. Run simulation scenarios and targeted verification commands.
+10. Clean temp artifacts, audit node processes, and emit closure receipts.
+
+## Verification Commands
+- `git diff --check`
+- `python3 -m pytest tests/runtime_neutral/test_router_bridge.py tests/runtime_neutral/test_governed_runtime_bridge.py`
+- `python3 -m pytest tests/runtime_neutral -k "hierarchy or child or specialist or completion"`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-governed-runtime-contract-gate.ps1`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-benchmark-autonomous-proof-gate.ps1`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-no-silent-fallback-contract-gate.ps1`
+- new targeted gates:
+  - `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-root-child-hierarchy-gate.ps1`
+  - `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-no-duplicate-canonical-surface-gate.ps1`
+  - `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-child-specialist-escalation-gate.ps1`
+- targeted repo checks:
+  - `rg -n "governance_scope|allow_requirement_freeze|allow_plan_freeze|allow_global_dispatch|allow_completion_claim|approved_specialist_dispatch|local_specialist_suggestions" config scripts/runtime protocols tests`
+
+## Stability Proof Strategy
+- Determinism:
+  - same root input yields the same root authority fields and child-lane restrictions
+- Non-duplication:
+  - one root run cannot create more than one canonical requirement or plan
+- Boundedness:
+  - child lanes cannot widen into top-level governance
+- Recovery:
+  - escalation paths remain explicit and do not silently self-approve
+- Regression safety:
+  - existing explicit `vibe` specialist-accounting proofs continue to pass after hierarchy support lands
+
+## Usability Proof Strategy
+- Operators can explain the model in one sentence:
+  - root `vibe` governs, child `vibe` executes, specialists assist
+- Execution artifacts make authority obvious without reading chat history.
+- Child-lane receipts show inherited context and limits clearly enough for debugging and audit.
+- Failure paths produce actionable escalation surfaces instead of ambiguous re-planning.
+
+## Intelligence Proof Strategy
+- Root routing can still identify the best high-level specialist pattern without surrendering runtime authority.
+- Child lanes can still use domain-specific specialist help inside approved boundaries.
+- Ambiguous child requests produce escalation instead of unsafe self-expansion.
+- Low-signal prompts still honor fallback hazard and non-authoritative truth semantics.
+
+## Risks and Mitigations
+- Risk: child lanes accidentally reopen requirement or plan surfaces
+  - Mitigation: hard authority flags plus gates that fail on duplicate canonical surfaces
+- Risk: specialist approval and child suggestion semantics drift apart
+  - Mitigation: explicit separate fields and dedicated escalation artifacts
+- Risk: hierarchy metadata becomes verbose but unenforced
+  - Mitigation: add execution-path gates that inspect real artifacts, not docs only
+- Risk: parent/child packet inheritance breaks current explicit `vibe` proofs
+  - Mitigation: keep additive contract design and run existing governed gates before claiming completion
+
+## Rollback Rules
+- If root authority becomes ambiguous, stop and restore the last state where explicit `vibe` remained the sole runtime owner.
+- If child lanes can write canonical requirement or plan surfaces, block completion until that regression is repaired.
+- If specialist escalation cannot be kept explicit, fall back to root-approved specialist dispatch only.
+- Do not revert unrelated user changes or existing untracked docs.
+
+## Phase Cleanup Contract
+- Remove scratch artifacts created for hierarchy simulation or gate fixtures.
+- Audit and clear stale managed node processes if any appear.
+- Keep only intended source/docs/test changes and proof artifacts.
+- Emit cleanup receipts for the verification wave before claiming closure.

--- a/docs/plans/2026-03-28-vibe-governor-native-specialist-skills-execution-plan.md
+++ b/docs/plans/2026-03-28-vibe-governor-native-specialist-skills-execution-plan.md
@@ -1,0 +1,53 @@
+# Vibe Governor + Native Specialist Skills
+
+## Execution Summary
+Implement the smallest coherent extension that lets explicit `vibe` runs freeze, plan, and execute native specialist assistance without surrendering runtime authority. Reuse existing router outputs, keep `runtime_selected_skill=vibe`, and add bounded specialist dispatch surfaces to requirement, plan, execution, verification, and documentation.
+
+## Frozen Inputs
+- Requirement doc: /home/lqf/table/table5/workspace/issue-57-ai-governance/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
+- Source task: `vibe` governor + native specialist skills
+- Runtime authority invariant: explicit `vibe` remains the only runtime owner
+
+## Internal Grade Decision
+- Grade: XL
+- User-facing runtime remains fixed; the grade is internal only.
+- Parallel work is warranted because code, tests, and governance docs can advance on disjoint write scopes.
+
+## Wave Plan
+- Wave 1: freeze contracts, inspect runtime surfaces, and define specialist recommendation schema
+- Wave 2: implement runtime packet, requirement, and plan surfacing
+- Wave 3: implement bounded specialist execution accounting and manifest recovery
+- Wave 4: update protocol/docs surfaces and operator guidance
+- Wave 5: add tests, run verification, and close with cleanup receipts
+
+## Ownership Boundaries
+- Runtime packet and artifact contract: `config/runtime-input-packet-policy.json`, `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+- Requirement/plan surfacing: `scripts/runtime/Write-RequirementDoc.ps1`, `scripts/runtime/Write-XlPlan.ps1`
+- Execution accounting: `scripts/runtime/Invoke-PlanExecute.ps1`
+- Protocol/docs authority model: `SKILL.md`, `protocols/runtime.md`, `protocols/team.md`, supporting docs
+- Verification: runtime tests and targeted gates
+- Subagent prompts must end with `$vibe`.
+
+## Specialist Skill Dispatch Plan
+- Dispatch only bounded specialist units; keep `vibe` as the sole runtime owner.
+- Preserve native specialist usage by carrying native workflow expectations, required inputs, expected outputs, and verification mode into the dispatch contract.
+- Do not auto-promote specialist recommendations into runtime ownership changes.
+- Record all specialist units in execution evidence and recover their outputs into the `vibe` manifest.
+
+## Verification Commands
+- `git diff --check`
+- `python3 -m py_compile scripts/runtime/*.ps1` is not applicable; instead validate PowerShell syntax via targeted gates and JSON schema checks
+- `python3 -m pytest tests/runtime_neutral -k "runtime_input_packet or plan_execute or specialist or requirement or plan"`
+- targeted `rg` checks for authority invariants such as `explicit_runtime_skill`, `shadow_only`, `specialist_recommendations`
+- repo cleanliness checks and node audit after each wave
+
+## Rollback Plan
+- Revert only the governor-specialist change set if authority invariants or regression tests fail.
+- Do not revert unrelated user changes or existing untracked docs.
+- If specialist execution accounting proves too invasive, fall back to metadata-only surfacing while keeping the new contracts explicit and non-authoritative.
+
+## Phase Cleanup Contract
+- Remove temporary logs or scratch files created during each wave.
+- Run node audit and clean stale managed node residue when present.
+- Leave the repository with only intended source, docs, tests, and proof artifacts.
+- Emit a cleanup receipt after verification closure.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -24,6 +24,7 @@ Those surfaces live under [`../status/README.md`](../status/README.md).
 
 ### Current Entry
 
+- [`2026-03-28-root-child-vibe-hierarchy-governance-plan.md`](./2026-03-28-root-child-vibe-hierarchy-governance-plan.md): root/child `vibe` 分层治理执行计划；聚焦把 child `$vibe` 收敛为 subordinate lane，并用批准式 specialist dispatch + escalation proof 防止递归总治理。
 - [`2026-03-27-ai-governance-consolidation-plan.md`](./2026-03-27-ai-governance-consolidation-plan.md): 内置 AI 治理层收敛整理执行计划；聚焦把 active runtime、doctor、helper scripts、one-shot 入口与 bundled 镜像统一到单一路径契约。
 - [`2026-03-27-ai-governance-historical-wording-cleanup-plan.md`](./2026-03-27-ai-governance-historical-wording-cleanup-plan.md): 内置 AI 治理层历史表述清理执行计划；聚焦清理 `vibe` 范围内已退役模型键名的历史残留表述。
 - [`2026-03-27-ai-governance-openai-compatible-only-plan.md`](./2026-03-27-ai-governance-openai-compatible-only-plan.md): 内置 AI 治理层 OpenAI-compatible-only 执行计划；聚焦收口权威 provider registry、vector diff 默认面、bootstrap/setup 和安装文档中的 Ark 分支。

--- a/docs/requirements/2026-03-28-root-child-vibe-hierarchy-governance.md
+++ b/docs/requirements/2026-03-28-root-child-vibe-hierarchy-governance.md
@@ -1,0 +1,104 @@
+# Root/Child Vibe Hierarchy Governance
+
+## Summary
+Resolve the governance ambiguity introduced by recursive `vibe` usage in XL multi-agent work. Keep `vibe` as the only governed runtime authority at the root task level while allowing child agents to inherit `vibe` discipline as subordinate execution lanes instead of reopening a second top-level governed runtime.
+
+## Goal
+Design and land a hierarchy model where:
+
+- one user task has exactly one root governed `vibe` runtime
+- child agents still run under `vibe` discipline
+- child agents do not create a second requirement or plan truth
+- specialist skills remain usable as bounded native helpers without taking runtime ownership
+
+## Deliverable
+A repository change set and documentation bundle that adds:
+
+- an explicit root/child governance-scope contract inside the runtime input packet
+- subordinate child-lane rules for XL execution
+- approved specialist dispatch versus child-local suggestion separation
+- execution/accounting/proof surfaces for root-owned completion and child-owned local receipts
+- protocol, requirement, plan, and stable governance docs for the hierarchy model
+- regression tests and verification gates proving authority preservation, non-duplication of canonical surfaces, bounded specialist usage, and predictable escalation behavior
+
+## Constraints
+- Do not remove `$vibe` from child-agent prompts.
+- Do not let child agents create a second visible governed startup surface.
+- Do not let child agents freeze a second canonical requirement document or execution plan.
+- Do not let child agents make global specialist-dispatch decisions on behalf of the root run.
+- Do not let specialist skills become runtime owners or make final completion claims.
+- Preserve existing explicit `vibe` authority invariants and current canonical router ownership.
+- Prefer additive metadata and execution-policy changes over broad router rewrites.
+
+## Acceptance Criteria
+- Runtime input packet distinguishes `root` versus `child` governance scope with machine-readable authority flags.
+- Root runs are the only runs allowed to freeze canonical requirement and plan surfaces under `docs/requirements/` and `docs/plans/`.
+- Child runs inherit the frozen requirement/plan context and write only subordinate receipts or artifacts.
+- Specialist dispatch is split into:
+  - root-approved specialist dispatch
+  - child-local specialist suggestions that require escalation before becoming globally active
+- Execution manifests preserve:
+  - single root completion authority
+  - child-unit evidence
+  - approved specialist dispatch accounting
+  - escalation requests and their outcomes
+- Protocol docs explain:
+  - root-governed authority
+  - child-governed subordinate execution
+  - specialist boundedness rules
+  - conflict-prevention rules for multi-agent work
+- Tests and gates prove:
+  - no duplicate canonical requirement/plan surfaces are created
+  - child runs cannot widen scope silently
+  - child runs cannot issue final completion claims
+  - child specialist suggestions stay advisory until root approval
+  - explicit `vibe` authority remains stable during hierarchical execution
+
+## Primary Objective
+Turn recursive multi-agent `vibe` usage from a layered-governance ambiguity into a single-root, subordinate-child execution model.
+
+## Proxy Signal
+Root runs freeze the only canonical requirement and plan, child runs inherit those surfaces as subordinate lanes, and specialist skills are executed or suggested without creating second governance truth.
+
+## Scope
+In scope:
+- runtime input packet hierarchy metadata
+- plan-execution handoff contract for child lanes
+- specialist dispatch approval versus suggestion semantics
+- execution manifest and proof surfacing
+- protocol and stable-governance documentation
+- regression tests and verification gates
+
+Out of scope:
+- redesigning the full canonical router ranking system
+- host-level interception of arbitrary non-`vibe` requests
+- per-skill metadata rewrites across the whole repository
+- generalized memory-system redesign
+
+## Completion
+The work is complete when XL `vibe` orchestration can use child agents and specialist skills without creating recursive top-level governance, duplicate canonical surfaces, or ambiguous completion authority.
+
+## Evidence
+- updated runtime/config/protocol/test surfaces
+- new governed requirement/plan docs for the hierarchy change
+- new stable governance design doc
+- passing targeted tests and gates
+- explicit proof artifacts and cleanup receipts from the verification pass
+
+## Non-Goals
+- Do not make child `vibe` lanes governance-free.
+- Do not replace `vibe` with specialist skills during explicit governed entry.
+- Do not allow child lanes to silently re-plan the entire task.
+- Do not hide escalation events or specialist conflict handling from execution evidence.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- Existing explicit `vibe` runtime surfaces are already strong enough to support a root/child extension.
+- Child lanes can inherit frozen context rather than regenerate it.
+- Specialist recommendations already present in the runtime packet can be separated into approved dispatch and local suggestions without a router redesign.
+- Stable hierarchy behavior can be proven with targeted runtime-neutral tests and governed PowerShell gates.
+
+## Evidence Inputs
+- Source task: design the root/child `vibe` hierarchy model that preserves governance while allowing bounded specialist usage

--- a/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
+++ b/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
@@ -1,0 +1,87 @@
+# Vibe Governor + Native Specialist Skills
+
+## Summary
+Keep `vibe` as the sole governed runtime authority while enabling it to call specialist skills as bounded native assistants. Router output must remain a single canonical routing truth, but explicit `vibe` runs should freeze specialist recommendations that can be consumed by planning and execution without handing control to a second runtime.
+
+## Goal
+Implement a minimal-change governed model where:
+
+- `vibe` remains the only runtime owner for requirement freeze, execution planning, execution receipts, verification, and cleanup.
+- specialist skills can be recommended, planned, dispatched, and verified as bounded native helpers.
+- specialist usage preserves each skill's native workflow expectations rather than flattening the skill into a label.
+
+## Deliverable
+A repository change set that adds:
+
+- a frozen runtime packet contract for `specialist_recommendations`
+- requirement and plan surfacing for native specialist dispatch
+- execution-manifest support for specialist units and their recovery into `vibe`
+- protocol and operator documentation for the governor-plus-specialists model
+- regression tests and proof artifacts demonstrating authority preservation, stability, usability, and intelligent specialist selection
+
+## Constraints
+- Do not change `runtime_selected_skill` away from `vibe` during explicit `vibe` runtime entry.
+- Do not create a second router, second requirement surface, second execution-plan surface, or second runtime authority.
+- Reuse existing router outputs and runtime artifacts as much as possible; prefer additive contract extensions over structural rewrites.
+- Preserve current host adapter boundaries; this task is not a host-entry auto-bridge project.
+- Specialist execution must remain bounded and must feed back into `vibe` verification and cleanup surfaces.
+- Specialist skills must retain native usage expectations, input contracts, workflow semantics, and validation style when dispatched.
+
+## Acceptance Criteria
+- Runtime input packet includes machine-readable `specialist_recommendations` for explicit `vibe` runs without changing `authority_flags.explicit_runtime_skill`.
+- Requirement documents surface specialist recommendations and native-usage expectations as frozen inputs.
+- Execution plans include an explicit `Specialist Skill Dispatch Plan` section describing bounded specialist use.
+- Execution manifests record specialist unit counts, outcomes, and recovery status while keeping `vibe` as runtime owner.
+- Protocol docs define the `vibe governor + native specialist skills` model and forbid specialist takeover of runtime truth.
+- Tests prove:
+  - `vibe` authority is preserved
+  - specialist recommendations are frozen and surfaced
+  - plan/execute artifacts include specialist dispatch data
+  - degraded specialist paths remain explicit and non-authoritative when appropriate
+
+> Fill the anti-drift fields once here. Downstream governed plan and completion surfaces should reuse them rather than restate them.
+
+## Primary Objective
+Enable `vibe` to orchestrate specialist skills natively without losing governed runtime authority.
+
+## Proxy Signal
+The system freezes specialist recommendations, plans them explicitly, executes them as bounded units, and records them in execution evidence.
+
+## Scope
+In scope:
+- runtime packet extension
+- requirement/plan surfacing
+- execution manifest specialist accounting
+- protocol and proof documentation
+- regression tests and cleanup receipts
+
+Out of scope:
+- host auto-interception of every incoming message
+- automatic replacement of `vibe` with router-selected specialist skills
+- global redesign of the router scoring system
+- skill-by-skill metadata rewrites across the entire repository
+
+## Completion
+The work is complete when explicit `vibe` runs can preserve runtime authority while still planning and executing native specialist assistance with traceable evidence and passing regression coverage.
+
+## Evidence
+- code changes in runtime/config/protocol/test surfaces
+- new or updated governed requirement/plan docs
+- passing targeted tests
+- cleanup receipts and node audit output
+
+## Non-Goals
+- Do not make router-selected specialist skills authoritative runtime owners.
+- Do not silently downgrade specialist usage into generic text-only hints.
+- Do not let any specialist skill create or own a separate execution plan.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- Existing router ranking already provides enough signal to derive specialist candidates without redesigning pack scoring.
+- The current runtime packet shadow model can be extended rather than replaced.
+- Specialist dispatch can first land as governed execution metadata and bounded units before any future deeper automation.
+
+## Evidence Inputs
+- Source task: implement `vibe` governor + native specialist skills with minimal framework change

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -19,6 +19,7 @@ Primary policy:
 
 ## Current Entry
 
+- [`2026-03-28-root-child-vibe-hierarchy-governance.md`](./2026-03-28-root-child-vibe-hierarchy-governance.md): 冻结“root/child `vibe` 分层治理”需求；聚焦把子代理 `$vibe` 收敛为从属执行态，避免递归顶层治理、重复专家分发与模糊 completion authority。
 - [`2026-03-27-ai-governance-consolidation.md`](./2026-03-27-ai-governance-consolidation.md): 冻结“内置 AI 治理层活跃路径整体收敛整理”的需求；聚焦让 runtime、doctor、install docs 与 helper surface 在 active shipped path 上完全对齐。
 - [`2026-03-27-ai-governance-historical-wording-cleanup.md`](./2026-03-27-ai-governance-historical-wording-cleanup.md): 冻结“内置 AI 治理层历史表述清理”的需求；聚焦在 `vibe` 范围内去掉退役模型键名的历史残留。
 - [`2026-03-27-ai-governance-openai-compatible-only.md`](./2026-03-27-ai-governance-openai-compatible-only.md): 冻结“内置 AI 治理层只保留 OpenAI-compatible 接入”的需求；聚焦移除 Ark 并行内置入口，统一公开安装、bootstrap、probe 与默认策略口径。

--- a/docs/root-child-vibe-hierarchy-governance.md
+++ b/docs/root-child-vibe-hierarchy-governance.md
@@ -1,0 +1,142 @@
+# Root/Child Vibe Hierarchy Governance
+
+This document defines the stable authority model for governed multi-agent `vibe` execution.
+
+## Why This Exists
+
+Recursive use of `$vibe` inside child-agent prompts is desirable for discipline, but dangerous when each child starts behaving like a fresh top-level governed runtime. Without a hierarchy contract, the system risks:
+
+- duplicate requirement freezes
+- duplicate execution-plan surfaces
+- repeated expert re-dispatch
+- ambiguous completion authority
+- soft loss of governance despite every lane "using `vibe`"
+
+The fix is not to remove child `$vibe`.
+The fix is to distinguish root governance from child execution.
+
+## Mental Model
+
+- Root `vibe`: the only top-level governor
+- Child `vibe`: a subordinate execution lane
+- Specialist skill: a bounded native helper
+
+Short form:
+
+`root vibe governs, child vibe executes, specialists assist`
+
+## Authority Layers
+
+### Root-Governed Lane
+
+Only the root-governed lane may:
+
+- freeze the canonical requirement document
+- freeze the canonical execution plan
+- approve global specialist dispatch
+- aggregate overall execution status
+- issue final completion claims
+
+### Child-Governed Lane
+
+Child-governed lanes must:
+
+- inherit frozen requirement and plan context from the root lane
+- stay inside assigned scope and write boundaries
+- emit local receipts and proof only
+- escalate when a new specialist is needed outside approved dispatch
+
+Child-governed lanes must not:
+
+- create a second requirement truth
+- create a second plan truth
+- widen the task silently
+- make final completion claims
+
+### Specialist-Native Lane
+
+Specialists are not runtime owners.
+
+They may:
+
+- execute bounded professional subtasks
+- preserve native workflow expectations
+- preserve native input/output contracts
+- emit skill-specific verification notes
+
+They may not:
+
+- take over stage ownership
+- replace `vibe` as runtime authority
+- create separate top-level planning truth
+
+## Dispatch Model
+
+### Approved Specialist Dispatch
+
+Specialist usage approved by the root-governed lane and written into the frozen plan.
+
+Properties:
+
+- executable without extra authority negotiation
+- carried into child-lane inputs
+- tracked in execution accounting
+
+### Local Specialist Suggestion
+
+A child lane may detect that more specialist help is useful, but this remains a suggestion until escalated and approved by root.
+
+Properties:
+
+- advisory only
+- not globally active
+- cannot mutate root authority by itself
+
+## Conflict Prevention Rules
+
+To prevent skills from "fighting", the system enforces:
+
+1. one runtime owner
+2. one canonical requirement surface
+3. one canonical execution-plan surface
+4. one final completion authority
+5. bounded specialist usage
+6. explicit escalation instead of silent self-expansion
+
+## Artifact Rules
+
+Canonical root artifacts:
+
+- `docs/requirements/YYYY-MM-DD-<topic>.md`
+- `docs/plans/YYYY-MM-DD-<topic>-execution-plan.md`
+- `outputs/runtime/vibe-sessions/<root-run-id>/...`
+
+Child artifacts:
+
+- subordinate receipts and proof nested under the root runtime session
+- no child-owned canonical docs
+
+## Safety Properties
+
+This hierarchy must preserve:
+
+- explicit `vibe` runtime authority
+- no silent fallback guarantees
+- no duplicate truth surfaces
+- specialist boundedness
+- explicit escalation for new specialist needs
+- root-owned completion claims only
+
+## What Success Looks Like
+
+When a root `vibe` task spawns children:
+
+- every child still behaves with `vibe` discipline
+- no child behaves like a second top-level governor
+- specialists can be used naturally
+- root evidence remains the single source of completion truth
+
+## Operator Rule Of Thumb
+
+If a child needs a new expert, it may ask.
+It may not self-upgrade into a new governor.

--- a/protocols/runtime.md
+++ b/protocols/runtime.md
@@ -38,11 +38,11 @@ Default mode.
 
 ### `benchmark_autonomous`
 
-Closed-loop mode.
+Legacy compatibility alias only.
 
-- do not keep asking the user after a full requirement is given
-- infer missing assumptions and record them explicitly
-- still generate requirement, plan, verification, and cleanup artifacts
+- normalize to `interactive_governed`
+- do not create a second unattended runtime plane
+- still generate the same requirement, plan, verification, and cleanup artifacts
 
 ## Fixed 6-Stage State Machine
 
@@ -117,6 +117,10 @@ Rules:
 - XL prefers Codex-native orchestration
 - spawned subagent prompts must end with `$vibe`
 - milestone evidence must be written before phase completion
+- if the canonical router surfaces specialist skills, record them as bounded native specialist recommendations under `vibe` governance
+- runtime-selected skill stays `vibe` for governed entry even when route truth points at a specialist
+- specialist use must preserve native workflow, required inputs, expected outputs, and validation style
+- child-governed lanes inherit root-frozen requirement/plan context and must not open second canonical requirement or plan truth surfaces
 
 ### Stage 6: `phase_cleanup`
 
@@ -173,6 +177,34 @@ Explicitly forbidden:
 Process-discipline layers may require that a workflow be followed.
 They may not replace, shadow, or duplicate governed runtime truth.
 
+## Root/Child Hierarchy Contract
+
+During XL delegation, governed execution is hierarchical rather than recursive top-level governance:
+
+- `root_governed` lane:
+  - owns canonical requirement freeze
+  - owns canonical plan freeze
+  - owns global specialist dispatch approval
+  - owns final completion claim for the full task
+- `child_governed` lane:
+  - inherits root-frozen requirement and plan context
+  - runs bounded delegated units
+  - emits local receipts and escalation requests only
+
+Child-governed lanes are required to keep `$vibe` discipline but are forbidden from creating second canonical truth surfaces.
+
+Explicitly forbidden for child-governed lanes:
+
+- writing a second canonical requirement document under `docs/requirements/`
+- writing a second canonical execution plan under `docs/plans/`
+- issuing final completion claims for the root-governed task
+- silently activating new global specialist dispatch without root approval
+
+Specialist dispatch semantics under hierarchy:
+
+- `approved_dispatch`: specialist execution approved by root and recorded in frozen plan
+- `local_suggestion`: child-surfaced specialist suggestion that remains advisory until escalation approval by root
+
 ## Artifact Contract
 
 Expected runtime artifacts:
@@ -183,6 +215,10 @@ Expected runtime artifacts:
 - execution plan
 - phase receipts
 - cleanup receipt
+- runtime-input packet specialist recommendations when bounded specialist help is available
+- execution-manifest specialist dispatch accounting when the plan uses bounded specialist help
+- hierarchy-scoped authority markers indicating `root_governed` versus `child_governed` lane
+- explicit escalation artifacts when child-governed lanes propose non-approved specialist dispatch
 
 ## Success Criteria
 

--- a/protocols/team.md
+++ b/protocols/team.md
@@ -32,6 +32,22 @@ ruflo remains optional for workflow/memory enhancements.
 
 All spawned subagent prompts must end with `$vibe` so the governed runtime remains the active contract inside delegated work.
 
+## Root/Child Authority Model
+
+XL delegation uses two governance scopes:
+
+- `root_governed`: one lane per user task; owns canonical requirement/plan truth and final completion claims
+- `child_governed`: delegated lane; inherits frozen context and emits local execution evidence
+
+Child-governed lanes keep `vibe` discipline but are not new top-level governors.
+
+Child-governed lanes must not:
+
+- create a second canonical requirement surface
+- create a second canonical execution-plan surface
+- emit final completion claims for the full root task
+- self-approve new global specialist dispatch
+
 ### Role Division
 
 | Concern | Provider | Tool |
@@ -59,6 +75,31 @@ Lead-agent rules:
 - subagents may surface report-only warnings, but must not invent a new hard gate,
 - if an existing approved policy or failed gate truly blocks progress, cite that exact surface,
 - aggregation must not flatten bounded-specialization outputs into generalized completion claims.
+- when a specialist skill is dispatched, keep its native workflow intact instead of rewriting it into generic lead-agent prose.
+- only root-governed aggregation may publish final completion claims for the full task.
+
+## Native Specialist Dispatch
+
+Within XL execution, a specialist skill is a bounded helper, not a replacement runtime.
+
+Rules:
+
+- `vibe` keeps final control of stage order, plan authority, and completion claims
+- specialist dispatch should be declared in the frozen plan before execution
+- each specialist receives a bounded subtask contract plus the frozen requirement context
+- specialist outputs must stay in the native format or workflow expected by that specialist skill
+- lead aggregation may summarize specialist output, but must not erase specialist-specific verification notes
+- a specialist recommendation is advisory until the governed plan chooses to dispatch it
+
+Hierarchy-specific dispatch semantics:
+
+- `approved_dispatch`: specialist usage approved by root and frozen in plan; child lanes may execute directly
+- `local_suggestion`: child-lane specialist suggestion; advisory until explicit root escalation approval
+
+Escalation rule:
+
+- child lanes needing non-approved specialists must emit explicit escalation evidence to root
+- no silent specialist activation is allowed in child lanes
 
 ## Orchestration Options
 
@@ -182,6 +223,7 @@ Contract rules:
 - Prefer `verification` that is command-shaped (copy/paste runnable).
 - If required info is missing, return `status=blocked` with `handoff_questions` (do not guess).
 - The same contract maps cleanly to the GSD wave contract (`entry_criteria`/`exit_criteria`/`verify_commands`).
+- If the subtask is owned by a specialist skill, keep the contract narrow enough that native specialist workflow still applies without improvising a new method.
 
 ## Shared Memory Contract (3-Tier)
 

--- a/scripts/runtime/Freeze-RuntimeInputPacket.ps1
+++ b/scripts/runtime/Freeze-RuntimeInputPacket.ps1
@@ -2,7 +2,14 @@ param(
     [Parameter(Mandatory)] [string]$Task,
     [string]$Mode = 'interactive_governed',
     [string]$RunId = '',
-    [string]$ArtifactRoot = ''
+    [string]$ArtifactRoot = '',
+    [AllowEmptyString()] [string]$GovernanceScope = '',
+    [AllowEmptyString()] [string]$RootRunId = '',
+    [AllowEmptyString()] [string]$ParentRunId = '',
+    [AllowEmptyString()] [string]$ParentUnitId = '',
+    [AllowEmptyString()] [string]$InheritedRequirementDocPath = '',
+    [AllowEmptyString()] [string]$InheritedExecutionPlanPath = '',
+    [string[]]$ApprovedSpecialistSkillIds = @()
 )
 
 Set-StrictMode -Version Latest
@@ -54,6 +61,223 @@ function New-VibeAdviceSnapshot {
     return [pscustomobject]$snapshot
 }
 
+function Get-VibeSkillMetadata {
+    param(
+        [Parameter(Mandatory)] [string]$RepoRoot,
+        [Parameter(Mandatory)] [string]$SkillId
+    )
+
+    $skillPath = Join-Path $RepoRoot ("bundled\skills\{0}\SKILL.md" -f $SkillId)
+    if (-not (Test-Path -LiteralPath $skillPath)) {
+        return [pscustomobject]@{
+            skill_id = $SkillId
+            skill_path = $null
+            description = $null
+        }
+    }
+
+    $description = $null
+    foreach ($line in @(Get-Content -LiteralPath $skillPath -Encoding UTF8 -TotalCount 20)) {
+        if ([string]$line -match '^\s*description:\s*(.+?)\s*$') {
+            $description = $Matches[1].Trim()
+            break
+        }
+    }
+
+    return [pscustomobject]@{
+        skill_id = $SkillId
+        skill_path = $skillPath
+        description = $description
+    }
+}
+
+function New-VibeSpecialistRecommendation {
+    param(
+        [Parameter(Mandatory)] [string]$RepoRoot,
+        [Parameter(Mandatory)] [string]$SkillId,
+        [Parameter(Mandatory)] [string]$Source,
+        [Parameter(Mandatory)] [string]$TaskType,
+        [Parameter(Mandatory)] [string]$Reason,
+        [AllowNull()] [object]$PackId,
+        [AllowNull()] [object]$Confidence,
+        [AllowNull()] [object]$Rank,
+        [Parameter(Mandatory)] [object]$DispatchContract
+    )
+
+    $metadata = Get-VibeSkillMetadata -RepoRoot $RepoRoot -SkillId $SkillId
+    return [pscustomobject]@{
+        skill_id = $SkillId
+        source = $Source
+        pack_id = if ($null -eq $PackId) { $null } else { [string]$PackId }
+        rank = if ($null -eq $Rank) { $null } else { [int]$Rank }
+        confidence = if ($null -eq $Confidence) { $null } else { [double]$Confidence }
+        reason = $Reason
+        task_type = $TaskType
+        recommended_scope = 'bounded specialist assistance inside vibe-governed runtime'
+        bounded_role = [string]$DispatchContract.bounded_role
+        native_usage_required = [bool]$DispatchContract.native_usage_required
+        must_preserve_workflow = [bool]$DispatchContract.must_preserve_workflow
+        required_inputs = @($DispatchContract.required_inputs)
+        expected_outputs = @($DispatchContract.expected_outputs)
+        verification_expectation = [string]$DispatchContract.verification_expectation
+        native_skill_entrypoint = if ($metadata.skill_path) { [string]$metadata.skill_path } else { $null }
+        native_skill_description = if ($metadata.description) { [string]$metadata.description } else { $null }
+    }
+}
+
+function Get-VibeSpecialistRecommendations {
+    param(
+        [Parameter(Mandatory)] [string]$RepoRoot,
+        [Parameter(Mandatory)] [object]$RouteResult,
+        [Parameter(Mandatory)] [string]$RuntimeSelectedSkill,
+        [Parameter(Mandatory)] [string]$TaskType,
+        [Parameter(Mandatory)] [object]$Policy
+    )
+
+    $limit = 4
+    if ($Policy.PSObject.Properties.Name -contains 'specialist_recommendation_limit' -and $Policy.specialist_recommendation_limit -ne $null) {
+        $limit = [int]$Policy.specialist_recommendation_limit
+    }
+    $dispatchContract = if ($Policy.PSObject.Properties.Name -contains 'specialist_dispatch_contract' -and $null -ne $Policy.specialist_dispatch_contract) {
+        $Policy.specialist_dispatch_contract
+    } else {
+        [pscustomobject]@{
+            bounded_role = 'specialist_assist'
+            native_usage_required = $true
+            must_preserve_workflow = $true
+            required_inputs = @('bounded specialist subtask contract')
+            expected_outputs = @('bounded specialist result')
+            verification_expectation = 'Preserve the specialist skill native workflow.'
+        }
+    }
+
+    $recommendations = @()
+    $seen = @{}
+
+    foreach ($ranked in @($RouteResult.ranked)) {
+        if (@($recommendations).Count -ge $limit) {
+            break
+        }
+
+        $skillId = $null
+        if ($ranked.PSObject.Properties.Name -contains 'selected_candidate') {
+            $skillId = [string]$ranked.selected_candidate
+        }
+        if ([string]::IsNullOrWhiteSpace($skillId)) {
+            continue
+        }
+        if ([string]::Equals($skillId, $RuntimeSelectedSkill, [System.StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+        if ($seen.ContainsKey($skillId)) {
+            continue
+        }
+
+        $reason = "top ranked specialist candidate from pack '{0}' via {1}" -f ([string]$ranked.pack_id), ([string]$ranked.candidate_selection_reason)
+        $recommendations += (New-VibeSpecialistRecommendation `
+            -RepoRoot $RepoRoot `
+            -SkillId $skillId `
+            -Source 'route_ranked' `
+            -TaskType $TaskType `
+            -Reason $reason `
+            -PackId ([string]$ranked.pack_id) `
+            -Confidence ([double]$ranked.score) `
+            -Rank (@($recommendations).Count + 1) `
+            -DispatchContract $dispatchContract)
+        $seen[$skillId] = $true
+    }
+
+    foreach ($overlayField in @($Policy.overlay_fields)) {
+        if (@($recommendations).Count -ge $limit) {
+            break
+        }
+        if (-not ($RouteResult.PSObject.Properties.Name -contains $overlayField)) {
+            continue
+        }
+        $advice = $RouteResult.$overlayField
+        if ($null -eq $advice) {
+            continue
+        }
+        if (-not ($advice.PSObject.Properties.Name -contains 'recommended_skill')) {
+            continue
+        }
+        $skillId = [string]$advice.recommended_skill
+        if ([string]::IsNullOrWhiteSpace($skillId)) {
+            continue
+        }
+        if ([string]::Equals($skillId, $RuntimeSelectedSkill, [System.StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+        if ($seen.ContainsKey($skillId)) {
+            continue
+        }
+
+        $reason = "overlay recommendation from '{0}'" -f $overlayField
+        $recommendations += (New-VibeSpecialistRecommendation `
+            -RepoRoot $RepoRoot `
+            -SkillId $skillId `
+            -Source ("overlay:{0}" -f $overlayField) `
+            -TaskType $TaskType `
+            -Reason $reason `
+            -PackId $null `
+            -Confidence 0.0 `
+            -Rank (@($recommendations).Count + 1) `
+            -DispatchContract $dispatchContract)
+        $seen[$skillId] = $true
+    }
+
+    return @($recommendations)
+}
+
+function Split-VibeSpecialistDispatch {
+    param(
+        [Parameter(Mandatory)] [string]$GovernanceScope,
+        [Parameter(Mandatory)] [object[]]$Recommendations,
+        [string[]]$ApprovedSpecialistSkillIds = @(),
+        [AllowNull()] [object]$SuggestionContract = $null
+    )
+
+    $approvedLookup = @{}
+    foreach ($skillId in @($ApprovedSpecialistSkillIds)) {
+        if (-not [string]::IsNullOrWhiteSpace([string]$skillId)) {
+            $approvedLookup[[string]$skillId] = $true
+        }
+    }
+
+    if ($GovernanceScope -eq 'root') {
+        return [pscustomobject]@{
+            approved_dispatch = @($Recommendations)
+            local_specialist_suggestions = @()
+            escalation_required = $false
+            escalation_status = 'not_required'
+        }
+    }
+
+    $approvedDispatch = @()
+    $localSuggestions = @()
+    foreach ($recommendation in @($Recommendations)) {
+        $skillId = [string]$recommendation.skill_id
+        if ($approvedLookup.ContainsKey($skillId)) {
+            $approvedDispatch += $recommendation
+        } else {
+            $localSuggestions += $recommendation
+        }
+    }
+
+    $escalationRequired = @($localSuggestions).Count -gt 0 -and (
+        $null -eq $SuggestionContract -or
+        -not ($SuggestionContract.PSObject.Properties.Name -contains 'escalation_required') -or
+        [bool]$SuggestionContract.escalation_required
+    )
+
+    return [pscustomobject]@{
+        approved_dispatch = @($approvedDispatch)
+        local_specialist_suggestions = @($localSuggestions)
+        escalation_required = [bool]$escalationRequired
+        escalation_status = if ($escalationRequired) { 'root_approval_required' } else { 'not_required' }
+    }
+}
+
 $runtime = Get-VibeRuntimeContext -ScriptPath $PSCommandPath
 $Mode = Resolve-VibeRuntimeMode -Mode $Mode -DefaultMode ([string]$runtime.runtime_modes.default_mode)
 if ([string]::IsNullOrWhiteSpace($RunId)) {
@@ -67,6 +291,15 @@ $taskType = Get-VibeRouterTaskType -Task $Task
 $routerScriptPath = Join-Path $runtime.repo_root ([string]$policy.router_script_path)
 $requestedSkill = if ($policy.default_requested_skill) { [string]$policy.default_requested_skill } else { 'vibe' }
 $unattended = $false
+$hierarchyState = Get-VibeHierarchyState `
+    -GovernanceScope $GovernanceScope `
+    -RunId $RunId `
+    -RootRunId $RootRunId `
+    -ParentRunId $ParentRunId `
+    -ParentUnitId $ParentUnitId `
+    -InheritedRequirementDocPath $InheritedRequirementDocPath `
+    -InheritedExecutionPlanPath $InheritedExecutionPlanPath `
+    -HierarchyContract $policy.hierarchy_contract
 
 $routeArgs = @(
     '-Prompt', $Task,
@@ -101,13 +334,28 @@ foreach ($overlayField in @($policy.overlay_fields)) {
 $confirmRequired = ([string]$routeResult.route_mode -eq 'confirm_required')
 $runtimeSelectedSkill = [string]$policy.explicit_runtime_skill
 $routerSelectedSkill = if ($routeResult.selected) { [string]$routeResult.selected.skill } else { $null }
+$specialistRecommendations = @(Get-VibeSpecialistRecommendations -RepoRoot $runtime.repo_root -RouteResult $routeResult -RuntimeSelectedSkill $runtimeSelectedSkill -TaskType $taskType -Policy $policy)
+$specialistDispatch = Split-VibeSpecialistDispatch `
+    -GovernanceScope ([string]$hierarchyState.governance_scope) `
+    -Recommendations @($specialistRecommendations) `
+    -ApprovedSpecialistSkillIds @($ApprovedSpecialistSkillIds) `
+    -SuggestionContract $policy.child_specialist_suggestion_contract
 $packet = [pscustomobject]@{
     stage = 'runtime_input_freeze'
     run_id = $RunId
+    governance_scope = [string]$hierarchyState.governance_scope
     task = $Task
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     runtime_mode = $Mode
     internal_grade = $grade
+    hierarchy = [pscustomobject]@{
+        governance_scope = [string]$hierarchyState.governance_scope
+        root_run_id = [string]$hierarchyState.root_run_id
+        parent_run_id = if ($null -eq $hierarchyState.parent_run_id) { $null } else { [string]$hierarchyState.parent_run_id }
+        parent_unit_id = if ($null -eq $hierarchyState.parent_unit_id) { $null } else { [string]$hierarchyState.parent_unit_id }
+        inherited_requirement_doc_path = if ($null -eq $hierarchyState.inherited_requirement_doc_path) { $null } else { [string]$hierarchyState.inherited_requirement_doc_path }
+        inherited_execution_plan_path = if ($null -eq $hierarchyState.inherited_execution_plan_path) { $null } else { [string]$hierarchyState.inherited_execution_plan_path }
+    }
     canonical_router = [pscustomobject]@{
         prompt = $Task
         task_type = $taskType
@@ -129,6 +377,17 @@ $packet = [pscustomobject]@{
         hazard_alert_required = [bool]$routeResult.hazard_alert_required
         unattended_override_applied = [bool]$routeResult.unattended_override_applied
     }
+    specialist_recommendations = @($specialistRecommendations)
+    specialist_dispatch = [pscustomobject]@{
+        approved_dispatch = @($specialistDispatch.approved_dispatch)
+        local_specialist_suggestions = @($specialistDispatch.local_specialist_suggestions)
+        approved_skill_ids = @($specialistDispatch.approved_dispatch | ForEach-Object { [string]$_.skill_id } | Select-Object -Unique)
+        local_suggestion_skill_ids = @($specialistDispatch.local_specialist_suggestions | ForEach-Object { [string]$_.skill_id } | Select-Object -Unique)
+        escalation_required = [bool]$specialistDispatch.escalation_required
+        escalation_status = [string]$specialistDispatch.escalation_status
+        approval_owner = if ($policy.child_specialist_suggestion_contract.PSObject.Properties.Name -contains 'approval_owner') { [string]$policy.child_specialist_suggestion_contract.approval_owner } else { 'root_vibe' }
+        status = if ($policy.child_specialist_suggestion_contract.PSObject.Properties.Name -contains 'status') { [string]$policy.child_specialist_suggestion_contract.status } else { 'advisory_until_root_approval' }
+    }
     overlay_decisions = @($overlayDecisions)
     authority_flags = [pscustomobject]@{
         runtime_entry = 'vibe'
@@ -136,6 +395,10 @@ $packet = [pscustomobject]@{
         router_truth_level = [string]$routeResult.truth_level
         shadow_only = [bool]$policy.shadow_only
         non_authoritative = [bool]$routeResult.non_authoritative
+        allow_requirement_freeze = [bool]$hierarchyState.allow_requirement_freeze
+        allow_plan_freeze = [bool]$hierarchyState.allow_plan_freeze
+        allow_global_dispatch = [bool]$hierarchyState.allow_global_dispatch
+        allow_completion_claim = [bool]$hierarchyState.allow_completion_claim
     }
     divergence_shadow = [pscustomobject]@{
         router_selected_skill = $routerSelectedSkill
@@ -144,6 +407,7 @@ $packet = [pscustomobject]@{
         confirm_required = [bool]$confirmRequired
         explicit_runtime_override_applied = [bool](-not [string]::IsNullOrWhiteSpace($runtimeSelectedSkill))
         explicit_runtime_override_reason = 'governed_runtime_entry'
+        governance_scope_mismatch = $false
     }
     provenance = [pscustomobject]@{
         source_of_truth = 'canonical_router_shadow_freeze'

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -5,7 +5,11 @@ param(
     [string]$RequirementDocPath = '',
     [string]$ExecutionPlanPath = '',
     [string]$RuntimeInputPacketPath = '',
-    [string]$ArtifactRoot = ''
+    [string]$ArtifactRoot = '',
+    [AllowEmptyString()] [string]$GovernanceScope = '',
+    [AllowEmptyString()] [string]$RootRunId = '',
+    [AllowEmptyString()] [string]$ParentRunId = '',
+    [AllowEmptyString()] [string]$ParentUnitId = ''
 )
 
 Set-StrictMode -Version Latest
@@ -256,7 +260,7 @@ function Get-VibePlanDerivedExecutionShadow {
 
     $sections = Get-VibePlanSections -PlanPath $PlanPath
     $units = @()
-    $sectionOrder = @('Wave Plan', 'Verification Commands', 'Phase Cleanup Contract')
+    $sectionOrder = @('Wave Plan', 'Specialist Skill Dispatch Plan', 'Verification Commands', 'Phase Cleanup Contract')
     $unitIndex = 0
 
     foreach ($sectionName in $sectionOrder) {
@@ -275,7 +279,10 @@ function Get-VibePlanDerivedExecutionShadow {
             $reason = 'narrative_bullet_without_executable_command'
             $inlineCommands = [regex]::Matches($trimmed, '`([^`]+)`') | ForEach-Object { $_.Groups[1].Value }
 
-            if (@($inlineCommands).Count -gt 0) {
+            if ($sectionName -eq 'Specialist Skill Dispatch Plan') {
+                $classification = 'specialist_dispatch_unit'
+                $reason = 'bounded_native_specialist_dispatch_declared'
+            } elseif (@($inlineCommands).Count -gt 0) {
                 $classification = 'executable_unit'
                 $reason = 'inline_command_detected'
             } elseif ($sectionName -eq 'Verification Commands') {
@@ -303,6 +310,7 @@ function Get-VibePlanDerivedExecutionShadow {
         execution_plan_path = $PlanPath
         candidate_unit_count = @($units).Count
         executable_unit_count = @($units | Where-Object { $_.classification -eq 'executable_unit' }).Count
+        specialist_dispatch_unit_count = @($units | Where-Object { $_.classification -eq 'specialist_dispatch_unit' }).Count
         advisory_only_unit_count = @($units | Where-Object { $_.classification -eq 'advisory_only_unit' }).Count
         ambiguous_unit_count = @($units | Where-Object { $_.classification -eq 'ambiguous_unit' }).Count
         unsafe_unit_count = @($units | Where-Object { $_.classification -eq 'unsafe_unit' }).Count
@@ -336,6 +344,15 @@ $runtimeInputPacket = if (Test-Path -LiteralPath $runtimeInputPath) {
 } else {
     $null
 }
+$hierarchyState = Get-VibeHierarchyState `
+    -GovernanceScope $(if ($runtimeInputPacket) { [string]$runtimeInputPacket.governance_scope } else { $GovernanceScope }) `
+    -RunId $RunId `
+    -RootRunId $(if ($runtimeInputPacket -and $runtimeInputPacket.hierarchy) { [string]$runtimeInputPacket.hierarchy.root_run_id } else { $RootRunId }) `
+    -ParentRunId $(if ($runtimeInputPacket -and $runtimeInputPacket.hierarchy) { [string]$runtimeInputPacket.hierarchy.parent_run_id } else { $ParentRunId }) `
+    -ParentUnitId $(if ($runtimeInputPacket -and $runtimeInputPacket.hierarchy) { [string]$runtimeInputPacket.hierarchy.parent_unit_id } else { $ParentUnitId }) `
+    -InheritedRequirementDocPath $(if ($runtimeInputPacket -and $runtimeInputPacket.hierarchy) { [string]$runtimeInputPacket.hierarchy.inherited_requirement_doc_path } else { $RequirementDocPath }) `
+    -InheritedExecutionPlanPath $(if ($runtimeInputPacket -and $runtimeInputPacket.hierarchy) { [string]$runtimeInputPacket.hierarchy.inherited_execution_plan_path } else { $ExecutionPlanPath }) `
+    -HierarchyContract $runtime.runtime_input_packet_policy.hierarchy_contract
 
 $policy = $runtime.benchmark_execution_policy
 $proofRegistry = $runtime.proof_class_registry
@@ -363,8 +380,31 @@ $tokens = @{
     '${REQUIREMENT_DOC}' = [System.IO.Path]::GetFullPath($requirementPath)
     '${EXECUTION_PLAN}' = [System.IO.Path]::GetFullPath($planPath)
     '${RUN_ID}' = [string]$RunId
+    '${ROOT_RUN_ID}' = [string]$hierarchyState.root_run_id
 }
 $planShadow = Get-VibePlanDerivedExecutionShadow -PlanPath $planPath -RunId $RunId -SessionRoot $sessionRoot
+$specialistRecommendations = if ($runtimeInputPacket) { @($runtimeInputPacket.specialist_recommendations) } else { @() }
+$approvedDispatch = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.approved_dispatch) } else { @() }
+$localSuggestions = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.local_specialist_suggestions) } else { @() }
+$specialistSkills = @($approvedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$escalationRequired = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { [bool]$runtimeInputPacket.specialist_dispatch.escalation_required } else { $false }
+$escalationPath = $null
+if ([string]$hierarchyState.governance_scope -eq 'child' -and $escalationRequired) {
+    $escalation = [pscustomobject]@{
+        run_id = $RunId
+        governance_scope = [string]$hierarchyState.governance_scope
+        root_run_id = [string]$hierarchyState.root_run_id
+        parent_run_id = if ($null -eq $hierarchyState.parent_run_id) { $null } else { [string]$hierarchyState.parent_run_id }
+        parent_unit_id = if ($null -eq $hierarchyState.parent_unit_id) { $null } else { [string]$hierarchyState.parent_unit_id }
+        approval_owner = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { [string]$runtimeInputPacket.specialist_dispatch.approval_owner } else { 'root_vibe' }
+        status = 'root_approval_required'
+        requested_specialist_skill_ids = @($localSuggestions | ForEach-Object { [string]$_.skill_id } | Select-Object -Unique)
+        local_specialist_suggestions = @($localSuggestions)
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    }
+    $escalationPath = Join-Path $sessionRoot 'specialist-escalation-request.json'
+    Write-VibeJsonArtifact -Path $escalationPath -Value $escalation
+}
 
 $waveReceipts = @()
 $resultPaths = @()
@@ -413,9 +453,11 @@ foreach ($wave in @($profile.waves)) {
     }
 }
 
+$baseStatus = if ($failedUnitCount -eq 0 -and $executedUnitCount -ge [int]$profile.expected_minimum_units) { 'completed' } elseif ($executedUnitCount -eq 0) { 'failed' } else { 'completed_with_failures' }
 $executionManifest = [pscustomobject]@{
     stage = 'plan_execute'
     run_id = $RunId
+    governance_scope = [string]$hierarchyState.governance_scope
     mode = $Mode
     internal_grade = $grade
     scheduler_kind = [string]$policy.scheduler.kind
@@ -432,6 +474,20 @@ $executionManifest = [pscustomobject]@{
     timed_out_unit_count = $timedOutUnitCount
     proof_class = [string]$proofRegistry.artifact_class_defaults.execution_manifest
     promotion_suitable = [string]$proofRegistry.promotion_suitability.runtime
+    hierarchy = [pscustomobject]@{
+        governance_scope = [string]$hierarchyState.governance_scope
+        root_run_id = [string]$hierarchyState.root_run_id
+        parent_run_id = if ($null -eq $hierarchyState.parent_run_id) { $null } else { [string]$hierarchyState.parent_run_id }
+        parent_unit_id = if ($null -eq $hierarchyState.parent_unit_id) { $null } else { [string]$hierarchyState.parent_unit_id }
+        inherited_requirement_doc_path = if ($null -eq $hierarchyState.inherited_requirement_doc_path) { $null } else { [string]$hierarchyState.inherited_requirement_doc_path }
+        inherited_execution_plan_path = if ($null -eq $hierarchyState.inherited_execution_plan_path) { $null } else { [string]$hierarchyState.inherited_execution_plan_path }
+    }
+    authority = [pscustomobject]@{
+        canonical_requirement_write_allowed = [bool]$hierarchyState.allow_requirement_freeze
+        canonical_plan_write_allowed = [bool]$hierarchyState.allow_plan_freeze
+        global_dispatch_allowed = [bool]$hierarchyState.allow_global_dispatch
+        completion_claim_allowed = [bool]$hierarchyState.allow_completion_claim
+    }
     route_runtime_alignment = [pscustomobject]@{
         router_selected_skill = if ($runtimeInputPacket) { [string]$runtimeInputPacket.route_snapshot.selected_skill } else { $null }
         runtime_selected_skill = if ($runtimeInputPacket) { [string]$runtimeInputPacket.authority_flags.explicit_runtime_skill } else { 'vibe' }
@@ -442,10 +498,25 @@ $executionManifest = [pscustomobject]@{
         path = $planShadow.path
         candidate_unit_count = [int]$planShadow.payload.candidate_unit_count
         executable_unit_count = [int]$planShadow.payload.executable_unit_count
+        specialist_dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
         advisory_only_unit_count = [int]$planShadow.payload.advisory_only_unit_count
         ambiguous_unit_count = [int]$planShadow.payload.ambiguous_unit_count
     }
-    status = if ($failedUnitCount -eq 0 -and $executedUnitCount -ge [int]$profile.expected_minimum_units) { 'completed' } elseif ($executedUnitCount -eq 0) { 'failed' } else { 'completed_with_failures' }
+    specialist_accounting = [pscustomobject]@{
+        recommendation_count = @($specialistRecommendations).Count
+        specialist_skill_count = @($specialistSkills).Count
+        specialist_skills = @($specialistSkills)
+        native_usage_required = [bool](@($specialistRecommendations | Where-Object { $_.native_usage_required }).Count -gt 0)
+        dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
+        recommendations = @($specialistRecommendations)
+        approved_dispatch_count = @($approvedDispatch).Count
+        approved_dispatch = @($approvedDispatch)
+        local_suggestion_count = @($localSuggestions).Count
+        local_specialist_suggestions = @($localSuggestions)
+        escalation_required = [bool]$escalationRequired
+        escalation_request_path = $escalationPath
+    }
+    status = if ([string]$hierarchyState.governance_scope -eq 'child' -and $baseStatus -eq 'completed') { 'completed_local_scope' } else { $baseStatus }
     waves = @($waveReceipts)
 }
 
@@ -468,6 +539,10 @@ $proofManifest = [pscustomobject]@{
     minimum_units_required = [int]$profile.expected_minimum_units
     proof_class = [string]$proofRegistry.artifact_class_defaults.benchmark_proof_manifest
     promotion_suitable = [string]$proofRegistry.promotion_suitability.runtime
+    specialist_recommendation_count = @($specialistRecommendations).Count
+    specialist_dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
+    governance_scope = [string]$hierarchyState.governance_scope
+    escalation_required = [bool]$escalationRequired
     proof_passed = [bool](($failedUnitCount -eq 0) -and ($executedUnitCount -ge [int]$profile.expected_minimum_units))
 }
 $proofManifestPath = Join-Path $proofRoot 'manifest.json'
@@ -483,6 +558,8 @@ $proofLines = @(
     ('- executed_unit_count: `{0}`' -f $executedUnitCount),
     ('- successful_unit_count: `{0}`' -f $successfulUnitCount),
     ('- failed_unit_count: `{0}`' -f $failedUnitCount),
+    ('- specialist_recommendation_count: `{0}`' -f @($specialistRecommendations).Count),
+    ('- specialist_dispatch_unit_count: `{0}`' -f [int]$planShadow.payload.specialist_dispatch_unit_count),
     ('- execution_manifest: `{0}`' -f $executionManifestPath),
     ('- plan_shadow: `{0}`' -f $planShadow.path),
     ''
@@ -504,6 +581,7 @@ Write-VibeMarkdownArtifact -Path $proofSummaryPath -Lines $proofLines
 $receipt = [pscustomobject]@{
     stage = 'plan_execute'
     run_id = $RunId
+    governance_scope = [string]$hierarchyState.governance_scope
     mode = $Mode
     internal_grade = $grade
     status = [string]$executionManifest.status
@@ -516,10 +594,19 @@ $receipt = [pscustomobject]@{
     executed_unit_count = $executedUnitCount
     successful_unit_count = $successfulUnitCount
     failed_unit_count = $failedUnitCount
+    specialist_recommendation_count = @($specialistRecommendations).Count
+    specialist_dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
+    specialist_skills = @($specialistSkills)
+    local_specialist_suggestion_count = @($localSuggestions).Count
+    escalation_required = [bool]$escalationRequired
+    escalation_request_path = $escalationPath
+    completion_claim_allowed = [bool]$hierarchyState.allow_completion_claim
     proof_class = [string]$proofRegistry.artifact_class_defaults.execution_manifest
     verification_contract = @(
         'No completion claim without verification evidence.',
         'All subagent prompts must end with $vibe.',
+        'Specialist help must preserve native workflow and remain bounded under vibe governance.',
+        'Child-governed lanes may not issue final completion claims or mutate canonical requirement/plan truth.',
         'Phase cleanup must run after execution.'
     )
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -49,6 +49,73 @@ function Resolve-VibeRuntimeMode {
     return $normalized
 }
 
+function Resolve-VibeGovernanceScope {
+    param(
+        [AllowEmptyString()] [string]$GovernanceScope,
+        [AllowEmptyString()] [string]$DefaultScope = 'root'
+    )
+
+    if ([string]::IsNullOrWhiteSpace($GovernanceScope)) {
+        return $DefaultScope
+    }
+
+    $normalized = $GovernanceScope.Trim().ToLowerInvariant()
+    if ($normalized -notin @('root', 'child')) {
+        throw "Unsupported governance scope: $GovernanceScope"
+    }
+
+    return $normalized
+}
+
+function Get-VibeHierarchyState {
+    param(
+        [Parameter(Mandatory)] [AllowEmptyString()] [string]$GovernanceScope,
+        [Parameter(Mandatory)] [string]$RunId,
+        [AllowEmptyString()] [string]$RootRunId = '',
+        [AllowEmptyString()] [string]$ParentRunId = '',
+        [AllowEmptyString()] [string]$ParentUnitId = '',
+        [AllowEmptyString()] [string]$InheritedRequirementDocPath = '',
+        [AllowEmptyString()] [string]$InheritedExecutionPlanPath = '',
+        [Parameter(Mandatory)] [object]$HierarchyContract
+    )
+
+    $scope = Resolve-VibeGovernanceScope -GovernanceScope $GovernanceScope -DefaultScope ([string]$HierarchyContract.default_governance_scope)
+    $authoritySource = if ($scope -eq 'child') {
+        $HierarchyContract.child_authority_flags
+    } else {
+        $HierarchyContract.root_authority_flags
+    }
+
+    $resolvedRootRunId = if ($scope -eq 'root') {
+        $RunId
+    } elseif (-not [string]::IsNullOrWhiteSpace($RootRunId)) {
+        $RootRunId
+    } elseif (-not [string]::IsNullOrWhiteSpace($ParentRunId)) {
+        $ParentRunId
+    } else {
+        $RunId
+    }
+
+    $resolvedParentRunId = if ($scope -eq 'child' -and -not [string]::IsNullOrWhiteSpace($ParentRunId)) {
+        $ParentRunId
+    } else {
+        $null
+    }
+
+    return [pscustomobject]@{
+        governance_scope = $scope
+        root_run_id = $resolvedRootRunId
+        parent_run_id = $resolvedParentRunId
+        parent_unit_id = if ($scope -eq 'child' -and -not [string]::IsNullOrWhiteSpace($ParentUnitId)) { $ParentUnitId } else { $null }
+        inherited_requirement_doc_path = if ($scope -eq 'child' -and -not [string]::IsNullOrWhiteSpace($InheritedRequirementDocPath)) { [System.IO.Path]::GetFullPath($InheritedRequirementDocPath) } else { $null }
+        inherited_execution_plan_path = if ($scope -eq 'child' -and -not [string]::IsNullOrWhiteSpace($InheritedExecutionPlanPath)) { [System.IO.Path]::GetFullPath($InheritedExecutionPlanPath) } else { $null }
+        allow_requirement_freeze = [bool]$authoritySource.allow_requirement_freeze
+        allow_plan_freeze = [bool]$authoritySource.allow_plan_freeze
+        allow_global_dispatch = [bool]$authoritySource.allow_global_dispatch
+        allow_completion_claim = [bool]$authoritySource.allow_completion_claim
+    }
+}
+
 function ConvertTo-VibeSlug {
     param(
         [AllowEmptyString()] [string]$Text

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -4,7 +4,13 @@ param(
     [string]$RunId = '',
     [string]$IntentContractPath = '',
     [string]$RuntimeInputPacketPath = '',
-    [string]$ArtifactRoot = ''
+    [string]$ArtifactRoot = '',
+    [AllowEmptyString()] [string]$GovernanceScope = '',
+    [AllowEmptyString()] [string]$RootRunId = '',
+    [AllowEmptyString()] [string]$ParentRunId = '',
+    [AllowEmptyString()] [string]$ParentUnitId = '',
+    [AllowEmptyString()] [string]$InheritedRequirementDocPath = '',
+    [AllowEmptyString()] [string]$InheritedExecutionPlanPath = ''
 )
 
 Set-StrictMode -Version Latest
@@ -19,13 +25,30 @@ if ([string]::IsNullOrWhiteSpace($RunId)) {
 }
 
 $sessionRoot = Ensure-VibeSessionRoot -RepoRoot $runtime.repo_root -RunId $RunId -ArtifactRoot $ArtifactRoot
+$hierarchyState = Get-VibeHierarchyState `
+    -GovernanceScope $GovernanceScope `
+    -RunId $RunId `
+    -RootRunId $RootRunId `
+    -ParentRunId $ParentRunId `
+    -ParentUnitId $ParentUnitId `
+    -InheritedRequirementDocPath $InheritedRequirementDocPath `
+    -InheritedExecutionPlanPath $InheritedExecutionPlanPath `
+    -HierarchyContract $runtime.runtime_input_packet_policy.hierarchy_contract
 if (-not [string]::IsNullOrWhiteSpace($IntentContractPath) -and (Test-Path -LiteralPath $IntentContractPath)) {
     $intentContract = Get-Content -LiteralPath $IntentContractPath -Raw -Encoding UTF8 | ConvertFrom-Json
 } else {
     $intentContract = New-VibeIntentContractObject -Task $Task -Mode $Mode
 }
 
-$docPath = Get-VibeRequirementDocPath -RepoRoot $runtime.repo_root -Task $Task -ArtifactRoot $ArtifactRoot
+$isChildScope = ([string]$hierarchyState.governance_scope -eq 'child')
+$docPath = if ($isChildScope) {
+    if ([string]::IsNullOrWhiteSpace([string]$hierarchyState.inherited_requirement_doc_path)) {
+        throw 'Child-governed requirement stage requires InheritedRequirementDocPath.'
+    }
+    [string]$hierarchyState.inherited_requirement_doc_path
+} else {
+    Get-VibeRequirementDocPath -RepoRoot $runtime.repo_root -Task $Task -ArtifactRoot $ArtifactRoot
+}
 $antiDriftDraft = New-VgoAntiProxyGoalDriftDraft -PrimaryObjective $intentContract.goal
 $runtimeInputPacket = if (-not [string]::IsNullOrWhiteSpace($RuntimeInputPacketPath) -and (Test-Path -LiteralPath $RuntimeInputPacketPath)) {
     Get-Content -LiteralPath $RuntimeInputPacketPath -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -83,6 +106,8 @@ if ($runtimeInputPacket) {
     $lines += @(
         '',
         '## Runtime Input Truth',
+        "- Governance scope: $([string]$runtimeInputPacket.governance_scope)",
+        "- Root run id: $([string]$runtimeInputPacket.hierarchy.root_run_id)",
         "- Selected pack: $([string]$runtimeInputPacket.route_snapshot.selected_pack)",
         "- Router-selected skill: $([string]$runtimeInputPacket.route_snapshot.selected_skill)",
         "- Runtime-selected skill: $([string]$runtimeInputPacket.authority_flags.explicit_runtime_skill)",
@@ -90,15 +115,61 @@ if ($runtimeInputPacket) {
         "- Route reason: $([string]$runtimeInputPacket.route_snapshot.route_reason)",
         "- Confirm required: $([bool]$runtimeInputPacket.route_snapshot.confirm_required)"
     )
+
+    $specialistRecommendations = @($runtimeInputPacket.specialist_recommendations)
+    if ($specialistRecommendations.Count -gt 0) {
+        $lines += @(
+            '',
+            '## Specialist Recommendations',
+            'These are bounded native specialist suggestions carried inside the governed `vibe` runtime. They do not replace runtime authority.'
+        )
+        foreach ($recommendation in $specialistRecommendations) {
+            $lines += @(
+                "- Skill: $([string]$recommendation.skill_id)",
+                "  Source: $([string]$recommendation.source); pack: $([string]$recommendation.pack_id); rank: $([string]$recommendation.rank); confidence: $([string]$recommendation.confidence)",
+                "  Role: $([string]$recommendation.bounded_role); native usage required: $([bool]$recommendation.native_usage_required); preserve workflow: $([bool]$recommendation.must_preserve_workflow)",
+                "  Reason: $([string]$recommendation.reason)",
+                "  Required inputs: $([string]::Join(', ', @($recommendation.required_inputs)))",
+                "  Expected outputs: $([string]::Join(', ', @($recommendation.expected_outputs)))",
+                "  Verification expectation: $([string]$recommendation.verification_expectation)"
+            )
+        }
+    }
 }
 
-Write-VibeMarkdownArtifact -Path $docPath -Lines $lines
+$childHandoffPath = $null
+if ($isChildScope) {
+    if (-not (Test-Path -LiteralPath $docPath)) {
+        throw ("Child-governed requirement stage cannot inherit missing canonical requirement doc: {0}" -f $docPath)
+    }
+
+    $childHandoffPath = Join-Path $sessionRoot 'child-requirement-handoff.md'
+    $handoffLines = @(
+        "# Child Requirement Handoff",
+        '',
+        '- governance_scope: child',
+        ('- inherited_requirement_doc: {0}' -f $docPath),
+        ('- root_run_id: {0}' -f [string]$hierarchyState.root_run_id),
+        ('- parent_run_id: {0}' -f [string]$hierarchyState.parent_run_id),
+        ('- parent_unit_id: {0}' -f [string]$hierarchyState.parent_unit_id),
+        '- canonical_write_allowed: false',
+        '',
+        'Child-governed lanes inherit the frozen root requirement and may not create a second canonical requirement surface.'
+    )
+    Write-VibeMarkdownArtifact -Path $childHandoffPath -Lines $handoffLines
+} else {
+    Write-VibeMarkdownArtifact -Path $docPath -Lines $lines
+}
 
 $receipt = [pscustomobject]@{
     stage = 'requirement_doc'
     run_id = $RunId
+    governance_scope = [string]$hierarchyState.governance_scope
     mode = $Mode
     requirement_doc_path = $docPath
+    child_requirement_handoff_path = $childHandoffPath
+    canonical_write_allowed = -not $isChildScope
+    inherited_requirement_doc_path = if ($isChildScope) { $docPath } else { $null }
     runtime_input_packet_path = $RuntimeInputPacketPath
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 }

--- a/scripts/runtime/Write-XlPlan.ps1
+++ b/scripts/runtime/Write-XlPlan.ps1
@@ -4,7 +4,13 @@ param(
     [string]$RunId = '',
     [string]$RequirementDocPath = '',
     [string]$RuntimeInputPacketPath = '',
-    [string]$ArtifactRoot = ''
+    [string]$ArtifactRoot = '',
+    [AllowEmptyString()] [string]$GovernanceScope = '',
+    [AllowEmptyString()] [string]$RootRunId = '',
+    [AllowEmptyString()] [string]$ParentRunId = '',
+    [AllowEmptyString()] [string]$ParentUnitId = '',
+    [AllowEmptyString()] [string]$InheritedRequirementDocPath = '',
+    [AllowEmptyString()] [string]$InheritedExecutionPlanPath = ''
 )
 
 Set-StrictMode -Version Latest
@@ -19,8 +25,25 @@ if ([string]::IsNullOrWhiteSpace($RunId)) {
 }
 
 $sessionRoot = Ensure-VibeSessionRoot -RepoRoot $runtime.repo_root -RunId $RunId -ArtifactRoot $ArtifactRoot
+$hierarchyState = Get-VibeHierarchyState `
+    -GovernanceScope $GovernanceScope `
+    -RunId $RunId `
+    -RootRunId $RootRunId `
+    -ParentRunId $ParentRunId `
+    -ParentUnitId $ParentUnitId `
+    -InheritedRequirementDocPath $InheritedRequirementDocPath `
+    -InheritedExecutionPlanPath $InheritedExecutionPlanPath `
+    -HierarchyContract $runtime.runtime_input_packet_policy.hierarchy_contract
 $grade = Get-VibeInternalGrade -Task $Task
-$planPath = Get-VibeExecutionPlanPath -RepoRoot $runtime.repo_root -Task $Task -ArtifactRoot $ArtifactRoot
+$isChildScope = ([string]$hierarchyState.governance_scope -eq 'child')
+$planPath = if ($isChildScope) {
+    if ([string]::IsNullOrWhiteSpace([string]$hierarchyState.inherited_execution_plan_path)) {
+        throw 'Child-governed plan stage requires InheritedExecutionPlanPath.'
+    }
+    [string]$hierarchyState.inherited_execution_plan_path
+} else {
+    Get-VibeExecutionPlanPath -RepoRoot $runtime.repo_root -Task $Task -ArtifactRoot $ArtifactRoot
+}
 $requirementPath = if (-not [string]::IsNullOrWhiteSpace($RequirementDocPath)) { $RequirementDocPath } else { Get-VibeRequirementDocPath -RepoRoot $runtime.repo_root -Task $Task -ArtifactRoot $ArtifactRoot }
 $antiDriftDraft = Get-VgoAntiProxyGoalDriftPacketFromRequirementDoc -RequirementDocPath $requirementPath
 $runtimeInputPacket = if (-not [string]::IsNullOrWhiteSpace($RuntimeInputPacketPath) -and (Test-Path -LiteralPath $RuntimeInputPacketPath)) {
@@ -66,6 +89,8 @@ $lines = @(
 $lines += @('')
 if ($runtimeInputPacket) {
     $lines += @(
+        "- Governance scope: $([string]$runtimeInputPacket.governance_scope)",
+        "- Root run id: $([string]$runtimeInputPacket.hierarchy.root_run_id)",
         "- Frozen route pack: $([string]$runtimeInputPacket.route_snapshot.selected_pack)",
         "- Frozen route skill: $([string]$runtimeInputPacket.route_snapshot.selected_skill)",
         "- Frozen route mode: $([string]$runtimeInputPacket.route_snapshot.route_mode)",
@@ -78,16 +103,52 @@ $lines += @(
     '## Internal Grade Decision',
     "- Grade: $grade",
     '- User-facing runtime remains fixed; grade is internal only.',
+    '- `vibe` remains the governor and final authority for execution flow.',
     '',
     '## Wave Plan'
 )
 $lines += $waveLines
+$approvedDispatch = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.approved_dispatch) } else { @() }
+$localSuggestions = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.local_specialist_suggestions) } else { @() }
+if (@($approvedDispatch).Count -gt 0 -or @($localSuggestions).Count -gt 0) {
+    $lines += @(
+        '',
+        '## Specialist Skill Dispatch Plan',
+        '- Specialist dispatch is advisory and bounded; it does not transfer runtime authority away from vibe.',
+        '- Each specialist must be invoked through its native workflow, input contract, and validation style.',
+        '- Specialist outputs remain subordinate to the frozen requirement and the governed plan.'
+    )
+    foreach ($recommendation in @($approvedDispatch)) {
+        $lines += @(
+            ('- Dispatch {0} as {1}.' -f [string]$recommendation.skill_id, [string]$recommendation.bounded_role),
+            ('  Reason: {0}' -f [string]$recommendation.reason),
+            ('  Required inputs: {0}' -f [string]::Join(', ', @($recommendation.required_inputs))),
+            ('  Expected outputs: {0}' -f [string]::Join(', ', @($recommendation.expected_outputs))),
+            ('  Verification: {0}' -f [string]$recommendation.verification_expectation)
+        )
+    }
+    if (@($localSuggestions).Count -gt 0) {
+        $lines += @(
+            '',
+            '## Child Specialist Escalation Suggestions',
+            '- These suggestions are advisory only until root-governed approval updates the canonical dispatch surface.'
+        )
+        foreach ($recommendation in @($localSuggestions)) {
+            $lines += @(
+                ('- Suggest {0}.' -f [string]$recommendation.skill_id),
+                ('  Reason: {0}' -f [string]$recommendation.reason),
+                '  Escalation required: true'
+            )
+        }
+    }
+}
 $lines += @(
     '',
     '## Ownership Boundaries',
     '- One owner per artifact set.',
     '- Parallel work must use disjoint write scopes.',
     '- Subagent prompts must end with `$vibe`.',
+    '- Specialist help stays bounded and native-mode; it must not become a second planner or a second runtime.',
     '',
     '## Verification Commands',
     '- Run targeted repo verification for changed surfaces.',
@@ -104,15 +165,43 @@ $lines += @(
     '- Write cleanup receipt before completion.'
 )
 
-Write-VibeMarkdownArtifact -Path $planPath -Lines $lines
+$childHandoffPath = $null
+if ($isChildScope) {
+    if (-not (Test-Path -LiteralPath $planPath)) {
+        throw ("Child-governed plan stage cannot inherit missing canonical execution plan: {0}" -f $planPath)
+    }
+
+    $childHandoffPath = Join-Path $sessionRoot 'child-execution-handoff.md'
+    $handoffLines = @(
+        "# Child Execution Handoff",
+        '',
+        '- governance_scope: child',
+        ('- inherited_execution_plan: {0}' -f $planPath),
+        ('- root_run_id: {0}' -f [string]$hierarchyState.root_run_id),
+        ('- parent_run_id: {0}' -f [string]$hierarchyState.parent_run_id),
+        ('- parent_unit_id: {0}' -f [string]$hierarchyState.parent_unit_id),
+        '- canonical_write_allowed: false',
+        ('- approved_specialist_dispatch_count: {0}' -f @($approvedDispatch).Count),
+        ('- local_specialist_suggestion_count: {0}' -f @($localSuggestions).Count),
+        '',
+        'Child-governed lanes inherit the frozen root plan and may not create a second canonical execution-plan surface.'
+    )
+    Write-VibeMarkdownArtifact -Path $childHandoffPath -Lines $handoffLines
+} else {
+    Write-VibeMarkdownArtifact -Path $planPath -Lines $lines
+}
 
 $receipt = [pscustomobject]@{
     stage = 'xl_plan'
     run_id = $RunId
+    governance_scope = [string]$hierarchyState.governance_scope
     mode = $Mode
     internal_grade = $grade
     requirement_doc_path = $requirementPath
     execution_plan_path = $planPath
+    child_execution_handoff_path = $childHandoffPath
+    canonical_write_allowed = -not $isChildScope
+    inherited_execution_plan_path = if ($isChildScope) { $planPath } else { $null }
     runtime_input_packet_path = $RuntimeInputPacketPath
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 }

--- a/scripts/runtime/invoke-vibe-runtime.ps1
+++ b/scripts/runtime/invoke-vibe-runtime.ps1
@@ -3,6 +3,13 @@ param(
     [ValidateSet('interactive_governed', 'benchmark_autonomous')] [string]$Mode = 'interactive_governed',
     [string]$RunId = '',
     [string]$ArtifactRoot = '',
+    [AllowEmptyString()] [string]$GovernanceScope = '',
+    [AllowEmptyString()] [string]$RootRunId = '',
+    [AllowEmptyString()] [string]$ParentRunId = '',
+    [AllowEmptyString()] [string]$ParentUnitId = '',
+    [AllowEmptyString()] [string]$InheritedRequirementDocPath = '',
+    [AllowEmptyString()] [string]$InheritedExecutionPlanPath = '',
+    [string[]]$ApprovedSpecialistSkillIds = @(),
     [switch]$ExecuteGovernanceCleanup,
     [switch]$ApplyManagedNodeCleanup
 )
@@ -68,13 +75,88 @@ if ([string]::IsNullOrWhiteSpace($RunId)) {
     $RunId = New-VibeRunId
 }
 $artifactBaseRoot = Get-VibeArtifactRoot -RepoRoot $runtime.repo_root -ArtifactRoot $ArtifactRoot
+$hierarchyState = Get-VibeHierarchyState `
+    -GovernanceScope $GovernanceScope `
+    -RunId $RunId `
+    -RootRunId $RootRunId `
+    -ParentRunId $ParentRunId `
+    -ParentUnitId $ParentUnitId `
+    -InheritedRequirementDocPath $InheritedRequirementDocPath `
+    -InheritedExecutionPlanPath $InheritedExecutionPlanPath `
+    -HierarchyContract $runtime.runtime_input_packet_policy.hierarchy_contract
+
+$hierarchyArgs = @{
+    GovernanceScope = [string]$hierarchyState.governance_scope
+}
+if (-not [string]::IsNullOrWhiteSpace([string]$hierarchyState.root_run_id)) {
+    $hierarchyArgs.RootRunId = [string]$hierarchyState.root_run_id
+}
+if (-not [string]::IsNullOrWhiteSpace([string]$hierarchyState.parent_run_id)) {
+    $hierarchyArgs.ParentRunId = [string]$hierarchyState.parent_run_id
+}
+if (-not [string]::IsNullOrWhiteSpace([string]$hierarchyState.parent_unit_id)) {
+    $hierarchyArgs.ParentUnitId = [string]$hierarchyState.parent_unit_id
+}
+if (-not [string]::IsNullOrWhiteSpace([string]$hierarchyState.inherited_requirement_doc_path)) {
+    $hierarchyArgs.InheritedRequirementDocPath = [string]$hierarchyState.inherited_requirement_doc_path
+}
+if (-not [string]::IsNullOrWhiteSpace([string]$hierarchyState.inherited_execution_plan_path)) {
+    $hierarchyArgs.InheritedExecutionPlanPath = [string]$hierarchyState.inherited_execution_plan_path
+}
 
 $skeleton = & (Join-Path $PSScriptRoot 'Invoke-SkeletonCheck.ps1') -Task $Task -Mode $Mode -RunId $RunId -ArtifactRoot $ArtifactRoot
-$runtimeInput = & (Join-Path $PSScriptRoot 'Freeze-RuntimeInputPacket.ps1') -Task $Task -Mode $Mode -RunId $RunId -ArtifactRoot $ArtifactRoot
+$freezeArgs = @{
+    Task = $Task
+    Mode = $Mode
+    RunId = $RunId
+    ArtifactRoot = $ArtifactRoot
+    ApprovedSpecialistSkillIds = $ApprovedSpecialistSkillIds
+}
+foreach ($key in @($hierarchyArgs.Keys)) {
+    $freezeArgs[$key] = $hierarchyArgs[$key]
+}
+$runtimeInput = & (Join-Path $PSScriptRoot 'Freeze-RuntimeInputPacket.ps1') @freezeArgs
 $interview = & (Join-Path $PSScriptRoot 'Invoke-DeepInterview.ps1') -Task $Task -Mode $Mode -RunId $RunId -ArtifactRoot $ArtifactRoot
-$requirement = & (Join-Path $PSScriptRoot 'Write-RequirementDoc.ps1') -Task $Task -Mode $Mode -RunId $RunId -IntentContractPath $interview.receipt_path -RuntimeInputPacketPath $runtimeInput.packet_path -ArtifactRoot $ArtifactRoot
-$plan = & (Join-Path $PSScriptRoot 'Write-XlPlan.ps1') -Task $Task -Mode $Mode -RunId $RunId -RequirementDocPath $requirement.requirement_doc_path -RuntimeInputPacketPath $runtimeInput.packet_path -ArtifactRoot $ArtifactRoot
-$execute = & (Join-Path $PSScriptRoot 'Invoke-PlanExecute.ps1') -Task $Task -Mode $Mode -RunId $RunId -RequirementDocPath $requirement.requirement_doc_path -ExecutionPlanPath $plan.execution_plan_path -RuntimeInputPacketPath $runtimeInput.packet_path -ArtifactRoot $ArtifactRoot
+$requirementArgs = @{
+    Task = $Task
+    Mode = $Mode
+    RunId = $RunId
+    IntentContractPath = $interview.receipt_path
+    RuntimeInputPacketPath = $runtimeInput.packet_path
+    ArtifactRoot = $ArtifactRoot
+}
+foreach ($key in @($hierarchyArgs.Keys)) {
+    $requirementArgs[$key] = $hierarchyArgs[$key]
+}
+$requirement = & (Join-Path $PSScriptRoot 'Write-RequirementDoc.ps1') @requirementArgs
+$planArgs = @{
+    Task = $Task
+    Mode = $Mode
+    RunId = $RunId
+    RequirementDocPath = $requirement.requirement_doc_path
+    RuntimeInputPacketPath = $runtimeInput.packet_path
+    ArtifactRoot = $ArtifactRoot
+}
+foreach ($key in @($hierarchyArgs.Keys)) {
+    $planArgs[$key] = $hierarchyArgs[$key]
+}
+$planArgs.InheritedRequirementDocPath = $requirement.requirement_doc_path
+$plan = & (Join-Path $PSScriptRoot 'Write-XlPlan.ps1') @planArgs
+$executeArgs = @{
+    Task = $Task
+    Mode = $Mode
+    RunId = $RunId
+    RequirementDocPath = $requirement.requirement_doc_path
+    ExecutionPlanPath = $plan.execution_plan_path
+    RuntimeInputPacketPath = $runtimeInput.packet_path
+    ArtifactRoot = $ArtifactRoot
+}
+foreach ($key in @('GovernanceScope', 'RootRunId', 'ParentRunId', 'ParentUnitId')) {
+    if ($hierarchyArgs.ContainsKey($key)) {
+        $executeArgs[$key] = $hierarchyArgs[$key]
+    }
+}
+$execute = & (Join-Path $PSScriptRoot 'Invoke-PlanExecute.ps1') @executeArgs
 $cleanup = & (Join-Path $PSScriptRoot 'Invoke-PhaseCleanup.ps1') -Task $Task -Mode $Mode -RunId $RunId -ArtifactRoot $ArtifactRoot -ExecuteGovernanceCleanup:$ExecuteGovernanceCleanup -ApplyManagedNodeCleanup:$ApplyManagedNodeCleanup
 
 $artifactReadiness = Wait-VibeArtifactSet -Paths @(
@@ -111,12 +193,20 @@ $relativeArtifacts = [ordered]@{
 
 $summary = [pscustomobject]@{
     run_id = $RunId
+    governance_scope = [string]$hierarchyState.governance_scope
     mode = $Mode
     task = $Task
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     artifact_root = $artifactBaseRoot
     session_root = $skeleton.session_root
     session_root_relative = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$skeleton.session_root)
+    hierarchy = [pscustomobject]@{
+        root_run_id = [string]$hierarchyState.root_run_id
+        parent_run_id = if ($null -eq $hierarchyState.parent_run_id) { $null } else { [string]$hierarchyState.parent_run_id }
+        parent_unit_id = if ($null -eq $hierarchyState.parent_unit_id) { $null } else { [string]$hierarchyState.parent_unit_id }
+        inherited_requirement_doc_path = if ($null -eq $hierarchyState.inherited_requirement_doc_path) { $null } else { [string]$hierarchyState.inherited_requirement_doc_path }
+        inherited_execution_plan_path = if ($null -eq $hierarchyState.inherited_execution_plan_path) { $null } else { [string]$hierarchyState.inherited_execution_plan_path }
+    }
     stage_order = @(
         'skeleton_check',
         'deep_interview',

--- a/scripts/verify/vibe-benchmark-autonomous-proof-gate.ps1
+++ b/scripts/verify/vibe-benchmark-autonomous-proof-gate.ps1
@@ -51,7 +51,7 @@ foreach ($relativePath in $requiredFiles) {
 
 $runId = "benchmark-proof-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
 $artifactRoot = Join-Path $repoRoot (".tmp\benchmark-proof-{0}" -f $runId)
-$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'benchmark autonomous proof closure' -Mode benchmark_autonomous -RunId $runId -ArtifactRoot $artifactRoot
+$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'I have a failing test and a stack trace. Help me debug systematically before proposing fixes.' -Mode benchmark_autonomous -RunId $runId -ArtifactRoot $artifactRoot
 
 $executeReceiptPath = [string]$summary.summary.artifacts.execute_receipt
 $executionManifestPath = [string]$summary.summary.artifacts.execution_manifest
@@ -74,14 +74,26 @@ Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.stage -eq
 Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.runtime_mode -eq 'interactive_governed') -Message 'runtime input packet records interactive_governed as the effective mode'
 Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$runtimeInputPacket.canonical_router.unattended) -Message 'legacy benchmark mode no longer drives unattended router execution'
 Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.provenance.proof_class -eq 'structure') -Message 'runtime input packet carries structure proof class'
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.route_snapshot.selected_skill -eq 'vibe') -Message 'runtime input packet keeps vibe as the frozen route skill for governed entry'
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'runtime input packet keeps vibe as runtime authority'
+Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$runtimeInputPacket.divergence_shadow.skill_mismatch) -Message 'runtime input packet keeps router/runtime alignment for explicit governed vibe entry'
+Add-Assertion -Results ([ref]$results) -Condition (@($runtimeInputPacket.specialist_recommendations).Count -ge 1) -Message 'runtime input packet carries specialist recommendations'
+Add-Assertion -Results ([ref]$results) -Condition ((@($runtimeInputPacket.specialist_recommendations | ForEach-Object { [string]$_.skill_id }) -contains 'systematic-debugging')) -Message 'runtime input packet carries systematic-debugging as bounded specialist recommendation'
 Add-Assertion -Results ([ref]$results) -Condition ($executeReceipt.status -ne 'execution-contract-prepared') -Message 'execute receipt is no longer receipt-only'
 Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.status -eq 'completed') -Message 'execution manifest status is completed' -Details $executionManifest.status
 Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.executed_unit_count -ge 2) -Message 'benchmark executed at least two real units' -Details $executionManifest.executed_unit_count
 Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.failed_unit_count -eq 0) -Message 'benchmark execution has zero failed units' -Details $executionManifest.failed_unit_count
 Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.proof_class -eq 'runtime') -Message 'execution manifest carries runtime proof class'
 Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath ([string]$executeReceipt.plan_shadow_path)) -Message 'plan-derived shadow manifest exists' -Details ([string]$executeReceipt.plan_shadow_path)
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executeReceipt.specialist_recommendation_count -ge 1) -Message 'execute receipt carries specialist recommendation count'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executeReceipt.specialist_dispatch_unit_count -ge 1) -Message 'execute receipt carries specialist dispatch unit count'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.specialist_accounting.recommendation_count -ge 1) -Message 'execution manifest carries specialist accounting'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.specialist_accounting.dispatch_unit_count -ge 1) -Message 'execution manifest carries specialist dispatch accounting'
+Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$executionManifest.route_runtime_alignment.skill_mismatch) -Message 'execution manifest preserves governed vibe alignment while still carrying specialist accounting'
 Add-Assertion -Results ([ref]$results) -Condition ([bool]$proofManifest.proof_passed) -Message 'benchmark proof manifest marks proof_passed=true'
 Add-Assertion -Results ([ref]$results) -Condition ($proofManifest.proof_class -eq 'runtime') -Message 'benchmark proof manifest carries runtime proof class'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$proofManifest.specialist_recommendation_count -ge 1) -Message 'benchmark proof manifest carries specialist recommendation count'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$proofManifest.specialist_dispatch_unit_count -ge 1) -Message 'benchmark proof manifest carries specialist dispatch count'
 Add-Assertion -Results ([ref]$results) -Condition ($cleanupReceipt.cleanup_mode -eq 'receipt_only') -Message 'legacy benchmark mode now uses interactive_governed cleanup defaults'
 Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$cleanupReceipt.default_bounded_cleanup_applied) -Message 'legacy benchmark mode no longer applies bounded cleanup by default'
 Add-Assertion -Results ([ref]$results) -Condition ($cleanupReceipt.proof_class -eq 'runtime') -Message 'cleanup receipt carries runtime proof class'

--- a/scripts/verify/vibe-child-specialist-escalation-gate.ps1
+++ b/scripts/verify/vibe-child-specialist-escalation-gate.ps1
@@ -1,0 +1,195 @@
+param(
+    [switch]$WriteArtifacts,
+    [string]$OutputDirectory = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
+. (Join-Path $PSScriptRoot '..\runtime\VibeRuntime.Common.ps1')
+
+function Add-Assertion {
+    param(
+        [ref]$Results,
+        [bool]$Condition,
+        [string]$Message,
+        [string]$Details = ''
+    )
+
+    $record = [pscustomobject]@{
+        passed = [bool]$Condition
+        message = $Message
+        details = $Details
+    }
+    $Results.Value += $record
+
+    if ($Condition) {
+        Write-Host "[PASS] $Message"
+    } else {
+        Write-Host "[FAIL] $Message" -ForegroundColor Red
+        if ($Details) {
+            Write-Host "       $Details" -ForegroundColor DarkRed
+        }
+    }
+}
+
+$context = Get-VgoGovernanceContext -ScriptPath $PSCommandPath -EnforceExecutionContext
+$repoRoot = $context.repoRoot
+$results = @()
+
+$policyText = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-input-packet-policy.json') -Raw -Encoding UTF8
+foreach ($token in @('specialist_dispatch', 'local_specialist_suggestions', 'escalation_required', 'advisory_until_root_approval')) {
+    Add-Assertion -Results ([ref]$results) -Condition ($policyText.Contains($token)) -Message ("runtime input policy contains specialist escalation token: {0}" -f $token)
+}
+
+$teamText = Get-Content -LiteralPath (Join-Path $repoRoot 'protocols\team.md') -Raw -Encoding UTF8
+$stableDocText = Get-Content -LiteralPath (Join-Path $repoRoot 'docs\root-child-vibe-hierarchy-governance.md') -Raw -Encoding UTF8
+Add-Assertion -Results ([ref]$results) -Condition ($teamText.Contains('advisory until the governed plan chooses to dispatch it')) -Message 'team protocol keeps specialist recommendation advisory-first'
+Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('this remains a suggestion until escalated and approved by root')) -Message 'stable hierarchy doc requires root approval for child-local specialist suggestion'
+
+$runId = "child-specialist-escalation-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
+$artifactRoot = Join-Path $repoRoot (".tmp\child-specialist-escalation-{0}" -f $runId)
+
+$rootSummary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') `
+    -Task 'Root specialist dispatch seed for child escalation gate.' `
+    -Mode benchmark_autonomous `
+    -GovernanceScope root `
+    -RunId ("{0}-root" -f $runId) `
+    -ArtifactRoot $artifactRoot
+
+Add-Assertion -Results ([ref]$results) -Condition ($null -ne $rootSummary) -Message 'root specialist escalation probe returned summary payload'
+$hasRootSummary = ($null -ne $rootSummary) -and ($rootSummary.PSObject.Properties.Name -contains 'summary')
+Add-Assertion -Results ([ref]$results) -Condition $hasRootSummary -Message 'root specialist escalation probe has summary object'
+
+$approvedForChild = @()
+if ($hasRootSummary) {
+    $rootRuntimeInputPacket = Get-Content -LiteralPath $rootSummary.summary.artifacts.runtime_input_packet -Raw -Encoding UTF8 | ConvertFrom-Json
+    Add-Assertion -Results ([ref]$results) -Condition ($rootRuntimeInputPacket.governance_scope -eq 'root') -Message 'root specialist escalation probe is in root scope'
+    Add-Assertion -Results ([ref]$results) -Condition ($rootRuntimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'root specialist escalation probe keeps vibe authority'
+
+    $rootApprovedDispatch = if ($rootRuntimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch') {
+        @($rootRuntimeInputPacket.specialist_dispatch.approved_dispatch)
+    } elseif ($rootRuntimeInputPacket.PSObject.Properties.Name -contains 'approved_specialist_dispatch') {
+        @($rootRuntimeInputPacket.approved_specialist_dispatch)
+    } else {
+        @()
+    }
+    if (@($rootApprovedDispatch).Count -gt 0) {
+        $firstSkillId = [string]$rootApprovedDispatch[0].skill_id
+        if (-not [string]::IsNullOrWhiteSpace($firstSkillId)) {
+            $approvedForChild = @($firstSkillId)
+        }
+    }
+}
+
+$childSummary = $null
+if ($hasRootSummary) {
+    $childSummary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') `
+        -Task 'Child specialist escalation advisory smoke.' `
+        -Mode benchmark_autonomous `
+        -GovernanceScope child `
+        -RunId ("{0}-child" -f $runId) `
+        -RootRunId ([string]$rootSummary.summary.run_id) `
+        -ParentRunId ([string]$rootSummary.summary.run_id) `
+        -ParentUnitId 'child-specialist-escalation-unit' `
+        -InheritedRequirementDocPath ([string]$rootSummary.summary.artifacts.requirement_doc) `
+        -InheritedExecutionPlanPath ([string]$rootSummary.summary.artifacts.execution_plan) `
+        -ApprovedSpecialistSkillIds $approvedForChild `
+        -ArtifactRoot $artifactRoot
+}
+
+Add-Assertion -Results ([ref]$results) -Condition ($null -ne $childSummary) -Message 'child specialist escalation probe returned summary payload'
+$hasChildSummary = ($null -ne $childSummary) -and ($childSummary.PSObject.Properties.Name -contains 'summary')
+Add-Assertion -Results ([ref]$results) -Condition $hasChildSummary -Message 'child specialist escalation probe has summary object'
+
+$approvedDispatch = @()
+$localSuggestions = @()
+$childClaims = @()
+if ($hasChildSummary) {
+    $runtimeInputPacket = Get-Content -LiteralPath $childSummary.summary.artifacts.runtime_input_packet -Raw -Encoding UTF8 | ConvertFrom-Json
+    $executionManifest = Get-Content -LiteralPath $childSummary.summary.artifacts.execution_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    $specialistDispatch = if ($runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch') {
+        $runtimeInputPacket.specialist_dispatch
+    } else {
+        $null
+    }
+
+    $approvedDispatch = if ($null -ne $specialistDispatch -and $specialistDispatch.PSObject.Properties.Name -contains 'approved_dispatch') {
+        @($specialistDispatch.approved_dispatch)
+    } elseif ($runtimeInputPacket.PSObject.Properties.Name -contains 'approved_specialist_dispatch') {
+        @($runtimeInputPacket.approved_specialist_dispatch)
+    } else {
+        @()
+    }
+
+    $localSuggestions = if ($null -ne $specialistDispatch -and $specialistDispatch.PSObject.Properties.Name -contains 'local_specialist_suggestions') {
+        @($specialistDispatch.local_specialist_suggestions)
+    } elseif ($runtimeInputPacket.PSObject.Properties.Name -contains 'local_specialist_suggestions') {
+        @($runtimeInputPacket.local_specialist_suggestions)
+    } else {
+        @()
+    }
+
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.governance_scope -eq 'child') -Message 'specialist escalation smoke runs in child scope'
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'specialist escalation smoke keeps vibe runtime authority'
+    Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$runtimeInputPacket.authority_flags.allow_completion_claim) -Message 'child runtime input packet disallows final completion claim'
+    Add-Assertion -Results ([ref]$results) -Condition ($null -ne $specialistDispatch) -Message 'runtime packet exposes specialist dispatch surface'
+
+    if ($null -ne $specialistDispatch) {
+        Add-Assertion -Results ([ref]$results) -Condition ([string]$specialistDispatch.status -eq 'advisory_until_root_approval') -Message 'child specialist suggestions remain advisory until root approval'
+        if (@($localSuggestions).Count -gt 0) {
+            Add-Assertion -Results ([ref]$results) -Condition ([bool]$specialistDispatch.escalation_required) -Message 'child local specialist suggestions require escalation'
+            Add-Assertion -Results ([ref]$results) -Condition ([string]$specialistDispatch.escalation_status -eq 'root_approval_required') -Message 'child local specialist escalation status is root_approval_required'
+        }
+    }
+
+    $approvedSkillIds = @($approvedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    foreach ($entry in $localSuggestions) {
+        $skillId = if ($entry.PSObject.Properties.Name -contains 'skill_id') { [string]$entry.skill_id } else { 'unknown-skill' }
+        Add-Assertion -Results ([ref]$results) -Condition (-not ($approvedSkillIds -contains $skillId)) -Message ("local specialist suggestion is not approved global dispatch: {0}" -f $skillId)
+    }
+
+    Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.governance_scope -eq 'child') -Message 'execution manifest is marked child scope'
+    Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$executionManifest.authority.completion_claim_allowed) -Message 'child execution manifest cannot issue final completion claim'
+    Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.route_runtime_alignment.runtime_selected_skill -eq 'vibe') -Message 'execution manifest keeps explicit vibe authority'
+
+    $childClaims = if ($executionManifest.PSObject.Properties.Name -contains 'child_completion_claims') { @($executionManifest.child_completion_claims) } else { @() }
+}
+
+$failureCount = @($results | Where-Object { -not $_.passed }).Count
+$gatePassed = ($failureCount -eq 0)
+$report = [pscustomobject]@{
+    generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    repo_root = $repoRoot
+    gate_passed = $gatePassed
+    assertion_count = @($results).Count
+    failure_count = $failureCount
+    runtime_summary_path = if ($null -ne $childSummary -and ($childSummary.PSObject.Properties.Name -contains 'summary_path')) { $childSummary.summary_path } else { $null }
+    approved_dispatch_count = @($approvedDispatch).Count
+    local_suggestion_count = @($localSuggestions).Count
+    child_claim_count = @($childClaims).Count
+    results = @($results)
+}
+
+if ($WriteArtifacts) {
+    $targetDir = if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        Join-Path $repoRoot 'outputs\verify\vibe-child-specialist-escalation'
+    } elseif ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+        [System.IO.Path]::GetFullPath($OutputDirectory)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDirectory))
+    }
+
+    New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    Write-VibeJsonArtifact -Path (Join-Path $targetDir 'vibe-child-specialist-escalation-gate.json') -Value $report
+} elseif (Test-Path -LiteralPath $artifactRoot) {
+    Remove-Item -LiteralPath $artifactRoot -Recurse -Force
+}
+
+if (-not $gatePassed) {
+    throw "vibe-child-specialist-escalation-gate failed with $failureCount failing assertion(s)."
+}
+
+$report

--- a/scripts/verify/vibe-governed-runtime-contract-gate.ps1
+++ b/scripts/verify/vibe-governed-runtime-contract-gate.ps1
@@ -98,7 +98,7 @@ Add-Assertion -Results ([ref]$results) -Condition ($teamText.Contains('$vibe')) 
 
 $runId = "contract-gate-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
 $artifactRoot = Join-Path $repoRoot (".tmp\governed-runtime-contract-{0}" -f $runId)
-$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'governed runtime contract smoke proof' -Mode benchmark_autonomous -RunId $runId -ArtifactRoot $artifactRoot
+$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'I have a failing test and a stack trace. Help me debug systematically before proposing fixes.' -Mode benchmark_autonomous -RunId $runId -ArtifactRoot $artifactRoot
 
 Add-Assertion -Results ([ref]$results) -Condition ($summary.mode -eq 'interactive_governed') -Message 'runtime smoke summary normalizes legacy benchmark mode to interactive_governed'
 
@@ -120,6 +120,7 @@ foreach ($artifactPath in $artifactPaths) {
 $executeReceipt = Get-Content -LiteralPath $summary.summary.artifacts.execute_receipt -Raw -Encoding UTF8 | ConvertFrom-Json
 $executionManifest = Get-Content -LiteralPath $summary.summary.artifacts.execution_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
 $proofManifest = Get-Content -LiteralPath $summary.summary.artifacts.benchmark_proof_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+$runtimeInputPacket = Get-Content -LiteralPath $summary.summary.artifacts.runtime_input_packet -Raw -Encoding UTF8 | ConvertFrom-Json
 $generatedRequirement = Get-Content -LiteralPath $summary.summary.artifacts.requirement_doc -Raw -Encoding UTF8
 $generatedPlan = Get-Content -LiteralPath $summary.summary.artifacts.execution_plan -Raw -Encoding UTF8
 
@@ -131,6 +132,15 @@ Add-Assertion -Results ([ref]$results) -Condition ($generatedRequirement.Contain
 Add-Assertion -Results ([ref]$results) -Condition ($generatedRequirement.Contains('## Completion State')) -Message 'runtime smoke requirement doc includes anti-drift completion section'
 Add-Assertion -Results ([ref]$results) -Condition ($generatedPlan.Contains('## Anti-Proxy-Goal-Drift Controls')) -Message 'runtime smoke execution plan includes anti-drift controls section'
 Add-Assertion -Results ([ref]$results) -Condition ($generatedPlan.Contains('### Primary Objective')) -Message 'runtime smoke execution plan includes anti-drift primary objective control'
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.route_snapshot.selected_skill -eq 'vibe') -Message 'runtime smoke keeps vibe as the frozen route skill for governed entry'
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'runtime smoke keeps vibe as explicit runtime skill'
+Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$runtimeInputPacket.divergence_shadow.skill_mismatch) -Message 'runtime smoke keeps router/runtime skill alignment for explicit governed vibe entry'
+Add-Assertion -Results ([ref]$results) -Condition (@($runtimeInputPacket.specialist_recommendations).Count -ge 1) -Message 'runtime smoke freezes bounded specialist recommendations'
+Add-Assertion -Results ([ref]$results) -Condition ((@($runtimeInputPacket.specialist_recommendations | ForEach-Object { [string]$_.skill_id }) -contains 'systematic-debugging')) -Message 'runtime smoke preserves systematic-debugging as a bounded specialist recommendation'
+Add-Assertion -Results ([ref]$results) -Condition ($generatedRequirement.Contains('## Specialist Recommendations')) -Message 'runtime smoke requirement doc includes specialist recommendations section'
+Add-Assertion -Results ([ref]$results) -Condition ($generatedPlan.Contains('## Specialist Skill Dispatch Plan')) -Message 'runtime smoke execution plan includes specialist dispatch section'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.specialist_accounting.recommendation_count -ge 1) -Message 'runtime smoke execution manifest carries specialist accounting'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.plan_shadow.specialist_dispatch_unit_count -ge 1) -Message 'runtime smoke plan shadow counts specialist dispatch units'
 
 $failureCount = @($results | Where-Object { -not $_.passed }).Count
 $gatePassed = ($failureCount -eq 0)

--- a/scripts/verify/vibe-no-duplicate-canonical-surface-gate.ps1
+++ b/scripts/verify/vibe-no-duplicate-canonical-surface-gate.ps1
@@ -1,0 +1,166 @@
+param(
+    [switch]$WriteArtifacts,
+    [string]$OutputDirectory = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
+. (Join-Path $PSScriptRoot '..\runtime\VibeRuntime.Common.ps1')
+
+function Add-Assertion {
+    param(
+        [ref]$Results,
+        [bool]$Condition,
+        [string]$Message,
+        [string]$Details = ''
+    )
+
+    $record = [pscustomobject]@{
+        passed = [bool]$Condition
+        message = $Message
+        details = $Details
+    }
+    $Results.Value += $record
+
+    if ($Condition) {
+        Write-Host "[PASS] $Message"
+    } else {
+        Write-Host "[FAIL] $Message" -ForegroundColor Red
+        if ($Details) {
+            Write-Host "       $Details" -ForegroundColor DarkRed
+        }
+    }
+}
+
+function Test-PathUnderDirectory {
+    param(
+        [Parameter(Mandatory)] [string]$CandidatePath,
+        [Parameter(Mandatory)] [string]$RootPath
+    )
+
+    $candidate = [System.IO.Path]::GetFullPath($CandidatePath)
+    $root = [System.IO.Path]::GetFullPath($RootPath)
+    if (-not $root.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
+        $root += [System.IO.Path]::DirectorySeparatorChar
+    }
+    return $candidate.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Convert-ToNormalizedPathToken {
+    param(
+        [Parameter(Mandatory)] [string]$PathValue
+    )
+
+    return ([System.IO.Path]::GetFullPath($PathValue)).Replace('\', '/')
+}
+
+$context = Get-VgoGovernanceContext -ScriptPath $PSCommandPath -EnforceExecutionContext
+$repoRoot = $context.repoRoot
+$results = @()
+
+$runId = "canonical-surface-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
+$artifactRoot = Join-Path $repoRoot (".tmp\canonical-surface-{0}" -f $runId)
+$task = "Canonical surface uniqueness probe $runId"
+$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task $task -Mode benchmark_autonomous -GovernanceScope root -RunId $runId -ArtifactRoot $artifactRoot
+
+Add-Assertion -Results ([ref]$results) -Condition ($null -ne $summary) -Message 'canonical surface probe returned summary payload'
+$hasSummary = ($null -ne $summary) -and ($summary.PSObject.Properties.Name -contains 'summary')
+Add-Assertion -Results ([ref]$results) -Condition $hasSummary -Message 'canonical surface probe has summary object'
+
+if ($hasSummary) {
+    $requirementDocPath = [string]$summary.summary.artifacts.requirement_doc
+    $executionPlanPath = [string]$summary.summary.artifacts.execution_plan
+    $runtimeInputPacketPath = [string]$summary.summary.artifacts.runtime_input_packet
+    $executionManifestPath = [string]$summary.summary.artifacts.execution_manifest
+
+    Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath $requirementDocPath) -Message 'canonical requirement artifact exists' -Details $requirementDocPath
+    Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath $executionPlanPath) -Message 'canonical execution plan artifact exists' -Details $executionPlanPath
+    $requirementPathToken = Convert-ToNormalizedPathToken -PathValue $requirementDocPath
+    $executionPlanPathToken = Convert-ToNormalizedPathToken -PathValue $executionPlanPath
+    Add-Assertion -Results ([ref]$results) -Condition (
+        $requirementPathToken.Contains('/docs/requirements/')
+    ) -Message 'canonical requirement lives under docs/requirements' -Details $requirementDocPath
+    Add-Assertion -Results ([ref]$results) -Condition (
+        $executionPlanPathToken.Contains('/docs/plans/')
+    ) -Message 'canonical execution plan lives under docs/plans' -Details $executionPlanPath
+
+    $runtimeInputPacket = Get-Content -LiteralPath $runtimeInputPacketPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.governance_scope -eq 'root') -Message 'canonical surface probe runs in root governance scope'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_requirement_freeze) -Message 'root scope keeps requirement freeze authority'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_plan_freeze) -Message 'root scope keeps plan freeze authority'
+
+    $stableDocText = Get-Content -LiteralPath (Join-Path $repoRoot 'docs\root-child-vibe-hierarchy-governance.md') -Raw -Encoding UTF8
+    Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('one canonical requirement surface')) -Message 'stable hierarchy doc forbids duplicate requirement truth'
+    Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('one canonical execution-plan surface')) -Message 'stable hierarchy doc forbids duplicate execution-plan truth'
+
+    $childRunId = "canonical-surface-child-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
+    $childSummary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') `
+        -Task ("Child canonical surface uniqueness probe {0}" -f $childRunId) `
+        -Mode benchmark_autonomous `
+        -GovernanceScope child `
+        -RunId $childRunId `
+        -RootRunId ([string]$summary.summary.run_id) `
+        -ParentRunId ([string]$summary.summary.run_id) `
+        -ParentUnitId 'canonical-surface-child-unit' `
+        -InheritedRequirementDocPath $requirementDocPath `
+        -InheritedExecutionPlanPath $executionPlanPath `
+        -ArtifactRoot $artifactRoot
+
+    Add-Assertion -Results ([ref]$results) -Condition ($null -ne $childSummary) -Message 'child canonical probe returned summary payload'
+    $hasChildSummary = ($null -ne $childSummary) -and ($childSummary.PSObject.Properties.Name -contains 'summary')
+    Add-Assertion -Results ([ref]$results) -Condition $hasChildSummary -Message 'child canonical probe has summary object'
+
+    if ($hasChildSummary) {
+        $childRequirementReceipt = Get-Content -LiteralPath $childSummary.summary.artifacts.requirement_receipt -Raw -Encoding UTF8 | ConvertFrom-Json
+        $childExecutionPlanReceipt = Get-Content -LiteralPath $childSummary.summary.artifacts.execution_plan_receipt -Raw -Encoding UTF8 | ConvertFrom-Json
+        $childExecutionManifest = Get-Content -LiteralPath $childSummary.summary.artifacts.execution_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+
+        Add-Assertion -Results ([ref]$results) -Condition ($childSummary.summary.governance_scope -eq 'child') -Message 'child canonical probe runs in child governance scope'
+        Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$childRequirementReceipt.canonical_write_allowed) -Message 'child requirement stage cannot write canonical requirement surface'
+        Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$childExecutionPlanReceipt.canonical_write_allowed) -Message 'child plan stage cannot write canonical plan surface'
+        Add-Assertion -Results ([ref]$results) -Condition (
+            [System.IO.Path]::GetFullPath([string]$childRequirementReceipt.requirement_doc_path) -eq [System.IO.Path]::GetFullPath([string]$requirementDocPath)
+        ) -Message 'child requirement stage reuses root canonical requirement path'
+        Add-Assertion -Results ([ref]$results) -Condition (
+            [System.IO.Path]::GetFullPath([string]$childExecutionPlanReceipt.execution_plan_path) -eq [System.IO.Path]::GetFullPath([string]$executionPlanPath)
+        ) -Message 'child plan stage reuses root canonical execution plan path'
+        Add-Assertion -Results ([ref]$results) -Condition ($childExecutionManifest.governance_scope -eq 'child') -Message 'child execution manifest is marked as child scope'
+        Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$childExecutionManifest.authority.completion_claim_allowed) -Message 'child execution manifest cannot issue final completion claims'
+    }
+}
+
+$failureCount = @($results | Where-Object { -not $_.passed }).Count
+$gatePassed = ($failureCount -eq 0)
+$report = [pscustomobject]@{
+    generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    repo_root = $repoRoot
+    gate_passed = $gatePassed
+    assertion_count = @($results).Count
+    failure_count = $failureCount
+    runtime_summary_path = if ($null -ne $summary -and ($summary.PSObject.Properties.Name -contains 'summary_path')) { $summary.summary_path } else { $null }
+    results = @($results)
+}
+
+if ($WriteArtifacts) {
+    $targetDir = if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        Join-Path $repoRoot 'outputs\verify\vibe-no-duplicate-canonical-surface'
+    } elseif ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+        [System.IO.Path]::GetFullPath($OutputDirectory)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDirectory))
+    }
+
+    New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    Write-VibeJsonArtifact -Path (Join-Path $targetDir 'vibe-no-duplicate-canonical-surface-gate.json') -Value $report
+} elseif (Test-Path -LiteralPath $artifactRoot) {
+    Remove-Item -LiteralPath $artifactRoot -Recurse -Force
+}
+
+if (-not $gatePassed) {
+    throw "vibe-no-duplicate-canonical-surface-gate failed with $failureCount failing assertion(s)."
+}
+
+$report

--- a/scripts/verify/vibe-root-child-hierarchy-gate.ps1
+++ b/scripts/verify/vibe-root-child-hierarchy-gate.ps1
@@ -1,0 +1,141 @@
+param(
+    [switch]$WriteArtifacts,
+    [string]$OutputDirectory = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
+. (Join-Path $PSScriptRoot '..\runtime\VibeRuntime.Common.ps1')
+
+function Add-Assertion {
+    param(
+        [ref]$Results,
+        [bool]$Condition,
+        [string]$Message,
+        [string]$Details = ''
+    )
+
+    $record = [pscustomobject]@{
+        passed = [bool]$Condition
+        message = $Message
+        details = $Details
+    }
+    $Results.Value += $record
+
+    if ($Condition) {
+        Write-Host "[PASS] $Message"
+    } else {
+        Write-Host "[FAIL] $Message" -ForegroundColor Red
+        if ($Details) {
+            Write-Host "       $Details" -ForegroundColor DarkRed
+        }
+    }
+}
+
+$context = Get-VgoGovernanceContext -ScriptPath $PSCommandPath -EnforceExecutionContext
+$repoRoot = $context.repoRoot
+$results = @()
+
+$requiredFiles = @(
+    'docs/root-child-vibe-hierarchy-governance.md',
+    'docs/requirements/2026-03-28-root-child-vibe-hierarchy-governance.md',
+    'docs/plans/2026-03-28-root-child-vibe-hierarchy-governance-plan.md',
+    'tests/runtime_neutral/test_root_child_hierarchy_bridge.py'
+)
+foreach ($relativePath in $requiredFiles) {
+    Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath)) -Message ("hierarchy required file exists: {0}" -f $relativePath)
+}
+
+$runtimeContract = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-contract.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeContract.entry_skill -eq 'vibe') -Message 'runtime contract entry skill remains vibe'
+
+$policyText = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-input-packet-policy.json') -Raw -Encoding UTF8
+foreach ($token in @(
+    'governance_scope',
+    'hierarchy_contract',
+    'child_specialist_suggestion_contract',
+    'allow_requirement_freeze',
+    'allow_plan_freeze',
+    'allow_global_dispatch',
+    'allow_completion_claim',
+    'specialist_dispatch',
+    'advisory_until_root_approval',
+    'escalation_required'
+)) {
+    Add-Assertion -Results ([ref]$results) -Condition ($policyText.Contains($token)) -Message ("runtime input policy contains hierarchy token: {0}" -f $token)
+}
+
+$runtimeText = Get-Content -LiteralPath (Join-Path $repoRoot 'protocols\runtime.md') -Raw -Encoding UTF8
+$teamText = Get-Content -LiteralPath (Join-Path $repoRoot 'protocols\team.md') -Raw -Encoding UTF8
+$stableDocText = Get-Content -LiteralPath (Join-Path $repoRoot 'docs\root-child-vibe-hierarchy-governance.md') -Raw -Encoding UTF8
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeText.Contains('runtime-selected skill stays `vibe`')) -Message 'runtime protocol documents explicit vibe authority preservation'
+Add-Assertion -Results ([ref]$results) -Condition ($teamText.Contains('`vibe` keeps final control')) -Message 'team protocol keeps vibe as final control'
+Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('root vibe governs, child vibe executes, specialists assist')) -Message 'stable hierarchy doc exposes root/child mental model'
+
+$runId = "root-child-hierarchy-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
+$artifactRoot = Join-Path $repoRoot (".tmp\root-child-hierarchy-{0}" -f $runId)
+$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'Root child hierarchy authority smoke.' -Mode benchmark_autonomous -GovernanceScope root -RunId $runId -ArtifactRoot $artifactRoot
+
+Add-Assertion -Results ([ref]$results) -Condition ($null -ne $summary) -Message 'runtime smoke returned summary payload'
+$hasSummary = ($null -ne $summary) -and ($summary.PSObject.Properties.Name -contains 'summary')
+Add-Assertion -Results ([ref]$results) -Condition $hasSummary -Message 'runtime smoke summary object exists'
+
+if ($hasSummary) {
+    $runtimeInputPacket = Get-Content -LiteralPath $summary.summary.artifacts.runtime_input_packet -Raw -Encoding UTF8 | ConvertFrom-Json
+    $executionManifest = Get-Content -LiteralPath $summary.summary.artifacts.execution_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    Add-Assertion -Results ([ref]$results) -Condition ($summary.mode -eq 'interactive_governed') -Message 'legacy benchmark mode is normalized to interactive_governed for hierarchy smoke'
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.route_snapshot.selected_skill -eq 'vibe') -Message 'root hierarchy smoke keeps vibe as frozen route skill'
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'root hierarchy smoke keeps vibe as runtime authority'
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.governance_scope -eq 'root') -Message 'runtime packet marks root governance scope'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_requirement_freeze) -Message 'root packet allows requirement freeze'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_plan_freeze) -Message 'root packet allows plan freeze'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_global_dispatch) -Message 'root packet allows global specialist dispatch'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_completion_claim) -Message 'root packet allows final completion claim'
+    $hasSpecialistDispatchSurface = ($runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch') -or ($runtimeInputPacket.PSObject.Properties.Name -contains 'approved_specialist_dispatch')
+    Add-Assertion -Results ([ref]$results) -Condition $hasSpecialistDispatchSurface -Message 'runtime packet includes specialist dispatch surface'
+    $hasEscalationSurface = ($runtimeInputPacket.PSObject.Properties.Name -contains 'escalation_required') -or (($runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch') -and ($runtimeInputPacket.specialist_dispatch.PSObject.Properties.Name -contains 'escalation_required'))
+    Add-Assertion -Results ([ref]$results) -Condition $hasEscalationSurface -Message 'runtime packet includes escalation marker surface'
+
+    $hasCompletionAuthority = ($executionManifest.PSObject.Properties.Name -contains 'authority')
+    Add-Assertion -Results ([ref]$results) -Condition $hasCompletionAuthority -Message 'execution manifest includes authority surface'
+    if ($hasCompletionAuthority) {
+        Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.governance_scope -eq 'root') -Message 'execution manifest marks root governance scope'
+        Add-Assertion -Results ([ref]$results) -Condition ([bool]$executionManifest.authority.completion_claim_allowed) -Message 'execution manifest allows final completion claim only for root scope'
+    }
+}
+
+$failureCount = @($results | Where-Object { -not $_.passed }).Count
+$gatePassed = ($failureCount -eq 0)
+$report = [pscustomobject]@{
+    generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    repo_root = $repoRoot
+    gate_passed = $gatePassed
+    assertion_count = @($results).Count
+    failure_count = $failureCount
+    runtime_summary_path = if ($null -ne $summary -and ($summary.PSObject.Properties.Name -contains 'summary_path')) { $summary.summary_path } else { $null }
+    results = @($results)
+}
+
+if ($WriteArtifacts) {
+    $targetDir = if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        Join-Path $repoRoot 'outputs\verify\vibe-root-child-hierarchy'
+    } elseif ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+        [System.IO.Path]::GetFullPath($OutputDirectory)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDirectory))
+    }
+
+    New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    Write-VibeJsonArtifact -Path (Join-Path $targetDir 'vibe-root-child-hierarchy-gate.json') -Value $report
+} elseif (Test-Path -LiteralPath $artifactRoot) {
+    Remove-Item -LiteralPath $artifactRoot -Recurse -Force
+}
+
+if (-not $gatePassed) {
+    throw "vibe-root-child-hierarchy-gate failed with $failureCount failing assertion(s)."
+}
+
+$report

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -51,6 +51,9 @@ def _create_fake_command(directory: Path, name: str) -> Path:
     return command_path
 
 
+SPECIALIST_TASK = "I have a failing test and a stack trace. Help me debug systematically before proposing fixes."
+
+
 def resolve_python_command_spec_via_powershell(command_spec: str, path_entries: list[Path]) -> dict[str, object]:
     shell = resolve_powershell()
     if shell is None:
@@ -138,7 +141,7 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
                 (
                     "& { "
                     f"$result = & '{script_path}' "
-                    "-Task 'bridge governed runtime into a verified temporary artifact root' "
+                    f"-Task '{SPECIALIST_TASK}' "
                     "-Mode benchmark_autonomous "
                     f"-RunId '{run_id}' "
                     f"-ArtifactRoot '{artifact_root}'; "
@@ -220,8 +223,11 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
                 self.assertIn("## Acceptance Criteria", requirement_doc)
                 self.assertIn("## Assumptions", requirement_doc)
                 self.assertIn("## Runtime Input Truth", requirement_doc)
+                self.assertIn("## Specialist Recommendations", requirement_doc)
             self.assertEqual("requirements", requirement_doc_path.parent.name)
             self.assertEqual("plans", execution_plan_path.parent.name)
+            execution_plan = execution_plan_path.read_text(encoding="utf-8")
+            self.assertIn("## Specialist Skill Dispatch Plan", execution_plan)
 
             runtime_input_packet = json.loads(runtime_input_packet_path.read_text(encoding="utf-8"))
             execute_receipt = json.loads(execute_receipt_path.read_text(encoding="utf-8"))
@@ -233,20 +239,39 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertFalse(runtime_input_packet["canonical_router"]["unattended"])
             self.assertEqual("structure", runtime_input_packet["provenance"]["proof_class"])
             self.assertEqual("vibe", runtime_input_packet["authority_flags"]["explicit_runtime_skill"])
+            self.assertEqual("vibe", runtime_input_packet["route_snapshot"]["selected_skill"])
+            self.assertFalse(runtime_input_packet["divergence_shadow"]["skill_mismatch"])
+            self.assertGreaterEqual(len(runtime_input_packet["specialist_recommendations"]), 1)
+            self.assertIn(
+                "systematic-debugging",
+                [item["skill_id"] for item in runtime_input_packet["specialist_recommendations"]],
+            )
             self.assertNotEqual("execution-contract-prepared", execute_receipt["status"])
             self.assertGreaterEqual(execute_receipt["executed_unit_count"], 2)
             self.assertTrue(Path(execute_receipt["plan_shadow_path"]).exists())
             self.assertEqual("runtime", execute_receipt["proof_class"])
+            self.assertGreaterEqual(execute_receipt["specialist_recommendation_count"], 1)
+            self.assertGreaterEqual(execute_receipt["specialist_dispatch_unit_count"], 1)
+            self.assertIn("systematic-debugging", execute_receipt["specialist_skills"])
             self.assertEqual(execute_receipt["executed_unit_count"], execution_manifest["executed_unit_count"])
             self.assertEqual("completed", execution_manifest["status"])
             self.assertGreaterEqual(execution_manifest["successful_unit_count"], 2)
             self.assertEqual(0, execution_manifest["failed_unit_count"])
             self.assertEqual("runtime", execution_manifest["proof_class"])
             self.assertTrue(Path(execution_manifest["plan_shadow"]["path"]).exists())
+            self.assertEqual("vibe", execution_manifest["route_runtime_alignment"]["router_selected_skill"])
+            self.assertEqual("vibe", execution_manifest["route_runtime_alignment"]["runtime_selected_skill"])
+            self.assertFalse(execution_manifest["route_runtime_alignment"]["skill_mismatch"])
+            self.assertGreaterEqual(execution_manifest["specialist_accounting"]["recommendation_count"], 1)
+            self.assertGreaterEqual(execution_manifest["specialist_accounting"]["dispatch_unit_count"], 1)
+            self.assertIn("systematic-debugging", execution_manifest["specialist_accounting"]["specialist_skills"])
+            self.assertGreaterEqual(execution_manifest["plan_shadow"]["specialist_dispatch_unit_count"], 1)
             self.assertTrue(benchmark_proof["proof_passed"])
             self.assertGreaterEqual(benchmark_proof["executed_unit_count"], 2)
             self.assertEqual("runtime", benchmark_proof["proof_class"])
             self.assertTrue(Path(benchmark_proof["plan_shadow_path"]).exists())
+            self.assertGreaterEqual(benchmark_proof["specialist_recommendation_count"], 1)
+            self.assertGreaterEqual(benchmark_proof["specialist_dispatch_unit_count"], 1)
 
             cleanup_receipt = json.loads(resolve_artifact_path("cleanup_receipt").read_text(encoding="utf-8"))
             self.assertEqual("receipt_only", cleanup_receipt["cleanup_mode"])

--- a/tests/runtime_neutral/test_root_child_hierarchy_bridge.py
+++ b/tests/runtime_neutral/test_root_child_hierarchy_bridge.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def resolve_powershell() -> str | None:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("pwsh.exe"),
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files\PowerShell\7-preview\pwsh.exe",
+        shutil.which("powershell"),
+        shutil.which("powershell.exe"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
+def run_governed_runtime(task: str, artifact_root: Path) -> dict[str, object]:
+    shell = resolve_powershell()
+    if shell is None:
+        raise unittest.SkipTest("PowerShell executable not available in PATH")
+
+    script_path = REPO_ROOT / "scripts" / "runtime" / "invoke-vibe-runtime.ps1"
+    run_id = "pytest-root-child-" + uuid.uuid4().hex[:10]
+    command = [
+        shell,
+        "-NoLogo",
+        "-NoProfile",
+        "-Command",
+        (
+            "& { "
+            f"$result = & '{script_path}' "
+            f"-Task '{task}' "
+            "-Mode benchmark_autonomous "
+            "-GovernanceScope root "
+            f"-RunId '{run_id}' "
+            f"-ArtifactRoot '{artifact_root}'; "
+            "$result | ConvertTo-Json -Depth 20 }"
+        ),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    stdout = completed.stdout.strip()
+    if stdout in ("", "null"):
+        raise AssertionError(
+            "invoke-vibe-runtime returned null payload. "
+            f"stderr={completed.stderr.strip()}"
+        )
+    return json.loads(stdout)
+
+
+def run_child_runtime(
+    task: str,
+    root_run_id: str,
+    inherited_requirement_doc_path: Path,
+    inherited_execution_plan_path: Path,
+    artifact_root: Path,
+    approved_specialist_skill_ids: list[str] | None = None,
+) -> dict[str, object]:
+    shell = resolve_powershell()
+    if shell is None:
+        raise unittest.SkipTest("PowerShell executable not available in PATH")
+
+    script_path = REPO_ROOT / "scripts" / "runtime" / "invoke-vibe-runtime.ps1"
+    run_id = "pytest-child-lane-" + uuid.uuid4().hex[:10]
+    approved = approved_specialist_skill_ids or []
+    approved_literal = (
+        "@(" + ",".join("'" + skill.replace("'", "''") + "'" for skill in approved) + ")"
+        if approved
+        else "@()"
+    )
+    command = [
+        shell,
+        "-NoLogo",
+        "-NoProfile",
+        "-Command",
+        (
+            "& { "
+            f"$result = & '{script_path}' "
+            f"-Task '{task}' "
+            "-Mode benchmark_autonomous "
+            "-GovernanceScope child "
+            f"-RunId '{run_id}' "
+            f"-RootRunId '{root_run_id}' "
+            f"-ParentRunId '{root_run_id}' "
+            "-ParentUnitId 'pytest-child-unit' "
+            f"-InheritedRequirementDocPath '{inherited_requirement_doc_path}' "
+            f"-InheritedExecutionPlanPath '{inherited_execution_plan_path}' "
+            f"-ApprovedSpecialistSkillIds {approved_literal} "
+            f"-ArtifactRoot '{artifact_root}'; "
+            "$result | ConvertTo-Json -Depth 20 }"
+        ),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    stdout = completed.stdout.strip()
+    if stdout in ("", "null"):
+        raise AssertionError(
+            "invoke-vibe-runtime(child) returned null payload. "
+            f"stderr={completed.stderr.strip()}"
+        )
+    return json.loads(stdout)
+
+
+class RootChildHierarchyBridgeTests(unittest.TestCase):
+    def test_contract_docs_exist(self) -> None:
+        requirement_doc = REPO_ROOT / "docs" / "requirements" / "2026-03-28-root-child-vibe-hierarchy-governance.md"
+        execution_plan = REPO_ROOT / "docs" / "plans" / "2026-03-28-root-child-vibe-hierarchy-governance-plan.md"
+        stable_doc = REPO_ROOT / "docs" / "root-child-vibe-hierarchy-governance.md"
+
+        self.assertTrue(requirement_doc.exists())
+        self.assertTrue(execution_plan.exists())
+        self.assertTrue(stable_doc.exists())
+
+        stable_text = stable_doc.read_text(encoding="utf-8")
+        self.assertIn("Root `vibe`: the only top-level governor", stable_text)
+        self.assertIn("Child `vibe`: a subordinate execution lane", stable_text)
+        self.assertIn("A child lane may detect that more specialist help is useful", stable_text)
+
+    def test_runtime_input_policy_declares_hierarchy_fields(self) -> None:
+        policy_path = REPO_ROOT / "config" / "runtime-input-packet-policy.json"
+        policy = json.loads(policy_path.read_text(encoding="utf-8"))
+        policy_text = json.dumps(policy, ensure_ascii=False, sort_keys=True)
+
+        expected_tokens = [
+            "governance_scope",
+            "hierarchy_contract",
+            "child_specialist_suggestion_contract",
+            "allow_requirement_freeze",
+            "allow_plan_freeze",
+            "allow_global_dispatch",
+            "allow_completion_claim",
+            "specialist_dispatch",
+            "advisory_until_root_approval",
+            "escalation_required",
+        ]
+        for token in expected_tokens:
+            with self.subTest(token=token):
+                self.assertIn(token, policy_text)
+
+    def test_root_runtime_keeps_vibe_authority_and_single_canonical_surfaces(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            payload = run_governed_runtime(
+                "Root child hierarchy runtime smoke for authority and canonical surface checks.",
+                artifact_root=Path(tempdir),
+            )
+            summary = payload["summary"]
+            artifacts = summary["artifacts"]
+
+            runtime_input_packet_path = Path(artifacts["runtime_input_packet"])
+            requirement_doc_path = Path(artifacts["requirement_doc"])
+            execution_plan_path = Path(artifacts["execution_plan"])
+            execution_manifest_path = Path(artifacts["execution_manifest"])
+
+            runtime_input_packet = json.loads(runtime_input_packet_path.read_text(encoding="utf-8"))
+            execution_manifest = json.loads(execution_manifest_path.read_text(encoding="utf-8"))
+
+            self.assertEqual("vibe", runtime_input_packet["route_snapshot"]["selected_skill"])
+            self.assertEqual("vibe", runtime_input_packet["authority_flags"]["explicit_runtime_skill"])
+            self.assertEqual("root", runtime_input_packet["governance_scope"])
+            self.assertTrue(runtime_input_packet["authority_flags"]["allow_requirement_freeze"])
+            self.assertTrue(runtime_input_packet["authority_flags"]["allow_plan_freeze"])
+            self.assertTrue(runtime_input_packet["authority_flags"]["allow_global_dispatch"])
+            self.assertTrue(runtime_input_packet["authority_flags"]["allow_completion_claim"])
+
+            self.assertEqual("requirements", requirement_doc_path.parent.name)
+            self.assertEqual("plans", execution_plan_path.parent.name)
+            self.assertEqual("root", execution_manifest["governance_scope"])
+            self.assertTrue(execution_manifest["authority"]["completion_claim_allowed"])
+            self.assertEqual("vibe", execution_manifest["route_runtime_alignment"]["runtime_selected_skill"])
+
+    def test_child_specialist_suggestions_are_advisory_until_root_approval(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            root_payload = run_governed_runtime(
+                "Root specialist dispatch seed for child escalation checks.",
+                artifact_root=artifact_root,
+            )
+            root_summary = root_payload["summary"]
+            root_artifacts = root_summary["artifacts"]
+            root_runtime_input_packet = json.loads(
+                Path(root_artifacts["runtime_input_packet"]).read_text(encoding="utf-8")
+            )
+
+            root_approved_dispatch = list(
+                (root_runtime_input_packet.get("specialist_dispatch") or {}).get("approved_dispatch") or []
+            )
+            approved_skill_ids: list[str] = []
+            if root_approved_dispatch:
+                first_skill_id = str(root_approved_dispatch[0].get("skill_id", "")).strip()
+                if first_skill_id:
+                    approved_skill_ids = [first_skill_id]
+
+            child_payload = run_child_runtime(
+                task="Child specialist escalation advisory smoke.",
+                root_run_id=str(root_summary["run_id"]),
+                inherited_requirement_doc_path=Path(root_artifacts["requirement_doc"]),
+                inherited_execution_plan_path=Path(root_artifacts["execution_plan"]),
+                artifact_root=artifact_root,
+                approved_specialist_skill_ids=approved_skill_ids,
+            )
+            child_summary = child_payload["summary"]
+            runtime_input_packet = json.loads(Path(child_summary["artifacts"]["runtime_input_packet"]).read_text(encoding="utf-8"))
+            execution_manifest = json.loads(Path(child_summary["artifacts"]["execution_manifest"]).read_text(encoding="utf-8"))
+            requirement_receipt = json.loads(Path(child_summary["artifacts"]["requirement_receipt"]).read_text(encoding="utf-8"))
+            plan_receipt = json.loads(Path(child_summary["artifacts"]["execution_plan_receipt"]).read_text(encoding="utf-8"))
+
+            self.assertEqual("child", child_summary["governance_scope"])
+            self.assertEqual("child", runtime_input_packet["governance_scope"])
+            self.assertEqual("vibe", runtime_input_packet["authority_flags"]["explicit_runtime_skill"])
+            self.assertFalse(runtime_input_packet["authority_flags"]["allow_requirement_freeze"])
+            self.assertFalse(runtime_input_packet["authority_flags"]["allow_plan_freeze"])
+            self.assertFalse(runtime_input_packet["authority_flags"]["allow_global_dispatch"])
+            self.assertFalse(runtime_input_packet["authority_flags"]["allow_completion_claim"])
+
+            self.assertFalse(requirement_receipt["canonical_write_allowed"])
+            self.assertFalse(plan_receipt["canonical_write_allowed"])
+            self.assertEqual(
+                str(Path(root_artifacts["requirement_doc"]).resolve()),
+                str(Path(requirement_receipt["requirement_doc_path"]).resolve()),
+            )
+            self.assertEqual(
+                str(Path(root_artifacts["execution_plan"]).resolve()),
+                str(Path(plan_receipt["execution_plan_path"]).resolve()),
+            )
+
+            specialist_dispatch = runtime_input_packet["specialist_dispatch"]
+            local_suggestions = list(specialist_dispatch.get("local_specialist_suggestions") or [])
+            approved_dispatch = list(specialist_dispatch.get("approved_dispatch") or [])
+            approved_ids = {str(entry.get("skill_id", "")) for entry in approved_dispatch}
+
+            if local_suggestions:
+                self.assertTrue(bool(specialist_dispatch.get("escalation_required", False)))
+                self.assertEqual("root_approval_required", str(specialist_dispatch.get("escalation_status", "")))
+                for suggestion in local_suggestions:
+                    with self.subTest(suggestion=str(suggestion.get("skill_id", ""))):
+                        self.assertNotIn(str(suggestion.get("skill_id", "")), approved_ids)
+
+            self.assertEqual("advisory_until_root_approval", str(specialist_dispatch.get("status", "")))
+            self.assertEqual("child", execution_manifest["governance_scope"])
+            self.assertFalse(execution_manifest["authority"]["completion_claim_allowed"])
+            self.assertEqual("vibe", execution_manifest["route_runtime_alignment"]["runtime_selected_skill"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime_neutral/test_router_bridge.py
+++ b/tests/runtime_neutral/test_router_bridge.py
@@ -73,6 +73,22 @@ class RouterBridgeTests(unittest.TestCase):
             self.assertTrue(result["confirm_ui"]["enabled"])
             self.assertGreaterEqual(len(result["confirm_ui"]["options"]), 1)
 
+    def test_requested_vibe_can_preserve_runtime_authority_while_router_selects_specialist(self) -> None:
+        result = run_bridge(
+            "I have a failing test and a stack trace. Help me debug systematically before proposing fixes.",
+            "XL",
+            "debug",
+            requested_skill="vibe",
+        )
+
+        self.assertEqual("confirm_required", result["route_mode"])
+        self.assertEqual("code-quality", result["selected"]["pack_id"])
+        self.assertEqual("systematic-debugging", result["selected"]["skill"])
+        self.assertEqual("vibe", result["alias"]["requested_canonical"])
+        self.assertEqual("vibe", result["ranked"][1]["selected_candidate"])
+        self.assertIn("confirm_ui", result)
+        self.assertTrue(result["confirm_ui"]["enabled"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
This PR turns explicit `vibe` execution into a single-governor hierarchy instead of letting delegated lanes behave like second top-level runtimes. It also makes native specialist skill use explicit and bounded under `vibe` authority, so specialist help can be planned and executed without surrendering runtime ownership.

## Problem
Before this change, the governed runtime had the right high-level intent, but the hierarchy contract was still underspecified in code and proof surfaces. That left two gaps that matter in practice:

1. Child lanes could inherit `vibe` discipline but did not have a fully frozen machine-readable authority split for requirement freeze, plan freeze, global dispatch, and final completion claims.
2. Specialist skills could be recommended and used, but the system did not fully prove the difference between root-approved dispatch and child-local advisory suggestions that still require root escalation.

That ambiguity risks recursive governance, duplicate canonical truth surfaces, and silent specialist expansion during XL execution.

## What changed
This PR adds a root/child hierarchy contract across runtime, docs, and verification.

At the runtime layer:
- freezes `governance_scope`, hierarchy metadata, authority flags, approved specialist dispatch, local specialist suggestions, and escalation state in the runtime input packet
- restricts child-governed lanes from freezing canonical requirement/plan surfaces or issuing final completion claims
- makes child requirement/plan stages emit handoff receipts instead of second canonical docs
- records hierarchy and specialist accounting in execution manifests, including escalation artifacts for child-local non-approved specialist requests

At the protocol and operator layer:
- documents the `vibe governor + native specialist skills` model
- documents the root/child `vibe` hierarchy model
- clarifies that `vibe` remains the only runtime authority while specialists stay bounded native helpers

At the verification layer:
- extends bridge tests to prove explicit `vibe` authority is preserved while specialist accounting is surfaced
- adds dedicated root/child hierarchy tests
- adds dedicated verify gates for hierarchy authority, duplicate canonical surface prevention, and child specialist escalation

## User impact
For users running explicit `vibe`, the system now behaves more predictably:
- there is one real top-level governor
- child agents stay governed but subordinate
- specialist help remains available without stealing runtime ownership
- canonical requirement and plan truth stay singular and traceable

This directly improves stability and auditability for XL and multi-agent flows.

## Validation
I ran the following checks locally:

- `python3 -m pytest tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_router_bridge.py`
- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-root-child-hierarchy-gate.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-no-duplicate-canonical-surface-gate.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-child-specialist-escalation-gate.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-governed-runtime-contract-gate.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-benchmark-autonomous-proof-gate.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-no-silent-fallback-contract-gate.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-no-self-introduced-fallback-gate.ps1`
- `git diff --check`
