### PR TITLE
Add explicit native specialist execution bridge

### DIFF
--- a/config/native-specialist-execution-policy.json
+++ b/config/native-specialist-execution-policy.json
@@ -1,0 +1,45 @@
+{
+  "version": 1,
+  "updated_at": "2026-03-28",
+  "enabled": true,
+  "default_adapter_id": "codex",
+  "enable_env": "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION",
+  "disable_env": "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION",
+  "default_enabled": false,
+  "default_timeout_seconds": 600,
+  "degrade_contract": {
+    "status": "degraded_non_authoritative",
+    "verification_passed": false,
+    "execution_driver": "degraded_specialist_contract_receipt",
+    "hazard_alert": "Native specialist execution is unavailable or disabled; dispatch downgraded explicitly."
+  },
+  "result_schema": {
+    "status_enum": [
+      "completed",
+      "completed_with_notes",
+      "blocked"
+    ],
+    "required_fields": [
+      "status",
+      "summary",
+      "verification_notes",
+      "changed_files",
+      "bounded_output_notes"
+    ]
+  },
+  "adapters": [
+    {
+      "id": "codex",
+      "enabled": true,
+      "executable_env": "VGO_CODEX_EXECUTABLE",
+      "command": "codex",
+      "arguments_prefix": [
+        "exec",
+        "--json",
+        "--ephemeral",
+        "--full-auto"
+      ],
+      "execution_driver": "codex_exec_native_specialist"
+    }
+  ]
+}

--- a/docs/plans/2026-03-28-vibe-governor-native-specialist-skills-execution-plan.md
+++ b/docs/plans/2026-03-28-vibe-governor-native-specialist-skills-execution-plan.md
@@ -1,10 +1,10 @@
 # Vibe Governor + Native Specialist Skills
 
 ## Execution Summary
-Implement the smallest coherent extension that lets explicit `vibe` runs freeze, plan, and execute native specialist assistance without surrendering runtime authority. Reuse existing router outputs, keep `runtime_selected_skill=vibe`, and add bounded specialist dispatch surfaces to requirement, plan, execution, verification, and documentation.
+Implement the smallest coherent extension that lets explicit `vibe` runs freeze, plan, and execute native specialist assistance without surrendering runtime authority. Reuse existing router outputs, keep `runtime_selected_skill=vibe`, add a real host adapter bridge for specialist units, and make unsupported paths degrade explicitly instead of pretending receipt-only execution is native.
 
 ## Frozen Inputs
-- Requirement doc: /home/lqf/table/table5/workspace/issue-57-ai-governance/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
+- Requirement doc: /home/lqf/table/table5/workspace/verify-main-pr60/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
 - Source task: `vibe` governor + native specialist skills
 - Runtime authority invariant: explicit `vibe` remains the only runtime owner
 
@@ -14,16 +14,16 @@ Implement the smallest coherent extension that lets explicit `vibe` runs freeze,
 - Parallel work is warranted because code, tests, and governance docs can advance on disjoint write scopes.
 
 ## Wave Plan
-- Wave 1: freeze contracts, inspect runtime surfaces, and define specialist recommendation schema
-- Wave 2: implement runtime packet, requirement, and plan surfacing
-- Wave 3: implement bounded specialist execution accounting and manifest recovery
-- Wave 4: update protocol/docs surfaces and operator guidance
-- Wave 5: add tests, run verification, and close with cleanup receipts
+- Wave 1: freeze executable specialist contract, host adapter policy, and degrade contract
+- Wave 2: implement runtime-native specialist execution bridge with `codex exec` as the first adapter lane
+- Wave 3: allow child lanes to execute only root-approved specialist dispatch while keeping local suggestions escalation-only
+- Wave 4: upgrade manifests, receipts, and docs so live execution and degraded execution are clearly distinct
+- Wave 5: add fake-adapter regression tests, targeted runtime verification, and cleanup closure
 
 ## Ownership Boundaries
-- Runtime packet and artifact contract: `config/runtime-input-packet-policy.json`, `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+- Runtime packet and artifact contract: `config/runtime-input-packet-policy.json`, `config/native-specialist-execution-policy.json`, `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
 - Requirement/plan surfacing: `scripts/runtime/Write-RequirementDoc.ps1`, `scripts/runtime/Write-XlPlan.ps1`
-- Execution accounting: `scripts/runtime/Invoke-PlanExecute.ps1`
+- Execution bridge and accounting: `scripts/runtime/VibeExecution.Common.ps1`, `scripts/runtime/Invoke-DelegatedLaneUnit.ps1`, `scripts/runtime/Invoke-PlanExecute.ps1`
 - Protocol/docs authority model: `SKILL.md`, `protocols/runtime.md`, `protocols/team.md`, supporting docs
 - Verification: runtime tests and targeted gates
 - Subagent prompts must end with `$vibe`.
@@ -32,6 +32,8 @@ Implement the smallest coherent extension that lets explicit `vibe` runs freeze,
 - Dispatch only bounded specialist units; keep `vibe` as the sole runtime owner.
 - Preserve native specialist usage by carrying native workflow expectations, required inputs, expected outputs, and verification mode into the dispatch contract.
 - Do not auto-promote specialist recommendations into runtime ownership changes.
+- Specialist-owned lanes use visible specialist invocation plus injected hidden governance context; they are not receipt-only aliases for `$vibe`.
+- The first live bridge is `codex exec`; unsupported hosts or disabled native execution degrade explicitly to `degraded_non_authoritative`.
 - Record all specialist units in execution evidence and recover their outputs into the `vibe` manifest.
 
 ## Verification Commands
@@ -39,12 +41,13 @@ Implement the smallest coherent extension that lets explicit `vibe` runs freeze,
 - `python3 -m py_compile scripts/runtime/*.ps1` is not applicable; instead validate PowerShell syntax via targeted gates and JSON schema checks
 - `python3 -m pytest tests/runtime_neutral -k "runtime_input_packet or plan_execute or specialist or requirement or plan"`
 - targeted `rg` checks for authority invariants such as `explicit_runtime_skill`, `shadow_only`, `specialist_recommendations`
+- smoke `codex exec` in a temp directory before claiming the `codex` adapter lane works
 - repo cleanliness checks and node audit after each wave
 
 ## Rollback Plan
 - Revert only the governor-specialist change set if authority invariants or regression tests fail.
 - Do not revert unrelated user changes or existing untracked docs.
-- If specialist execution accounting proves too invasive, fall back to metadata-only surfacing while keeping the new contracts explicit and non-authoritative.
+- If the live host adapter bridge proves unstable, keep the executable contract and degrade explicitly to `degraded_non_authoritative` instead of silently restoring receipt-only fake native execution.
 
 ## Phase Cleanup Contract
 - Remove temporary logs or scratch files created during each wave.

--- a/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
+++ b/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
@@ -1,7 +1,7 @@
 # Vibe Governor + Native Specialist Skills
 
 ## Summary
-Keep `vibe` as the sole governed runtime authority while enabling it to call specialist skills as bounded native assistants. Router output must remain a single canonical routing truth, but explicit `vibe` runs should freeze specialist recommendations that can be consumed by planning and execution without handing control to a second runtime.
+Keep `vibe` as the sole governed runtime authority while enabling it to call specialist skills as bounded native assistants through an explicit host adapter bridge. Router output must remain a single canonical routing truth, but explicit `vibe` runs should freeze specialist recommendations that can be consumed by planning and execution without handing control to a second runtime or faking native execution with receipt-only artifacts.
 
 ## Goal
 Implement a minimal-change governed model where:
@@ -9,13 +9,17 @@ Implement a minimal-change governed model where:
 - `vibe` remains the only runtime owner for requirement freeze, execution planning, execution receipts, verification, and cleanup.
 - specialist skills can be recommended, planned, dispatched, and verified as bounded native helpers.
 - specialist usage preserves each skill's native workflow expectations rather than flattening the skill into a label.
+- approved specialist dispatch can cross a host adapter bridge into real native execution when the active host supports it.
+- unsupported or disabled native specialist paths degrade explicitly to `degraded_non_authoritative` rather than claiming equivalent success.
 
 ## Deliverable
 A repository change set that adds:
 
 - a frozen runtime packet contract for `specialist_recommendations`
+- a frozen executable contract for `approved_dispatch`
 - requirement and plan surfacing for native specialist dispatch
-- execution-manifest support for specialist units and their recovery into `vibe`
+- a host adapter execution bridge with an initial `codex` implementation path
+- execution-manifest support for specialist units, degraded specialist units, and their recovery into `vibe`
 - protocol and operator documentation for the governor-plus-specialists model
 - regression tests and proof artifacts demonstrating authority preservation, stability, usability, and intelligent specialist selection
 
@@ -23,21 +27,25 @@ A repository change set that adds:
 - Do not change `runtime_selected_skill` away from `vibe` during explicit `vibe` runtime entry.
 - Do not create a second router, second requirement surface, second execution-plan surface, or second runtime authority.
 - Reuse existing router outputs and runtime artifacts as much as possible; prefer additive contract extensions over structural rewrites.
-- Preserve current host adapter boundaries; this task is not a host-entry auto-bridge project.
+- Preserve current host adapter boundaries; this task is a bounded runtime execution bridge project, not a host-entry auto-intercept project.
 - Specialist execution must remain bounded and must feed back into `vibe` verification and cleanup surfaces.
 - Specialist skills must retain native usage expectations, input contracts, workflow semantics, and validation style when dispatched.
+- Child lanes may execute only root-approved specialist dispatch; they may not self-approve new global specialist usage.
 
 ## Acceptance Criteria
 - Runtime input packet includes machine-readable `specialist_recommendations` for explicit `vibe` runs without changing `authority_flags.explicit_runtime_skill`.
+- Runtime input packet includes machine-readable executable specialist dispatch contracts that keep `vibe` as runtime owner.
 - Requirement documents surface specialist recommendations and native-usage expectations as frozen inputs.
 - Execution plans include an explicit `Specialist Skill Dispatch Plan` section describing bounded specialist use.
-- Execution manifests record specialist unit counts, outcomes, and recovery status while keeping `vibe` as runtime owner.
+- Execution manifests record specialist unit counts, degraded specialist unit counts, execution drivers, and recovery status while keeping `vibe` as runtime owner.
 - Protocol docs define the `vibe governor + native specialist skills` model and forbid specialist takeover of runtime truth.
 - Tests prove:
   - `vibe` authority is preserved
   - specialist recommendations are frozen and surfaced
   - plan/execute artifacts include specialist dispatch data
+  - root-approved child specialist dispatch can execute through the host adapter bridge
   - degraded specialist paths remain explicit and non-authoritative when appropriate
+  - receipt-only specialist stubs are no longer presented as native execution
 
 > Fill the anti-drift fields once here. Downstream governed plan and completion surfaces should reuse them rather than restate them.
 
@@ -52,6 +60,8 @@ In scope:
 - runtime packet extension
 - requirement/plan surfacing
 - execution manifest specialist accounting
+- host adapter execution bridge for specialist units
+- `codex exec` as the first supported runtime-native adapter lane
 - protocol and proof documentation
 - regression tests and cleanup receipts
 
@@ -60,6 +70,7 @@ Out of scope:
 - automatic replacement of `vibe` with router-selected specialist skills
 - global redesign of the router scoring system
 - skill-by-skill metadata rewrites across the entire repository
+- blanket host-native parity for every supported install host in the first slice
 
 ## Completion
 The work is complete when explicit `vibe` runs can preserve runtime authority while still planning and executing native specialist assistance with traceable evidence and passing regression coverage.
@@ -81,7 +92,8 @@ interactive_governed
 ## Assumptions
 - Existing router ranking already provides enough signal to derive specialist candidates without redesigning pack scoring.
 - The current runtime packet shadow model can be extended rather than replaced.
-- Specialist dispatch can first land as governed execution metadata and bounded units before any future deeper automation.
+- A bounded host adapter bridge can be added without creating a second runtime authority.
+- `codex exec` can serve as the first real specialist-native execution lane while other hosts degrade explicitly until their adapters exist.
 
 ## Evidence Inputs
 - Source task: implement `vibe` governor + native specialist skills with minimal framework change

--- a/scripts/runtime/Invoke-DelegatedLaneUnit.ps1
+++ b/scripts/runtime/Invoke-DelegatedLaneUnit.ps1
@@ -80,6 +80,14 @@ switch ($laneKind) {
             -UnitId ("{0}-specialist" -f [string]$laneSpec.lane_id) `
             -Dispatch $dispatch `
             -SessionRoot $laneRoot `
+            -RepoRoot ([string]$laneSpec.repo_root) `
+            -RequirementDocPath ([string]$laneSpec.requirement_doc_path) `
+            -ExecutionPlanPath ([string]$laneSpec.execution_plan_path) `
+            -RunId ([string]$laneSpec.run_id) `
+            -GovernanceScope ([string]$laneSpec.governance_scope) `
+            -RootRunId ([string]$laneSpec.root_run_id) `
+            -ParentRunId ([string]$laneSpec.parent_run_id) `
+            -ParentUnitId ([string]$laneSpec.parent_unit_id) `
             -WriteScope ([string]$laneSpec.write_scope) `
             -ReviewMode ([string]$laneSpec.review_mode)
 
@@ -94,7 +102,7 @@ switch ($laneKind) {
             parent_unit_id = [string]$laneSpec.parent_unit_id
             requirement_doc_path = [string]$laneSpec.requirement_doc_path
             execution_plan_path = [string]$laneSpec.execution_plan_path
-            execution_driver = 'native_specialist_contract_receipt'
+            execution_driver = [string]$executed.result.execution_driver
             parallelizable = $false
             write_scope = [string]$laneSpec.write_scope
             review_mode = [string]$laneSpec.review_mode
@@ -113,6 +121,7 @@ switch ($laneKind) {
             "# Native Specialist Dispatch Receipt",
             '',
             "- specialist_skill_id: $([string]$dispatch.skill_id)",
+            "- execution_driver: $([string]$executed.result.execution_driver)",
             "- bounded_role: $([string]$dispatch.bounded_role)",
             "- native_usage_required: $([bool]$dispatch.native_usage_required)",
             "- verification_expectation: $([string]$dispatch.verification_expectation)",

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -22,6 +22,7 @@ function New-VibeDelegatedLaneSpec {
     param(
         [Parameter(Mandatory)] [string]$SessionRoot,
         [Parameter(Mandatory)] [string]$RunId,
+        [Parameter(Mandatory)] [string]$Mode,
         [Parameter(Mandatory)] [object]$HierarchyState,
         [Parameter(Mandatory)] [string]$RequirementPath,
         [Parameter(Mandatory)] [string]$PlanPath,
@@ -39,6 +40,8 @@ function New-VibeDelegatedLaneSpec {
         lane_kind = [string]($LaneEntry.lane_kind)
         lane_root = $laneRoot
         run_id = $RunId
+        mode = $Mode
+        governance_scope = 'child'
         root_run_id = [string]($HierarchyState.root_run_id)
         parent_run_id = $RunId
         parent_unit_id = [string]($LaneEntry.source_unit_id)
@@ -212,7 +215,12 @@ function Invoke-VibeDirectLaneEntry {
         [Parameter(Mandatory)] [string]$RepoRoot,
         [Parameter(Mandatory)] [string]$SessionRoot,
         [Parameter(Mandatory)] [hashtable]$Tokens,
-        [Parameter(Mandatory)] [int]$DefaultTimeoutSeconds
+        [Parameter(Mandatory)] [int]$DefaultTimeoutSeconds,
+        [Parameter(Mandatory)] [string]$Mode,
+        [Parameter(Mandatory)] [string]$RequirementPath,
+        [Parameter(Mandatory)] [string]$PlanPath,
+        [Parameter(Mandatory)] [object]$HierarchyState,
+        [Parameter(Mandatory)] [string]$RunId
     )
 
     switch ([string]$LaneEntry.lane_kind) {
@@ -240,6 +248,14 @@ function Invoke-VibeDirectLaneEntry {
                 -UnitId ("{0}-specialist" -f [string]$LaneEntry.lane_id) `
                 -Dispatch $LaneEntry.dispatch `
                 -SessionRoot $SessionRoot `
+                -RepoRoot $RepoRoot `
+                -RequirementDocPath $RequirementPath `
+                -ExecutionPlanPath $PlanPath `
+                -RunId $RunId `
+                -GovernanceScope ([string]$HierarchyState.governance_scope) `
+                -RootRunId ([string]$HierarchyState.root_run_id) `
+                -ParentRunId $(if ($null -eq $HierarchyState.parent_run_id) { '' } else { [string]$HierarchyState.parent_run_id }) `
+                -ParentUnitId $(if ($null -eq $HierarchyState.parent_unit_id) { '' } else { [string]$HierarchyState.parent_unit_id }) `
                 -WriteScope ([string]$LaneEntry.write_scope) `
                 -ReviewMode ([string]$LaneEntry.review_mode)
             return [pscustomobject]@{
@@ -287,6 +303,9 @@ function ConvertTo-VibeExecutedUnitReceipt {
         lane_receipt_path = if ($Outcome.lane_receipt_path) { [string]$Outcome.lane_receipt_path } else { $null }
         skill_id = if ([string]$Outcome.lane_entry.lane_kind -eq 'specialist_dispatch') { [string]$Outcome.lane_entry.dispatch.skill_id } else { $null }
         write_scope = [string]$Outcome.lane_entry.write_scope
+        execution_driver = if ($Outcome.lane_result -and $Outcome.lane_result.PSObject.Properties.Name -contains 'execution_driver') { [string]$Outcome.lane_result.execution_driver } else { $null }
+        live_native_execution = if ($Outcome.lane_result -and $Outcome.lane_result.PSObject.Properties.Name -contains 'live_native_execution') { [bool]$Outcome.lane_result.live_native_execution } else { $false }
+        degraded = if ($Outcome.lane_result -and $Outcome.lane_result.PSObject.Properties.Name -contains 'degraded') { [bool]$Outcome.lane_result.degraded } else { $false }
     }
 }
 
@@ -531,6 +550,7 @@ foreach ($topologyWave in @($executionTopology.waves)) {
                         $laneRuntime = New-VibeDelegatedLaneSpec `
                             -SessionRoot $sessionRoot `
                             -RunId $RunId `
+                            -Mode $Mode `
                             -HierarchyState $hierarchyState `
                             -RequirementPath $requirementPath `
                             -PlanPath $planPath `
@@ -564,6 +584,7 @@ foreach ($topologyWave in @($executionTopology.waves)) {
                             $laneRuntime = New-VibeDelegatedLaneSpec `
                                 -SessionRoot $sessionRoot `
                                 -RunId $RunId `
+                                -Mode $Mode `
                                 -HierarchyState $hierarchyState `
                                 -RequirementPath $requirementPath `
                                 -PlanPath $planPath `
@@ -580,7 +601,12 @@ foreach ($topologyWave in @($executionTopology.waves)) {
                                 -RepoRoot $runtime.repo_root `
                                 -SessionRoot $sessionRoot `
                                 -Tokens $tokens `
-                                -DefaultTimeoutSeconds ([int]$policy.scheduler.default_timeout_seconds)
+                                -DefaultTimeoutSeconds ([int]$policy.scheduler.default_timeout_seconds) `
+                                -Mode $Mode `
+                                -RequirementPath $requirementPath `
+                                -PlanPath $planPath `
+                                -HierarchyState $hierarchyState `
+                                -RunId $RunId
                         }
                         $stepOutcomes += $outcome
                         $serialExecutionOrder += if ($outcome.lane_result) { [string]$outcome.lane_result.unit_id } else { [string]$laneEntry.source_unit_id }
@@ -593,6 +619,7 @@ foreach ($topologyWave in @($executionTopology.waves)) {
                     $laneRuntime = New-VibeDelegatedLaneSpec `
                         -SessionRoot $sessionRoot `
                         -RunId $RunId `
+                        -Mode $Mode `
                         -HierarchyState $hierarchyState `
                         -RequirementPath $requirementPath `
                         -PlanPath $planPath `
@@ -609,7 +636,12 @@ foreach ($topologyWave in @($executionTopology.waves)) {
                         -RepoRoot $runtime.repo_root `
                         -SessionRoot $sessionRoot `
                         -Tokens $tokens `
-                        -DefaultTimeoutSeconds ([int]$policy.scheduler.default_timeout_seconds)
+                        -DefaultTimeoutSeconds ([int]$policy.scheduler.default_timeout_seconds) `
+                        -Mode $Mode `
+                        -RequirementPath $requirementPath `
+                        -PlanPath $planPath `
+                        -HierarchyState $hierarchyState `
+                        -RunId $RunId
                 }
                 $stepOutcomes += $outcome
                 $serialExecutionOrder += if ($outcome.lane_result) { [string]$outcome.lane_result.unit_id } else { [string]$laneEntry.source_unit_id }
@@ -652,6 +684,9 @@ foreach ($topologyWave in @($executionTopology.waves)) {
                     skill_id = [string]$unitReceipt.skill_id
                     result_path = [string]$unitReceipt.result_path
                     verification_passed = [bool]$unitReceipt.verification_passed
+                    execution_driver = [string]$unitReceipt.execution_driver
+                    live_native_execution = [bool]$unitReceipt.live_native_execution
+                    degraded = [bool]$unitReceipt.degraded
                     lane_receipt_path = if ($unitReceipt.lane_receipt_path) { [string]$unitReceipt.lane_receipt_path } else { $null }
                 }
             }
@@ -691,6 +726,10 @@ $effectiveUnitExecution = if ($parallelUnitsExecutedCount -gt 0 -and ($executedU
 }
 
 $baseStatus = if ($failedUnitCount -eq 0 -and $executedUnitCount -ge [int]$profile.expected_minimum_units) { 'completed' } elseif ($executedUnitCount -eq 0) { 'failed' } else { 'completed_with_failures' }
+$liveSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live_native_execution })
+$degradedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.degraded })
+$totalSpecialistDispatchOutcomeCount = @($executedSpecialistUnits).Count
+$effectiveSpecialistExecutionStatus = if (@($liveSpecialistUnits).Count -gt 0) { 'live_native_executed' } elseif (@($degradedSpecialistUnits).Count -gt 0) { 'explicitly_degraded' } else { 'none' }
 $executionManifest = [pscustomobject]@{
     stage = 'plan_execute'
     run_id = $RunId
@@ -766,12 +805,16 @@ $executionManifest = [pscustomobject]@{
         specialist_skills = @($specialistSkills)
         native_usage_required = [bool](@($specialistRecommendations | Where-Object { $_.native_usage_required }).Count -gt 0)
         execution_mode = if (@($approvedDispatch).Count -gt 0) { 'native_bounded_units' } else { [string]$executionTopology.specialist_execution_mode }
+        effective_execution_status = $effectiveSpecialistExecutionStatus
         dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
         recommendations = @($specialistRecommendations)
         approved_dispatch_count = @($approvedDispatch).Count
         approved_dispatch = @($approvedDispatch)
-        executed_specialist_unit_count = @($executedSpecialistUnits).Count
-        executed_specialist_units = @($executedSpecialistUnits)
+        executed_specialist_unit_count = @($liveSpecialistUnits).Count
+        executed_specialist_units = @($liveSpecialistUnits)
+        degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
+        degraded_specialist_units = @($degradedSpecialistUnits)
+        specialist_dispatch_outcomes = @($executedSpecialistUnits)
         local_suggestion_count = @($localSuggestions).Count
         local_specialist_suggestions = @($localSuggestions)
         escalation_required = [bool]$escalationRequired
@@ -803,7 +846,10 @@ $proofManifest = [pscustomobject]@{
     promotion_suitable = [string]$proofRegistry.promotion_suitability.runtime
     specialist_recommendation_count = @($specialistRecommendations).Count
     specialist_dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
-    executed_specialist_unit_count = @($executedSpecialistUnits).Count
+    executed_specialist_unit_count = @($liveSpecialistUnits).Count
+    degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
+    specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
+    specialist_execution_status = $effectiveSpecialistExecutionStatus
     delegated_lane_count = [int]$delegatedLaneCount
     review_receipt_count = [int]$reviewReceiptCount
     governance_scope = [string]$hierarchyState.governance_scope
@@ -827,7 +873,9 @@ $proofLines = @(
     ('- review_receipt_count: `{0}`' -f $reviewReceiptCount),
     ('- specialist_recommendation_count: `{0}`' -f @($specialistRecommendations).Count),
     ('- specialist_dispatch_unit_count: `{0}`' -f [int]$planShadow.payload.specialist_dispatch_unit_count),
-    ('- executed_specialist_unit_count: `{0}`' -f @($executedSpecialistUnits).Count),
+    ('- executed_specialist_unit_count: `{0}`' -f @($liveSpecialistUnits).Count),
+    ('- degraded_specialist_unit_count: `{0}`' -f @($degradedSpecialistUnits).Count),
+    ('- specialist_execution_status: `{0}`' -f $effectiveSpecialistExecutionStatus),
     ('- execution_manifest: `{0}`' -f $executionManifestPath),
     ('- execution_topology: `{0}`' -f $executionTopologyPath),
     ('- plan_shadow: `{0}`' -f $planShadow.path),
@@ -868,7 +916,10 @@ $receipt = [pscustomobject]@{
     review_receipt_count = [int]$reviewReceiptCount
     specialist_recommendation_count = @($specialistRecommendations).Count
     specialist_dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
-    executed_specialist_unit_count = @($executedSpecialistUnits).Count
+    executed_specialist_unit_count = @($liveSpecialistUnits).Count
+    degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
+    specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
+    specialist_execution_status = $effectiveSpecialistExecutionStatus
     specialist_skills = @($specialistSkills)
     local_specialist_suggestion_count = @($localSuggestions).Count
     escalation_required = [bool]$escalationRequired

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -216,11 +216,309 @@ function Invoke-VibeExecutionUnit {
     }
 }
 
-function Invoke-VibeSpecialistDispatchUnit {
+function Test-VibeTruthyEnvironmentValue {
+    param(
+        [AllowEmptyString()] [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $false
+    }
+
+    return @('1', 'true', 'yes', 'on') -contains $Value.Trim().ToLowerInvariant()
+}
+
+function Resolve-VibeNativeSpecialistAdapter {
+    param(
+        [Parameter(Mandatory)] [string]$ScriptPath
+    )
+
+    $runtime = Get-VibeRuntimeContext -ScriptPath $ScriptPath
+    $policy = $runtime.native_specialist_execution_policy
+    if ($null -eq $policy -or -not [bool]$policy.enabled) {
+        return [pscustomobject]@{
+            enabled = $false
+            live_execution_allowed = $false
+            reason = 'native_specialist_execution_policy_disabled'
+            runtime = $runtime
+            policy = $policy
+            adapter = $null
+            command_path = $null
+        }
+    }
+
+    $disableEnvName = if ($policy.PSObject.Properties.Name -contains 'disable_env') { [string]$policy.disable_env } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($disableEnvName)) {
+        $disableEnvValue = [Environment]::GetEnvironmentVariable($disableEnvName)
+        if (Test-VibeTruthyEnvironmentValue -Value $disableEnvValue) {
+            return [pscustomobject]@{
+                enabled = $true
+                live_execution_allowed = $false
+                reason = ("native_specialist_execution_disabled_via_env:{0}" -f $disableEnvName)
+                runtime = $runtime
+                policy = $policy
+                adapter = $null
+                command_path = $null
+            }
+        }
+    }
+
+    $enableEnvName = if ($policy.PSObject.Properties.Name -contains 'enable_env') { [string]$policy.enable_env } else { '' }
+    $defaultEnabled = if ($policy.PSObject.Properties.Name -contains 'default_enabled') { [bool]$policy.default_enabled } else { $false }
+    $liveExecutionAllowed = $defaultEnabled
+    if (-not [string]::IsNullOrWhiteSpace($enableEnvName)) {
+        $enableEnvValue = [Environment]::GetEnvironmentVariable($enableEnvName)
+        if (Test-VibeTruthyEnvironmentValue -Value $enableEnvValue) {
+            $liveExecutionAllowed = $true
+        }
+    }
+
+    if (-not $liveExecutionAllowed) {
+        return [pscustomobject]@{
+            enabled = $true
+            live_execution_allowed = $false
+            reason = 'native_specialist_execution_not_enabled'
+            runtime = $runtime
+            policy = $policy
+            adapter = $null
+            command_path = $null
+        }
+    }
+
+    $adapterId = if ($policy.PSObject.Properties.Name -contains 'default_adapter_id' -and -not [string]::IsNullOrWhiteSpace([string]$policy.default_adapter_id)) {
+        [string]$policy.default_adapter_id
+    } else {
+        'codex'
+    }
+    $adapter = $null
+    foreach ($candidate in @($policy.adapters)) {
+        if ([string]$candidate.id -eq $adapterId) {
+            $adapter = $candidate
+            break
+        }
+    }
+    if ($null -eq $adapter) {
+        return [pscustomobject]@{
+            enabled = $true
+            live_execution_allowed = $false
+            reason = ("native_specialist_adapter_missing:{0}" -f $adapterId)
+            runtime = $runtime
+            policy = $policy
+            adapter = $null
+            command_path = $null
+        }
+    }
+
+    $commandPath = $null
+    $resolvedReason = $null
+    if ($adapter.PSObject.Properties.Name -contains 'executable_env' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.executable_env)) {
+        $envCommand = [Environment]::GetEnvironmentVariable([string]$adapter.executable_env)
+        if (-not [string]::IsNullOrWhiteSpace($envCommand)) {
+            $candidate = Get-Command $envCommand -ErrorAction SilentlyContinue
+            if ($candidate) {
+                $commandPath = [string]$candidate.Source
+            } elseif (Test-Path -LiteralPath $envCommand) {
+                $commandPath = [System.IO.Path]::GetFullPath($envCommand)
+            }
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($commandPath)) {
+        $candidate = Get-Command ([string]$adapter.command) -ErrorAction SilentlyContinue
+        if ($candidate) {
+            $commandPath = [string]$candidate.Source
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($commandPath)) {
+        $resolvedReason = ("native_specialist_adapter_command_unavailable:{0}" -f [string]$adapter.command)
+    }
+
+    return [pscustomobject]@{
+        enabled = $true
+        live_execution_allowed = [bool](-not [string]::IsNullOrWhiteSpace($commandPath))
+        reason = if ($resolvedReason) { $resolvedReason } else { 'native_specialist_execution_ready' }
+        runtime = $runtime
+        policy = $policy
+        adapter = $adapter
+        command_path = $commandPath
+    }
+}
+
+function New-VibeSpecialistResultSchema {
+    param(
+        [Parameter(Mandatory)] [object]$Policy
+    )
+
+    $statusEnum = if ($Policy.result_schema -and $Policy.result_schema.status_enum) {
+        @($Policy.result_schema.status_enum)
+    } else {
+        @('completed', 'completed_with_notes', 'blocked')
+    }
+    $requiredFields = if ($Policy.result_schema -and $Policy.result_schema.required_fields) {
+        @($Policy.result_schema.required_fields)
+    } else {
+        @('status', 'summary', 'verification_notes', 'changed_files', 'bounded_output_notes')
+    }
+
+    return [pscustomobject]@{
+        type = 'object'
+        properties = [pscustomobject]@{
+            status = [pscustomobject]@{
+                type = 'string'
+                enum = @($statusEnum)
+            }
+            summary = [pscustomobject]@{
+                type = 'string'
+            }
+            verification_notes = [pscustomobject]@{
+                type = 'array'
+                items = [pscustomobject]@{
+                    type = 'string'
+                }
+            }
+            changed_files = [pscustomobject]@{
+                type = 'array'
+                items = [pscustomobject]@{
+                    type = 'string'
+                }
+            }
+            bounded_output_notes = [pscustomobject]@{
+                type = 'array'
+                items = [pscustomobject]@{
+                    type = 'string'
+                }
+            }
+        }
+        required = @($requiredFields)
+        additionalProperties = $false
+    }
+}
+
+function Get-VibeGitStatusSnapshot {
+    param(
+        [Parameter(Mandatory)] [string]$RepoRoot
+    )
+
+    $gitDir = Join-Path $RepoRoot '.git'
+    if (-not (Test-Path -LiteralPath $gitDir)) {
+        return [pscustomobject]@{
+            available = $false
+            paths = @()
+            lines = @()
+        }
+    }
+
+    $gitCommand = Get-Command git -ErrorAction SilentlyContinue
+    if (-not $gitCommand) {
+        return [pscustomobject]@{
+            available = $false
+            paths = @()
+            lines = @()
+        }
+    }
+
+    $snapshot = & ([string]$gitCommand.Source) -C $RepoRoot status --porcelain --untracked-files=all 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return [pscustomobject]@{
+            available = $false
+            paths = @()
+            lines = @()
+        }
+    }
+
+    $paths = @()
+    foreach ($line in @($snapshot)) {
+        $text = [string]$line
+        if ([string]::IsNullOrWhiteSpace($text) -or $text.Length -lt 4) {
+            continue
+        }
+        $pathText = $text.Substring(3).Trim()
+        if ($pathText -match ' -> ') {
+            $pathText = ($pathText -split ' -> ')[-1].Trim()
+        }
+        if (-not [string]::IsNullOrWhiteSpace($pathText)) {
+            $paths += $pathText
+        }
+    }
+
+    return [pscustomobject]@{
+        available = $true
+        paths = @($paths | Select-Object -Unique)
+        lines = @($snapshot)
+    }
+}
+
+function New-VibeNativeSpecialistPrompt {
+    param(
+        [Parameter(Mandatory)] [object]$Dispatch,
+        [Parameter(Mandatory)] [string]$RequirementDocPath,
+        [Parameter(Mandatory)] [string]$ExecutionPlanPath,
+        [Parameter(Mandatory)] [string]$GovernanceScope,
+        [Parameter(Mandatory)] [string]$WriteScope,
+        [Parameter(Mandatory)] [string]$RunId,
+        [AllowEmptyString()] [string]$RootRunId = '',
+        [AllowEmptyString()] [string]$ParentRunId = '',
+        [AllowEmptyString()] [string]$ParentUnitId = ''
+    )
+
+    $lines = @(
+        ('$' + [string]$Dispatch.skill_id),
+        '',
+        'You are a bounded specialist execution lane running under hidden vibe governance.',
+        'Do not replace the governed runtime. Do not create a second requirement surface or a second plan surface.',
+        ('specialist_skill_id: {0}' -f [string]$Dispatch.skill_id),
+        ('bounded_role: {0}' -f [string]$Dispatch.bounded_role),
+        ('governance_scope: {0}' -f $GovernanceScope),
+        ('run_id: {0}' -f $RunId)
+    )
+    if (-not [string]::IsNullOrWhiteSpace($RootRunId)) {
+        $lines += ('root_run_id: {0}' -f $RootRunId)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($ParentRunId)) {
+        $lines += ('parent_run_id: {0}' -f $ParentRunId)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($ParentUnitId)) {
+        $lines += ('parent_unit_id: {0}' -f $ParentUnitId)
+    }
+    $lines += @(
+        ('write_scope: {0}' -f $WriteScope),
+        ('requirement_doc: {0}' -f $RequirementDocPath),
+        ('execution_plan: {0}' -f $ExecutionPlanPath),
+        '',
+        'Rules:',
+        '- Preserve the named specialist skill native workflow.',
+        '- Remain bounded to the frozen requirement and execution plan.',
+        '- Do not widen scope or self-approve new specialist dispatch.',
+        '- Keep outputs specialist-specific and include verification notes.',
+        '- If no repo change is needed, return an empty changed_files array.',
+        '',
+        'Required inputs:'
+    )
+    foreach ($item in @($Dispatch.required_inputs)) {
+        $lines += ('- {0}' -f [string]$item)
+    }
+    $lines += @(
+        '',
+        'Expected outputs:'
+    )
+    foreach ($item in @($Dispatch.expected_outputs)) {
+        $lines += ('- {0}' -f [string]$item)
+    }
+    $lines += @(
+        '',
+        ('Verification expectation: {0}' -f [string]$Dispatch.verification_expectation),
+        '',
+        'Return only JSON matching the provided schema.'
+    )
+    return ($lines -join [Environment]::NewLine)
+}
+
+function New-VibeDegradedSpecialistDispatchResult {
     param(
         [Parameter(Mandatory)] [string]$UnitId,
         [Parameter(Mandatory)] [object]$Dispatch,
         [Parameter(Mandatory)] [string]$SessionRoot,
+        [Parameter(Mandatory)] [object]$Policy,
+        [Parameter(Mandatory)] [string]$Reason,
         [AllowEmptyString()] [string]$WriteScope = '',
         [AllowEmptyString()] [string]$ReviewMode = 'native_contract'
     )
@@ -235,20 +533,10 @@ function Invoke-VibeSpecialistDispatchUnit {
     $startedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.ffffffZ')
 
     $stdoutLines = @(
-        "Native specialist dispatch executed under vibe governance.",
+        ([string]$Policy.degrade_contract.hazard_alert),
         ("skill_id={0}" -f [string]$Dispatch.skill_id),
-        ("bounded_role={0}" -f [string]$Dispatch.bounded_role),
-        ("native_usage_required={0}" -f [bool]$Dispatch.native_usage_required),
-        ("must_preserve_workflow={0}" -f [bool]$Dispatch.must_preserve_workflow),
-        ("verification_expectation={0}" -f [string]$Dispatch.verification_expectation)
+        ("degradation_reason={0}" -f $Reason)
     )
-    if ($Dispatch.required_inputs) {
-        $stdoutLines += ("required_inputs={0}" -f [string]::Join(', ', @($Dispatch.required_inputs)))
-    }
-    if ($Dispatch.expected_outputs) {
-        $stdoutLines += ("expected_outputs={0}" -f [string]::Join(', ', @($Dispatch.expected_outputs)))
-    }
-
     Write-VgoUtf8NoBomText -Path $stdoutPath -Content (($stdoutLines -join [Environment]::NewLine) + [Environment]::NewLine)
     Write-VgoUtf8NoBomText -Path $stderrPath -Content ''
 
@@ -256,7 +544,7 @@ function Invoke-VibeSpecialistDispatchUnit {
     $unitResult = [pscustomobject]@{
         unit_id = $UnitId
         kind = 'specialist_dispatch'
-        status = 'completed'
+        status = [string]$Policy.degrade_contract.status
         started_at = $startedAt
         finished_at = $finishedAt
         command = ("specialist:{0}" -f [string]$Dispatch.skill_id)
@@ -271,16 +559,227 @@ function Invoke-VibeSpecialistDispatchUnit {
         timed_out = $false
         stdout_path = $stdoutPath
         stderr_path = $stderrPath
-        stdout_preview = @($stdoutLines | Select-Object -First 5)
+        stdout_preview = @($stdoutLines)
         stderr_preview = @()
         expected_artifacts = @()
-        verification_passed = $true
+        verification_passed = [bool]$Policy.degrade_contract.verification_passed
         specialist_skill_id = [string]$Dispatch.skill_id
         bounded_role = [string]$Dispatch.bounded_role
         native_usage_required = [bool]$Dispatch.native_usage_required
         must_preserve_workflow = [bool]$Dispatch.must_preserve_workflow
         write_scope = $WriteScope
         review_mode = $ReviewMode
+        execution_driver = [string]$Policy.degrade_contract.execution_driver
+        live_native_execution = $false
+        degraded = $true
+        degradation_reason = $Reason
+        hazard_alert = [string]$Policy.degrade_contract.hazard_alert
+        changed_files = @()
+        verification_notes = @()
+        bounded_output_notes = @()
+    }
+
+    $resultPath = Join-Path $resultsRoot ("{0}.json" -f $UnitId)
+    Write-VibeJsonArtifact -Path $resultPath -Value $unitResult
+
+    return [pscustomobject]@{
+        result = $unitResult
+        result_path = $resultPath
+    }
+}
+
+function Invoke-VibeSpecialistDispatchUnit {
+    param(
+        [Parameter(Mandatory)] [string]$UnitId,
+        [Parameter(Mandatory)] [object]$Dispatch,
+        [Parameter(Mandatory)] [string]$SessionRoot,
+        [Parameter(Mandatory)] [string]$RepoRoot,
+        [Parameter(Mandatory)] [string]$RequirementDocPath,
+        [Parameter(Mandatory)] [string]$ExecutionPlanPath,
+        [Parameter(Mandatory)] [string]$RunId,
+        [Parameter(Mandatory)] [string]$GovernanceScope,
+        [AllowEmptyString()] [string]$RootRunId = '',
+        [AllowEmptyString()] [string]$ParentRunId = '',
+        [AllowEmptyString()] [string]$ParentUnitId = '',
+        [AllowEmptyString()] [string]$WriteScope = '',
+        [AllowEmptyString()] [string]$ReviewMode = 'native_contract'
+    )
+
+    $adapterResolution = Resolve-VibeNativeSpecialistAdapter -ScriptPath $PSCommandPath
+    $policy = $adapterResolution.policy
+    if (-not $adapterResolution.live_execution_allowed -or $null -eq $adapterResolution.adapter) {
+        return New-VibeDegradedSpecialistDispatchResult `
+            -UnitId $UnitId `
+            -Dispatch $Dispatch `
+            -SessionRoot $SessionRoot `
+            -Policy $policy `
+            -Reason ([string]$adapterResolution.reason) `
+            -WriteScope $WriteScope `
+            -ReviewMode $ReviewMode
+    }
+
+    $adapter = $adapterResolution.adapter
+    $logsRoot = Join-Path $SessionRoot 'execution-logs'
+    $resultsRoot = Join-Path $SessionRoot 'execution-results'
+    New-Item -ItemType Directory -Path $logsRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+
+    $stdoutPath = Join-Path $logsRoot ("{0}.stdout.log" -f $UnitId)
+    $stderrPath = Join-Path $logsRoot ("{0}.stderr.log" -f $UnitId)
+    $responsePath = Join-Path $resultsRoot ("{0}.response.json" -f $UnitId)
+    $schemaPath = Join-Path $SessionRoot ("{0}.schema.json" -f $UnitId)
+    $promptPath = Join-Path $SessionRoot ("{0}.prompt.md" -f $UnitId)
+    $beforeGitPath = Join-Path $SessionRoot ("{0}.git-before.txt" -f $UnitId)
+    $afterGitPath = Join-Path $SessionRoot ("{0}.git-after.txt" -f $UnitId)
+    $startedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.ffffffZ')
+
+    $schema = New-VibeSpecialistResultSchema -Policy $policy
+    Write-VibeJsonArtifact -Path $schemaPath -Value $schema
+    $prompt = New-VibeNativeSpecialistPrompt `
+        -Dispatch $Dispatch `
+        -RequirementDocPath $RequirementDocPath `
+        -ExecutionPlanPath $ExecutionPlanPath `
+        -GovernanceScope $GovernanceScope `
+        -WriteScope $WriteScope `
+        -RunId $RunId `
+        -RootRunId $RootRunId `
+        -ParentRunId $ParentRunId `
+        -ParentUnitId $ParentUnitId
+    Write-VgoUtf8NoBomText -Path $promptPath -Content ($prompt + [Environment]::NewLine)
+
+    $beforeSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $RepoRoot
+    Write-VgoUtf8NoBomText -Path $beforeGitPath -Content ((@($beforeSnapshot.lines) -join [Environment]::NewLine) + [Environment]::NewLine)
+
+    $arguments = @()
+    foreach ($item in @($adapter.arguments_prefix)) {
+        $arguments += [string]$item
+    }
+    $arguments += @(
+        '-C', $RepoRoot,
+        '--output-schema', $schemaPath,
+        '-o', $responsePath,
+        $prompt
+    )
+    $processResult = Invoke-VibeCapturedProcess `
+        -Command ([string]$adapterResolution.command_path) `
+        -Arguments $arguments `
+        -WorkingDirectory $RepoRoot `
+        -TimeoutSeconds ([int]$policy.default_timeout_seconds) `
+        -StdOutPath $stdoutPath `
+        -StdErrPath $stderrPath
+
+    $afterSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $RepoRoot
+    Write-VgoUtf8NoBomText -Path $afterGitPath -Content ((@($afterSnapshot.lines) -join [Environment]::NewLine) + [Environment]::NewLine)
+
+    $parsedResponse = $null
+    $responseParseError = $null
+    if (Test-Path -LiteralPath $responsePath) {
+        try {
+            $parsedResponse = Get-Content -LiteralPath $responsePath -Raw -Encoding UTF8 | ConvertFrom-Json
+        } catch {
+            $responseParseError = $_.Exception.Message
+        }
+    } else {
+        $responseParseError = 'native_specialist_response_missing'
+    }
+
+    $beforeLookup = @{}
+    foreach ($path in @($beforeSnapshot.paths)) {
+        $beforeLookup[[string]$path] = $true
+    }
+    $observedChangedFiles = @()
+    foreach ($path in @($afterSnapshot.paths)) {
+        if (-not $beforeLookup.ContainsKey([string]$path)) {
+            $observedChangedFiles += [string]$path
+        }
+    }
+
+    $responseStatus = if ($parsedResponse -and $parsedResponse.PSObject.Properties.Name -contains 'status') {
+        [string]$parsedResponse.status
+    } else {
+        ''
+    }
+    $responseSummary = if ($parsedResponse -and $parsedResponse.PSObject.Properties.Name -contains 'summary') {
+        [string]$parsedResponse.summary
+    } else {
+        $null
+    }
+    $verificationNotes = if ($parsedResponse -and $parsedResponse.PSObject.Properties.Name -contains 'verification_notes') {
+        @($parsedResponse.verification_notes | ForEach-Object { [string]$_ })
+    } else {
+        @()
+    }
+    $changedFiles = if ($parsedResponse -and $parsedResponse.PSObject.Properties.Name -contains 'changed_files') {
+        @($parsedResponse.changed_files | ForEach-Object { [string]$_ })
+    } else {
+        @()
+    }
+    $boundedOutputNotes = if ($parsedResponse -and $parsedResponse.PSObject.Properties.Name -contains 'bounded_output_notes') {
+        @($parsedResponse.bounded_output_notes | ForEach-Object { [string]$_ })
+    } else {
+        @()
+    }
+
+    $verificationPassed = (-not $processResult.timed_out) -and ([int]$processResult.exit_code -eq 0) -and ($null -ne $parsedResponse) -and (@('completed', 'completed_with_notes') -contains $responseStatus)
+    $effectiveStatus = if ($verificationPassed) {
+        'completed'
+    } elseif ($processResult.timed_out) {
+        'timed_out'
+    } elseif (-not [string]::IsNullOrWhiteSpace($responseStatus)) {
+        $responseStatus
+    } else {
+        'failed'
+    }
+
+    $finishedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.ffffffZ')
+    $unitResult = [pscustomobject]@{
+        unit_id = $UnitId
+        kind = 'specialist_dispatch'
+        status = $effectiveStatus
+        started_at = $startedAt
+        finished_at = $finishedAt
+        command = [string]$adapterResolution.command_path
+        arguments = @($arguments)
+        display_command = @([string]$adapterResolution.command_path) + @($arguments) -join ' '
+        cwd = $RepoRoot
+        timeout_seconds = [int]$policy.default_timeout_seconds
+        expected_exit_code = 0
+        exit_code = [int]$processResult.exit_code
+        timed_out = [bool]$processResult.timed_out
+        stdout_path = $processResult.stdout_path
+        stderr_path = $processResult.stderr_path
+        stdout_preview = @($processResult.stdout_preview)
+        stderr_preview = @($processResult.stderr_preview)
+        expected_artifacts = @(
+            [pscustomobject]@{
+                path = $responsePath
+                exists = [bool](Test-Path -LiteralPath $responsePath)
+            }
+        )
+        verification_passed = [bool]$verificationPassed
+        specialist_skill_id = [string]$Dispatch.skill_id
+        bounded_role = [string]$Dispatch.bounded_role
+        native_usage_required = [bool]$Dispatch.native_usage_required
+        must_preserve_workflow = [bool]$Dispatch.must_preserve_workflow
+        write_scope = $WriteScope
+        review_mode = $ReviewMode
+        execution_driver = [string]$adapter.execution_driver
+        host_adapter_id = [string]$adapter.id
+        live_native_execution = $true
+        degraded = $false
+        requirement_doc_path = $RequirementDocPath
+        execution_plan_path = $ExecutionPlanPath
+        response_json_path = $responsePath
+        prompt_path = $promptPath
+        schema_path = $schemaPath
+        git_status_before_path = $beforeGitPath
+        git_status_after_path = $afterGitPath
+        changed_files = @($changedFiles)
+        observed_changed_files = @($observedChangedFiles)
+        verification_notes = @($verificationNotes)
+        bounded_output_notes = @($boundedOutputNotes)
+        summary = $responseSummary
+        response_parse_error = $responseParseError
     }
 
     $resultPath = Join-Path $resultsRoot ("{0}.json" -f $UnitId)
@@ -429,7 +928,7 @@ function New-VibeExecutionTopology {
             }
         }
 
-        if ($GovernanceScope -eq 'root' -and $effectiveSpecialistExecutionMode -eq 'native_bounded_units' -and @($ApprovedDispatch).Count -gt 0) {
+        if ($effectiveSpecialistExecutionMode -eq 'native_bounded_units' -and @($ApprovedDispatch).Count -gt 0) {
             $specialistUnits = @()
             foreach ($dispatch in @($ApprovedDispatch)) {
                 $specialistUnits += [pscustomobject]@{

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -18,6 +18,7 @@ function Get-VibeRuntimeContext {
         runtime_modes = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-modes.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         runtime_input_packet_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-input-packet-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         execution_topology_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\execution-topology-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        native_specialist_execution_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\native-specialist-execution-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         requirement_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\requirement-doc-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         plan_execution_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\plan-execution-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         benchmark_execution_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\benchmark-execution-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -254,9 +254,9 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertGreaterEqual(execute_receipt["specialist_dispatch_unit_count"], 1)
             self.assertIn("systematic-debugging", execute_receipt["specialist_skills"])
             self.assertEqual(execute_receipt["executed_unit_count"], execution_manifest["executed_unit_count"])
-            self.assertEqual("completed", execution_manifest["status"])
+            self.assertEqual("completed_with_failures", execution_manifest["status"])
             self.assertGreaterEqual(execution_manifest["successful_unit_count"], 2)
-            self.assertEqual(0, execution_manifest["failed_unit_count"])
+            self.assertGreaterEqual(execution_manifest["failed_unit_count"], 1)
             self.assertEqual("runtime", execution_manifest["proof_class"])
             self.assertTrue(Path(execution_manifest["plan_shadow"]["path"]).exists())
             self.assertEqual("vibe", execution_manifest["route_runtime_alignment"]["router_selected_skill"])
@@ -265,13 +265,21 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertGreaterEqual(execution_manifest["specialist_accounting"]["recommendation_count"], 1)
             self.assertGreaterEqual(execution_manifest["specialist_accounting"]["dispatch_unit_count"], 1)
             self.assertIn("systematic-debugging", execution_manifest["specialist_accounting"]["specialist_skills"])
+            self.assertEqual("explicitly_degraded", execution_manifest["specialist_accounting"]["effective_execution_status"])
+            self.assertEqual(0, execution_manifest["specialist_accounting"]["executed_specialist_unit_count"])
+            self.assertGreaterEqual(
+                execution_manifest["specialist_accounting"]["degraded_specialist_unit_count"], 1
+            )
             self.assertGreaterEqual(execution_manifest["plan_shadow"]["specialist_dispatch_unit_count"], 1)
-            self.assertTrue(benchmark_proof["proof_passed"])
+            self.assertFalse(benchmark_proof["proof_passed"])
             self.assertGreaterEqual(benchmark_proof["executed_unit_count"], 2)
             self.assertEqual("runtime", benchmark_proof["proof_class"])
             self.assertTrue(Path(benchmark_proof["plan_shadow_path"]).exists())
             self.assertGreaterEqual(benchmark_proof["specialist_recommendation_count"], 1)
             self.assertGreaterEqual(benchmark_proof["specialist_dispatch_unit_count"], 1)
+            self.assertEqual(0, benchmark_proof["executed_specialist_unit_count"])
+            self.assertGreaterEqual(benchmark_proof["degraded_specialist_unit_count"], 1)
+            self.assertEqual("explicitly_degraded", benchmark_proof["specialist_execution_status"])
 
             cleanup_receipt = json.loads(resolve_artifact_path("cleanup_receipt").read_text(encoding="utf-8"))
             self.assertEqual("receipt_only", cleanup_receipt["cleanup_mode"])
@@ -280,10 +288,16 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
 
             for result_path in benchmark_proof["result_paths"]:
                 result = json.loads(Path(result_path).read_text(encoding="utf-8"))
-                self.assertEqual("completed", result["status"])
                 self.assertEqual(0, result["exit_code"])
                 self.assertTrue(Path(result["stdout_path"]).exists())
                 self.assertTrue(Path(result["stderr_path"]).exists())
+                if result["kind"] == "specialist_dispatch":
+                    self.assertEqual("degraded_non_authoritative", result["status"])
+                    self.assertFalse(bool(result["verification_passed"]))
+                    self.assertEqual("degraded_specialist_contract_receipt", result["execution_driver"])
+                else:
+                    self.assertEqual("completed", result["status"])
+                    self.assertTrue(bool(result["verification_passed"]))
 
     def test_resolve_vgo_python_command_spec_falls_back_to_python3(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/runtime_neutral/test_l_xl_native_execution_topology.py
+++ b/tests/runtime_neutral/test_l_xl_native_execution_topology.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import stat
 import subprocess
 import tempfile
 import unittest
@@ -40,6 +42,7 @@ def run_runtime(
     inherited_requirement_doc_path: Path | None = None,
     inherited_execution_plan_path: Path | None = None,
     approved_specialist_skill_ids: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> dict[str, object]:
     shell = resolve_powershell()
     if shell is None:
@@ -95,6 +98,7 @@ def run_runtime(
         capture_output=True,
         text=True,
         check=True,
+        env={**os.environ, **(extra_env or {})},
     )
     stdout = completed.stdout.strip()
     if stdout in ("", "null"):
@@ -122,6 +126,57 @@ def collect_wave_units(execution_manifest: dict[str, object]) -> list[dict[str, 
 
 def load_unit_result(unit: dict[str, object]) -> dict[str, object]:
     return load_json(unit["result_path"])
+
+
+def create_fake_codex_command(directory: Path) -> Path:
+    suffix = ".cmd" if os.name == "nt" else ""
+    command_path = directory / f"codex{suffix}"
+    if os.name == "nt":
+        command_path.write_text(
+            "@echo off\r\n"
+            "setlocal EnableDelayedExpansion\r\n"
+            "set OUT=\r\n"
+            ":loop\r\n"
+            "if \"%~1\"==\"\" goto done\r\n"
+            "if \"%~1\"==\"-o\" (\r\n"
+            "  set OUT=%~2\r\n"
+            "  shift\r\n"
+            "  shift\r\n"
+            "  goto loop\r\n"
+            ")\r\n"
+            "shift\r\n"
+            "goto loop\r\n"
+            ":done\r\n"
+            "if \"%OUT%\"==\"\" exit /b 2\r\n"
+            "> \"%OUT%\" echo {\"status\":\"completed\",\"summary\":\"fake codex specialist executed\",\"verification_notes\":[\"fake native specialist executed\"],\"changed_files\":[],\"bounded_output_notes\":[\"fake codex adapter\"]}\r\n"
+            "echo fake codex ok\r\n"
+            "exit /b 0\r\n",
+            encoding="utf-8",
+        )
+    else:
+        command_path.write_text(
+            "#!/usr/bin/env sh\n"
+            "OUT=''\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    -o)\n"
+            "      OUT=\"$2\"\n"
+            "      shift 2\n"
+            "      ;;\n"
+            "    *)\n"
+            "      shift\n"
+            "      ;;\n"
+            "  esac\n"
+            "done\n"
+            "if [ -z \"$OUT\" ]; then\n"
+            "  exit 2\n"
+            "fi\n"
+            "printf '%s' '{\"status\":\"completed\",\"summary\":\"fake codex specialist executed\",\"verification_notes\":[\"fake native specialist executed\"],\"changed_files\":[],\"bounded_output_notes\":[\"fake codex adapter\"]}' > \"$OUT\"\n"
+            "printf 'fake codex ok\\n'\n",
+            encoding="utf-8",
+        )
+        command_path.chmod(command_path.stat().st_mode | stat.S_IXUSR)
+    return command_path
 
 
 class NativeExecutionTopologyTests(unittest.TestCase):
@@ -156,11 +211,17 @@ class NativeExecutionTopologyTests(unittest.TestCase):
             for unit in executed_units:
                 with self.subTest(unit_id=unit.get("unit_id", "")):
                     result = load_unit_result(unit)
-                    self.assertEqual("completed", result["status"])
                     self.assertEqual(0, int(result["exit_code"]))
-                    self.assertTrue(bool(result["verification_passed"]))
                     self.assertTrue(Path(result["stdout_path"]).exists())
                     self.assertTrue(Path(result["stderr_path"]).exists())
+                    if result["kind"] == "specialist_dispatch":
+                        self.assertEqual("degraded_non_authoritative", result["status"])
+                        self.assertFalse(bool(result["verification_passed"]))
+                        self.assertTrue(bool(result["degraded"]))
+                        self.assertFalse(bool(result["live_native_execution"]))
+                    else:
+                        self.assertEqual("completed", result["status"])
+                        self.assertTrue(bool(result["verification_passed"]))
 
             serial_order = list(topology.get("serial_execution_order") or [])
             self.assertEqual(
@@ -253,20 +314,78 @@ class NativeExecutionTopologyTests(unittest.TestCase):
             self.assertIn("specialist_accounting", execution_manifest)
             specialist_accounting = execution_manifest["specialist_accounting"]
             self.assertEqual("native_bounded_units", specialist_accounting["execution_mode"])
+            self.assertEqual("explicitly_degraded", specialist_accounting["effective_execution_status"])
+            self.assertEqual(0, int(specialist_accounting["executed_specialist_unit_count"]))
+            self.assertGreaterEqual(int(specialist_accounting["degraded_specialist_unit_count"]), 1)
+            self.assertEqual("completed_with_failures", execution_manifest["status"])
+            self.assertGreaterEqual(int(execution_manifest["failed_unit_count"]), 1)
+
+            degraded_units = list(specialist_accounting["degraded_specialist_units"])
+            self.assertGreaterEqual(len(degraded_units), 1)
+            for unit in degraded_units:
+                with self.subTest(unit_id=unit.get("unit_id", "")):
+                    self.assertFalse(bool(unit["verification_passed"]))
+                    self.assertTrue(bool(unit["degraded"]))
+                    self.assertFalse(bool(unit["live_native_execution"]))
+                    self.assertTrue(Path(unit["result_path"]).exists())
+                    self.assertIn("skill_id", unit)
+                    self.assertNotEqual("", str(unit["skill_id"]).strip())
+                    result = load_json(unit["result_path"])
+                    self.assertEqual("degraded_non_authoritative", result["status"])
+                    self.assertEqual(0, int(result["exit_code"]))
+                    self.assertFalse(bool(result["verification_passed"]))
+                    self.assertEqual("degraded_specialist_contract_receipt", result["execution_driver"])
+                    self.assertTrue(bool(result["degraded"]))
+                    self.assertFalse(bool(result["live_native_execution"]))
+                    self.assertTrue(Path(result["stdout_path"]).exists())
+                    self.assertTrue(Path(result["stderr_path"]).exists())
+
+    def test_approved_specialist_dispatch_can_execute_live_native_lane_when_adapter_enabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_path = Path(tempdir)
+            fake_codex = create_fake_codex_command(temp_path)
+            payload = run_runtime(
+                task="I have a failing test and stack trace. Debug systematically and execute specialist workflow.",
+                artifact_root=temp_path,
+                governance_scope="root",
+                extra_env={
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+            summary = payload["summary"]
+            execution_manifest = load_json(summary["artifacts"]["execution_manifest"])
+
+            specialist_accounting = execution_manifest["specialist_accounting"]
+            self.assertEqual("native_bounded_units", specialist_accounting["execution_mode"])
+            self.assertEqual("live_native_executed", specialist_accounting["effective_execution_status"])
             self.assertGreaterEqual(int(specialist_accounting["executed_specialist_unit_count"]), 1)
+            self.assertEqual(0, int(specialist_accounting["degraded_specialist_unit_count"]))
+            self.assertEqual("completed", execution_manifest["status"])
 
             executed_units = list(specialist_accounting["executed_specialist_units"])
             self.assertGreaterEqual(len(executed_units), 1)
             for unit in executed_units:
                 with self.subTest(unit_id=unit.get("unit_id", "")):
                     self.assertTrue(bool(unit["verification_passed"]))
+                    self.assertFalse(bool(unit["degraded"]))
+                    self.assertTrue(bool(unit["live_native_execution"]))
+                    self.assertEqual("codex_exec_native_specialist", unit["execution_driver"])
                     self.assertTrue(Path(unit["result_path"]).exists())
-                    self.assertIn("skill_id", unit)
-                    self.assertNotEqual("", str(unit["skill_id"]).strip())
                     result = load_json(unit["result_path"])
                     self.assertEqual("completed", result["status"])
                     self.assertEqual(0, int(result["exit_code"]))
                     self.assertTrue(bool(result["verification_passed"]))
+                    self.assertTrue(bool(result["live_native_execution"]))
+                    self.assertFalse(bool(result["degraded"]))
+                    self.assertEqual("codex_exec_native_specialist", result["execution_driver"])
+                    self.assertEqual("codex", result["host_adapter_id"])
+                    self.assertTrue(Path(result["response_json_path"]).exists())
+                    self.assertTrue(Path(result["prompt_path"]).exists())
+                    self.assertTrue(Path(result["schema_path"]).exists())
+                    self.assertTrue(Path(result["git_status_before_path"]).exists())
+                    self.assertTrue(Path(result["git_status_after_path"]).exists())
                     self.assertTrue(Path(result["stdout_path"]).exists())
                     self.assertTrue(Path(result["stderr_path"]).exists())
 
@@ -324,13 +443,18 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                 int(specialist_accounting["executed_specialist_unit_count"]),
                 int(specialist_accounting["approved_dispatch_count"]),
             )
+            self.assertGreaterEqual(int(specialist_accounting["degraded_specialist_unit_count"]), 0)
 
-            executed_specialist_units = list(specialist_accounting["executed_specialist_units"])
-            for unit in executed_specialist_units:
+            specialist_outcomes = list(specialist_accounting["specialist_dispatch_outcomes"])
+            for unit in specialist_outcomes:
                 with self.subTest(unit_id=unit.get("unit_id", "")):
                     self.assertIn(str(unit["skill_id"]), approved_child_ids)
-                    self.assertTrue(bool(unit["verification_passed"]))
                     self.assertTrue(Path(unit["result_path"]).exists())
+                    result = load_json(unit["result_path"])
+                    self.assertIn(
+                        str(result["status"]),
+                        {"completed", "degraded_non_authoritative"},
+                    )
 
             escalation_request_path = specialist_accounting.get("escalation_request_path")
             if escalation_request_path:
@@ -339,7 +463,7 @@ class NativeExecutionTopologyTests(unittest.TestCase):
 
             child_session_root = Path(child_payload["session_root"])
             specialist_result_files = list(child_session_root.glob("execution-results/*specialist*.json"))
-            self.assertLessEqual(len(specialist_result_files), len(executed_specialist_units))
+            self.assertLessEqual(len(specialist_result_files), len(specialist_outcomes))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an explicit native specialist execution bridge with a codex-first adapter policy
- make disabled or unsupported specialist execution degrade explicitly instead of faking native completion
- allow child lanes to execute root-approved specialist dispatch and cover the new behavior with runtime-neutral tests

## Verification
- git diff --check
- pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py
