### PR TITLE
Harden native specialist failure proofing under vibe

### DIFF
--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
@@ -999,10 +999,22 @@ $effectiveUnitExecution = if ($parallelUnitsExecutedCount -gt 0 -and ($executedU
 }
 
 $baseStatus = if ($failedUnitCount -eq 0 -and $executedUnitCount -ge [int]$profile.expected_minimum_units) { 'completed' } elseif ($executedUnitCount -eq 0) { 'failed' } else { 'completed_with_failures' }
-$liveSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live_native_execution })
+$liveAttemptedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live_native_execution })
+$liveSpecialistUnits = @($liveAttemptedSpecialistUnits | Where-Object { [bool]$_.verification_passed })
+$failedLiveSpecialistUnits = @($liveAttemptedSpecialistUnits | Where-Object { -not [bool]$_.verification_passed })
 $degradedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.degraded })
 $totalSpecialistDispatchOutcomeCount = @($executedSpecialistUnits).Count
-$effectiveSpecialistExecutionStatus = if (@($liveSpecialistUnits).Count -gt 0) { 'live_native_executed' } elseif (@($degradedSpecialistUnits).Count -gt 0) { 'explicitly_degraded' } else { 'none' }
+$effectiveSpecialistExecutionStatus = if (@($liveSpecialistUnits).Count -gt 0 -and @($failedLiveSpecialistUnits).Count -eq 0) {
+    'live_native_executed'
+} elseif (@($liveSpecialistUnits).Count -gt 0 -and @($failedLiveSpecialistUnits).Count -gt 0) {
+    'live_native_partial_failures'
+} elseif (@($failedLiveSpecialistUnits).Count -gt 0) {
+    'live_native_failed'
+} elseif (@($degradedSpecialistUnits).Count -gt 0) {
+    'explicitly_degraded'
+} else {
+    'none'
+}
 $specialistDispatchUnitCount = @($approvedDispatch).Count
 $executionManifest = [pscustomobject]@{
     stage = 'plan_execute'
@@ -1104,8 +1116,11 @@ $executionManifest = [pscustomobject]@{
             verification = @($approvedDispatch | Where-Object { [string]$_.dispatch_phase -eq 'verification' }).Count
         }
         parallelizable_dispatch_count = @($approvedDispatch | Where-Object { [bool]$_.parallelizable_in_root_xl }).Count
+        attempted_specialist_unit_count = @($liveAttemptedSpecialistUnits).Count
         executed_specialist_unit_count = @($liveSpecialistUnits).Count
+        failed_specialist_unit_count = @($failedLiveSpecialistUnits).Count
         executed_specialist_units = @($liveSpecialistUnits)
+        failed_specialist_units = @($failedLiveSpecialistUnits)
         degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
         degraded_specialist_units = @($degradedSpecialistUnits)
         specialist_dispatch_outcomes = @($executedSpecialistUnits)
@@ -1143,7 +1158,9 @@ $proofManifest = [pscustomobject]@{
     promotion_suitable = [string]$proofRegistry.promotion_suitability.runtime
     specialist_recommendation_count = @($specialistRecommendations).Count
     specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
+    attempted_specialist_unit_count = @($liveAttemptedSpecialistUnits).Count
     executed_specialist_unit_count = @($liveSpecialistUnits).Count
+    failed_specialist_unit_count = @($failedLiveSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
     specialist_execution_status = $effectiveSpecialistExecutionStatus
@@ -1173,7 +1190,9 @@ $proofLines = @(
     ('- review_receipt_count: `{0}`' -f $reviewReceiptCount),
     ('- specialist_recommendation_count: `{0}`' -f @($specialistRecommendations).Count),
     ('- specialist_dispatch_unit_count: `{0}`' -f [int]$specialistDispatchUnitCount),
+    ('- attempted_specialist_unit_count: `{0}`' -f @($liveAttemptedSpecialistUnits).Count),
     ('- executed_specialist_unit_count: `{0}`' -f @($liveSpecialistUnits).Count),
+    ('- failed_specialist_unit_count: `{0}`' -f @($failedLiveSpecialistUnits).Count),
     ('- degraded_specialist_unit_count: `{0}`' -f @($degradedSpecialistUnits).Count),
     ('- auto_approved_specialist_unit_count: `{0}`' -f @($autoApprovedDispatch).Count),
     ('- residual_local_specialist_suggestion_count: `{0}`' -f @($localSuggestions).Count),
@@ -1218,7 +1237,9 @@ $receipt = [pscustomobject]@{
     review_receipt_count = [int]$reviewReceiptCount
     specialist_recommendation_count = @($specialistRecommendations).Count
     specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
+    attempted_specialist_unit_count = @($liveAttemptedSpecialistUnits).Count
     executed_specialist_unit_count = @($liveSpecialistUnits).Count
+    failed_specialist_unit_count = @($failedLiveSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
     specialist_execution_status = $effectiveSpecialistExecutionStatus

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/VibeExecution.Common.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/VibeExecution.Common.ps1
@@ -393,6 +393,86 @@ function New-VibeSpecialistResultSchema {
     }
 }
 
+function Test-VibeSpecialistResponseAgainstSchema {
+    param(
+        [AllowNull()] [object]$Response,
+        [Parameter(Mandatory)] [object]$Schema
+    )
+
+    $errors = @()
+    if ($null -eq $Response) {
+        return [pscustomobject]@{
+            passed = $false
+            errors = @('response_missing')
+        }
+    }
+
+    $responseProperties = @($Response.PSObject.Properties.Name | ForEach-Object { [string]$_ })
+    $schemaProperties = if ($Schema.PSObject.Properties.Name -contains 'properties' -and $Schema.properties) {
+        @($Schema.properties.PSObject.Properties.Name | ForEach-Object { [string]$_ })
+    } else {
+        @()
+    }
+
+    foreach ($requiredField in @($Schema.required)) {
+        $fieldName = [string]$requiredField
+        if (-not ($responseProperties -contains $fieldName)) {
+            $errors += ("missing_required_field:{0}" -f $fieldName)
+        }
+    }
+
+    if ($Schema.PSObject.Properties.Name -contains 'additionalProperties' -and -not [bool]$Schema.additionalProperties) {
+        foreach ($responseField in @($responseProperties)) {
+            if (-not ($schemaProperties -contains [string]$responseField)) {
+                $errors += ("unexpected_field:{0}" -f [string]$responseField)
+            }
+        }
+    }
+
+    foreach ($schemaField in @($schemaProperties)) {
+        if (-not ($responseProperties -contains [string]$schemaField)) {
+            continue
+        }
+
+        $fieldSchema = $Schema.properties.$schemaField
+        $fieldValue = $Response.$schemaField
+        $expectedType = if ($fieldSchema.PSObject.Properties.Name -contains 'type') { [string]$fieldSchema.type } else { '' }
+
+        switch ($expectedType) {
+            'string' {
+                if ($fieldValue -isnot [string]) {
+                    $errors += ("invalid_type:{0}:expected_string" -f [string]$schemaField)
+                    continue
+                }
+                if ($fieldSchema.PSObject.Properties.Name -contains 'enum' -and @($fieldSchema.enum).Count -gt 0) {
+                    $allowedValues = @($fieldSchema.enum | ForEach-Object { [string]$_ })
+                    if (-not ($allowedValues -contains [string]$fieldValue)) {
+                        $errors += ("invalid_enum:{0}:{1}" -f [string]$schemaField, [string]$fieldValue)
+                    }
+                }
+            }
+            'array' {
+                if ($fieldValue -is [string]) {
+                    $errors += ("invalid_type:{0}:expected_array" -f [string]$schemaField)
+                    continue
+                }
+                $items = @($fieldValue)
+                foreach ($item in @($items)) {
+                    if ($item -isnot [string]) {
+                        $errors += ("invalid_array_item_type:{0}:expected_string" -f [string]$schemaField)
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        passed = [bool]($errors.Count -eq 0)
+        errors = @($errors)
+    }
+}
+
 function Get-VibeGitStatusSnapshot {
     param(
         [Parameter(Mandatory)] [string]$RepoRoot
@@ -720,13 +800,14 @@ function Invoke-VibeSpecialistDispatchUnit {
         @()
     }
 
-    $verificationPassed = (-not $processResult.timed_out) -and ([int]$processResult.exit_code -eq 0) -and ($null -ne $parsedResponse) -and (@('completed', 'completed_with_notes') -contains $responseStatus)
+    $schemaValidation = Test-VibeSpecialistResponseAgainstSchema -Response $parsedResponse -Schema $schema
+    $verificationPassed = (-not $processResult.timed_out) -and ([int]$processResult.exit_code -eq 0) -and ($null -ne $parsedResponse) -and [bool]$schemaValidation.passed -and (@('completed', 'completed_with_notes') -contains $responseStatus)
     $effectiveStatus = if ($verificationPassed) {
         'completed'
     } elseif ($processResult.timed_out) {
         'timed_out'
-    } elseif (-not [string]::IsNullOrWhiteSpace($responseStatus)) {
-        $responseStatus
+    } elseif ($responseStatus -eq 'blocked' -and [int]$processResult.exit_code -eq 0 -and [string]::IsNullOrWhiteSpace($responseParseError) -and [bool]$schemaValidation.passed) {
+        'blocked'
     } else {
         'failed'
     }
@@ -780,6 +861,7 @@ function Invoke-VibeSpecialistDispatchUnit {
         bounded_output_notes = @($boundedOutputNotes)
         summary = $responseSummary
         response_parse_error = $responseParseError
+        response_schema_errors = @($schemaValidation.errors)
     }
 
     $resultPath = Join-Path $resultsRoot ("{0}.json" -f $UnitId)

--- a/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
@@ -999,10 +999,22 @@ $effectiveUnitExecution = if ($parallelUnitsExecutedCount -gt 0 -and ($executedU
 }
 
 $baseStatus = if ($failedUnitCount -eq 0 -and $executedUnitCount -ge [int]$profile.expected_minimum_units) { 'completed' } elseif ($executedUnitCount -eq 0) { 'failed' } else { 'completed_with_failures' }
-$liveSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live_native_execution })
+$liveAttemptedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live_native_execution })
+$liveSpecialistUnits = @($liveAttemptedSpecialistUnits | Where-Object { [bool]$_.verification_passed })
+$failedLiveSpecialistUnits = @($liveAttemptedSpecialistUnits | Where-Object { -not [bool]$_.verification_passed })
 $degradedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.degraded })
 $totalSpecialistDispatchOutcomeCount = @($executedSpecialistUnits).Count
-$effectiveSpecialistExecutionStatus = if (@($liveSpecialistUnits).Count -gt 0) { 'live_native_executed' } elseif (@($degradedSpecialistUnits).Count -gt 0) { 'explicitly_degraded' } else { 'none' }
+$effectiveSpecialistExecutionStatus = if (@($liveSpecialistUnits).Count -gt 0 -and @($failedLiveSpecialistUnits).Count -eq 0) {
+    'live_native_executed'
+} elseif (@($liveSpecialistUnits).Count -gt 0 -and @($failedLiveSpecialistUnits).Count -gt 0) {
+    'live_native_partial_failures'
+} elseif (@($failedLiveSpecialistUnits).Count -gt 0) {
+    'live_native_failed'
+} elseif (@($degradedSpecialistUnits).Count -gt 0) {
+    'explicitly_degraded'
+} else {
+    'none'
+}
 $specialistDispatchUnitCount = @($approvedDispatch).Count
 $executionManifest = [pscustomobject]@{
     stage = 'plan_execute'
@@ -1104,8 +1116,11 @@ $executionManifest = [pscustomobject]@{
             verification = @($approvedDispatch | Where-Object { [string]$_.dispatch_phase -eq 'verification' }).Count
         }
         parallelizable_dispatch_count = @($approvedDispatch | Where-Object { [bool]$_.parallelizable_in_root_xl }).Count
+        attempted_specialist_unit_count = @($liveAttemptedSpecialistUnits).Count
         executed_specialist_unit_count = @($liveSpecialistUnits).Count
+        failed_specialist_unit_count = @($failedLiveSpecialistUnits).Count
         executed_specialist_units = @($liveSpecialistUnits)
+        failed_specialist_units = @($failedLiveSpecialistUnits)
         degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
         degraded_specialist_units = @($degradedSpecialistUnits)
         specialist_dispatch_outcomes = @($executedSpecialistUnits)
@@ -1143,7 +1158,9 @@ $proofManifest = [pscustomobject]@{
     promotion_suitable = [string]$proofRegistry.promotion_suitability.runtime
     specialist_recommendation_count = @($specialistRecommendations).Count
     specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
+    attempted_specialist_unit_count = @($liveAttemptedSpecialistUnits).Count
     executed_specialist_unit_count = @($liveSpecialistUnits).Count
+    failed_specialist_unit_count = @($failedLiveSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
     specialist_execution_status = $effectiveSpecialistExecutionStatus
@@ -1173,7 +1190,9 @@ $proofLines = @(
     ('- review_receipt_count: `{0}`' -f $reviewReceiptCount),
     ('- specialist_recommendation_count: `{0}`' -f @($specialistRecommendations).Count),
     ('- specialist_dispatch_unit_count: `{0}`' -f [int]$specialistDispatchUnitCount),
+    ('- attempted_specialist_unit_count: `{0}`' -f @($liveAttemptedSpecialistUnits).Count),
     ('- executed_specialist_unit_count: `{0}`' -f @($liveSpecialistUnits).Count),
+    ('- failed_specialist_unit_count: `{0}`' -f @($failedLiveSpecialistUnits).Count),
     ('- degraded_specialist_unit_count: `{0}`' -f @($degradedSpecialistUnits).Count),
     ('- auto_approved_specialist_unit_count: `{0}`' -f @($autoApprovedDispatch).Count),
     ('- residual_local_specialist_suggestion_count: `{0}`' -f @($localSuggestions).Count),
@@ -1218,7 +1237,9 @@ $receipt = [pscustomobject]@{
     review_receipt_count = [int]$reviewReceiptCount
     specialist_recommendation_count = @($specialistRecommendations).Count
     specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
+    attempted_specialist_unit_count = @($liveAttemptedSpecialistUnits).Count
     executed_specialist_unit_count = @($liveSpecialistUnits).Count
+    failed_specialist_unit_count = @($failedLiveSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
     specialist_execution_status = $effectiveSpecialistExecutionStatus

--- a/bundled/skills/vibe/scripts/runtime/VibeExecution.Common.ps1
+++ b/bundled/skills/vibe/scripts/runtime/VibeExecution.Common.ps1
@@ -393,6 +393,86 @@ function New-VibeSpecialistResultSchema {
     }
 }
 
+function Test-VibeSpecialistResponseAgainstSchema {
+    param(
+        [AllowNull()] [object]$Response,
+        [Parameter(Mandatory)] [object]$Schema
+    )
+
+    $errors = @()
+    if ($null -eq $Response) {
+        return [pscustomobject]@{
+            passed = $false
+            errors = @('response_missing')
+        }
+    }
+
+    $responseProperties = @($Response.PSObject.Properties.Name | ForEach-Object { [string]$_ })
+    $schemaProperties = if ($Schema.PSObject.Properties.Name -contains 'properties' -and $Schema.properties) {
+        @($Schema.properties.PSObject.Properties.Name | ForEach-Object { [string]$_ })
+    } else {
+        @()
+    }
+
+    foreach ($requiredField in @($Schema.required)) {
+        $fieldName = [string]$requiredField
+        if (-not ($responseProperties -contains $fieldName)) {
+            $errors += ("missing_required_field:{0}" -f $fieldName)
+        }
+    }
+
+    if ($Schema.PSObject.Properties.Name -contains 'additionalProperties' -and -not [bool]$Schema.additionalProperties) {
+        foreach ($responseField in @($responseProperties)) {
+            if (-not ($schemaProperties -contains [string]$responseField)) {
+                $errors += ("unexpected_field:{0}" -f [string]$responseField)
+            }
+        }
+    }
+
+    foreach ($schemaField in @($schemaProperties)) {
+        if (-not ($responseProperties -contains [string]$schemaField)) {
+            continue
+        }
+
+        $fieldSchema = $Schema.properties.$schemaField
+        $fieldValue = $Response.$schemaField
+        $expectedType = if ($fieldSchema.PSObject.Properties.Name -contains 'type') { [string]$fieldSchema.type } else { '' }
+
+        switch ($expectedType) {
+            'string' {
+                if ($fieldValue -isnot [string]) {
+                    $errors += ("invalid_type:{0}:expected_string" -f [string]$schemaField)
+                    continue
+                }
+                if ($fieldSchema.PSObject.Properties.Name -contains 'enum' -and @($fieldSchema.enum).Count -gt 0) {
+                    $allowedValues = @($fieldSchema.enum | ForEach-Object { [string]$_ })
+                    if (-not ($allowedValues -contains [string]$fieldValue)) {
+                        $errors += ("invalid_enum:{0}:{1}" -f [string]$schemaField, [string]$fieldValue)
+                    }
+                }
+            }
+            'array' {
+                if ($fieldValue -is [string]) {
+                    $errors += ("invalid_type:{0}:expected_array" -f [string]$schemaField)
+                    continue
+                }
+                $items = @($fieldValue)
+                foreach ($item in @($items)) {
+                    if ($item -isnot [string]) {
+                        $errors += ("invalid_array_item_type:{0}:expected_string" -f [string]$schemaField)
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        passed = [bool]($errors.Count -eq 0)
+        errors = @($errors)
+    }
+}
+
 function Get-VibeGitStatusSnapshot {
     param(
         [Parameter(Mandatory)] [string]$RepoRoot
@@ -720,13 +800,14 @@ function Invoke-VibeSpecialistDispatchUnit {
         @()
     }
 
-    $verificationPassed = (-not $processResult.timed_out) -and ([int]$processResult.exit_code -eq 0) -and ($null -ne $parsedResponse) -and (@('completed', 'completed_with_notes') -contains $responseStatus)
+    $schemaValidation = Test-VibeSpecialistResponseAgainstSchema -Response $parsedResponse -Schema $schema
+    $verificationPassed = (-not $processResult.timed_out) -and ([int]$processResult.exit_code -eq 0) -and ($null -ne $parsedResponse) -and [bool]$schemaValidation.passed -and (@('completed', 'completed_with_notes') -contains $responseStatus)
     $effectiveStatus = if ($verificationPassed) {
         'completed'
     } elseif ($processResult.timed_out) {
         'timed_out'
-    } elseif (-not [string]::IsNullOrWhiteSpace($responseStatus)) {
-        $responseStatus
+    } elseif ($responseStatus -eq 'blocked' -and [int]$processResult.exit_code -eq 0 -and [string]::IsNullOrWhiteSpace($responseParseError) -and [bool]$schemaValidation.passed) {
+        'blocked'
     } else {
         'failed'
     }
@@ -780,6 +861,7 @@ function Invoke-VibeSpecialistDispatchUnit {
         bounded_output_notes = @($boundedOutputNotes)
         summary = $responseSummary
         response_parse_error = $responseParseError
+        response_schema_errors = @($schemaValidation.errors)
     }
 
     $resultPath = Join-Path $resultsRoot ("{0}.json" -f $UnitId)

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -999,10 +999,22 @@ $effectiveUnitExecution = if ($parallelUnitsExecutedCount -gt 0 -and ($executedU
 }
 
 $baseStatus = if ($failedUnitCount -eq 0 -and $executedUnitCount -ge [int]$profile.expected_minimum_units) { 'completed' } elseif ($executedUnitCount -eq 0) { 'failed' } else { 'completed_with_failures' }
-$liveSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live_native_execution })
+$liveAttemptedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live_native_execution })
+$liveSpecialistUnits = @($liveAttemptedSpecialistUnits | Where-Object { [bool]$_.verification_passed })
+$failedLiveSpecialistUnits = @($liveAttemptedSpecialistUnits | Where-Object { -not [bool]$_.verification_passed })
 $degradedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.degraded })
 $totalSpecialistDispatchOutcomeCount = @($executedSpecialistUnits).Count
-$effectiveSpecialistExecutionStatus = if (@($liveSpecialistUnits).Count -gt 0) { 'live_native_executed' } elseif (@($degradedSpecialistUnits).Count -gt 0) { 'explicitly_degraded' } else { 'none' }
+$effectiveSpecialistExecutionStatus = if (@($liveSpecialistUnits).Count -gt 0 -and @($failedLiveSpecialistUnits).Count -eq 0) {
+    'live_native_executed'
+} elseif (@($liveSpecialistUnits).Count -gt 0 -and @($failedLiveSpecialistUnits).Count -gt 0) {
+    'live_native_partial_failures'
+} elseif (@($failedLiveSpecialistUnits).Count -gt 0) {
+    'live_native_failed'
+} elseif (@($degradedSpecialistUnits).Count -gt 0) {
+    'explicitly_degraded'
+} else {
+    'none'
+}
 $specialistDispatchUnitCount = @($approvedDispatch).Count
 $executionManifest = [pscustomobject]@{
     stage = 'plan_execute'
@@ -1104,8 +1116,11 @@ $executionManifest = [pscustomobject]@{
             verification = @($approvedDispatch | Where-Object { [string]$_.dispatch_phase -eq 'verification' }).Count
         }
         parallelizable_dispatch_count = @($approvedDispatch | Where-Object { [bool]$_.parallelizable_in_root_xl }).Count
+        attempted_specialist_unit_count = @($liveAttemptedSpecialistUnits).Count
         executed_specialist_unit_count = @($liveSpecialistUnits).Count
+        failed_specialist_unit_count = @($failedLiveSpecialistUnits).Count
         executed_specialist_units = @($liveSpecialistUnits)
+        failed_specialist_units = @($failedLiveSpecialistUnits)
         degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
         degraded_specialist_units = @($degradedSpecialistUnits)
         specialist_dispatch_outcomes = @($executedSpecialistUnits)
@@ -1143,7 +1158,9 @@ $proofManifest = [pscustomobject]@{
     promotion_suitable = [string]$proofRegistry.promotion_suitability.runtime
     specialist_recommendation_count = @($specialistRecommendations).Count
     specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
+    attempted_specialist_unit_count = @($liveAttemptedSpecialistUnits).Count
     executed_specialist_unit_count = @($liveSpecialistUnits).Count
+    failed_specialist_unit_count = @($failedLiveSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
     specialist_execution_status = $effectiveSpecialistExecutionStatus
@@ -1173,7 +1190,9 @@ $proofLines = @(
     ('- review_receipt_count: `{0}`' -f $reviewReceiptCount),
     ('- specialist_recommendation_count: `{0}`' -f @($specialistRecommendations).Count),
     ('- specialist_dispatch_unit_count: `{0}`' -f [int]$specialistDispatchUnitCount),
+    ('- attempted_specialist_unit_count: `{0}`' -f @($liveAttemptedSpecialistUnits).Count),
     ('- executed_specialist_unit_count: `{0}`' -f @($liveSpecialistUnits).Count),
+    ('- failed_specialist_unit_count: `{0}`' -f @($failedLiveSpecialistUnits).Count),
     ('- degraded_specialist_unit_count: `{0}`' -f @($degradedSpecialistUnits).Count),
     ('- auto_approved_specialist_unit_count: `{0}`' -f @($autoApprovedDispatch).Count),
     ('- residual_local_specialist_suggestion_count: `{0}`' -f @($localSuggestions).Count),
@@ -1218,7 +1237,9 @@ $receipt = [pscustomobject]@{
     review_receipt_count = [int]$reviewReceiptCount
     specialist_recommendation_count = @($specialistRecommendations).Count
     specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
+    attempted_specialist_unit_count = @($liveAttemptedSpecialistUnits).Count
     executed_specialist_unit_count = @($liveSpecialistUnits).Count
+    failed_specialist_unit_count = @($failedLiveSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
     specialist_execution_status = $effectiveSpecialistExecutionStatus

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -393,6 +393,86 @@ function New-VibeSpecialistResultSchema {
     }
 }
 
+function Test-VibeSpecialistResponseAgainstSchema {
+    param(
+        [AllowNull()] [object]$Response,
+        [Parameter(Mandatory)] [object]$Schema
+    )
+
+    $errors = @()
+    if ($null -eq $Response) {
+        return [pscustomobject]@{
+            passed = $false
+            errors = @('response_missing')
+        }
+    }
+
+    $responseProperties = @($Response.PSObject.Properties.Name | ForEach-Object { [string]$_ })
+    $schemaProperties = if ($Schema.PSObject.Properties.Name -contains 'properties' -and $Schema.properties) {
+        @($Schema.properties.PSObject.Properties.Name | ForEach-Object { [string]$_ })
+    } else {
+        @()
+    }
+
+    foreach ($requiredField in @($Schema.required)) {
+        $fieldName = [string]$requiredField
+        if (-not ($responseProperties -contains $fieldName)) {
+            $errors += ("missing_required_field:{0}" -f $fieldName)
+        }
+    }
+
+    if ($Schema.PSObject.Properties.Name -contains 'additionalProperties' -and -not [bool]$Schema.additionalProperties) {
+        foreach ($responseField in @($responseProperties)) {
+            if (-not ($schemaProperties -contains [string]$responseField)) {
+                $errors += ("unexpected_field:{0}" -f [string]$responseField)
+            }
+        }
+    }
+
+    foreach ($schemaField in @($schemaProperties)) {
+        if (-not ($responseProperties -contains [string]$schemaField)) {
+            continue
+        }
+
+        $fieldSchema = $Schema.properties.$schemaField
+        $fieldValue = $Response.$schemaField
+        $expectedType = if ($fieldSchema.PSObject.Properties.Name -contains 'type') { [string]$fieldSchema.type } else { '' }
+
+        switch ($expectedType) {
+            'string' {
+                if ($fieldValue -isnot [string]) {
+                    $errors += ("invalid_type:{0}:expected_string" -f [string]$schemaField)
+                    continue
+                }
+                if ($fieldSchema.PSObject.Properties.Name -contains 'enum' -and @($fieldSchema.enum).Count -gt 0) {
+                    $allowedValues = @($fieldSchema.enum | ForEach-Object { [string]$_ })
+                    if (-not ($allowedValues -contains [string]$fieldValue)) {
+                        $errors += ("invalid_enum:{0}:{1}" -f [string]$schemaField, [string]$fieldValue)
+                    }
+                }
+            }
+            'array' {
+                if ($fieldValue -is [string]) {
+                    $errors += ("invalid_type:{0}:expected_array" -f [string]$schemaField)
+                    continue
+                }
+                $items = @($fieldValue)
+                foreach ($item in @($items)) {
+                    if ($item -isnot [string]) {
+                        $errors += ("invalid_array_item_type:{0}:expected_string" -f [string]$schemaField)
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        passed = [bool]($errors.Count -eq 0)
+        errors = @($errors)
+    }
+}
+
 function Get-VibeGitStatusSnapshot {
     param(
         [Parameter(Mandatory)] [string]$RepoRoot
@@ -720,13 +800,14 @@ function Invoke-VibeSpecialistDispatchUnit {
         @()
     }
 
-    $verificationPassed = (-not $processResult.timed_out) -and ([int]$processResult.exit_code -eq 0) -and ($null -ne $parsedResponse) -and (@('completed', 'completed_with_notes') -contains $responseStatus)
+    $schemaValidation = Test-VibeSpecialistResponseAgainstSchema -Response $parsedResponse -Schema $schema
+    $verificationPassed = (-not $processResult.timed_out) -and ([int]$processResult.exit_code -eq 0) -and ($null -ne $parsedResponse) -and [bool]$schemaValidation.passed -and (@('completed', 'completed_with_notes') -contains $responseStatus)
     $effectiveStatus = if ($verificationPassed) {
         'completed'
     } elseif ($processResult.timed_out) {
         'timed_out'
-    } elseif (-not [string]::IsNullOrWhiteSpace($responseStatus)) {
-        $responseStatus
+    } elseif ($responseStatus -eq 'blocked' -and [int]$processResult.exit_code -eq 0 -and [string]::IsNullOrWhiteSpace($responseParseError) -and [bool]$schemaValidation.passed) {
+        'blocked'
     } else {
         'failed'
     }
@@ -780,6 +861,7 @@ function Invoke-VibeSpecialistDispatchUnit {
         bounded_output_notes = @($boundedOutputNotes)
         summary = $responseSummary
         response_parse_error = $responseParseError
+        response_schema_errors = @($schemaValidation.errors)
     }
 
     $resultPath = Join-Path $resultsRoot ("{0}.json" -f $UnitId)

--- a/tests/runtime_neutral/test_native_specialist_failure_injection.py
+++ b/tests/runtime_neutral/test_native_specialist_failure_injection.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def resolve_powershell() -> str | None:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("pwsh.exe"),
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files\PowerShell\7-preview\pwsh.exe",
+        shutil.which("powershell"),
+        shutil.which("powershell.exe"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
+def run_runtime(
+    task: str,
+    artifact_root: Path,
+    *,
+    governance_scope: str = "root",
+    extra_env: dict[str, str] | None = None,
+) -> dict[str, object]:
+    shell = resolve_powershell()
+    if shell is None:
+        raise unittest.SkipTest("PowerShell executable not available in PATH")
+
+    script_path = REPO_ROOT / "scripts/runtime/invoke-vibe-runtime.ps1"
+    run_id = "pytest-native-failure-" + uuid.uuid4().hex[:10]
+    command = [
+        shell,
+        "-NoLogo",
+        "-NoProfile",
+        "-Command",
+        (
+            "& { "
+            f"$result = & '{script_path}' "
+            f"-Task '{task}' "
+            "-Mode benchmark_autonomous "
+            f"-GovernanceScope {governance_scope} "
+            f"-RunId '{run_id}' "
+            f"-ArtifactRoot '{artifact_root}'; "
+            "$result | ConvertTo-Json -Depth 20 }"
+        ),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={**os.environ, **(extra_env or {})},
+    )
+    stdout = completed.stdout.strip()
+    if stdout in ("", "null"):
+        raise AssertionError(
+            "invoke-vibe-runtime returned null payload. "
+            f"stderr={completed.stderr.strip()}"
+        )
+    return json.loads(stdout)
+
+
+def load_json(path: str | Path) -> dict[str, object]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def create_fake_codex_command(directory: Path, *, mode: str) -> Path:
+    suffix = ".cmd" if os.name == "nt" else ""
+    command_path = directory / f"codex{suffix}"
+    if os.name == "nt":
+        behaviors = {
+            "malformed_json": (
+                "> \"%OUT%\" echo {bad-json\r\n"
+                "echo fake codex malformed\r\n"
+                "exit /b 0\r\n"
+            ),
+            "missing_required_fields": (
+                "> \"%OUT%\" echo {\"status\":\"completed\",\"summary\":\"missing arrays\"}\r\n"
+                "echo fake codex schema gap\r\n"
+                "exit /b 0\r\n"
+            ),
+            "missing_response": (
+                "echo fake codex no response\r\n"
+                "exit /b 0\r\n"
+            ),
+            "nonzero_with_response": (
+                "> \"%OUT%\" echo {\"status\":\"completed\",\"summary\":\"fake codex wrote payload before failing\",\"verification_notes\":[\"nonzero exit injected\"],\"changed_files\":[],\"bounded_output_notes\":[\"failure injection\"]}\r\n"
+                "echo fake codex nonzero with response\r\n"
+                "exit /b 17\r\n"
+            ),
+        }
+        behavior = behaviors[mode]
+        command_path.write_text(
+            "@echo off\r\n"
+            "setlocal EnableDelayedExpansion\r\n"
+            "set OUT=\r\n"
+            ":loop\r\n"
+            "if \"%~1\"==\"\" goto done\r\n"
+            "if \"%~1\"==\"-o\" (\r\n"
+            "  set OUT=%~2\r\n"
+            "  shift\r\n"
+            "  shift\r\n"
+            "  goto loop\r\n"
+            ")\r\n"
+            "shift\r\n"
+            "goto loop\r\n"
+            ":done\r\n"
+            "if \"%OUT%\"==\"\" exit /b 2\r\n"
+            + behavior,
+            encoding="utf-8",
+        )
+    else:
+        behaviors = {
+            "malformed_json": (
+                "printf '%s' '{bad-json' > \"$OUT\"\n"
+                "printf 'fake codex malformed\\n'\n"
+                "exit 0\n"
+            ),
+            "missing_required_fields": (
+                "printf '%s' '{\"status\":\"completed\",\"summary\":\"missing arrays\"}' > \"$OUT\"\n"
+                "printf 'fake codex schema gap\\n'\n"
+                "exit 0\n"
+            ),
+            "missing_response": (
+                "printf 'fake codex no response\\n'\n"
+                "exit 0\n"
+            ),
+            "nonzero_with_response": (
+                "printf '%s' '{\"status\":\"completed\",\"summary\":\"fake codex wrote payload before failing\",\"verification_notes\":[\"nonzero exit injected\"],\"changed_files\":[],\"bounded_output_notes\":[\"failure injection\"]}' > \"$OUT\"\n"
+                "printf 'fake codex nonzero with response\\n'\n"
+                "exit 17\n"
+            ),
+        }
+        behavior = behaviors[mode]
+        command_path.write_text(
+            "#!/usr/bin/env sh\n"
+            "OUT=''\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    -o)\n"
+            "      OUT=\"$2\"\n"
+            "      shift 2\n"
+            "      ;;\n"
+            "    *)\n"
+            "      shift\n"
+            "      ;;\n"
+            "  esac\n"
+            "done\n"
+            "if [ -z \"$OUT\" ]; then\n"
+            "  exit 2\n"
+            "fi\n"
+            + behavior,
+            encoding="utf-8",
+        )
+        command_path.chmod(command_path.stat().st_mode | stat.S_IXUSR)
+    return command_path
+
+
+class NativeSpecialistFailureInjectionTests(unittest.TestCase):
+    TASK = "I have a failing test and stack trace. Debug systematically and execute specialist workflow."
+
+    def run_failure_case(
+        self, mode: str
+    ) -> tuple[dict[str, object], dict[str, object], list[tuple[dict[str, object], dict[str, object]]]]:
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_path = Path(tempdir)
+            fake_codex = create_fake_codex_command(temp_path, mode=mode)
+            payload = run_runtime(
+                task=self.TASK,
+                artifact_root=temp_path,
+                governance_scope="root",
+                extra_env={
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+            summary = payload["summary"]
+            execution_manifest = load_json(summary["artifacts"]["execution_manifest"])
+            specialist_accounting = execution_manifest["specialist_accounting"]
+            live_failures = [
+                (unit, load_json(unit["result_path"]))
+                for unit in list(specialist_accounting["failed_specialist_units"])
+            ]
+            self.assertGreaterEqual(len(live_failures), 1)
+            self.assertEqual("live_native_failed", specialist_accounting["effective_execution_status"])
+            self.assertGreaterEqual(int(specialist_accounting["attempted_specialist_unit_count"]), 1)
+            self.assertEqual(0, int(specialist_accounting["executed_specialist_unit_count"]))
+            self.assertGreaterEqual(int(specialist_accounting["failed_specialist_unit_count"]), 1)
+            self.assertEqual("completed_with_failures", execution_manifest["status"])
+
+            benchmark_proof = load_json(summary["artifacts"]["benchmark_proof_manifest"])
+            self.assertEqual("live_native_failed", benchmark_proof["specialist_execution_status"])
+            self.assertEqual(
+                int(specialist_accounting["failed_specialist_unit_count"]),
+                int(benchmark_proof["failed_specialist_unit_count"]),
+            )
+            return payload, execution_manifest, live_failures
+
+    def test_malformed_json_response_is_recorded_as_live_native_failure(self) -> None:
+        _, _, live_failures = self.run_failure_case("malformed_json")
+        for unit, result in live_failures:
+            with self.subTest(unit_id=unit.get("unit_id", "")):
+                expected_artifacts = list(result["expected_artifacts"])
+                self.assertEqual(1, len(expected_artifacts))
+                self.assertEqual("failed", result["status"])
+                self.assertEqual(0, int(result["exit_code"]))
+                self.assertFalse(bool(result["verification_passed"]))
+                self.assertTrue(bool(result["live_native_execution"]))
+                self.assertFalse(bool(result["degraded"]))
+                self.assertTrue(bool(expected_artifacts[0]["exists"]))
+                self.assertTrue(result["response_parse_error"])
+                self.assertNotEqual("native_specialist_response_missing", result["response_parse_error"])
+
+    def test_missing_response_file_is_recorded_as_live_native_failure(self) -> None:
+        _, _, live_failures = self.run_failure_case("missing_response")
+        for unit, result in live_failures:
+            with self.subTest(unit_id=unit.get("unit_id", "")):
+                expected_artifacts = list(result["expected_artifacts"])
+                self.assertEqual(1, len(expected_artifacts))
+                self.assertEqual("failed", result["status"])
+                self.assertEqual(0, int(result["exit_code"]))
+                self.assertFalse(bool(result["verification_passed"]))
+                self.assertTrue(bool(result["live_native_execution"]))
+                self.assertFalse(bool(result["degraded"]))
+                self.assertFalse(Path(result["response_json_path"]).exists())
+                self.assertEqual("native_specialist_response_missing", result["response_parse_error"])
+                self.assertFalse(bool(expected_artifacts[0]["exists"]))
+
+    def test_missing_required_fields_fail_schema_validation(self) -> None:
+        _, _, live_failures = self.run_failure_case("missing_required_fields")
+        for unit, result in live_failures:
+            with self.subTest(unit_id=unit.get("unit_id", "")):
+                self.assertEqual("failed", result["status"])
+                self.assertEqual(0, int(result["exit_code"]))
+                self.assertFalse(bool(result["verification_passed"]))
+                self.assertTrue(bool(result["live_native_execution"]))
+                self.assertFalse(bool(result["degraded"]))
+                self.assertIsNone(result["response_parse_error"])
+                self.assertIn("missing_required_field:verification_notes", list(result["response_schema_errors"]))
+                self.assertIn("missing_required_field:changed_files", list(result["response_schema_errors"]))
+                self.assertIn("missing_required_field:bounded_output_notes", list(result["response_schema_errors"]))
+
+    def test_nonzero_exit_with_response_is_not_misclassified_as_completed(self) -> None:
+        _, _, live_failures = self.run_failure_case("nonzero_with_response")
+        for unit, result in live_failures:
+            with self.subTest(unit_id=unit.get("unit_id", "")):
+                expected_artifacts = list(result["expected_artifacts"])
+                self.assertEqual(1, len(expected_artifacts))
+                self.assertEqual("failed", result["status"])
+                self.assertEqual(17, int(result["exit_code"]))
+                self.assertFalse(bool(result["verification_passed"]))
+                self.assertTrue(bool(result["live_native_execution"]))
+                self.assertFalse(bool(result["degraded"]))
+                self.assertTrue(bool(expected_artifacts[0]["exists"]))
+                self.assertIsNone(result["response_parse_error"])
+                self.assertEqual(
+                    "fake codex wrote payload before failing",
+                    result["summary"],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- harden native specialist execution classification so failed live runs are not reported as successful
- validate native specialist JSON responses against the frozen schema before accepting completion
- add failure-injection coverage for malformed JSON, missing response files, missing required schema fields, and non-zero exits with response payloads

## What changed
- force live native specialist units to report `failed` unless the adapter both exits cleanly and satisfies the schema contract
- split specialist accounting into attempted / successful / failed live-native counts and surface `live_native_failed` / `live_native_partial_failures` aggregate states
- persist schema validation errors in specialist unit receipts
- sync bundled runtime mirrors with the primary runtime implementation
- add `tests/runtime_neutral/test_native_specialist_failure_injection.py`

## Verification
- `pytest -q tests/runtime_neutral/test_native_specialist_failure_injection.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py`
- `pwsh -NoProfile -File scripts/verify/vibe-root-child-hierarchy-gate.ps1`
- `pwsh -NoProfile -File scripts/verify/vibe-child-specialist-escalation-gate.ps1`

## Notes
- this is a follow-up after merged PR #64
- keeps the existing root/child authority model and stage-bound specialist topology intact while tightening proof semantics