### PR TITLE
[codex] child specialist same-round auto-absorb

### DIFF
--- a/bundled/skills/vibe/bundled/skills/vibe/config/runtime-input-packet-policy.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/runtime-input-packet-policy.json
@@ -9,16 +9,72 @@
   "shadow_only": true,
   "required_fields": [
     "run_id",
+    "governance_scope",
+    "hierarchy",
     "task",
     "runtime_mode",
     "internal_grade",
     "canonical_router",
     "route_snapshot",
+    "specialist_recommendations",
+    "specialist_dispatch",
     "overlay_decisions",
     "authority_flags",
     "divergence_shadow",
     "provenance"
   ],
+  "hierarchy_contract": {
+    "default_governance_scope": "root",
+    "child_receipt_only_stages": [
+      "requirement_doc",
+      "xl_plan"
+    ],
+    "root_authority_flags": {
+      "allow_requirement_freeze": true,
+      "allow_plan_freeze": true,
+      "allow_global_dispatch": true,
+      "allow_completion_claim": true
+    },
+    "child_authority_flags": {
+      "allow_requirement_freeze": false,
+      "allow_plan_freeze": false,
+      "allow_global_dispatch": false,
+      "allow_completion_claim": false
+    }
+  },
+  "specialist_dispatch_contract": {
+    "bounded_role": "specialist_assist",
+    "native_usage_required": true,
+    "must_preserve_workflow": true,
+    "required_inputs": [
+      "bounded specialist subtask contract",
+      "frozen requirement context",
+      "relevant source files or domain artifacts"
+    ],
+    "expected_outputs": [
+      "bounded specialist findings or code changes",
+      "verification notes aligned with the specialist skill"
+    ],
+    "verification_expectation": "Preserve the specialist skill's native workflow, boundaries, and validation style."
+  },
+  "child_specialist_suggestion_contract": {
+    "field_name": "local_specialist_suggestions",
+    "escalation_required": true,
+    "approval_owner": "root_vibe",
+    "status": "advisory_until_root_approval",
+    "auto_absorb_gate": {
+      "enabled": true,
+      "same_round": true,
+      "approval_source": "root_vibe_auto_absorb_gate",
+      "required_runtime_skill": "vibe",
+      "require_known_recommendation": true,
+      "require_native_workflow": true,
+      "require_native_usage_required": true,
+      "max_auto_absorb_count": 4,
+      "disable_env": "VGO_DISABLE_CHILD_SPECIALIST_AUTO_ABSORB",
+      "force_escalation_env": "VGO_FORCE_CHILD_SPECIALIST_ESCALATION"
+    }
+  },
   "overlay_fields": [
     "openspec_advice",
     "gsd_overlay_advice",
@@ -42,5 +98,6 @@
     "llm_acceleration_advice",
     "heartbeat_advice"
   ],
+  "specialist_recommendation_limit": 4,
   "bounded_router_task_type_default": "planning"
 }

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
@@ -309,6 +309,266 @@ function ConvertTo-VibeExecutedUnitReceipt {
     }
 }
 
+function Resolve-VibeEffectiveSpecialistDispatch {
+    param(
+        [Parameter(Mandatory)] [string]$SessionRoot,
+        [Parameter(Mandatory)] [object]$HierarchyState,
+        [AllowNull()] [object]$RuntimeInputPacket = $null,
+        [AllowEmptyCollection()] [object[]]$ApprovedDispatch = @(),
+        [AllowEmptyCollection()] [object[]]$LocalSuggestions = @(),
+        [AllowNull()] [object]$SuggestionContract = $null
+    )
+
+    $frozenApprovedDispatch = @($ApprovedDispatch)
+    $originalLocalSuggestions = @($LocalSuggestions)
+    $frozenApprovedSkillIds = @($frozenApprovedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $originalLocalSkillIds = @($originalLocalSuggestions | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $originalEscalationRequired = if ($RuntimeInputPacket -and $RuntimeInputPacket.specialist_dispatch) {
+        [bool]$RuntimeInputPacket.specialist_dispatch.escalation_required
+    } else {
+        @($originalLocalSuggestions).Count -gt 0
+    }
+    $originalEscalationStatus = if ($RuntimeInputPacket -and $RuntimeInputPacket.specialist_dispatch -and $RuntimeInputPacket.specialist_dispatch.escalation_status) {
+        [string]$RuntimeInputPacket.specialist_dispatch.escalation_status
+    } elseif ($originalEscalationRequired) {
+        'root_approval_required'
+    } else {
+        'not_required'
+    }
+
+    $result = [ordered]@{
+        frozen_approved_dispatch = @($frozenApprovedDispatch)
+        frozen_approved_skill_ids = @($frozenApprovedSkillIds)
+        effective_approved_dispatch = @($frozenApprovedDispatch)
+        effective_approved_skill_ids = @($frozenApprovedSkillIds)
+        auto_approved_dispatch = @()
+        auto_approved_skill_ids = @()
+        original_local_specialist_suggestions = @($originalLocalSuggestions)
+        original_local_suggestion_skill_ids = @($originalLocalSkillIds)
+        residual_local_specialist_suggestions = @($originalLocalSuggestions)
+        residual_local_suggestion_skill_ids = @($originalLocalSkillIds)
+        escalation_required = [bool]$originalEscalationRequired
+        escalation_status = [string]$originalEscalationStatus
+        approval_owner = if ($SuggestionContract -and $SuggestionContract.PSObject.Properties.Name -contains 'approval_owner') {
+            [string]$SuggestionContract.approval_owner
+        } else {
+            'root_vibe'
+        }
+        auto_absorb_gate = [pscustomobject]@{
+            enabled = $false
+            same_round = $false
+            status = if ([string]$HierarchyState.governance_scope -eq 'child' -and @($originalLocalSuggestions).Count -gt 0) { 'disabled' } else { 'not_applicable' }
+            approval_source = $null
+            auto_approved_skill_ids = @()
+            rejected_skill_ids = @()
+            rejected_suggestions = @()
+            receipt_path = $null
+        }
+    }
+
+    if ([string]$HierarchyState.governance_scope -ne 'child' -or @($originalLocalSuggestions).Count -eq 0) {
+        return [pscustomobject]$result
+    }
+
+    $autoAbsorbGate = if ($SuggestionContract -and $SuggestionContract.PSObject.Properties.Name -contains 'auto_absorb_gate') {
+        $SuggestionContract.auto_absorb_gate
+    } else {
+        $null
+    }
+    if ($null -eq $autoAbsorbGate -or -not [bool]$autoAbsorbGate.enabled) {
+        return [pscustomobject]$result
+    }
+
+    $sameRound = $true
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'same_round' -and $null -ne $autoAbsorbGate.same_round) {
+        $sameRound = [bool]$autoAbsorbGate.same_round
+    }
+    $approvalSource = if ($autoAbsorbGate.PSObject.Properties.Name -contains 'approval_source' -and -not [string]::IsNullOrWhiteSpace([string]$autoAbsorbGate.approval_source)) {
+        [string]$autoAbsorbGate.approval_source
+    } else {
+        'root_vibe_auto_absorb_gate'
+    }
+    $result.auto_absorb_gate.enabled = $true
+    $result.auto_absorb_gate.same_round = [bool]$sameRound
+    $result.auto_absorb_gate.approval_source = $approvalSource
+
+    if (-not $sameRound) {
+        $result.auto_absorb_gate.status = 'not_same_round'
+        return [pscustomobject]$result
+    }
+
+    if (@($frozenApprovedDispatch).Count -eq 0) {
+        $result.auto_absorb_gate.status = 'requires_existing_root_dispatch'
+        return [pscustomobject]$result
+    }
+
+    $disableEnvName = if ($autoAbsorbGate.PSObject.Properties.Name -contains 'disable_env') { [string]$autoAbsorbGate.disable_env } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($disableEnvName) -and (Test-VibeTruthyEnvironmentValue -Value ([Environment]::GetEnvironmentVariable($disableEnvName)))) {
+        $result.auto_absorb_gate.status = ("disabled_via_env:{0}" -f $disableEnvName)
+        return [pscustomobject]$result
+    }
+
+    $forceEscalationEnvName = if ($autoAbsorbGate.PSObject.Properties.Name -contains 'force_escalation_env') { [string]$autoAbsorbGate.force_escalation_env } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($forceEscalationEnvName) -and (Test-VibeTruthyEnvironmentValue -Value ([Environment]::GetEnvironmentVariable($forceEscalationEnvName)))) {
+        $result.auto_absorb_gate.status = ("forced_escalation_via_env:{0}" -f $forceEscalationEnvName)
+        return [pscustomobject]$result
+    }
+
+    $requiredRuntimeSkill = if ($autoAbsorbGate.PSObject.Properties.Name -contains 'required_runtime_skill') {
+        [string]$autoAbsorbGate.required_runtime_skill
+    } else {
+        ''
+    }
+    if (-not [string]::IsNullOrWhiteSpace($requiredRuntimeSkill)) {
+        $effectiveRuntimeSkill = if ($RuntimeInputPacket -and $RuntimeInputPacket.authority_flags) {
+            [string]$RuntimeInputPacket.authority_flags.explicit_runtime_skill
+        } else {
+            'vibe'
+        }
+        if (-not [string]::Equals($effectiveRuntimeSkill, $requiredRuntimeSkill, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $result.auto_absorb_gate.status = 'runtime_authority_mismatch'
+            return [pscustomobject]$result
+        }
+    }
+
+    $requireKnownRecommendation = $true
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'require_known_recommendation' -and $null -ne $autoAbsorbGate.require_known_recommendation) {
+        $requireKnownRecommendation = [bool]$autoAbsorbGate.require_known_recommendation
+    }
+    $requireNativeWorkflow = $true
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'require_native_workflow' -and $null -ne $autoAbsorbGate.require_native_workflow) {
+        $requireNativeWorkflow = [bool]$autoAbsorbGate.require_native_workflow
+    }
+    $requireNativeUsageRequired = $true
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'require_native_usage_required' -and $null -ne $autoAbsorbGate.require_native_usage_required) {
+        $requireNativeUsageRequired = [bool]$autoAbsorbGate.require_native_usage_required
+    }
+    $maxAutoAbsorbCount = [int]::MaxValue
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'max_auto_absorb_count' -and $null -ne $autoAbsorbGate.max_auto_absorb_count) {
+        $maxAutoAbsorbCount = [int]$autoAbsorbGate.max_auto_absorb_count
+    }
+
+    $recommendationLookup = @{}
+    if ($RuntimeInputPacket -and $RuntimeInputPacket.PSObject.Properties.Name -contains 'specialist_recommendations') {
+        foreach ($recommendation in @($RuntimeInputPacket.specialist_recommendations)) {
+            $skillId = [string]$recommendation.skill_id
+            if (-not [string]::IsNullOrWhiteSpace($skillId) -and -not $recommendationLookup.ContainsKey($skillId)) {
+                $recommendationLookup[$skillId] = $recommendation
+            }
+        }
+    }
+
+    $effectiveLookup = @{}
+    foreach ($skillId in @($frozenApprovedSkillIds)) {
+        $effectiveLookup[$skillId] = $true
+    }
+
+    $autoApprovedDispatch = @()
+    $rejectedSuggestions = @()
+    foreach ($suggestion in @($originalLocalSuggestions)) {
+        $skillId = [string]$suggestion.skill_id
+        $rejectionReason = $null
+        $effectiveSuggestion = $suggestion
+
+        if ([string]::IsNullOrWhiteSpace($skillId)) {
+            $rejectionReason = 'missing_skill_id'
+        } elseif ($effectiveLookup.ContainsKey($skillId)) {
+            $rejectionReason = 'already_effective'
+        } elseif ($requireKnownRecommendation -and -not $recommendationLookup.ContainsKey($skillId)) {
+            $rejectionReason = 'not_in_frozen_recommendations'
+        } else {
+            if ($recommendationLookup.ContainsKey($skillId)) {
+                $effectiveSuggestion = $recommendationLookup[$skillId]
+            }
+
+            if ($requireNativeWorkflow -and -not [bool]$effectiveSuggestion.must_preserve_workflow) {
+                $rejectionReason = 'must_preserve_workflow_missing'
+            } elseif ($requireNativeUsageRequired -and -not [bool]$effectiveSuggestion.native_usage_required) {
+                $rejectionReason = 'native_usage_required_missing'
+            } elseif (@($autoApprovedDispatch).Count -ge $maxAutoAbsorbCount) {
+                $rejectionReason = 'max_auto_absorb_count_exceeded'
+            }
+        }
+
+        if ($rejectionReason) {
+            $rejectedSuggestions += [pscustomobject]@{
+                skill_id = if ([string]::IsNullOrWhiteSpace($skillId)) { $null } else { $skillId }
+                reason = $rejectionReason
+                suggestion = $suggestion
+            }
+            continue
+        }
+
+        $autoApprovedDispatch += $effectiveSuggestion
+        $effectiveLookup[$skillId] = $true
+    }
+
+    $residualSuggestions = @($rejectedSuggestions | ForEach-Object { $_.suggestion })
+    $residualSkillIds = @($residualSuggestions | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $effectiveApprovedDispatch = @($frozenApprovedDispatch + $autoApprovedDispatch)
+    $effectiveApprovedSkillIds = @($effectiveApprovedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+
+    $result.effective_approved_dispatch = @($effectiveApprovedDispatch)
+    $result.effective_approved_skill_ids = @($effectiveApprovedSkillIds)
+    $result.auto_approved_dispatch = @($autoApprovedDispatch)
+    $result.auto_approved_skill_ids = @($autoApprovedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $result.residual_local_specialist_suggestions = @($residualSuggestions)
+    $result.residual_local_suggestion_skill_ids = @($residualSkillIds)
+    $result.escalation_required = @($residualSuggestions).Count -gt 0 -and (
+        $null -eq $SuggestionContract -or
+        -not ($SuggestionContract.PSObject.Properties.Name -contains 'escalation_required') -or
+        [bool]$SuggestionContract.escalation_required
+    )
+    $result.escalation_status = if ([bool]$result.escalation_required) {
+        'root_approval_required'
+    } elseif (@($autoApprovedDispatch).Count -gt 0) {
+        'root_auto_approved_same_round'
+    } else {
+        'not_required'
+    }
+
+    $result.auto_absorb_gate.status = if (@($autoApprovedDispatch).Count -gt 0 -and @($residualSuggestions).Count -eq 0) {
+        'auto_approved_same_round'
+    } elseif (@($autoApprovedDispatch).Count -gt 0) {
+        'partially_auto_approved_same_round'
+    } elseif (@($originalLocalSuggestions).Count -gt 0) {
+        'rejected_all_candidates'
+    } else {
+        'not_applicable'
+    }
+    $result.auto_absorb_gate.auto_approved_skill_ids = @($result.auto_approved_skill_ids)
+    $result.auto_absorb_gate.rejected_skill_ids = @($rejectedSuggestions | ForEach-Object {
+        if ($_.skill_id) { [string]$_.skill_id }
+    } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $result.auto_absorb_gate.rejected_suggestions = @($rejectedSuggestions)
+
+    $resolutionReceipt = [pscustomobject]@{
+        run_id = if ($RuntimeInputPacket) { [string]$RuntimeInputPacket.run_id } else { $null }
+        governance_scope = [string]$HierarchyState.governance_scope
+        root_run_id = [string]$HierarchyState.root_run_id
+        parent_run_id = if ($null -eq $HierarchyState.parent_run_id) { $null } else { [string]$HierarchyState.parent_run_id }
+        parent_unit_id = if ($null -eq $HierarchyState.parent_unit_id) { $null } else { [string]$HierarchyState.parent_unit_id }
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        approval_owner = [string]$result.approval_owner
+        approval_source = [string]$approvalSource
+        same_round = [bool]$sameRound
+        frozen_approved_skill_ids = @($frozenApprovedSkillIds)
+        original_local_suggestion_skill_ids = @($originalLocalSkillIds)
+        effective_approved_skill_ids = @($effectiveApprovedSkillIds)
+        auto_approved_skill_ids = @($result.auto_approved_skill_ids)
+        residual_local_suggestion_skill_ids = @($residualSkillIds)
+        escalation_required = [bool]$result.escalation_required
+        escalation_status = [string]$result.escalation_status
+        gate_status = [string]$result.auto_absorb_gate.status
+        rejected_suggestions = @($rejectedSuggestions)
+    }
+    $resolutionReceiptPath = Join-Path $SessionRoot 'specialist-dispatch-resolution.json'
+    Write-VibeJsonArtifact -Path $resolutionReceiptPath -Value $resolutionReceipt
+    $result.auto_absorb_gate.receipt_path = $resolutionReceiptPath
+
+    return [pscustomobject]$result
+}
+
 function Get-VibePlanSections {
     param(
         [Parameter(Mandatory)] [string]$PlanPath
@@ -455,24 +715,30 @@ $tokens = @{
 }
 $planShadow = Get-VibePlanDerivedExecutionShadow -PlanPath $planPath -RunId $RunId -SessionRoot $sessionRoot
 $specialistRecommendations = if ($runtimeInputPacket) { @($runtimeInputPacket.specialist_recommendations) } else { @() }
-$approvedDispatch = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.approved_dispatch) } else { @() }
-$localSuggestions = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.local_specialist_suggestions) } else { @() }
+$frozenApprovedDispatch = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.approved_dispatch) } else { @() }
+$frozenLocalSuggestions = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.local_specialist_suggestions) } else { @() }
+$specialistDispatchResolution = Resolve-VibeEffectiveSpecialistDispatch `
+    -SessionRoot $sessionRoot `
+    -HierarchyState $hierarchyState `
+    -RuntimeInputPacket $runtimeInputPacket `
+    -ApprovedDispatch @($frozenApprovedDispatch) `
+    -LocalSuggestions @($frozenLocalSuggestions) `
+    -SuggestionContract $runtime.runtime_input_packet_policy.child_specialist_suggestion_contract
+$approvedDispatch = @($specialistDispatchResolution.effective_approved_dispatch)
+$localSuggestions = @($specialistDispatchResolution.residual_local_specialist_suggestions)
+$autoApprovedDispatch = @($specialistDispatchResolution.auto_approved_dispatch)
 $executionTopologyPath = Get-VibeExecutionTopologyPath -RepoRoot $runtime.repo_root -RunId $RunId -ArtifactRoot $ArtifactRoot
-$executionTopology = if (Test-Path -LiteralPath $executionTopologyPath) {
-    Get-Content -LiteralPath $executionTopologyPath -Raw -Encoding UTF8 | ConvertFrom-Json
-} else {
-    $derivedTopology = New-VibeExecutionTopology `
-        -RunId $RunId `
-        -Grade $grade `
-        -GovernanceScope ([string]$hierarchyState.governance_scope) `
-        -BenchmarkPolicy $policy `
-        -TopologyPolicy $runtime.execution_topology_policy `
-        -ApprovedDispatch @($approvedDispatch)
-    Write-VibeJsonArtifact -Path $executionTopologyPath -Value $derivedTopology
-    $derivedTopology
-}
+$executionTopology = New-VibeExecutionTopology `
+    -RunId $RunId `
+    -Grade $grade `
+    -GovernanceScope ([string]$hierarchyState.governance_scope) `
+    -BenchmarkPolicy $policy `
+    -TopologyPolicy $runtime.execution_topology_policy `
+    -ApprovedDispatch @($approvedDispatch)
+Write-VibeJsonArtifact -Path $executionTopologyPath -Value $executionTopology
+$executionTopologyPath = Get-VibeExecutionTopologyPath -RepoRoot $runtime.repo_root -RunId $RunId -ArtifactRoot $ArtifactRoot
 $specialistSkills = @($approvedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-$escalationRequired = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { [bool]$runtimeInputPacket.specialist_dispatch.escalation_required } else { $false }
+$escalationRequired = [bool]$specialistDispatchResolution.escalation_required
 $escalationPath = $null
 if ([string]$hierarchyState.governance_scope -eq 'child' -and $escalationRequired) {
     $escalation = [pscustomobject]@{
@@ -481,8 +747,8 @@ if ([string]$hierarchyState.governance_scope -eq 'child' -and $escalationRequire
         root_run_id = [string]$hierarchyState.root_run_id
         parent_run_id = if ($null -eq $hierarchyState.parent_run_id) { $null } else { [string]$hierarchyState.parent_run_id }
         parent_unit_id = if ($null -eq $hierarchyState.parent_unit_id) { $null } else { [string]$hierarchyState.parent_unit_id }
-        approval_owner = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { [string]$runtimeInputPacket.specialist_dispatch.approval_owner } else { 'root_vibe' }
-        status = 'root_approval_required'
+        approval_owner = [string]$specialistDispatchResolution.approval_owner
+        status = [string]$specialistDispatchResolution.escalation_status
         requested_specialist_skill_ids = @($localSuggestions | ForEach-Object { [string]$_.skill_id } | Select-Object -Unique)
         local_specialist_suggestions = @($localSuggestions)
         generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
@@ -730,6 +996,7 @@ $liveSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live
 $degradedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.degraded })
 $totalSpecialistDispatchOutcomeCount = @($executedSpecialistUnits).Count
 $effectiveSpecialistExecutionStatus = if (@($liveSpecialistUnits).Count -gt 0) { 'live_native_executed' } elseif (@($degradedSpecialistUnits).Count -gt 0) { 'explicitly_degraded' } else { 'none' }
+$specialistDispatchUnitCount = @($approvedDispatch).Count
 $executionManifest = [pscustomobject]@{
     stage = 'plan_execute'
     run_id = $RunId
@@ -785,6 +1052,13 @@ $executionManifest = [pscustomobject]@{
         parallel_execution_windows = @($parallelExecutionWindows)
         serial_execution_order = @($serialExecutionOrder)
         review_mode = [string]$executionTopology.review_mode
+        dispatch_resolution = [pscustomobject]@{
+            source = 'plan_execute_effective_dispatch'
+            frozen_approved_dispatch_count = @($frozenApprovedDispatch).Count
+            effective_approved_dispatch_count = @($approvedDispatch).Count
+            auto_approved_dispatch_count = @($autoApprovedDispatch).Count
+            same_round_auto_absorb_applied = [bool](@($autoApprovedDispatch).Count -gt 0)
+        }
         two_stage_review = [pscustomobject]@{
             enabled = [bool]([string]$executionTopology.review_mode -eq 'two_stage_after_unit')
             review_receipt_count = [int]$reviewReceiptCount
@@ -806,17 +1080,24 @@ $executionManifest = [pscustomobject]@{
         native_usage_required = [bool](@($specialistRecommendations | Where-Object { $_.native_usage_required }).Count -gt 0)
         execution_mode = if (@($approvedDispatch).Count -gt 0) { 'native_bounded_units' } else { [string]$executionTopology.specialist_execution_mode }
         effective_execution_status = $effectiveSpecialistExecutionStatus
-        dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
+        dispatch_unit_count = [int]$specialistDispatchUnitCount
         recommendations = @($specialistRecommendations)
+        frozen_approved_dispatch_count = @($frozenApprovedDispatch).Count
+        frozen_approved_dispatch = @($frozenApprovedDispatch)
         approved_dispatch_count = @($approvedDispatch).Count
         approved_dispatch = @($approvedDispatch)
+        auto_approved_dispatch_count = @($autoApprovedDispatch).Count
+        auto_approved_dispatch = @($autoApprovedDispatch)
         executed_specialist_unit_count = @($liveSpecialistUnits).Count
         executed_specialist_units = @($liveSpecialistUnits)
         degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
         degraded_specialist_units = @($degradedSpecialistUnits)
         specialist_dispatch_outcomes = @($executedSpecialistUnits)
+        original_local_suggestion_count = @($frozenLocalSuggestions).Count
+        original_local_specialist_suggestions = @($frozenLocalSuggestions)
         local_suggestion_count = @($localSuggestions).Count
         local_specialist_suggestions = @($localSuggestions)
+        auto_absorb_gate = $specialistDispatchResolution.auto_absorb_gate
         escalation_required = [bool]$escalationRequired
         escalation_request_path = $escalationPath
     }
@@ -845,11 +1126,14 @@ $proofManifest = [pscustomobject]@{
     proof_class = [string]$proofRegistry.artifact_class_defaults.benchmark_proof_manifest
     promotion_suitable = [string]$proofRegistry.promotion_suitability.runtime
     specialist_recommendation_count = @($specialistRecommendations).Count
-    specialist_dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
+    specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
     executed_specialist_unit_count = @($liveSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
     specialist_execution_status = $effectiveSpecialistExecutionStatus
+    auto_approved_specialist_unit_count = @($autoApprovedDispatch).Count
+    residual_local_specialist_suggestion_count = @($localSuggestions).Count
+    specialist_dispatch_resolution_path = if ($specialistDispatchResolution.auto_absorb_gate.receipt_path) { [string]$specialistDispatchResolution.auto_absorb_gate.receipt_path } else { $null }
     delegated_lane_count = [int]$delegatedLaneCount
     review_receipt_count = [int]$reviewReceiptCount
     governance_scope = [string]$hierarchyState.governance_scope
@@ -872,9 +1156,11 @@ $proofLines = @(
     ('- delegated_lane_count: `{0}`' -f $delegatedLaneCount),
     ('- review_receipt_count: `{0}`' -f $reviewReceiptCount),
     ('- specialist_recommendation_count: `{0}`' -f @($specialistRecommendations).Count),
-    ('- specialist_dispatch_unit_count: `{0}`' -f [int]$planShadow.payload.specialist_dispatch_unit_count),
+    ('- specialist_dispatch_unit_count: `{0}`' -f [int]$specialistDispatchUnitCount),
     ('- executed_specialist_unit_count: `{0}`' -f @($liveSpecialistUnits).Count),
     ('- degraded_specialist_unit_count: `{0}`' -f @($degradedSpecialistUnits).Count),
+    ('- auto_approved_specialist_unit_count: `{0}`' -f @($autoApprovedDispatch).Count),
+    ('- residual_local_specialist_suggestion_count: `{0}`' -f @($localSuggestions).Count),
     ('- specialist_execution_status: `{0}`' -f $effectiveSpecialistExecutionStatus),
     ('- execution_manifest: `{0}`' -f $executionManifestPath),
     ('- execution_topology: `{0}`' -f $executionTopologyPath),
@@ -915,15 +1201,17 @@ $receipt = [pscustomobject]@{
     delegated_lane_count = [int]$delegatedLaneCount
     review_receipt_count = [int]$reviewReceiptCount
     specialist_recommendation_count = @($specialistRecommendations).Count
-    specialist_dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
+    specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
     executed_specialist_unit_count = @($liveSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
     specialist_execution_status = $effectiveSpecialistExecutionStatus
     specialist_skills = @($specialistSkills)
+    auto_approved_specialist_unit_count = @($autoApprovedDispatch).Count
     local_specialist_suggestion_count = @($localSuggestions).Count
     escalation_required = [bool]$escalationRequired
     escalation_request_path = $escalationPath
+    specialist_dispatch_resolution_path = if ($specialistDispatchResolution.auto_absorb_gate.receipt_path) { [string]$specialistDispatchResolution.auto_absorb_gate.receipt_path } else { $null }
     completion_claim_allowed = [bool]$hierarchyState.allow_completion_claim
     proof_class = [string]$proofRegistry.artifact_class_defaults.execution_manifest
     verification_contract = @(

--- a/bundled/skills/vibe/config/runtime-input-packet-policy.json
+++ b/bundled/skills/vibe/config/runtime-input-packet-policy.json
@@ -9,16 +9,72 @@
   "shadow_only": true,
   "required_fields": [
     "run_id",
+    "governance_scope",
+    "hierarchy",
     "task",
     "runtime_mode",
     "internal_grade",
     "canonical_router",
     "route_snapshot",
+    "specialist_recommendations",
+    "specialist_dispatch",
     "overlay_decisions",
     "authority_flags",
     "divergence_shadow",
     "provenance"
   ],
+  "hierarchy_contract": {
+    "default_governance_scope": "root",
+    "child_receipt_only_stages": [
+      "requirement_doc",
+      "xl_plan"
+    ],
+    "root_authority_flags": {
+      "allow_requirement_freeze": true,
+      "allow_plan_freeze": true,
+      "allow_global_dispatch": true,
+      "allow_completion_claim": true
+    },
+    "child_authority_flags": {
+      "allow_requirement_freeze": false,
+      "allow_plan_freeze": false,
+      "allow_global_dispatch": false,
+      "allow_completion_claim": false
+    }
+  },
+  "specialist_dispatch_contract": {
+    "bounded_role": "specialist_assist",
+    "native_usage_required": true,
+    "must_preserve_workflow": true,
+    "required_inputs": [
+      "bounded specialist subtask contract",
+      "frozen requirement context",
+      "relevant source files or domain artifacts"
+    ],
+    "expected_outputs": [
+      "bounded specialist findings or code changes",
+      "verification notes aligned with the specialist skill"
+    ],
+    "verification_expectation": "Preserve the specialist skill's native workflow, boundaries, and validation style."
+  },
+  "child_specialist_suggestion_contract": {
+    "field_name": "local_specialist_suggestions",
+    "escalation_required": true,
+    "approval_owner": "root_vibe",
+    "status": "advisory_until_root_approval",
+    "auto_absorb_gate": {
+      "enabled": true,
+      "same_round": true,
+      "approval_source": "root_vibe_auto_absorb_gate",
+      "required_runtime_skill": "vibe",
+      "require_known_recommendation": true,
+      "require_native_workflow": true,
+      "require_native_usage_required": true,
+      "max_auto_absorb_count": 4,
+      "disable_env": "VGO_DISABLE_CHILD_SPECIALIST_AUTO_ABSORB",
+      "force_escalation_env": "VGO_FORCE_CHILD_SPECIALIST_ESCALATION"
+    }
+  },
   "overlay_fields": [
     "openspec_advice",
     "gsd_overlay_advice",
@@ -42,5 +98,6 @@
     "llm_acceleration_advice",
     "heartbeat_advice"
   ],
+  "specialist_recommendation_limit": 4,
   "bounded_router_task_type_default": "planning"
 }

--- a/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
@@ -309,6 +309,266 @@ function ConvertTo-VibeExecutedUnitReceipt {
     }
 }
 
+function Resolve-VibeEffectiveSpecialistDispatch {
+    param(
+        [Parameter(Mandatory)] [string]$SessionRoot,
+        [Parameter(Mandatory)] [object]$HierarchyState,
+        [AllowNull()] [object]$RuntimeInputPacket = $null,
+        [AllowEmptyCollection()] [object[]]$ApprovedDispatch = @(),
+        [AllowEmptyCollection()] [object[]]$LocalSuggestions = @(),
+        [AllowNull()] [object]$SuggestionContract = $null
+    )
+
+    $frozenApprovedDispatch = @($ApprovedDispatch)
+    $originalLocalSuggestions = @($LocalSuggestions)
+    $frozenApprovedSkillIds = @($frozenApprovedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $originalLocalSkillIds = @($originalLocalSuggestions | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $originalEscalationRequired = if ($RuntimeInputPacket -and $RuntimeInputPacket.specialist_dispatch) {
+        [bool]$RuntimeInputPacket.specialist_dispatch.escalation_required
+    } else {
+        @($originalLocalSuggestions).Count -gt 0
+    }
+    $originalEscalationStatus = if ($RuntimeInputPacket -and $RuntimeInputPacket.specialist_dispatch -and $RuntimeInputPacket.specialist_dispatch.escalation_status) {
+        [string]$RuntimeInputPacket.specialist_dispatch.escalation_status
+    } elseif ($originalEscalationRequired) {
+        'root_approval_required'
+    } else {
+        'not_required'
+    }
+
+    $result = [ordered]@{
+        frozen_approved_dispatch = @($frozenApprovedDispatch)
+        frozen_approved_skill_ids = @($frozenApprovedSkillIds)
+        effective_approved_dispatch = @($frozenApprovedDispatch)
+        effective_approved_skill_ids = @($frozenApprovedSkillIds)
+        auto_approved_dispatch = @()
+        auto_approved_skill_ids = @()
+        original_local_specialist_suggestions = @($originalLocalSuggestions)
+        original_local_suggestion_skill_ids = @($originalLocalSkillIds)
+        residual_local_specialist_suggestions = @($originalLocalSuggestions)
+        residual_local_suggestion_skill_ids = @($originalLocalSkillIds)
+        escalation_required = [bool]$originalEscalationRequired
+        escalation_status = [string]$originalEscalationStatus
+        approval_owner = if ($SuggestionContract -and $SuggestionContract.PSObject.Properties.Name -contains 'approval_owner') {
+            [string]$SuggestionContract.approval_owner
+        } else {
+            'root_vibe'
+        }
+        auto_absorb_gate = [pscustomobject]@{
+            enabled = $false
+            same_round = $false
+            status = if ([string]$HierarchyState.governance_scope -eq 'child' -and @($originalLocalSuggestions).Count -gt 0) { 'disabled' } else { 'not_applicable' }
+            approval_source = $null
+            auto_approved_skill_ids = @()
+            rejected_skill_ids = @()
+            rejected_suggestions = @()
+            receipt_path = $null
+        }
+    }
+
+    if ([string]$HierarchyState.governance_scope -ne 'child' -or @($originalLocalSuggestions).Count -eq 0) {
+        return [pscustomobject]$result
+    }
+
+    $autoAbsorbGate = if ($SuggestionContract -and $SuggestionContract.PSObject.Properties.Name -contains 'auto_absorb_gate') {
+        $SuggestionContract.auto_absorb_gate
+    } else {
+        $null
+    }
+    if ($null -eq $autoAbsorbGate -or -not [bool]$autoAbsorbGate.enabled) {
+        return [pscustomobject]$result
+    }
+
+    $sameRound = $true
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'same_round' -and $null -ne $autoAbsorbGate.same_round) {
+        $sameRound = [bool]$autoAbsorbGate.same_round
+    }
+    $approvalSource = if ($autoAbsorbGate.PSObject.Properties.Name -contains 'approval_source' -and -not [string]::IsNullOrWhiteSpace([string]$autoAbsorbGate.approval_source)) {
+        [string]$autoAbsorbGate.approval_source
+    } else {
+        'root_vibe_auto_absorb_gate'
+    }
+    $result.auto_absorb_gate.enabled = $true
+    $result.auto_absorb_gate.same_round = [bool]$sameRound
+    $result.auto_absorb_gate.approval_source = $approvalSource
+
+    if (-not $sameRound) {
+        $result.auto_absorb_gate.status = 'not_same_round'
+        return [pscustomobject]$result
+    }
+
+    if (@($frozenApprovedDispatch).Count -eq 0) {
+        $result.auto_absorb_gate.status = 'requires_existing_root_dispatch'
+        return [pscustomobject]$result
+    }
+
+    $disableEnvName = if ($autoAbsorbGate.PSObject.Properties.Name -contains 'disable_env') { [string]$autoAbsorbGate.disable_env } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($disableEnvName) -and (Test-VibeTruthyEnvironmentValue -Value ([Environment]::GetEnvironmentVariable($disableEnvName)))) {
+        $result.auto_absorb_gate.status = ("disabled_via_env:{0}" -f $disableEnvName)
+        return [pscustomobject]$result
+    }
+
+    $forceEscalationEnvName = if ($autoAbsorbGate.PSObject.Properties.Name -contains 'force_escalation_env') { [string]$autoAbsorbGate.force_escalation_env } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($forceEscalationEnvName) -and (Test-VibeTruthyEnvironmentValue -Value ([Environment]::GetEnvironmentVariable($forceEscalationEnvName)))) {
+        $result.auto_absorb_gate.status = ("forced_escalation_via_env:{0}" -f $forceEscalationEnvName)
+        return [pscustomobject]$result
+    }
+
+    $requiredRuntimeSkill = if ($autoAbsorbGate.PSObject.Properties.Name -contains 'required_runtime_skill') {
+        [string]$autoAbsorbGate.required_runtime_skill
+    } else {
+        ''
+    }
+    if (-not [string]::IsNullOrWhiteSpace($requiredRuntimeSkill)) {
+        $effectiveRuntimeSkill = if ($RuntimeInputPacket -and $RuntimeInputPacket.authority_flags) {
+            [string]$RuntimeInputPacket.authority_flags.explicit_runtime_skill
+        } else {
+            'vibe'
+        }
+        if (-not [string]::Equals($effectiveRuntimeSkill, $requiredRuntimeSkill, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $result.auto_absorb_gate.status = 'runtime_authority_mismatch'
+            return [pscustomobject]$result
+        }
+    }
+
+    $requireKnownRecommendation = $true
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'require_known_recommendation' -and $null -ne $autoAbsorbGate.require_known_recommendation) {
+        $requireKnownRecommendation = [bool]$autoAbsorbGate.require_known_recommendation
+    }
+    $requireNativeWorkflow = $true
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'require_native_workflow' -and $null -ne $autoAbsorbGate.require_native_workflow) {
+        $requireNativeWorkflow = [bool]$autoAbsorbGate.require_native_workflow
+    }
+    $requireNativeUsageRequired = $true
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'require_native_usage_required' -and $null -ne $autoAbsorbGate.require_native_usage_required) {
+        $requireNativeUsageRequired = [bool]$autoAbsorbGate.require_native_usage_required
+    }
+    $maxAutoAbsorbCount = [int]::MaxValue
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'max_auto_absorb_count' -and $null -ne $autoAbsorbGate.max_auto_absorb_count) {
+        $maxAutoAbsorbCount = [int]$autoAbsorbGate.max_auto_absorb_count
+    }
+
+    $recommendationLookup = @{}
+    if ($RuntimeInputPacket -and $RuntimeInputPacket.PSObject.Properties.Name -contains 'specialist_recommendations') {
+        foreach ($recommendation in @($RuntimeInputPacket.specialist_recommendations)) {
+            $skillId = [string]$recommendation.skill_id
+            if (-not [string]::IsNullOrWhiteSpace($skillId) -and -not $recommendationLookup.ContainsKey($skillId)) {
+                $recommendationLookup[$skillId] = $recommendation
+            }
+        }
+    }
+
+    $effectiveLookup = @{}
+    foreach ($skillId in @($frozenApprovedSkillIds)) {
+        $effectiveLookup[$skillId] = $true
+    }
+
+    $autoApprovedDispatch = @()
+    $rejectedSuggestions = @()
+    foreach ($suggestion in @($originalLocalSuggestions)) {
+        $skillId = [string]$suggestion.skill_id
+        $rejectionReason = $null
+        $effectiveSuggestion = $suggestion
+
+        if ([string]::IsNullOrWhiteSpace($skillId)) {
+            $rejectionReason = 'missing_skill_id'
+        } elseif ($effectiveLookup.ContainsKey($skillId)) {
+            $rejectionReason = 'already_effective'
+        } elseif ($requireKnownRecommendation -and -not $recommendationLookup.ContainsKey($skillId)) {
+            $rejectionReason = 'not_in_frozen_recommendations'
+        } else {
+            if ($recommendationLookup.ContainsKey($skillId)) {
+                $effectiveSuggestion = $recommendationLookup[$skillId]
+            }
+
+            if ($requireNativeWorkflow -and -not [bool]$effectiveSuggestion.must_preserve_workflow) {
+                $rejectionReason = 'must_preserve_workflow_missing'
+            } elseif ($requireNativeUsageRequired -and -not [bool]$effectiveSuggestion.native_usage_required) {
+                $rejectionReason = 'native_usage_required_missing'
+            } elseif (@($autoApprovedDispatch).Count -ge $maxAutoAbsorbCount) {
+                $rejectionReason = 'max_auto_absorb_count_exceeded'
+            }
+        }
+
+        if ($rejectionReason) {
+            $rejectedSuggestions += [pscustomobject]@{
+                skill_id = if ([string]::IsNullOrWhiteSpace($skillId)) { $null } else { $skillId }
+                reason = $rejectionReason
+                suggestion = $suggestion
+            }
+            continue
+        }
+
+        $autoApprovedDispatch += $effectiveSuggestion
+        $effectiveLookup[$skillId] = $true
+    }
+
+    $residualSuggestions = @($rejectedSuggestions | ForEach-Object { $_.suggestion })
+    $residualSkillIds = @($residualSuggestions | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $effectiveApprovedDispatch = @($frozenApprovedDispatch + $autoApprovedDispatch)
+    $effectiveApprovedSkillIds = @($effectiveApprovedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+
+    $result.effective_approved_dispatch = @($effectiveApprovedDispatch)
+    $result.effective_approved_skill_ids = @($effectiveApprovedSkillIds)
+    $result.auto_approved_dispatch = @($autoApprovedDispatch)
+    $result.auto_approved_skill_ids = @($autoApprovedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $result.residual_local_specialist_suggestions = @($residualSuggestions)
+    $result.residual_local_suggestion_skill_ids = @($residualSkillIds)
+    $result.escalation_required = @($residualSuggestions).Count -gt 0 -and (
+        $null -eq $SuggestionContract -or
+        -not ($SuggestionContract.PSObject.Properties.Name -contains 'escalation_required') -or
+        [bool]$SuggestionContract.escalation_required
+    )
+    $result.escalation_status = if ([bool]$result.escalation_required) {
+        'root_approval_required'
+    } elseif (@($autoApprovedDispatch).Count -gt 0) {
+        'root_auto_approved_same_round'
+    } else {
+        'not_required'
+    }
+
+    $result.auto_absorb_gate.status = if (@($autoApprovedDispatch).Count -gt 0 -and @($residualSuggestions).Count -eq 0) {
+        'auto_approved_same_round'
+    } elseif (@($autoApprovedDispatch).Count -gt 0) {
+        'partially_auto_approved_same_round'
+    } elseif (@($originalLocalSuggestions).Count -gt 0) {
+        'rejected_all_candidates'
+    } else {
+        'not_applicable'
+    }
+    $result.auto_absorb_gate.auto_approved_skill_ids = @($result.auto_approved_skill_ids)
+    $result.auto_absorb_gate.rejected_skill_ids = @($rejectedSuggestions | ForEach-Object {
+        if ($_.skill_id) { [string]$_.skill_id }
+    } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $result.auto_absorb_gate.rejected_suggestions = @($rejectedSuggestions)
+
+    $resolutionReceipt = [pscustomobject]@{
+        run_id = if ($RuntimeInputPacket) { [string]$RuntimeInputPacket.run_id } else { $null }
+        governance_scope = [string]$HierarchyState.governance_scope
+        root_run_id = [string]$HierarchyState.root_run_id
+        parent_run_id = if ($null -eq $HierarchyState.parent_run_id) { $null } else { [string]$HierarchyState.parent_run_id }
+        parent_unit_id = if ($null -eq $HierarchyState.parent_unit_id) { $null } else { [string]$HierarchyState.parent_unit_id }
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        approval_owner = [string]$result.approval_owner
+        approval_source = [string]$approvalSource
+        same_round = [bool]$sameRound
+        frozen_approved_skill_ids = @($frozenApprovedSkillIds)
+        original_local_suggestion_skill_ids = @($originalLocalSkillIds)
+        effective_approved_skill_ids = @($effectiveApprovedSkillIds)
+        auto_approved_skill_ids = @($result.auto_approved_skill_ids)
+        residual_local_suggestion_skill_ids = @($residualSkillIds)
+        escalation_required = [bool]$result.escalation_required
+        escalation_status = [string]$result.escalation_status
+        gate_status = [string]$result.auto_absorb_gate.status
+        rejected_suggestions = @($rejectedSuggestions)
+    }
+    $resolutionReceiptPath = Join-Path $SessionRoot 'specialist-dispatch-resolution.json'
+    Write-VibeJsonArtifact -Path $resolutionReceiptPath -Value $resolutionReceipt
+    $result.auto_absorb_gate.receipt_path = $resolutionReceiptPath
+
+    return [pscustomobject]$result
+}
+
 function Get-VibePlanSections {
     param(
         [Parameter(Mandatory)] [string]$PlanPath
@@ -455,24 +715,30 @@ $tokens = @{
 }
 $planShadow = Get-VibePlanDerivedExecutionShadow -PlanPath $planPath -RunId $RunId -SessionRoot $sessionRoot
 $specialistRecommendations = if ($runtimeInputPacket) { @($runtimeInputPacket.specialist_recommendations) } else { @() }
-$approvedDispatch = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.approved_dispatch) } else { @() }
-$localSuggestions = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.local_specialist_suggestions) } else { @() }
+$frozenApprovedDispatch = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.approved_dispatch) } else { @() }
+$frozenLocalSuggestions = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.local_specialist_suggestions) } else { @() }
+$specialistDispatchResolution = Resolve-VibeEffectiveSpecialistDispatch `
+    -SessionRoot $sessionRoot `
+    -HierarchyState $hierarchyState `
+    -RuntimeInputPacket $runtimeInputPacket `
+    -ApprovedDispatch @($frozenApprovedDispatch) `
+    -LocalSuggestions @($frozenLocalSuggestions) `
+    -SuggestionContract $runtime.runtime_input_packet_policy.child_specialist_suggestion_contract
+$approvedDispatch = @($specialistDispatchResolution.effective_approved_dispatch)
+$localSuggestions = @($specialistDispatchResolution.residual_local_specialist_suggestions)
+$autoApprovedDispatch = @($specialistDispatchResolution.auto_approved_dispatch)
 $executionTopologyPath = Get-VibeExecutionTopologyPath -RepoRoot $runtime.repo_root -RunId $RunId -ArtifactRoot $ArtifactRoot
-$executionTopology = if (Test-Path -LiteralPath $executionTopologyPath) {
-    Get-Content -LiteralPath $executionTopologyPath -Raw -Encoding UTF8 | ConvertFrom-Json
-} else {
-    $derivedTopology = New-VibeExecutionTopology `
-        -RunId $RunId `
-        -Grade $grade `
-        -GovernanceScope ([string]$hierarchyState.governance_scope) `
-        -BenchmarkPolicy $policy `
-        -TopologyPolicy $runtime.execution_topology_policy `
-        -ApprovedDispatch @($approvedDispatch)
-    Write-VibeJsonArtifact -Path $executionTopologyPath -Value $derivedTopology
-    $derivedTopology
-}
+$executionTopology = New-VibeExecutionTopology `
+    -RunId $RunId `
+    -Grade $grade `
+    -GovernanceScope ([string]$hierarchyState.governance_scope) `
+    -BenchmarkPolicy $policy `
+    -TopologyPolicy $runtime.execution_topology_policy `
+    -ApprovedDispatch @($approvedDispatch)
+Write-VibeJsonArtifact -Path $executionTopologyPath -Value $executionTopology
+$executionTopologyPath = Get-VibeExecutionTopologyPath -RepoRoot $runtime.repo_root -RunId $RunId -ArtifactRoot $ArtifactRoot
 $specialistSkills = @($approvedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-$escalationRequired = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { [bool]$runtimeInputPacket.specialist_dispatch.escalation_required } else { $false }
+$escalationRequired = [bool]$specialistDispatchResolution.escalation_required
 $escalationPath = $null
 if ([string]$hierarchyState.governance_scope -eq 'child' -and $escalationRequired) {
     $escalation = [pscustomobject]@{
@@ -481,8 +747,8 @@ if ([string]$hierarchyState.governance_scope -eq 'child' -and $escalationRequire
         root_run_id = [string]$hierarchyState.root_run_id
         parent_run_id = if ($null -eq $hierarchyState.parent_run_id) { $null } else { [string]$hierarchyState.parent_run_id }
         parent_unit_id = if ($null -eq $hierarchyState.parent_unit_id) { $null } else { [string]$hierarchyState.parent_unit_id }
-        approval_owner = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { [string]$runtimeInputPacket.specialist_dispatch.approval_owner } else { 'root_vibe' }
-        status = 'root_approval_required'
+        approval_owner = [string]$specialistDispatchResolution.approval_owner
+        status = [string]$specialistDispatchResolution.escalation_status
         requested_specialist_skill_ids = @($localSuggestions | ForEach-Object { [string]$_.skill_id } | Select-Object -Unique)
         local_specialist_suggestions = @($localSuggestions)
         generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
@@ -730,6 +996,7 @@ $liveSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live
 $degradedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.degraded })
 $totalSpecialistDispatchOutcomeCount = @($executedSpecialistUnits).Count
 $effectiveSpecialistExecutionStatus = if (@($liveSpecialistUnits).Count -gt 0) { 'live_native_executed' } elseif (@($degradedSpecialistUnits).Count -gt 0) { 'explicitly_degraded' } else { 'none' }
+$specialistDispatchUnitCount = @($approvedDispatch).Count
 $executionManifest = [pscustomobject]@{
     stage = 'plan_execute'
     run_id = $RunId
@@ -785,6 +1052,13 @@ $executionManifest = [pscustomobject]@{
         parallel_execution_windows = @($parallelExecutionWindows)
         serial_execution_order = @($serialExecutionOrder)
         review_mode = [string]$executionTopology.review_mode
+        dispatch_resolution = [pscustomobject]@{
+            source = 'plan_execute_effective_dispatch'
+            frozen_approved_dispatch_count = @($frozenApprovedDispatch).Count
+            effective_approved_dispatch_count = @($approvedDispatch).Count
+            auto_approved_dispatch_count = @($autoApprovedDispatch).Count
+            same_round_auto_absorb_applied = [bool](@($autoApprovedDispatch).Count -gt 0)
+        }
         two_stage_review = [pscustomobject]@{
             enabled = [bool]([string]$executionTopology.review_mode -eq 'two_stage_after_unit')
             review_receipt_count = [int]$reviewReceiptCount
@@ -806,17 +1080,24 @@ $executionManifest = [pscustomobject]@{
         native_usage_required = [bool](@($specialistRecommendations | Where-Object { $_.native_usage_required }).Count -gt 0)
         execution_mode = if (@($approvedDispatch).Count -gt 0) { 'native_bounded_units' } else { [string]$executionTopology.specialist_execution_mode }
         effective_execution_status = $effectiveSpecialistExecutionStatus
-        dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
+        dispatch_unit_count = [int]$specialistDispatchUnitCount
         recommendations = @($specialistRecommendations)
+        frozen_approved_dispatch_count = @($frozenApprovedDispatch).Count
+        frozen_approved_dispatch = @($frozenApprovedDispatch)
         approved_dispatch_count = @($approvedDispatch).Count
         approved_dispatch = @($approvedDispatch)
+        auto_approved_dispatch_count = @($autoApprovedDispatch).Count
+        auto_approved_dispatch = @($autoApprovedDispatch)
         executed_specialist_unit_count = @($liveSpecialistUnits).Count
         executed_specialist_units = @($liveSpecialistUnits)
         degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
         degraded_specialist_units = @($degradedSpecialistUnits)
         specialist_dispatch_outcomes = @($executedSpecialistUnits)
+        original_local_suggestion_count = @($frozenLocalSuggestions).Count
+        original_local_specialist_suggestions = @($frozenLocalSuggestions)
         local_suggestion_count = @($localSuggestions).Count
         local_specialist_suggestions = @($localSuggestions)
+        auto_absorb_gate = $specialistDispatchResolution.auto_absorb_gate
         escalation_required = [bool]$escalationRequired
         escalation_request_path = $escalationPath
     }
@@ -845,11 +1126,14 @@ $proofManifest = [pscustomobject]@{
     proof_class = [string]$proofRegistry.artifact_class_defaults.benchmark_proof_manifest
     promotion_suitable = [string]$proofRegistry.promotion_suitability.runtime
     specialist_recommendation_count = @($specialistRecommendations).Count
-    specialist_dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
+    specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
     executed_specialist_unit_count = @($liveSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
     specialist_execution_status = $effectiveSpecialistExecutionStatus
+    auto_approved_specialist_unit_count = @($autoApprovedDispatch).Count
+    residual_local_specialist_suggestion_count = @($localSuggestions).Count
+    specialist_dispatch_resolution_path = if ($specialistDispatchResolution.auto_absorb_gate.receipt_path) { [string]$specialistDispatchResolution.auto_absorb_gate.receipt_path } else { $null }
     delegated_lane_count = [int]$delegatedLaneCount
     review_receipt_count = [int]$reviewReceiptCount
     governance_scope = [string]$hierarchyState.governance_scope
@@ -872,9 +1156,11 @@ $proofLines = @(
     ('- delegated_lane_count: `{0}`' -f $delegatedLaneCount),
     ('- review_receipt_count: `{0}`' -f $reviewReceiptCount),
     ('- specialist_recommendation_count: `{0}`' -f @($specialistRecommendations).Count),
-    ('- specialist_dispatch_unit_count: `{0}`' -f [int]$planShadow.payload.specialist_dispatch_unit_count),
+    ('- specialist_dispatch_unit_count: `{0}`' -f [int]$specialistDispatchUnitCount),
     ('- executed_specialist_unit_count: `{0}`' -f @($liveSpecialistUnits).Count),
     ('- degraded_specialist_unit_count: `{0}`' -f @($degradedSpecialistUnits).Count),
+    ('- auto_approved_specialist_unit_count: `{0}`' -f @($autoApprovedDispatch).Count),
+    ('- residual_local_specialist_suggestion_count: `{0}`' -f @($localSuggestions).Count),
     ('- specialist_execution_status: `{0}`' -f $effectiveSpecialistExecutionStatus),
     ('- execution_manifest: `{0}`' -f $executionManifestPath),
     ('- execution_topology: `{0}`' -f $executionTopologyPath),
@@ -915,15 +1201,17 @@ $receipt = [pscustomobject]@{
     delegated_lane_count = [int]$delegatedLaneCount
     review_receipt_count = [int]$reviewReceiptCount
     specialist_recommendation_count = @($specialistRecommendations).Count
-    specialist_dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
+    specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
     executed_specialist_unit_count = @($liveSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
     specialist_execution_status = $effectiveSpecialistExecutionStatus
     specialist_skills = @($specialistSkills)
+    auto_approved_specialist_unit_count = @($autoApprovedDispatch).Count
     local_specialist_suggestion_count = @($localSuggestions).Count
     escalation_required = [bool]$escalationRequired
     escalation_request_path = $escalationPath
+    specialist_dispatch_resolution_path = if ($specialistDispatchResolution.auto_absorb_gate.receipt_path) { [string]$specialistDispatchResolution.auto_absorb_gate.receipt_path } else { $null }
     completion_claim_allowed = [bool]$hierarchyState.allow_completion_claim
     proof_class = [string]$proofRegistry.artifact_class_defaults.execution_manifest
     verification_contract = @(

--- a/config/runtime-input-packet-policy.json
+++ b/config/runtime-input-packet-policy.json
@@ -61,7 +61,19 @@
     "field_name": "local_specialist_suggestions",
     "escalation_required": true,
     "approval_owner": "root_vibe",
-    "status": "advisory_until_root_approval"
+    "status": "advisory_until_root_approval",
+    "auto_absorb_gate": {
+      "enabled": true,
+      "same_round": true,
+      "approval_source": "root_vibe_auto_absorb_gate",
+      "required_runtime_skill": "vibe",
+      "require_known_recommendation": true,
+      "require_native_workflow": true,
+      "require_native_usage_required": true,
+      "max_auto_absorb_count": 4,
+      "disable_env": "VGO_DISABLE_CHILD_SPECIALIST_AUTO_ABSORB",
+      "force_escalation_env": "VGO_FORCE_CHILD_SPECIALIST_ESCALATION"
+    }
   },
   "overlay_fields": [
     "openspec_advice",

--- a/docs/root-child-vibe-hierarchy-governance.md
+++ b/docs/root-child-vibe-hierarchy-governance.md
@@ -90,12 +90,12 @@ Properties:
 
 ### Local Specialist Suggestion
 
-A child lane may detect that more specialist help is useful, but this remains a suggestion until escalated and approved by root.
+A child lane may detect that more specialist help is useful. The frozen packet keeps that request as a suggestion first, and the root-governed execute stage may same-round auto-approve safe suggestions without handing authority to the child lane.
 
 Properties:
 
-- advisory only
-- not globally active
+- advisory in the frozen packet
+- executable only after root-governed approval or same-round auto-absorb
 - cannot mutate root authority by itself
 
 ## Conflict Prevention Rules

--- a/protocols/do.md
+++ b/protocols/do.md
@@ -95,7 +95,7 @@ If VCO router output includes:
    - No blanket multi-agent fan-out
 3. Optional delegated units must remain bounded and explicitly planned
    - If subagents are spawned, prompts must end with `$vibe`
-   - Child lane specialist ideas stay advisory until root approval
+   - Child lane specialist ideas stay advisory in the frozen packet; execute may same-round auto-absorb only under root-governed approval logic
 4. Use runtime-neutral state_store to track progress across tasks
 5. Final review with Superpowers verification-before-completion
 

--- a/protocols/runtime.md
+++ b/protocols/runtime.md
@@ -207,7 +207,7 @@ Explicitly forbidden for child-governed lanes:
 Specialist dispatch semantics under hierarchy:
 
 - `approved_dispatch`: specialist execution approved by root and recorded in frozen plan
-- `local_suggestion`: child-surfaced specialist suggestion that remains advisory until escalation approval by root
+- `local_suggestion`: child-surfaced specialist suggestion that remains advisory in the frozen packet until root-governed execution either escalates it or auto-absorbs it through the same-round approval gate
 
 ## Artifact Contract
 

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -309,6 +309,266 @@ function ConvertTo-VibeExecutedUnitReceipt {
     }
 }
 
+function Resolve-VibeEffectiveSpecialistDispatch {
+    param(
+        [Parameter(Mandatory)] [string]$SessionRoot,
+        [Parameter(Mandatory)] [object]$HierarchyState,
+        [AllowNull()] [object]$RuntimeInputPacket = $null,
+        [AllowEmptyCollection()] [object[]]$ApprovedDispatch = @(),
+        [AllowEmptyCollection()] [object[]]$LocalSuggestions = @(),
+        [AllowNull()] [object]$SuggestionContract = $null
+    )
+
+    $frozenApprovedDispatch = @($ApprovedDispatch)
+    $originalLocalSuggestions = @($LocalSuggestions)
+    $frozenApprovedSkillIds = @($frozenApprovedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $originalLocalSkillIds = @($originalLocalSuggestions | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $originalEscalationRequired = if ($RuntimeInputPacket -and $RuntimeInputPacket.specialist_dispatch) {
+        [bool]$RuntimeInputPacket.specialist_dispatch.escalation_required
+    } else {
+        @($originalLocalSuggestions).Count -gt 0
+    }
+    $originalEscalationStatus = if ($RuntimeInputPacket -and $RuntimeInputPacket.specialist_dispatch -and $RuntimeInputPacket.specialist_dispatch.escalation_status) {
+        [string]$RuntimeInputPacket.specialist_dispatch.escalation_status
+    } elseif ($originalEscalationRequired) {
+        'root_approval_required'
+    } else {
+        'not_required'
+    }
+
+    $result = [ordered]@{
+        frozen_approved_dispatch = @($frozenApprovedDispatch)
+        frozen_approved_skill_ids = @($frozenApprovedSkillIds)
+        effective_approved_dispatch = @($frozenApprovedDispatch)
+        effective_approved_skill_ids = @($frozenApprovedSkillIds)
+        auto_approved_dispatch = @()
+        auto_approved_skill_ids = @()
+        original_local_specialist_suggestions = @($originalLocalSuggestions)
+        original_local_suggestion_skill_ids = @($originalLocalSkillIds)
+        residual_local_specialist_suggestions = @($originalLocalSuggestions)
+        residual_local_suggestion_skill_ids = @($originalLocalSkillIds)
+        escalation_required = [bool]$originalEscalationRequired
+        escalation_status = [string]$originalEscalationStatus
+        approval_owner = if ($SuggestionContract -and $SuggestionContract.PSObject.Properties.Name -contains 'approval_owner') {
+            [string]$SuggestionContract.approval_owner
+        } else {
+            'root_vibe'
+        }
+        auto_absorb_gate = [pscustomobject]@{
+            enabled = $false
+            same_round = $false
+            status = if ([string]$HierarchyState.governance_scope -eq 'child' -and @($originalLocalSuggestions).Count -gt 0) { 'disabled' } else { 'not_applicable' }
+            approval_source = $null
+            auto_approved_skill_ids = @()
+            rejected_skill_ids = @()
+            rejected_suggestions = @()
+            receipt_path = $null
+        }
+    }
+
+    if ([string]$HierarchyState.governance_scope -ne 'child' -or @($originalLocalSuggestions).Count -eq 0) {
+        return [pscustomobject]$result
+    }
+
+    $autoAbsorbGate = if ($SuggestionContract -and $SuggestionContract.PSObject.Properties.Name -contains 'auto_absorb_gate') {
+        $SuggestionContract.auto_absorb_gate
+    } else {
+        $null
+    }
+    if ($null -eq $autoAbsorbGate -or -not [bool]$autoAbsorbGate.enabled) {
+        return [pscustomobject]$result
+    }
+
+    $sameRound = $true
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'same_round' -and $null -ne $autoAbsorbGate.same_round) {
+        $sameRound = [bool]$autoAbsorbGate.same_round
+    }
+    $approvalSource = if ($autoAbsorbGate.PSObject.Properties.Name -contains 'approval_source' -and -not [string]::IsNullOrWhiteSpace([string]$autoAbsorbGate.approval_source)) {
+        [string]$autoAbsorbGate.approval_source
+    } else {
+        'root_vibe_auto_absorb_gate'
+    }
+    $result.auto_absorb_gate.enabled = $true
+    $result.auto_absorb_gate.same_round = [bool]$sameRound
+    $result.auto_absorb_gate.approval_source = $approvalSource
+
+    if (-not $sameRound) {
+        $result.auto_absorb_gate.status = 'not_same_round'
+        return [pscustomobject]$result
+    }
+
+    if (@($frozenApprovedDispatch).Count -eq 0) {
+        $result.auto_absorb_gate.status = 'requires_existing_root_dispatch'
+        return [pscustomobject]$result
+    }
+
+    $disableEnvName = if ($autoAbsorbGate.PSObject.Properties.Name -contains 'disable_env') { [string]$autoAbsorbGate.disable_env } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($disableEnvName) -and (Test-VibeTruthyEnvironmentValue -Value ([Environment]::GetEnvironmentVariable($disableEnvName)))) {
+        $result.auto_absorb_gate.status = ("disabled_via_env:{0}" -f $disableEnvName)
+        return [pscustomobject]$result
+    }
+
+    $forceEscalationEnvName = if ($autoAbsorbGate.PSObject.Properties.Name -contains 'force_escalation_env') { [string]$autoAbsorbGate.force_escalation_env } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($forceEscalationEnvName) -and (Test-VibeTruthyEnvironmentValue -Value ([Environment]::GetEnvironmentVariable($forceEscalationEnvName)))) {
+        $result.auto_absorb_gate.status = ("forced_escalation_via_env:{0}" -f $forceEscalationEnvName)
+        return [pscustomobject]$result
+    }
+
+    $requiredRuntimeSkill = if ($autoAbsorbGate.PSObject.Properties.Name -contains 'required_runtime_skill') {
+        [string]$autoAbsorbGate.required_runtime_skill
+    } else {
+        ''
+    }
+    if (-not [string]::IsNullOrWhiteSpace($requiredRuntimeSkill)) {
+        $effectiveRuntimeSkill = if ($RuntimeInputPacket -and $RuntimeInputPacket.authority_flags) {
+            [string]$RuntimeInputPacket.authority_flags.explicit_runtime_skill
+        } else {
+            'vibe'
+        }
+        if (-not [string]::Equals($effectiveRuntimeSkill, $requiredRuntimeSkill, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $result.auto_absorb_gate.status = 'runtime_authority_mismatch'
+            return [pscustomobject]$result
+        }
+    }
+
+    $requireKnownRecommendation = $true
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'require_known_recommendation' -and $null -ne $autoAbsorbGate.require_known_recommendation) {
+        $requireKnownRecommendation = [bool]$autoAbsorbGate.require_known_recommendation
+    }
+    $requireNativeWorkflow = $true
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'require_native_workflow' -and $null -ne $autoAbsorbGate.require_native_workflow) {
+        $requireNativeWorkflow = [bool]$autoAbsorbGate.require_native_workflow
+    }
+    $requireNativeUsageRequired = $true
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'require_native_usage_required' -and $null -ne $autoAbsorbGate.require_native_usage_required) {
+        $requireNativeUsageRequired = [bool]$autoAbsorbGate.require_native_usage_required
+    }
+    $maxAutoAbsorbCount = [int]::MaxValue
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'max_auto_absorb_count' -and $null -ne $autoAbsorbGate.max_auto_absorb_count) {
+        $maxAutoAbsorbCount = [int]$autoAbsorbGate.max_auto_absorb_count
+    }
+
+    $recommendationLookup = @{}
+    if ($RuntimeInputPacket -and $RuntimeInputPacket.PSObject.Properties.Name -contains 'specialist_recommendations') {
+        foreach ($recommendation in @($RuntimeInputPacket.specialist_recommendations)) {
+            $skillId = [string]$recommendation.skill_id
+            if (-not [string]::IsNullOrWhiteSpace($skillId) -and -not $recommendationLookup.ContainsKey($skillId)) {
+                $recommendationLookup[$skillId] = $recommendation
+            }
+        }
+    }
+
+    $effectiveLookup = @{}
+    foreach ($skillId in @($frozenApprovedSkillIds)) {
+        $effectiveLookup[$skillId] = $true
+    }
+
+    $autoApprovedDispatch = @()
+    $rejectedSuggestions = @()
+    foreach ($suggestion in @($originalLocalSuggestions)) {
+        $skillId = [string]$suggestion.skill_id
+        $rejectionReason = $null
+        $effectiveSuggestion = $suggestion
+
+        if ([string]::IsNullOrWhiteSpace($skillId)) {
+            $rejectionReason = 'missing_skill_id'
+        } elseif ($effectiveLookup.ContainsKey($skillId)) {
+            $rejectionReason = 'already_effective'
+        } elseif ($requireKnownRecommendation -and -not $recommendationLookup.ContainsKey($skillId)) {
+            $rejectionReason = 'not_in_frozen_recommendations'
+        } else {
+            if ($recommendationLookup.ContainsKey($skillId)) {
+                $effectiveSuggestion = $recommendationLookup[$skillId]
+            }
+
+            if ($requireNativeWorkflow -and -not [bool]$effectiveSuggestion.must_preserve_workflow) {
+                $rejectionReason = 'must_preserve_workflow_missing'
+            } elseif ($requireNativeUsageRequired -and -not [bool]$effectiveSuggestion.native_usage_required) {
+                $rejectionReason = 'native_usage_required_missing'
+            } elseif (@($autoApprovedDispatch).Count -ge $maxAutoAbsorbCount) {
+                $rejectionReason = 'max_auto_absorb_count_exceeded'
+            }
+        }
+
+        if ($rejectionReason) {
+            $rejectedSuggestions += [pscustomobject]@{
+                skill_id = if ([string]::IsNullOrWhiteSpace($skillId)) { $null } else { $skillId }
+                reason = $rejectionReason
+                suggestion = $suggestion
+            }
+            continue
+        }
+
+        $autoApprovedDispatch += $effectiveSuggestion
+        $effectiveLookup[$skillId] = $true
+    }
+
+    $residualSuggestions = @($rejectedSuggestions | ForEach-Object { $_.suggestion })
+    $residualSkillIds = @($residualSuggestions | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $effectiveApprovedDispatch = @($frozenApprovedDispatch + $autoApprovedDispatch)
+    $effectiveApprovedSkillIds = @($effectiveApprovedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+
+    $result.effective_approved_dispatch = @($effectiveApprovedDispatch)
+    $result.effective_approved_skill_ids = @($effectiveApprovedSkillIds)
+    $result.auto_approved_dispatch = @($autoApprovedDispatch)
+    $result.auto_approved_skill_ids = @($autoApprovedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $result.residual_local_specialist_suggestions = @($residualSuggestions)
+    $result.residual_local_suggestion_skill_ids = @($residualSkillIds)
+    $result.escalation_required = @($residualSuggestions).Count -gt 0 -and (
+        $null -eq $SuggestionContract -or
+        -not ($SuggestionContract.PSObject.Properties.Name -contains 'escalation_required') -or
+        [bool]$SuggestionContract.escalation_required
+    )
+    $result.escalation_status = if ([bool]$result.escalation_required) {
+        'root_approval_required'
+    } elseif (@($autoApprovedDispatch).Count -gt 0) {
+        'root_auto_approved_same_round'
+    } else {
+        'not_required'
+    }
+
+    $result.auto_absorb_gate.status = if (@($autoApprovedDispatch).Count -gt 0 -and @($residualSuggestions).Count -eq 0) {
+        'auto_approved_same_round'
+    } elseif (@($autoApprovedDispatch).Count -gt 0) {
+        'partially_auto_approved_same_round'
+    } elseif (@($originalLocalSuggestions).Count -gt 0) {
+        'rejected_all_candidates'
+    } else {
+        'not_applicable'
+    }
+    $result.auto_absorb_gate.auto_approved_skill_ids = @($result.auto_approved_skill_ids)
+    $result.auto_absorb_gate.rejected_skill_ids = @($rejectedSuggestions | ForEach-Object {
+        if ($_.skill_id) { [string]$_.skill_id }
+    } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $result.auto_absorb_gate.rejected_suggestions = @($rejectedSuggestions)
+
+    $resolutionReceipt = [pscustomobject]@{
+        run_id = if ($RuntimeInputPacket) { [string]$RuntimeInputPacket.run_id } else { $null }
+        governance_scope = [string]$HierarchyState.governance_scope
+        root_run_id = [string]$HierarchyState.root_run_id
+        parent_run_id = if ($null -eq $HierarchyState.parent_run_id) { $null } else { [string]$HierarchyState.parent_run_id }
+        parent_unit_id = if ($null -eq $HierarchyState.parent_unit_id) { $null } else { [string]$HierarchyState.parent_unit_id }
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        approval_owner = [string]$result.approval_owner
+        approval_source = [string]$approvalSource
+        same_round = [bool]$sameRound
+        frozen_approved_skill_ids = @($frozenApprovedSkillIds)
+        original_local_suggestion_skill_ids = @($originalLocalSkillIds)
+        effective_approved_skill_ids = @($effectiveApprovedSkillIds)
+        auto_approved_skill_ids = @($result.auto_approved_skill_ids)
+        residual_local_suggestion_skill_ids = @($residualSkillIds)
+        escalation_required = [bool]$result.escalation_required
+        escalation_status = [string]$result.escalation_status
+        gate_status = [string]$result.auto_absorb_gate.status
+        rejected_suggestions = @($rejectedSuggestions)
+    }
+    $resolutionReceiptPath = Join-Path $SessionRoot 'specialist-dispatch-resolution.json'
+    Write-VibeJsonArtifact -Path $resolutionReceiptPath -Value $resolutionReceipt
+    $result.auto_absorb_gate.receipt_path = $resolutionReceiptPath
+
+    return [pscustomobject]$result
+}
+
 function Get-VibePlanSections {
     param(
         [Parameter(Mandatory)] [string]$PlanPath
@@ -455,24 +715,30 @@ $tokens = @{
 }
 $planShadow = Get-VibePlanDerivedExecutionShadow -PlanPath $planPath -RunId $RunId -SessionRoot $sessionRoot
 $specialistRecommendations = if ($runtimeInputPacket) { @($runtimeInputPacket.specialist_recommendations) } else { @() }
-$approvedDispatch = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.approved_dispatch) } else { @() }
-$localSuggestions = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.local_specialist_suggestions) } else { @() }
+$frozenApprovedDispatch = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.approved_dispatch) } else { @() }
+$frozenLocalSuggestions = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { @($runtimeInputPacket.specialist_dispatch.local_specialist_suggestions) } else { @() }
+$specialistDispatchResolution = Resolve-VibeEffectiveSpecialistDispatch `
+    -SessionRoot $sessionRoot `
+    -HierarchyState $hierarchyState `
+    -RuntimeInputPacket $runtimeInputPacket `
+    -ApprovedDispatch @($frozenApprovedDispatch) `
+    -LocalSuggestions @($frozenLocalSuggestions) `
+    -SuggestionContract $runtime.runtime_input_packet_policy.child_specialist_suggestion_contract
+$approvedDispatch = @($specialistDispatchResolution.effective_approved_dispatch)
+$localSuggestions = @($specialistDispatchResolution.residual_local_specialist_suggestions)
+$autoApprovedDispatch = @($specialistDispatchResolution.auto_approved_dispatch)
 $executionTopologyPath = Get-VibeExecutionTopologyPath -RepoRoot $runtime.repo_root -RunId $RunId -ArtifactRoot $ArtifactRoot
-$executionTopology = if (Test-Path -LiteralPath $executionTopologyPath) {
-    Get-Content -LiteralPath $executionTopologyPath -Raw -Encoding UTF8 | ConvertFrom-Json
-} else {
-    $derivedTopology = New-VibeExecutionTopology `
-        -RunId $RunId `
-        -Grade $grade `
-        -GovernanceScope ([string]$hierarchyState.governance_scope) `
-        -BenchmarkPolicy $policy `
-        -TopologyPolicy $runtime.execution_topology_policy `
-        -ApprovedDispatch @($approvedDispatch)
-    Write-VibeJsonArtifact -Path $executionTopologyPath -Value $derivedTopology
-    $derivedTopology
-}
+$executionTopology = New-VibeExecutionTopology `
+    -RunId $RunId `
+    -Grade $grade `
+    -GovernanceScope ([string]$hierarchyState.governance_scope) `
+    -BenchmarkPolicy $policy `
+    -TopologyPolicy $runtime.execution_topology_policy `
+    -ApprovedDispatch @($approvedDispatch)
+Write-VibeJsonArtifact -Path $executionTopologyPath -Value $executionTopology
+$executionTopologyPath = Get-VibeExecutionTopologyPath -RepoRoot $runtime.repo_root -RunId $RunId -ArtifactRoot $ArtifactRoot
 $specialistSkills = @($approvedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-$escalationRequired = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { [bool]$runtimeInputPacket.specialist_dispatch.escalation_required } else { $false }
+$escalationRequired = [bool]$specialistDispatchResolution.escalation_required
 $escalationPath = $null
 if ([string]$hierarchyState.governance_scope -eq 'child' -and $escalationRequired) {
     $escalation = [pscustomobject]@{
@@ -481,8 +747,8 @@ if ([string]$hierarchyState.governance_scope -eq 'child' -and $escalationRequire
         root_run_id = [string]$hierarchyState.root_run_id
         parent_run_id = if ($null -eq $hierarchyState.parent_run_id) { $null } else { [string]$hierarchyState.parent_run_id }
         parent_unit_id = if ($null -eq $hierarchyState.parent_unit_id) { $null } else { [string]$hierarchyState.parent_unit_id }
-        approval_owner = if ($runtimeInputPacket -and $runtimeInputPacket.specialist_dispatch) { [string]$runtimeInputPacket.specialist_dispatch.approval_owner } else { 'root_vibe' }
-        status = 'root_approval_required'
+        approval_owner = [string]$specialistDispatchResolution.approval_owner
+        status = [string]$specialistDispatchResolution.escalation_status
         requested_specialist_skill_ids = @($localSuggestions | ForEach-Object { [string]$_.skill_id } | Select-Object -Unique)
         local_specialist_suggestions = @($localSuggestions)
         generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
@@ -730,6 +996,7 @@ $liveSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live
 $degradedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.degraded })
 $totalSpecialistDispatchOutcomeCount = @($executedSpecialistUnits).Count
 $effectiveSpecialistExecutionStatus = if (@($liveSpecialistUnits).Count -gt 0) { 'live_native_executed' } elseif (@($degradedSpecialistUnits).Count -gt 0) { 'explicitly_degraded' } else { 'none' }
+$specialistDispatchUnitCount = @($approvedDispatch).Count
 $executionManifest = [pscustomobject]@{
     stage = 'plan_execute'
     run_id = $RunId
@@ -785,6 +1052,13 @@ $executionManifest = [pscustomobject]@{
         parallel_execution_windows = @($parallelExecutionWindows)
         serial_execution_order = @($serialExecutionOrder)
         review_mode = [string]$executionTopology.review_mode
+        dispatch_resolution = [pscustomobject]@{
+            source = 'plan_execute_effective_dispatch'
+            frozen_approved_dispatch_count = @($frozenApprovedDispatch).Count
+            effective_approved_dispatch_count = @($approvedDispatch).Count
+            auto_approved_dispatch_count = @($autoApprovedDispatch).Count
+            same_round_auto_absorb_applied = [bool](@($autoApprovedDispatch).Count -gt 0)
+        }
         two_stage_review = [pscustomobject]@{
             enabled = [bool]([string]$executionTopology.review_mode -eq 'two_stage_after_unit')
             review_receipt_count = [int]$reviewReceiptCount
@@ -806,17 +1080,24 @@ $executionManifest = [pscustomobject]@{
         native_usage_required = [bool](@($specialistRecommendations | Where-Object { $_.native_usage_required }).Count -gt 0)
         execution_mode = if (@($approvedDispatch).Count -gt 0) { 'native_bounded_units' } else { [string]$executionTopology.specialist_execution_mode }
         effective_execution_status = $effectiveSpecialistExecutionStatus
-        dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
+        dispatch_unit_count = [int]$specialistDispatchUnitCount
         recommendations = @($specialistRecommendations)
+        frozen_approved_dispatch_count = @($frozenApprovedDispatch).Count
+        frozen_approved_dispatch = @($frozenApprovedDispatch)
         approved_dispatch_count = @($approvedDispatch).Count
         approved_dispatch = @($approvedDispatch)
+        auto_approved_dispatch_count = @($autoApprovedDispatch).Count
+        auto_approved_dispatch = @($autoApprovedDispatch)
         executed_specialist_unit_count = @($liveSpecialistUnits).Count
         executed_specialist_units = @($liveSpecialistUnits)
         degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
         degraded_specialist_units = @($degradedSpecialistUnits)
         specialist_dispatch_outcomes = @($executedSpecialistUnits)
+        original_local_suggestion_count = @($frozenLocalSuggestions).Count
+        original_local_specialist_suggestions = @($frozenLocalSuggestions)
         local_suggestion_count = @($localSuggestions).Count
         local_specialist_suggestions = @($localSuggestions)
+        auto_absorb_gate = $specialistDispatchResolution.auto_absorb_gate
         escalation_required = [bool]$escalationRequired
         escalation_request_path = $escalationPath
     }
@@ -845,11 +1126,14 @@ $proofManifest = [pscustomobject]@{
     proof_class = [string]$proofRegistry.artifact_class_defaults.benchmark_proof_manifest
     promotion_suitable = [string]$proofRegistry.promotion_suitability.runtime
     specialist_recommendation_count = @($specialistRecommendations).Count
-    specialist_dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
+    specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
     executed_specialist_unit_count = @($liveSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
     specialist_execution_status = $effectiveSpecialistExecutionStatus
+    auto_approved_specialist_unit_count = @($autoApprovedDispatch).Count
+    residual_local_specialist_suggestion_count = @($localSuggestions).Count
+    specialist_dispatch_resolution_path = if ($specialistDispatchResolution.auto_absorb_gate.receipt_path) { [string]$specialistDispatchResolution.auto_absorb_gate.receipt_path } else { $null }
     delegated_lane_count = [int]$delegatedLaneCount
     review_receipt_count = [int]$reviewReceiptCount
     governance_scope = [string]$hierarchyState.governance_scope
@@ -872,9 +1156,11 @@ $proofLines = @(
     ('- delegated_lane_count: `{0}`' -f $delegatedLaneCount),
     ('- review_receipt_count: `{0}`' -f $reviewReceiptCount),
     ('- specialist_recommendation_count: `{0}`' -f @($specialistRecommendations).Count),
-    ('- specialist_dispatch_unit_count: `{0}`' -f [int]$planShadow.payload.specialist_dispatch_unit_count),
+    ('- specialist_dispatch_unit_count: `{0}`' -f [int]$specialistDispatchUnitCount),
     ('- executed_specialist_unit_count: `{0}`' -f @($liveSpecialistUnits).Count),
     ('- degraded_specialist_unit_count: `{0}`' -f @($degradedSpecialistUnits).Count),
+    ('- auto_approved_specialist_unit_count: `{0}`' -f @($autoApprovedDispatch).Count),
+    ('- residual_local_specialist_suggestion_count: `{0}`' -f @($localSuggestions).Count),
     ('- specialist_execution_status: `{0}`' -f $effectiveSpecialistExecutionStatus),
     ('- execution_manifest: `{0}`' -f $executionManifestPath),
     ('- execution_topology: `{0}`' -f $executionTopologyPath),
@@ -915,15 +1201,17 @@ $receipt = [pscustomobject]@{
     delegated_lane_count = [int]$delegatedLaneCount
     review_receipt_count = [int]$reviewReceiptCount
     specialist_recommendation_count = @($specialistRecommendations).Count
-    specialist_dispatch_unit_count = [int]$planShadow.payload.specialist_dispatch_unit_count
+    specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
     executed_specialist_unit_count = @($liveSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
     specialist_execution_status = $effectiveSpecialistExecutionStatus
     specialist_skills = @($specialistSkills)
+    auto_approved_specialist_unit_count = @($autoApprovedDispatch).Count
     local_specialist_suggestion_count = @($localSuggestions).Count
     escalation_required = [bool]$escalationRequired
     escalation_request_path = $escalationPath
+    specialist_dispatch_resolution_path = if ($specialistDispatchResolution.auto_absorb_gate.receipt_path) { [string]$specialistDispatchResolution.auto_absorb_gate.receipt_path } else { $null }
     completion_claim_allowed = [bool]$hierarchyState.allow_completion_claim
     proof_class = [string]$proofRegistry.artifact_class_defaults.execution_manifest
     verification_contract = @(

--- a/scripts/verify/vibe-child-specialist-escalation-gate.ps1
+++ b/scripts/verify/vibe-child-specialist-escalation-gate.ps1
@@ -39,14 +39,14 @@ $repoRoot = $context.repoRoot
 $results = @()
 
 $policyText = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-input-packet-policy.json') -Raw -Encoding UTF8
-foreach ($token in @('specialist_dispatch', 'local_specialist_suggestions', 'escalation_required', 'advisory_until_root_approval')) {
+foreach ($token in @('specialist_dispatch', 'local_specialist_suggestions', 'escalation_required', 'advisory_until_root_approval', 'auto_absorb_gate')) {
     Add-Assertion -Results ([ref]$results) -Condition ($policyText.Contains($token)) -Message ("runtime input policy contains specialist escalation token: {0}" -f $token)
 }
 
 $teamText = Get-Content -LiteralPath (Join-Path $repoRoot 'protocols\team.md') -Raw -Encoding UTF8
 $stableDocText = Get-Content -LiteralPath (Join-Path $repoRoot 'docs\root-child-vibe-hierarchy-governance.md') -Raw -Encoding UTF8
 Add-Assertion -Results ([ref]$results) -Condition ($teamText.Contains('advisory until the governed plan chooses to dispatch it')) -Message 'team protocol keeps specialist recommendation advisory-first'
-Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('this remains a suggestion until escalated and approved by root')) -Message 'stable hierarchy doc requires root approval for child-local specialist suggestion'
+Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('same-round auto-approve safe suggestions')) -Message 'stable hierarchy doc documents root-governed same-round absorb path'
 
 $runId = "child-specialist-escalation-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
 $artifactRoot = Join-Path $repoRoot (".tmp\child-specialist-escalation-{0}" -f $runId)
@@ -154,6 +154,13 @@ if ($hasChildSummary) {
     Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.governance_scope -eq 'child') -Message 'execution manifest is marked child scope'
     Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$executionManifest.authority.completion_claim_allowed) -Message 'child execution manifest cannot issue final completion claim'
     Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.route_runtime_alignment.runtime_selected_skill -eq 'vibe') -Message 'execution manifest keeps explicit vibe authority'
+    $specialistAccounting = if ($executionManifest.PSObject.Properties.Name -contains 'specialist_accounting') { $executionManifest.specialist_accounting } else { $null }
+    if ($null -ne $specialistAccounting -and $specialistAccounting.PSObject.Properties.Name -contains 'auto_absorb_gate') {
+        Add-Assertion -Results ([ref]$results) -Condition ([bool]$specialistAccounting.auto_absorb_gate.enabled) -Message 'child execution manifest exposes enabled same-round auto-absorb gate'
+        if ($specialistAccounting.auto_absorb_gate.receipt_path) {
+            Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath ([string]$specialistAccounting.auto_absorb_gate.receipt_path)) -Message 'same-round auto-absorb gate emits receipt'
+        }
+    }
 
     $childClaims = if ($executionManifest.PSObject.Properties.Name -contains 'child_completion_claims') { @($executionManifest.child_completion_claims) } else { @() }
 }

--- a/scripts/verify/vibe-root-child-hierarchy-gate.ps1
+++ b/scripts/verify/vibe-root-child-hierarchy-gate.ps1
@@ -62,7 +62,8 @@ foreach ($token in @(
     'allow_completion_claim',
     'specialist_dispatch',
     'advisory_until_root_approval',
-    'escalation_required'
+    'escalation_required',
+    'auto_absorb_gate'
 )) {
     Add-Assertion -Results ([ref]$results) -Condition ($policyText.Contains($token)) -Message ("runtime input policy contains hierarchy token: {0}" -f $token)
 }

--- a/tests/runtime_neutral/test_l_xl_native_execution_topology.py
+++ b/tests/runtime_neutral/test_l_xl_native_execution_topology.py
@@ -393,8 +393,12 @@ class NativeExecutionTopologyTests(unittest.TestCase):
     def test_child_escalation_remains_advisory_and_blocks_unapproved_specialist_execution(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             artifact_root = Path(tempdir)
+            composite_task = (
+                "Analyze biological sequences with Python, draft a scientific report, "
+                "and prepare the execution planning notes."
+            )
             root_payload = run_runtime(
-                task="Root run prepares specialist dispatch and child escalation baseline.",
+                task=composite_task,
                 artifact_root=artifact_root,
                 governance_scope="root",
             )
@@ -413,7 +417,7 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                 self.skipTest("Root run did not expose approved specialist dispatch skill ids")
 
             child_payload = run_runtime(
-                task="Child lane requests extra specialist help beyond approved dispatch.",
+                task=composite_task + " Child lane requests extra specialist help beyond approved dispatch.",
                 artifact_root=artifact_root,
                 governance_scope="child",
                 root_run_id=str(root_summary["run_id"]),
@@ -429,22 +433,32 @@ class NativeExecutionTopologyTests(unittest.TestCase):
 
             specialist_dispatch = child_runtime_input["specialist_dispatch"]
             self.assertEqual("advisory_until_root_approval", str(specialist_dispatch["status"]))
-            self.assertTrue(bool(specialist_dispatch["escalation_required"]))
-            self.assertEqual("root_approval_required", str(specialist_dispatch["escalation_status"]))
+            frozen_local_ids = {
+                str(entry.get("skill_id", "")).strip()
+                for entry in list(specialist_dispatch.get("local_specialist_suggestions") or [])
+                if str(entry.get("skill_id", "")).strip()
+            }
+            if frozen_local_ids:
+                self.assertTrue(bool(specialist_dispatch["escalation_required"]))
+                self.assertEqual("root_approval_required", str(specialist_dispatch["escalation_status"]))
 
             specialist_accounting = child_execution_manifest["specialist_accounting"]
             approved_child_dispatch = list(specialist_accounting["approved_dispatch"])
             approved_child_ids = {
                 str(entry.get("skill_id", "")).strip() for entry in approved_child_dispatch if str(entry.get("skill_id", "")).strip()
             }
-            self.assertEqual(1, int(specialist_accounting["approved_dispatch_count"]))
-            self.assertEqual(1, len(approved_child_ids))
-            self.assertEqual(set(approved_skill_ids[:1]), approved_child_ids)
+            self.assertEqual(1, int(specialist_accounting["frozen_approved_dispatch_count"]))
+            self.assertTrue(set(approved_skill_ids[:1]).issubset(approved_child_ids))
+            self.assertEqual(int(specialist_accounting["approved_dispatch_count"]), len(approved_child_ids))
             self.assertLessEqual(
                 int(specialist_accounting["executed_specialist_unit_count"]),
                 int(specialist_accounting["approved_dispatch_count"]),
             )
             self.assertGreaterEqual(int(specialist_accounting["degraded_specialist_unit_count"]), 0)
+            auto_absorb_gate = specialist_accounting["auto_absorb_gate"]
+            self.assertTrue(bool(auto_absorb_gate["enabled"]))
+            self.assertTrue(Path(auto_absorb_gate["receipt_path"]).exists())
+            self.assertTrue(set(auto_absorb_gate["auto_approved_skill_ids"]).issubset(frozen_local_ids))
 
             specialist_outcomes = list(specialist_accounting["specialist_dispatch_outcomes"])
             for unit in specialist_outcomes:
@@ -458,13 +472,130 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                     )
 
             escalation_request_path = specialist_accounting.get("escalation_request_path")
-            if escalation_request_path:
+            if specialist_accounting["local_suggestion_count"]:
+                self.assertTrue(escalation_request_path)
                 self.assertTrue(Path(escalation_request_path).exists())
+            else:
+                self.assertFalse(bool(escalation_request_path))
             self.assertFalse(bool(child_execution_manifest["authority"]["completion_claim_allowed"]))
 
             child_session_root = Path(child_payload["session_root"])
             specialist_result_files = list(child_session_root.glob("execution-results/*specialist*.json"))
             self.assertLessEqual(len(specialist_result_files), len(specialist_outcomes))
+
+    def test_child_auto_absorb_can_fallback_to_root_escalation_when_gate_disabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            composite_task = (
+                "Analyze biological sequences with Python, draft a scientific report, "
+                "and prepare the execution planning notes."
+            )
+            root_payload = run_runtime(
+                task=composite_task,
+                artifact_root=artifact_root,
+                governance_scope="root",
+            )
+            root_summary = root_payload["summary"]
+            root_artifacts = root_summary["artifacts"]
+            root_runtime_input = load_json(root_artifacts["runtime_input_packet"])
+            root_approved_dispatch = list(
+                (root_runtime_input.get("specialist_dispatch") or {}).get("approved_dispatch") or []
+            )
+            approved_skill_ids = [
+                str(item.get("skill_id", "")).strip()
+                for item in root_approved_dispatch
+                if str(item.get("skill_id", "")).strip()
+            ]
+            if len(approved_skill_ids) < 1:
+                self.skipTest("Root run did not expose approved specialist dispatch skill ids")
+
+            child_payload = run_runtime(
+                task=composite_task + " Child lane requests extra specialist help beyond approved dispatch.",
+                artifact_root=artifact_root,
+                governance_scope="child",
+                root_run_id=str(root_summary["run_id"]),
+                parent_run_id=str(root_summary["run_id"]),
+                parent_unit_id="pytest-child-topology-fallback-unit",
+                inherited_requirement_doc_path=Path(root_artifacts["requirement_doc"]),
+                inherited_execution_plan_path=Path(root_artifacts["execution_plan"]),
+                approved_specialist_skill_ids=approved_skill_ids[:1],
+                extra_env={"VGO_DISABLE_CHILD_SPECIALIST_AUTO_ABSORB": "1"},
+            )
+            child_summary = child_payload["summary"]
+            child_execution_manifest = load_json(child_summary["artifacts"]["execution_manifest"])
+
+            specialist_accounting = child_execution_manifest["specialist_accounting"]
+            approved_child_ids = {
+                str(entry.get("skill_id", "")).strip()
+                for entry in list(specialist_accounting["approved_dispatch"])
+                if str(entry.get("skill_id", "")).strip()
+            }
+            self.assertEqual(set(approved_skill_ids[:1]), approved_child_ids)
+            self.assertGreaterEqual(int(specialist_accounting["local_suggestion_count"]), 1)
+            self.assertTrue(bool(specialist_accounting["escalation_required"]))
+            self.assertTrue(Path(specialist_accounting["escalation_request_path"]).exists())
+            self.assertEqual(
+                "disabled_via_env:VGO_DISABLE_CHILD_SPECIALIST_AUTO_ABSORB",
+                str(specialist_accounting["auto_absorb_gate"]["status"]),
+            )
+            self.assertFalse(bool(child_execution_manifest["authority"]["completion_claim_allowed"]))
+
+    def test_child_auto_absorbed_specialist_dispatch_can_execute_live_native_lane_when_adapter_enabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_path = Path(tempdir)
+            fake_codex = create_fake_codex_command(temp_path)
+            composite_task = (
+                "Analyze biological sequences with Python, draft a scientific report, "
+                "and prepare the execution planning notes."
+            )
+            root_payload = run_runtime(
+                task=composite_task,
+                artifact_root=temp_path,
+                governance_scope="root",
+            )
+            root_summary = root_payload["summary"]
+            root_artifacts = root_summary["artifacts"]
+            root_runtime_input = load_json(root_artifacts["runtime_input_packet"])
+            root_approved_dispatch = list(
+                (root_runtime_input.get("specialist_dispatch") or {}).get("approved_dispatch") or []
+            )
+            approved_skill_ids = [
+                str(item.get("skill_id", "")).strip()
+                for item in root_approved_dispatch
+                if str(item.get("skill_id", "")).strip()
+            ]
+            if len(approved_skill_ids) < 1:
+                self.skipTest("Root run did not expose approved specialist dispatch skill ids")
+
+            child_payload = run_runtime(
+                task=composite_task + " Child lane requests extra specialist help beyond approved dispatch.",
+                artifact_root=temp_path,
+                governance_scope="child",
+                root_run_id=str(root_summary["run_id"]),
+                parent_run_id=str(root_summary["run_id"]),
+                parent_unit_id="pytest-child-topology-live-native-unit",
+                inherited_requirement_doc_path=Path(root_artifacts["requirement_doc"]),
+                inherited_execution_plan_path=Path(root_artifacts["execution_plan"]),
+                approved_specialist_skill_ids=approved_skill_ids[:1],
+                extra_env={
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+            child_summary = child_payload["summary"]
+            child_execution_manifest = load_json(child_summary["artifacts"]["execution_manifest"])
+
+            specialist_accounting = child_execution_manifest["specialist_accounting"]
+            self.assertEqual("live_native_executed", specialist_accounting["effective_execution_status"])
+            self.assertGreaterEqual(int(specialist_accounting["auto_approved_dispatch_count"]), 1)
+            self.assertGreaterEqual(int(specialist_accounting["executed_specialist_unit_count"]), 1)
+            self.assertEqual(0, int(specialist_accounting["degraded_specialist_unit_count"]))
+            self.assertFalse(bool(child_execution_manifest["authority"]["completion_claim_allowed"]))
+            self.assertIn(
+                str(specialist_accounting["auto_absorb_gate"]["status"]),
+                {"auto_approved_same_round", "partially_auto_approved_same_round"},
+            )
 
     def test_child_divergent_specialist_request_without_overlap_escalates_without_crashing(self) -> None:
         cases = [
@@ -532,6 +663,15 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                     escalation_request_path = specialist_accounting.get("escalation_request_path")
                     self.assertTrue(escalation_request_path)
                     self.assertTrue(Path(escalation_request_path).exists())
+                    escalation_request = load_json(escalation_request_path)
+                    self.assertEqual(
+                        sorted(str(skill_id) for skill_id in escalation_request["requested_specialist_skill_ids"]),
+                        sorted(
+                            str(entry.get("skill_id", "")).strip()
+                            for entry in list(specialist_accounting["local_specialist_suggestions"])
+                            if str(entry.get("skill_id", "")).strip()
+                        ),
+                    )
                     self.assertEqual("completed_local_scope", child_execution_manifest["status"])
                     self.assertFalse(bool(child_execution_manifest["authority"]["completion_claim_allowed"]))
 

--- a/tests/runtime_neutral/test_root_child_hierarchy_bridge.py
+++ b/tests/runtime_neutral/test_root_child_hierarchy_bridge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import tempfile
@@ -73,6 +74,7 @@ def run_child_runtime(
     inherited_execution_plan_path: Path,
     artifact_root: Path,
     approved_specialist_skill_ids: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> dict[str, object]:
     shell = resolve_powershell()
     if shell is None:
@@ -114,6 +116,7 @@ def run_child_runtime(
         capture_output=True,
         text=True,
         check=True,
+        env={**os.environ, **(extra_env or {})},
     )
     stdout = completed.stdout.strip()
     if stdout in ("", "null"):
@@ -191,11 +194,15 @@ class RootChildHierarchyBridgeTests(unittest.TestCase):
             self.assertTrue(execution_manifest["authority"]["completion_claim_allowed"])
             self.assertEqual("vibe", execution_manifest["route_runtime_alignment"]["runtime_selected_skill"])
 
-    def test_child_specialist_suggestions_are_advisory_until_root_approval(self) -> None:
+    def test_child_specialist_suggestions_stay_frozen_advisory_but_auto_absorb_same_round(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             artifact_root = Path(tempdir)
+            composite_task = (
+                "Analyze biological sequences with Python, draft a scientific report, "
+                "and prepare the execution planning notes."
+            )
             root_payload = run_governed_runtime(
-                "Root specialist dispatch seed for child escalation checks.",
+                composite_task,
                 artifact_root=artifact_root,
             )
             root_summary = root_payload["summary"]
@@ -214,7 +221,7 @@ class RootChildHierarchyBridgeTests(unittest.TestCase):
                     approved_skill_ids = [first_skill_id]
 
             child_payload = run_child_runtime(
-                task="Child specialist escalation advisory smoke.",
+                task=composite_task + " Child lane requests extra specialist help inside the same governed round.",
                 root_run_id=str(root_summary["run_id"]),
                 inherited_requirement_doc_path=Path(root_artifacts["requirement_doc"]),
                 inherited_execution_plan_path=Path(root_artifacts["execution_plan"]),
@@ -250,6 +257,11 @@ class RootChildHierarchyBridgeTests(unittest.TestCase):
             local_suggestions = list(specialist_dispatch.get("local_specialist_suggestions") or [])
             approved_dispatch = list(specialist_dispatch.get("approved_dispatch") or [])
             approved_ids = {str(entry.get("skill_id", "")) for entry in approved_dispatch}
+            frozen_local_ids = {
+                str(entry.get("skill_id", "")).strip()
+                for entry in local_suggestions
+                if str(entry.get("skill_id", "")).strip()
+            }
 
             if local_suggestions:
                 self.assertTrue(bool(specialist_dispatch.get("escalation_required", False)))
@@ -262,6 +274,37 @@ class RootChildHierarchyBridgeTests(unittest.TestCase):
             self.assertEqual("child", execution_manifest["governance_scope"])
             self.assertFalse(execution_manifest["authority"]["completion_claim_allowed"])
             self.assertEqual("vibe", execution_manifest["route_runtime_alignment"]["runtime_selected_skill"])
+
+            specialist_accounting = execution_manifest["specialist_accounting"]
+            effective_approved_ids = {
+                str(entry.get("skill_id", "")).strip()
+                for entry in list(specialist_accounting.get("approved_dispatch") or [])
+                if str(entry.get("skill_id", "")).strip()
+            }
+            residual_ids = {
+                str(entry.get("skill_id", "")).strip()
+                for entry in list(specialist_accounting.get("local_specialist_suggestions") or [])
+                if str(entry.get("skill_id", "")).strip()
+            }
+            auto_absorb_gate = specialist_accounting["auto_absorb_gate"]
+
+            self.assertTrue(bool(auto_absorb_gate["enabled"]))
+            self.assertTrue(Path(auto_absorb_gate["receipt_path"]).exists())
+            self.assertTrue(approved_ids.issubset(effective_approved_ids))
+            self.assertEqual(frozen_local_ids, set(auto_absorb_gate["auto_approved_skill_ids"]) | residual_ids)
+
+            if frozen_local_ids:
+                self.assertGreaterEqual(len(auto_absorb_gate["auto_approved_skill_ids"]), 1)
+                self.assertIn(
+                    str(auto_absorb_gate["status"]),
+                    {"auto_approved_same_round", "partially_auto_approved_same_round"},
+                )
+            if residual_ids:
+                self.assertTrue(bool(specialist_accounting["escalation_required"]))
+                self.assertTrue(Path(specialist_accounting["escalation_request_path"]).exists())
+            else:
+                self.assertFalse(bool(specialist_accounting["escalation_required"]))
+                self.assertFalse(bool(specialist_accounting["escalation_request_path"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR closes the gap between child-scoped specialist discovery and governed same-round execution.

Before this change, a child `vibe` lane could discover additional specialist skills, but those skills stayed trapped in `local_specialist_suggestions` for the rest of the run. The frozen packet was correct, but the execute stage never computed a root-governed effective dispatch surface, so the newly discovered specialists could not be used in the same round even when they were safe and already known to the frozen recommendation set.

The fix keeps the hierarchy contract intact and deliberately does not mutate the frozen runtime input packet. Instead, `plan_execute` now performs a root-governed same-round auto-absorb decision that derives an execution-local `effective_approved_dispatch`. This preserves the invariant that the packet remains advisory-first, while allowing execution to continue in the same round when the request is still under `vibe` authority, comes from the frozen recommendation set, preserves native specialist workflow requirements, and extends an existing root-approved dispatch baseline.

The change also keeps the fallback boundary hard. If a child lane has no existing root-approved dispatch baseline, or if a suggested skill fails the absorb gate, the system still writes an escalation artifact and does not silently activate the specialist. That preserves the zero-overlap safety behavior and prevents child lanes from manufacturing global authority on their own.

The runtime now emits explicit accounting for frozen dispatch, auto-approved dispatch, residual local suggestions, gate status, and a dedicated `specialist-dispatch-resolution.json` receipt so that same-round approval decisions remain auditable. The policy and bundled mirrors were updated together, and the hierarchy documentation plus verification gates were tightened to reflect the difference between the frozen advisory surface and the execute-time effective dispatch surface.

Validation performed for this PR:

- `pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py`
- `pwsh -NoProfile -File scripts/verify/vibe-root-child-hierarchy-gate.ps1`
- `pwsh -NoProfile -File scripts/verify/vibe-child-specialist-escalation-gate.ps1`

All checks passed locally, including the new same-round auto-absorb path, the live-native child specialist path, and the zero-overlap fallback path.
