### PR TITLE
[codex] release v2.3.51

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -291,7 +291,7 @@ The governed runtime should leave behind:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 2.3.50
-- Updated: 2026-03-26
+- Version: 2.3.51
+- Updated: 2026-03-28
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/bundled/skills/vibe/SKILL.md
+++ b/bundled/skills/vibe/SKILL.md
@@ -291,7 +291,7 @@ The governed runtime should leave behind:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 2.3.50
-- Updated: 2026-03-26
+- Version: 2.3.51
+- Updated: 2026-03-28
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/bundled/skills/vibe/bundled/skills/vibe/SKILL.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/SKILL.md
@@ -291,7 +291,7 @@ The governed runtime should leave behind:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 2.3.50
-- Updated: 2026-03-26
+- Version: 2.3.51
+- Updated: 2026-03-28
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/bundled/skills/vibe/bundled/skills/vibe/check.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/check.ps1
@@ -136,6 +136,66 @@ function Format-OptionalValue {
   return $Value
 }
 
+function Resolve-CodexDuplicateSkillRoot {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  if ([string]$HostId -ne 'codex') {
+    return $null
+  }
+
+  $leaf = (Split-Path -Path $TargetRoot -Leaf).ToLowerInvariant()
+  if ($leaf -ne '.codex') {
+    return $null
+  }
+
+  $parent = Get-VgoParentPath -Path $TargetRoot
+  if ([string]::IsNullOrWhiteSpace($parent)) {
+    return $null
+  }
+
+  return (Join-Path $parent '.agents\skills\vibe')
+}
+
+function Test-VibeSkillDirectory {
+  param([string]$Path)
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return $false
+  }
+
+  $skillMd = Join-Path $Path 'SKILL.md'
+  if (-not (Test-Path -LiteralPath $skillMd)) {
+    return $false
+  }
+
+  $lines = Get-Content -LiteralPath $skillMd -TotalCount 20 -Encoding UTF8
+  return [bool](@($lines | Where-Object { $_ -match '^\s*name:\s*vibe\s*$' }).Count -gt 0)
+}
+
+function Check-CodexDuplicateSkillSurface {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  $duplicateRoot = Resolve-CodexDuplicateSkillRoot -TargetRoot $TargetRoot -HostId $HostId
+  if ([string]::IsNullOrWhiteSpace($duplicateRoot) -or -not (Test-Path -LiteralPath $duplicateRoot -PathType Container)) {
+    return
+  }
+
+  if (Test-VibeSkillDirectory -Path $duplicateRoot) {
+    Write-Host ("[FAIL] duplicate Codex-discovered vibe skill surface -> {0}" -f $duplicateRoot) -ForegroundColor Red
+    Write-Host '[FAIL] Re-run install.ps1 for the default Codex root to quarantine the legacy .agents copy, or move it out of .agents/skills manually.' -ForegroundColor Red
+    $script:fail++
+    return
+  }
+
+  Warn-Note -Message ("unexpected directory exists at Codex duplicate-surface path: {0}" -f $duplicateRoot)
+}
+
 function Test-ReceiptTargetFreshness {
   param(
     [string]$TargetRoot,
@@ -413,6 +473,18 @@ function Check-Path {
   }
 }
 
+function Check-PathAbsent {
+  param([string]$Label, [string]$Path)
+
+  if (Test-Path -LiteralPath $Path) {
+    Write-Host "[FAIL] $Label -> $Path" -ForegroundColor Red
+    $script:fail++
+  } else {
+    Write-Host "[OK] $Label"
+    $script:pass++
+  }
+}
+
 function Invoke-AdapterSpecificChecks {
   param(
     [psobject]$Adapter,
@@ -487,6 +559,8 @@ function Invoke-AdapterSpecificChecks {
     Check-Path -Label "vibe bundled exploration intent profiles config" -Path (Join-Path $RuntimeNestedSkillRoot 'config\exploration-intent-profiles.json') -Required:$NestedBundledRequired
     Check-Path -Label "vibe bundled exploration domain map config" -Path (Join-Path $RuntimeNestedSkillRoot 'config\exploration-domain-map.json') -Required:$NestedBundledRequired
     Check-Path -Label "vibe bundled llm acceleration policy config" -Path (Join-Path $RuntimeNestedSkillRoot 'config\llm-acceleration-policy.json') -Required:$NestedBundledRequired
+    Check-PathAbsent -Label "vibe nested bundled skill entrypoint hidden" -Path (Join-Path $RuntimeNestedSkillRoot 'SKILL.md')
+    Check-Path -Label "vibe nested bundled skill runtime mirror" -Path (Join-Path $RuntimeNestedSkillRoot 'SKILL.runtime-mirror.md') -Required:$NestedBundledRequired
   } else {
     Write-Host ("[OK] vibe nested bundled config checks skipped (target absent; policy={0})" -f $NestedBundledPresencePolicy)
     $script:pass++
@@ -552,6 +626,7 @@ if ($null -ne $startupGovernance -and $startupGovernance.PSObject.Properties.Nam
 }
 
 Invoke-AdapterSpecificChecks -Adapter $Adapter -TargetRoot $TargetRoot -RuntimeSkillRoot $runtimeSkillRoot -RuntimeNestedSkillRoot $runtimeNestedSkillRoot -NestedBundledRequired:$nestedBundledRequired -NestedBundledPresencePolicy $nestedBundledPresencePolicy
+Check-CodexDuplicateSkillSurface -TargetRoot $TargetRoot -HostId $HostId
 
 Invoke-RuntimeFreshnessCheck -RepoRoot $RepoRoot -TargetRoot $TargetRoot -SkipGate:$SkipRuntimeFreshnessGate
 Invoke-RuntimeFrontmatterCheck -RepoRoot $RepoRoot -TargetRoot $TargetRoot

--- a/bundled/skills/vibe/bundled/skills/vibe/check.sh
+++ b/bundled/skills/vibe/bundled/skills/vibe/check.sh
@@ -80,6 +80,17 @@ resolve_default_target_root() {
   fi
 }
 
+safe_parent_dir() {
+  local path="${1:-}"
+  [[ -n "${path}" ]] || return 0
+  local parent=""
+  parent="$(cd "${path}/.." 2>/dev/null && pwd || true)"
+  if [[ -z "${parent}" || "${parent}" == "${path}" || "${parent}" == "/" ]]; then
+    return 0
+  fi
+  printf '%s' "${parent}"
+}
+
 canonical_repo_available() {
   local current="${1:-}"
   [[ -n "${current}" ]] || return 1
@@ -204,6 +215,54 @@ if [[ -z "${TARGET_ROOT}" ]]; then
 fi
 assert_target_root_matches_host_intent "${TARGET_ROOT}" "${HOST_ID}"
 
+resolve_codex_duplicate_skill_root() {
+  if [[ "${HOST_ID}" != "codex" ]]; then
+    return 1
+  fi
+
+  local leaf=""
+  leaf="$(basename "${TARGET_ROOT}")"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${leaf}" != ".codex" ]]; then
+    return 1
+  fi
+
+  local parent=""
+  parent="$(safe_parent_dir "${TARGET_ROOT}")"
+  if [[ -z "${parent}" ]]; then
+    return 1
+  fi
+
+  printf '%s' "${parent}/.agents/skills/vibe"
+}
+
+test_vibe_skill_dir() {
+  local root="${1:-}"
+  local skill_md="${root}/SKILL.md"
+  [[ -f "${skill_md}" ]] || return 1
+  if grep -Eq '^[[:space:]]*name:[[:space:]]*vibe[[:space:]]*$' "${skill_md}"; then
+    return 0
+  fi
+  return 1
+}
+
+check_codex_duplicate_skill_surface() {
+  local duplicate_root=""
+  duplicate_root="$(resolve_codex_duplicate_skill_root || true)"
+  if [[ -z "${duplicate_root}" || ! -d "${duplicate_root}" ]]; then
+    return 0
+  fi
+
+  if test_vibe_skill_dir "${duplicate_root}"; then
+    echo "[FAIL] duplicate Codex-discovered vibe skill surface -> ${duplicate_root}"
+    echo "[FAIL] Re-run install.sh for the default Codex root to quarantine the legacy .agents copy, or move it out of .agents/skills manually."
+    FAIL=$((FAIL+1))
+    return 0
+  fi
+
+  warn_note "unexpected directory exists at Codex duplicate-surface path: ${duplicate_root}"
+}
+
 PASS=0
 FAIL=0
 WARN=0
@@ -219,6 +278,17 @@ check_path() {
   else
     echo "[WARN] $label -> $path"
     WARN=$((WARN+1))
+  fi
+}
+
+check_absent_path() {
+  local label="$1"; local path="$2"
+  if [[ -e "$path" ]]; then
+    echo "[FAIL] $label -> $path"
+    FAIL=$((FAIL+1))
+  else
+    echo "[OK] $label"
+    PASS=$((PASS+1))
   fi
 }
 
@@ -686,6 +756,7 @@ fi
 if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   check_path "plugins manifest" "${TARGET_ROOT}/config/plugins-manifest.codex.json"
 fi
+check_codex_duplicate_skill_surface
 check_path "upstream lock" "${TARGET_ROOT}/config/upstream-lock.json"
 check_path "vibe version governance config" "${TARGET_ROOT}/${runtime_target_rel}/config/version-governance.json"
 check_path "vibe release ledger" "${runtime_skill_root}/references/release-ledger.jsonl"
@@ -721,6 +792,8 @@ if [[ -d "${runtime_nested_skill_root}" ]]; then
   check_path "vibe bundled exploration intent profiles config" "${runtime_nested_skill_root}/config/exploration-intent-profiles.json"
   check_path "vibe bundled exploration domain map config" "${runtime_nested_skill_root}/config/exploration-domain-map.json"
   check_path "vibe bundled llm acceleration policy config" "${runtime_nested_skill_root}/config/llm-acceleration-policy.json"
+  check_absent_path "vibe nested bundled skill entrypoint hidden" "${runtime_nested_skill_root}/SKILL.md"
+  check_path "vibe nested bundled skill runtime mirror" "${runtime_nested_skill_root}/SKILL.runtime-mirror.md"
 else
   echo "[OK] vibe nested bundled config checks skipped (target absent; policy=optional)"
   PASS=$((PASS+1))

--- a/bundled/skills/vibe/bundled/skills/vibe/config/benchmark-execution-policy.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/benchmark-execution-policy.json
@@ -30,6 +30,8 @@
             {
               "unit_id": "runtime-neutral-freshness-gate-tests",
               "kind": "python_command",
+              "parallelizable": true,
+              "write_scope": "tests/runtime_neutral",
               "command": "${VGO_PYTHON}",
               "arguments": [
                 "-m",
@@ -49,6 +51,8 @@
             {
               "unit_id": "version-consistency-gate",
               "kind": "powershell_file",
+              "parallelizable": true,
+              "write_scope": "scripts/verify",
               "script_path": "scripts/verify/vibe-version-consistency-gate.ps1",
               "arguments": [],
               "cwd": "${REPO_ROOT}",

--- a/bundled/skills/vibe/bundled/skills/vibe/config/execution-topology-policy.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/execution-topology-policy.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "updated_at": "2026-03-28",
+  "default_step_execution": "sequential",
+  "default_step_parallelizable": false,
+  "default_review_mode": "none",
+  "default_specialist_execution_mode": "metadata_only",
+  "default_write_scope_prefix": "unit",
+  "grades": {
+    "M": {
+      "delegation_mode": "none",
+      "unit_execution": "sequential",
+      "max_parallel_units": 1,
+      "review_mode": "none",
+      "specialist_execution_mode": "metadata_only"
+    },
+    "L": {
+      "delegation_mode": "serial_child_lanes",
+      "unit_execution": "sequential",
+      "max_parallel_units": 1,
+      "review_mode": "two_stage_after_unit",
+      "specialist_execution_mode": "metadata_only"
+    },
+    "XL": {
+      "delegation_mode": "selective_parallel_child_lanes",
+      "unit_execution": "bounded_parallel",
+      "max_parallel_units": 2,
+      "review_mode": "checkpoint_per_step",
+      "specialist_execution_mode": "native_bounded_units"
+    }
+  }
+}

--- a/bundled/skills/vibe/bundled/skills/vibe/config/native-specialist-execution-policy.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/native-specialist-execution-policy.json
@@ -1,0 +1,45 @@
+{
+  "version": 1,
+  "updated_at": "2026-03-28",
+  "enabled": true,
+  "default_adapter_id": "codex",
+  "enable_env": "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION",
+  "disable_env": "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION",
+  "default_enabled": false,
+  "default_timeout_seconds": 600,
+  "degrade_contract": {
+    "status": "degraded_non_authoritative",
+    "verification_passed": false,
+    "execution_driver": "degraded_specialist_contract_receipt",
+    "hazard_alert": "Native specialist execution is unavailable or disabled; dispatch downgraded explicitly."
+  },
+  "result_schema": {
+    "status_enum": [
+      "completed",
+      "completed_with_notes",
+      "blocked"
+    ],
+    "required_fields": [
+      "status",
+      "summary",
+      "verification_notes",
+      "changed_files",
+      "bounded_output_notes"
+    ]
+  },
+  "adapters": [
+    {
+      "id": "codex",
+      "enabled": true,
+      "executable_env": "VGO_CODEX_EXECUTABLE",
+      "command": "codex",
+      "arguments_prefix": [
+        "exec",
+        "--json",
+        "--ephemeral",
+        "--full-auto"
+      ],
+      "execution_driver": "codex_exec_native_specialist"
+    }
+  ]
+}

--- a/bundled/skills/vibe/bundled/skills/vibe/config/project-delivery-acceptance-contract.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/project-delivery-acceptance-contract.json
@@ -1,0 +1,64 @@
+{
+  "contract_id": "vibe-project-delivery-acceptance-v1",
+  "version": 1,
+  "truth_layers": [
+    "governance_truth",
+    "engineering_verification_truth",
+    "workflow_completion_truth",
+    "product_acceptance_truth"
+  ],
+  "truth_states": {
+    "passing": {
+      "counts_as_success": true,
+      "completion_language_allowed": true
+    },
+    "manual_review_required": {
+      "counts_as_success": false,
+      "completion_language_allowed": false
+    },
+    "partial": {
+      "counts_as_success": false,
+      "completion_language_allowed": false
+    },
+    "degraded": {
+      "counts_as_success": false,
+      "completion_language_allowed": false
+    },
+    "failing": {
+      "counts_as_success": false,
+      "completion_language_allowed": false
+    },
+    "not_run": {
+      "counts_as_success": false,
+      "completion_language_allowed": false
+    }
+  },
+  "forbidden_completion_collapses": [
+    {
+      "source": "runtime_status",
+      "value": "completed_with_failures",
+      "reason": "partial execution cannot be reported as full downstream delivery"
+    },
+    {
+      "source": "runtime_status",
+      "value": "degraded_non_authoritative",
+      "reason": "degraded execution cannot be reported as equivalent delivery success"
+    },
+    {
+      "source": "readiness_state",
+      "value": "manual_actions_pending",
+      "reason": "pending manual actions cannot be reported as fully ready delivery"
+    }
+  ],
+  "report_requirements": {
+    "must_report_fields": [
+      "governance_truth",
+      "engineering_verification_truth",
+      "workflow_completion_truth",
+      "product_acceptance_truth",
+      "completion_language_allowed",
+      "residual_risks",
+      "manual_spot_checks"
+    ]
+  }
+}

--- a/bundled/skills/vibe/bundled/skills/vibe/config/runtime-input-packet-policy.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/runtime-input-packet-policy.json
@@ -46,6 +46,12 @@
     "bounded_role": "specialist_assist",
     "native_usage_required": true,
     "must_preserve_workflow": true,
+    "dispatch_phase": "in_execution",
+    "execution_priority": 50,
+    "lane_policy": "inherit_grade",
+    "parallelizable_in_root_xl": true,
+    "write_scope_template": "specialist:{skill_id}",
+    "review_mode": "native_contract",
     "required_inputs": [
       "bounded specialist subtask contract",
       "frozen requirement context",
@@ -73,6 +79,84 @@
       "max_auto_absorb_count": 4,
       "disable_env": "VGO_DISABLE_CHILD_SPECIALIST_AUTO_ABSORB",
       "force_escalation_env": "VGO_FORCE_CHILD_SPECIALIST_ESCALATION"
+    }
+  },
+  "specialist_binding_profiles": {
+    "planning": {
+      "match_skill_patterns": [
+        "plan",
+        "architect",
+        "spec",
+        "design",
+        "roadmap",
+        "strategy"
+      ],
+      "dispatch_phase": "pre_execution",
+      "execution_priority": 10,
+      "lane_policy": "serial",
+      "parallelizable_in_root_xl": false,
+      "write_scope_template": "specialist:planning",
+      "review_mode": "native_contract"
+    },
+    "implementation": {
+      "match_skill_patterns": [
+        "pipeline",
+        "analysis",
+        "debug",
+        "bio",
+        "python",
+        "ml",
+        "model",
+        "workflow",
+        "data"
+      ],
+      "dispatch_phase": "in_execution",
+      "execution_priority": 50,
+      "lane_policy": "bounded_parallel",
+      "parallelizable_in_root_xl": true,
+      "write_scope_template": "specialist:execution:{skill_id}",
+      "review_mode": "native_contract"
+    },
+    "deliverable": {
+      "match_skill_patterns": [
+        "writing",
+        "report",
+        "publish",
+        "document",
+        "slide",
+        "poster",
+        "manuscript"
+      ],
+      "dispatch_phase": "post_execution",
+      "execution_priority": 70,
+      "lane_policy": "bounded_parallel",
+      "parallelizable_in_root_xl": true,
+      "write_scope_template": "specialist:deliverable:{skill_id}",
+      "review_mode": "checkpoint_after_step"
+    },
+    "verification": {
+      "match_skill_patterns": [
+        "review",
+        "qa",
+        "verify",
+        "assurance",
+        "audit",
+        "guard"
+      ],
+      "dispatch_phase": "verification",
+      "execution_priority": 90,
+      "lane_policy": "serial",
+      "parallelizable_in_root_xl": false,
+      "write_scope_template": "specialist:verification",
+      "review_mode": "checkpoint_after_step"
+    },
+    "default": {
+      "dispatch_phase": "in_execution",
+      "execution_priority": 50,
+      "lane_policy": "inherit_grade",
+      "parallelizable_in_root_xl": true,
+      "write_scope_template": "specialist:{skill_id}",
+      "review_mode": "native_contract"
     }
   },
   "overlay_fields": [

--- a/bundled/skills/vibe/bundled/skills/vibe/config/version-governance.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/version-governance.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
   "release": {
-    "version": "2.3.50",
-    "updated": "2026-03-26",
+    "version": "2.3.51",
+    "updated": "2026-03-28",
     "channel": "stable",
-    "notes": "Adds router AI connectivity proofing, tightens llm acceleration overlay handling, expands host-adapter/install truth across OpenClaw/OpenCode/Cursor/Windsurf, and switches Windows install verification guidance to built-in PowerShell."
+    "notes": "Adds main-chain delivery acceptance under vibe, hardens stage-bound specialist dispatch and Windows specialist runtime handoff, and promotes stricter completion-language truth for governed runs."
   },
   "source_of_truth": {
     "canonical_root": ".",

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/README.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/README.md
@@ -16,6 +16,9 @@
 
 - [`install/one-click-install-release-copy.md`](./install/one-click-install-release-copy.md)：面向普通用户的一键安装发布文案与 AI 助手复制提示词
 - [`install/one-click-install-release-copy.en.md`](./install/one-click-install-release-copy.en.md)：ordinary-user public release copy and copy-paste onboarding prompt
+- Governed runtime canonical surfaces live in [`../SKILL.md`](../SKILL.md), [`../protocols/runtime.md`](../protocols/runtime.md), and [`../protocols/team.md`](../protocols/team.md). Do not create a second runtime-governance truth document.
+- [`root-child-vibe-hierarchy-governance.md`](./root-child-vibe-hierarchy-governance.md)：稳定说明 root/child `vibe` 分层治理，以及 `L` 串行原生执行、`XL` 分波顺序+步骤级有界并行、批准式 specialist 可执行 bounded units 与 child escalation 规则。
+- [`specialist-dispatch-governance.md`](./specialist-dispatch-governance.md)：稳定说明 specialist skills 如何以阶段绑定、写域隔离、`L` 串行 / `XL` 有界并行的方式接入 `vibe`，避免技能荒废或互相冲突。
 
 - [`status/README.md`](./status/README.md)：当前运行态、proof 入口与阶段回执总索引。
 - [`status/current-state.md`](./status/current-state.md)：当前 closure batch 的 runtime summary。

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-26-codex-vibe-dedupe-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-26-codex-vibe-dedupe-plan.md
@@ -1,0 +1,13 @@
+# Plan: Codex `vibe` Duplicate Surface Fix
+
+- Internal grade: `M`
+- Scope: `install.sh`, `install.ps1`, `check.sh`, `check.ps1`, adapter installers, runtime-neutral install/check tests
+
+## Steps
+
+1. Detect the bounded duplicate candidate only for Codex default roots shaped like `.../.codex`.
+2. During install, quarantine legacy `.agents/skills/vibe` into `.agents/skills-disabled/`.
+3. During install, hide nested runtime-mirror `SKILL.md` entrypoints after materialization so hosts do not discover duplicate skills.
+4. Preserve bootstrap continuity by restoring `SKILL.md` when a sanitized runtime mirror is copied into a real top-level skill lane.
+5. During check, fail explicitly if the duplicate surface still exists or if nested runtime mirrors remain discoverable.
+6. Verify with targeted runtime script tests and direct shell/PowerShell checks where available.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-consolidation-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-consolidation-plan.md
@@ -1,0 +1,35 @@
+# Plan: Consolidate Built-In AI Governance to a Stable Single-Path Contract
+
+## Internal Grade
+
+`L`
+
+## Intent
+
+Finish the built-in AI governance tightening by aligning runtime behavior, doctor/reporting surfaces, helper scripts, and install entry docs to one active OpenAI-compatible contract.
+
+## Execution Steps
+
+1. Freeze the requirement and plan for the consolidation pass.
+2. Update bootstrap doctor implementations to report both API key state and governance model state.
+3. Update one-shot and related active install entry docs so the follow-up guidance explicitly includes `VCO_RUCNLPIR_MODEL`.
+4. Remove Ark-specific built-in governance helper scripts from the active shipped path.
+5. Update active verification helpers so they no longer test Ark-specific built-in governance branches.
+6. Sync all changed active assets into both bundled mirrors.
+7. Run verification for diff hygiene, runtime behavior, residual legacy active-path matches, and mirror parity.
+
+## Verification
+
+- `git diff --check`
+- `python3 ./scripts/verify/runtime_neutral/bootstrap_doctor.py --target-root "$(mktemp -d)"`
+- `python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --target-root "$(mktemp -d)" --prefix-detected`
+- `rg -n "ARK_API_KEY|ARK_BASE_URL|VOLC_ARK_BASE_URL|02-volc-ark|persist-codex-ark-env|Invoke-VolcArkEmbeddingsCreate" config docs/install docs/one-shot-setup.md scripts/bootstrap scripts/verify scripts/router adapters/codex`
+- `cmp -s` between changed source assets and both bundled mirrors
+
+## Rollback Rule
+
+If any consolidation step makes readiness reporting less accurate or breaks the active OpenAI-compatible path, repair that regression before completion.
+
+## Cleanup Expectation
+
+Leave only the consolidated active source changes, synchronized bundled mirrors, verification evidence, and cleanup receipts.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-historical-wording-cleanup-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-historical-wording-cleanup-plan.md
@@ -1,0 +1,31 @@
+# Plan: Clean Residual Historical Multi-Key Wording From Vibe Governance Docs
+
+## Internal Grade
+
+`M`
+
+## Intent
+
+Perform a focused cleanup pass over remaining `vibe` history and current governance artifacts so the repo no longer carries avoidable exact strings for the retired secondary model-key lanes.
+
+## Execution Steps
+
+1. Freeze the requirement and plan for the historical wording cleanup.
+2. Update residual `vibe` change logs and older planning docs to use generic legacy wording instead of the retired key names.
+3. Update current governance requirement and plan artifacts created in this run to use generic wording for removed lanes where exact names are no longer necessary.
+4. Sync any changed shipped history docs into both bundled `vibe` mirrors.
+5. Run repo-wide search to confirm the retired secondary model-key strings no longer appear in `vibe` docs or current governance artifacts.
+6. Record any remaining out-of-scope matches outside `vibe`.
+
+## Verification
+
+- `git diff --check`
+- `rg -n "<retired-secondary-model-key-pattern>" docs docs/requirements docs/plans bundled/skills/vibe`
+
+## Rollback Rule
+
+If a document becomes misleading after removing the exact legacy names, restore clarity first and only then complete the cleanup.
+
+## Cleanup Expectation
+
+Leave only the updated governance artifacts, synchronized bundled mirrors, and an explicit note for any out-of-scope non-`vibe` residue.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-install-clarity-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-install-clarity-plan.md
@@ -1,0 +1,34 @@
+# Plan: Clarify AI Governance Install-Time API Configuration
+
+## Internal Grade
+
+`L`
+
+## Intent
+
+Unify the install-time wording, runtime hints, and quick-check guidance so the latest repo tells users one concrete story about how to bring the AI governance advice path online.
+
+## Execution Steps
+
+1. Freeze the requirement and plan for issue `#57`.
+2. Rewrite `docs/install/configuration-guide.*` around the actual probe/runtime key resolution path.
+3. Tighten the single install entry and install prompts so they tell users exactly which local keys to set after install.
+4. Update install rules and supporting install docs that still present `VCO_AI_PROVIDER_*` as the primary local guidance.
+5. Patch runtime-facing bootstrap/probe messages so install-time output matches the docs.
+6. Sync updated install docs into both bundled install-doc mirrors.
+7. Run diff/parity/keyword verification and confirm no stale primary guidance remains on the public install path.
+
+## Verification
+
+- `git diff --check -- docs/requirements/2026-03-27-ai-governance-install-clarity.md docs/plans/2026-03-27-ai-governance-install-clarity-plan.md docs/requirements/README.md docs/plans/README.md docs/install scripts/bootstrap scripts/verify/runtime_neutral/router_ai_connectivity_probe.py bundled/skills/vibe/docs/install bundled/skills/vibe/bundled/skills/vibe/docs/install`
+- `cmp -s` between each updated source install doc and both bundled mirrors
+- `rg -n "VCO_AI_PROVIDER_URL|VCO_AI_PROVIDER_API_KEY" docs/install/one-click-install-release-copy.md docs/install/one-click-install-release-copy.en.md docs/install/configuration-guide.md docs/install/configuration-guide.en.md docs/install/prompts/full-version-install.md docs/install/prompts/full-version-install.en.md docs/install/prompts/framework-only-install.md docs/install/prompts/framework-only-install.en.md docs/install/installation-rules.md docs/install/installation-rules.en.md`
+- `python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --help`
+
+## Rollback Rule
+
+If the changes weaken truthfulness around install vs online readiness, or if source and bundled docs diverge, fix that before completion.
+
+## Cleanup Expectation
+
+Leave only the new requirement/plan docs, the clarified install/runtime guidance, mirrored bundled docs, and verification evidence.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-openai-compatible-only-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-openai-compatible-only-plan.md
@@ -1,0 +1,37 @@
+# Plan: Restrict the Built-In AI Governance Layer to OpenAI-Compatible Integration
+
+## Internal Grade
+
+`L`
+
+## Intent
+
+Close the remaining Ark-specific branches on the active built-in governance path so shipped runtime, install UX, and verification all tell one OpenAI-compatible story.
+
+## Execution Steps
+
+1. Freeze the requirement and plan for the OpenAI-compatible-only restriction.
+2. Update active governance defaults and provider authority:
+   - `config/llm-acceleration-policy.json`
+   - `config/router-provider-registry.json`
+   - active runtime/overlay scripts
+3. Update active bootstrap/setup and doctor surfaces so they no longer seed or recommend Ark-specific settings.
+4. Update public install/setup docs and prompts to remove Ark-compatible guidance from the built-in path.
+5. Update active fixtures/templates that still advertise Ark as a built-in lane.
+6. Sync the changed source assets into both bundled mirrors.
+7. Run verification for diff hygiene, mirror parity, and probe behavior.
+
+## Verification
+
+- `git diff --check`
+- `python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --target-root "$(mktemp -d)" --prefix-detected`
+- `cmp -s` between changed source assets and both bundled mirrors
+- `rg -n "ARK_API_KEY|ARK_BASE_URL|VOLC_ARK_BASE_URL|ark-compatible|volc_ark" docs/install docs/one-shot-setup.md config scripts/bootstrap scripts/verify/runtime_neutral scripts/router/modules/48-llm-acceleration-overlay.ps1 config/router-provider-registry.json config/llm-acceleration-policy.json config/settings.template.codex.json adapters/codex/settings-map.json`
+
+## Rollback Rule
+
+If the active built-in path still advertises a second provider family after the change, keep tightening before completion.
+
+## Cleanup Expectation
+
+Leave only the requirement/plan docs, the OpenAI-compatible-only source changes, the synced bundled mirrors, and the verification evidence.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-single-model-key-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-single-model-key-plan.md
@@ -1,0 +1,62 @@
+# Plan: Converge the Built-In AI Governance Layer to One Model Key
+
+## Internal Grade
+
+`L`
+
+## Intent
+
+Finish the install-clarity tightening by removing the remaining multi-key model guidance from the active built-in governance path and standardizing on `VCO_RUCNLPIR_MODEL`.
+
+## Wave Structure
+
+### Wave 1: Freeze
+
+1. Freeze the requirement and plan for the single-model-key convergence.
+2. Record the active surfaces that still mention retired secondary model-key wording.
+
+### Wave 2: Runtime and Setup
+
+1. Update the runtime-neutral AI connectivity probe to read and recommend `VCO_RUCNLPIR_MODEL` only.
+2. Update bootstrap/setup guidance so the built-in governance path recommends one model key only.
+3. Update active settings templates so the built-in governance model slot uses the same key.
+
+### Wave 3: Public Docs
+
+1. Update active Chinese and English install docs to document only `VCO_RUCNLPIR_MODEL`.
+2. Update install/update prompt templates to use the same one-key wording.
+3. Remove active wording that still presents a retired fallback model key on the public path.
+
+### Wave 4: Mirrors and Proof
+
+1. Sync the changed active source assets into both bundled mirrors.
+2. Run verification for diff hygiene, runtime behavior, text references, and mirror parity.
+3. Emit cleanup receipts and leave the worktree free of temporary artifacts.
+
+## Ownership Boundaries
+
+- Runtime and verification behavior: `scripts/verify/runtime_neutral/router_ai_connectivity_probe.py`
+- Bootstrap/setup guidance: `scripts/bootstrap/one-shot-setup.sh`, `scripts/bootstrap/one-shot-setup.ps1`
+- Active shipped templates: `config/settings.template.claude.json`, related source assets
+- Public install docs and prompts: `docs/install/**`
+- Bundled shipped mirrors: `bundled/skills/vibe/**` and `bundled/skills/vibe/bundled/skills/vibe/**`
+
+## Verification
+
+- `git diff --check`
+- `python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --target-root "$(mktemp -d)" --prefix-detected`
+- `rg -n "<retired-secondary-model-key-pattern>" docs/install docs/one-shot-setup.md scripts/bootstrap scripts/verify/runtime_neutral scripts/verify/vibe-bootstrap-doctor-gate.ps1 config adapters/codex`
+- `cmp -s` between changed source assets and both bundled mirrors
+
+## Rollback Rule
+
+If the active shipped path still exposes a second model-key lane after the change, keep tightening before claiming completion.
+
+## Cleanup Expectation
+
+Leave only:
+
+- the frozen requirement and plan docs
+- the active source changes for the one-key contract
+- synchronized bundled mirrors
+- verification evidence and cleanup receipts

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-28-l-xl-native-execution-closure-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-28-l-xl-native-execution-closure-plan.md
@@ -1,0 +1,234 @@
+# L / XL Native Execution Closure Plan
+
+## Execution Summary
+Align runtime truth with public and protocol truth. The current repository already has governance packets, hierarchy semantics, specialist recommendation contracts, and proof accounting. What is still missing is the actual orchestrator. This plan lands that orchestrator in the smallest coherent way: first `L` native serial execution, then `XL` selective-parallel execution, then executable native specialist dispatch, all under the existing single-root `vibe` authority model.
+
+## Frozen Inputs
+- Requirement doc: /home/lqf/table/table5/workspace/release-v2.3.50-main/docs/requirements/2026-03-28-l-xl-native-execution-closure.md
+- Current mismatch:
+  - protocol and README promise stronger `L` / `XL` execution semantics than runtime currently performs
+  - scheduler policy is still sequential with `max_parallel_units=1`
+  - plan execution currently runs proof units directly rather than child-lane orchestration
+  - specialist dispatch is mostly surfaced as plan-shadow accounting
+- Authority invariants that must remain unchanged:
+  - canonical router owns route selection
+  - `vibe` owns runtime authority
+  - root owns canonical requirement and plan truth
+  - child lanes stay subordinate
+
+## Internal Grade Decision
+- Grade: XL
+- The work changes runtime topology, policy, hierarchy execution, specialist execution, proofs, and verification.
+- Parallel implementation is justified by disjoint write scopes, but the resulting runtime must use selective bounded parallelism, not blanket concurrency.
+
+## Design Overview
+
+### Design Principle 1: Separate Governance From Scheduling
+- Governance already exists and should stay stable.
+- What needs to be added is a scheduler/orchestrator layer under stage 5 `plan_execute`.
+- The router still decides the route.
+- `vibe` still freezes requirement and plan truth.
+- The new execution layer only decides how frozen units are executed.
+
+### Design Principle 2: One Execution Topology Policy, Three Runtime Grades
+- `M`: single-lane execution
+- `L`: serial child-lane execution with review checkpoints
+- `XL`: wave-sequential, step-selective parallel child-lane execution
+- Remove the current implicit assumption that all governed execution can use one sequential benchmark profile.
+
+### Design Principle 3: Step-Scoped Parallelism Only
+- A wave may contain multiple steps.
+- Steps run sequentially by dependency.
+- A step may contain multiple units.
+- Only units marked `parallelizable=true` and with disjoint write scopes may execute concurrently.
+- This directly answers the current gap: parallelism should happen when useful inside the `vibe` serial workflow, not as an always-on mode.
+
+### Design Principle 4: Specialist Skills Become Executable Bounded Units
+- `approved_dispatch` should be convertible into real execution units.
+- `local_specialist_suggestions` remain advisory until root approval.
+- A specialist unit carries:
+  - native skill id
+  - bounded goal
+  - required inputs
+  - expected outputs
+  - verification expectation
+  - write-scope boundary
+- Specialist execution results must feed back into the root execution manifest and verification bundle.
+
+## Target Runtime Architecture
+
+### A. Execution Topology Policy
+Replace the current repo-safe benchmark-only scheduler interpretation with a topology policy that supports:
+
+- `wave_execution`: sequential
+- `step_execution`: sequential
+- `unit_execution`: sequential or bounded_parallel
+- `max_parallel_units`: configurable and greater than 1 only for `XL`
+- `delegation_mode`: `none`, `serial_child_lanes`, `selective_parallel_child_lanes`
+- `specialist_execution_mode`: `metadata_only`, `native_bounded_units`
+
+### B. Plan Artifact Evolution
+Extend the frozen plan to express executable topology:
+
+- wave
+- step
+- unit
+- owner
+- write_scope
+- parallelizable
+- requires_root_approval
+- specialist_skill_id when applicable
+- review_stage
+
+This should remain one canonical plan surface, not a second planner.
+
+### C. L Native Serial Orchestrator
+`L` should execute as:
+
+1. root freezes requirement and plan
+2. root emits ordered child units
+3. each child unit runs as a real child-governed lane
+4. lead performs stage review after each child unit or small batch
+5. final two-stage review is recorded before completion
+
+This makes `L` truly “serial native execution”, not just a line in docs.
+
+### D. XL Selective-Parallel Orchestrator
+`XL` should execute as:
+
+1. root freezes requirement and plan
+2. root walks waves sequentially
+3. inside each wave, root walks steps sequentially
+4. for a step marked parallelizable, root dispatches independent child lanes concurrently
+5. root waits, aggregates evidence, resolves escalations, then advances to the next step
+
+This makes parallelism local, bounded, and intelligible.
+
+### E. Root/Child Specialist Coordination
+- Root-approved specialists may execute directly inside child lanes if already frozen in the plan.
+- Child lanes may suggest additional specialists.
+- New specialists discovered by child lanes produce escalation artifacts, not silent activation.
+- Root may accept and append them to the active dispatch surface only through explicit governed update logic.
+
+## Wave Plan
+
+### Wave 1: Freeze Execution-Topology Contract
+- Create a dedicated execution-topology policy schema and config surface.
+- Define the runtime distinction between wave, step, and unit.
+- Define `parallelizable`, `write_scope`, and `review_stage` fields.
+- Preserve current single-root authority semantics.
+
+### Wave 2: Refactor Plan Generation For Executable Topology
+- Update `Write-XlPlan.ps1` so the plan can express executable step/unit structure instead of only narrative bullets.
+- Keep the current human-readable plan, but add machine-readable companion data for stage 5.
+- Ensure specialist dispatch is represented as executable bounded units when approved.
+
+### Wave 3: Land L Native Serial Execution
+- Introduce an `L` execution path in `Invoke-PlanExecute.ps1`.
+- Convert the documented `subagent execution → two-stage review` sequence into actual runtime behavior.
+- Child units should be real delegated runs with inherited frozen context and subordinate receipts.
+- Add explicit review receipts so `L` is not just “serial execution”, but “serial governed execution”.
+
+### Wave 4: Land XL Selective-Parallel Execution
+- Introduce a scheduler that can execute a step in bounded parallel only when:
+  - units are marked parallelizable
+  - write scopes do not overlap
+  - global specialist approval constraints are satisfied
+- Keep wave order sequential.
+- Keep root aggregation and checkpoint review mandatory between steps.
+
+### Wave 5: Convert Specialist Dispatch From Metadata To Execution
+- Add an executable specialist-unit adapter shape.
+- For approved dispatch:
+  - spawn bounded child unit
+  - preserve native specialist contract
+  - collect specialist-specific outputs and verification notes
+- For local suggestions:
+  - emit escalation artifact
+  - do not execute until root approval
+
+### Wave 6: Proof And Verification Upgrade
+- Extend tests to prove actual delegated execution behavior:
+  - `L` child units execute in order
+  - `XL` parallel step executes more than one unit when allowed
+  - non-parallel steps remain sequential
+  - overlapping write scopes block parallel execution
+  - specialist units execute only when approved
+- Upgrade manifests and proof bundles to distinguish:
+  - metadata-only dispatch
+  - executed specialist dispatch
+  - serial child-lane execution
+  - bounded parallel child-lane execution
+
+### Wave 7: Cleanup And Documentation Closure
+- Update `SKILL.md`, `protocols/runtime.md`, `protocols/do.md`, `protocols/team.md`, and README wording so public truth matches runtime truth.
+- Remove any wording that overstates behavior before the new orchestrator ships.
+- Re-run node audit and clear temp artifacts produced by the implementation wave.
+
+## Ownership Boundaries
+- Execution policy and topology config:
+  - `config/benchmark-execution-policy.json`
+  - new or adjacent topology policy files
+- Runtime packet and dispatch metadata:
+  - `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+  - `config/runtime-input-packet-policy.json`
+- Plan generation:
+  - `scripts/runtime/Write-XlPlan.ps1`
+- Execution engine:
+  - `scripts/runtime/Invoke-PlanExecute.ps1`
+  - `scripts/runtime/invoke-vibe-runtime.ps1`
+- Hierarchy and docs:
+  - `SKILL.md`
+  - `protocols/runtime.md`
+  - `protocols/do.md`
+  - `protocols/team.md`
+  - `README.md`
+  - `README.zh.md`
+- Verification:
+  - `tests/runtime_neutral/*`
+  - governed `scripts/verify/*` gates
+
+## Verification Commands
+- `git diff --check`
+- `python3 -m pytest tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py -v`
+- `python3 -m pytest tests/runtime_neutral -k "specialist or hierarchy or runtime or plan_execute" -v`
+- `rg -n "spawn_agent|send_input|wait_agent|close_agent|parallelizable|write_scope|review_stage" scripts/runtime protocols docs README*`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-governed-runtime-contract-gate.ps1`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-child-specialist-escalation-gate.ps1`
+
+## Rollback Plan
+- If real delegated execution threatens root-owned authority, revert to the last state where hierarchy metadata is correct and execution remains explicit.
+- If selective parallelism causes scope overlap or artifact races, keep the topology contract but temporarily force affected steps back to serial mode.
+- If native specialist execution proves unstable, degrade explicitly to metadata-only specialist dispatch rather than silently pretending execution occurred.
+- Never revert unrelated user changes.
+
+## Stability Proof Strategy
+- Authority:
+  - only root may freeze canonical requirement and plan truth
+  - only root may issue final completion claims
+- Scheduling:
+  - `L` remains ordered
+  - `XL` runs only approved bounded parallel steps
+  - overlapping scopes are blocked from concurrent execution
+- Specialist safety:
+  - approved specialists may execute
+  - unapproved specialists remain escalation-only
+- Observability:
+  - manifests prove what actually executed, not only what was recommended
+
+## Usability Proof Strategy
+- Operators can explain the runtime in one sentence:
+  - `L` is serial governed execution; `XL` is wave-sequential with step-level bounded parallelism.
+- Plans show where concurrency happens and where it does not.
+- Specialists remain understandable as bounded helpers, not hidden runtime replacements.
+
+## Intelligence Proof Strategy
+- The system should choose concurrency only where the dependency graph allows it.
+- The system should preserve specialist expertise without losing `vibe` sovereignty.
+- Complex composite tasks can be decomposed into sequential macro-steps with local parallel micro-steps.
+
+## Phase Cleanup Contract
+- Remove scratch artifacts, temporary logs, and simulation outputs created during the implementation wave.
+- Audit managed node processes and clear stale residue after each implementation batch.
+- Preserve only intended source, docs, tests, and proof artifacts.
+- Emit cleanup receipts before any completion claim.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-28-root-child-vibe-hierarchy-governance-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-28-root-child-vibe-hierarchy-governance-plan.md
@@ -1,0 +1,184 @@
+# Root/Child Vibe Hierarchy Governance Plan
+
+## Execution Summary
+Land a hierarchy model for XL governed execution so one user task has one root `vibe` runtime, child agents inherit `vibe` as subordinate execution lanes, and specialist skills remain bounded assistants rather than recursive governance owners. The design must preserve current explicit `vibe` authority, prevent duplicate canonical surfaces, and produce proof that the new hierarchy is stable, usable, and intelligent under realistic task delegation flows.
+
+## Frozen Inputs
+- Requirement doc: /home/lqf/table/table5/workspace/issue-57-ai-governance/docs/requirements/2026-03-28-root-child-vibe-hierarchy-governance.md
+- Problem statement: recursive child-agent `vibe` use currently risks layered governance, repeated specialist dispatch, and ambiguous completion authority
+- Existing authority invariants:
+  - canonical router keeps route authority
+  - explicit `vibe` remains runtime owner
+  - no second requirement truth
+  - no second execution-plan truth
+
+## Internal Grade Decision
+- Grade: XL
+- The change spans runtime packet policy, execution topology, manifests, protocol docs, and proof gates.
+- Parallel implementation is justified, but final authority semantics must be integrated and verified as one coherent contract.
+
+## Design Overview
+
+### Target Model
+- `root_governed`: the only runtime allowed to freeze canonical requirement and plan surfaces and make final completion claims
+- `child_governed`: a subordinate `vibe` lane that inherits frozen context, keeps verification/cleanup discipline, and emits local receipts only
+- `specialist_native`: a bounded helper execution style that can be root-approved for direct use or child-suggested for escalation
+
+### Runtime Packet Additions
+- `governance_scope`: `root` or `child`
+- `root_run_id`
+- `parent_run_id`
+- `parent_unit_id`
+- `inherited_requirement_doc_path`
+- `inherited_execution_plan_path`
+- `allow_requirement_freeze`
+- `allow_plan_freeze`
+- `allow_global_dispatch`
+- `allow_completion_claim`
+- `approved_specialist_dispatch`
+- `local_specialist_suggestions`
+- `escalation_required`
+
+### Authority Split
+- Root owns:
+  - requirement freeze
+  - plan freeze
+  - global specialist approval
+  - overall completion claim
+  - root execution manifest
+- Child owns:
+  - bounded execution inside assigned scope
+  - local receipts and proof
+  - escalation requests when approved specialist coverage is insufficient
+- Specialists own:
+  - native workflow execution only
+  - skill-specific validation notes and outputs
+  - no runtime ownership and no top-level completion claims
+
+## Wave Plan
+
+### Wave 1: Contract Freeze
+- Update requirement, plan, and stable governance docs to define the hierarchy model.
+- Freeze naming for root versus child governance scope and approved dispatch versus local suggestion surfaces.
+- Confirm which existing runtime packet fields can be extended without breaking current proofs.
+
+### Wave 2: Runtime Packet and Policy
+- Extend `config/runtime-input-packet-policy.json` with hierarchy fields and scope-specific authority flags.
+- Update `scripts/runtime/Freeze-RuntimeInputPacket.ps1` to emit root or child packets.
+- Ensure explicit `vibe` authority remains the runtime-selected skill for both scopes.
+
+### Wave 3: Execution Topology and Artifact Boundaries
+- Update `scripts/runtime/Invoke-PlanExecute.ps1` to spawn child lanes as subordinate runs instead of fresh top-level governed runs.
+- Ensure child lanes inherit frozen requirement/plan paths and cannot write canonical docs.
+- Add child receipt and escalation artifact surfaces under root-owned runtime outputs.
+
+### Wave 4: Specialist Dispatch Semantics
+- Split specialist data into:
+  - root-approved dispatch
+  - child-local suggestion
+- Prevent child lanes from activating new global specialists without escalation approval.
+- Preserve native specialist workflow, inputs, outputs, and verification expectations.
+
+### Wave 5: Protocol and Operator Documentation
+- Update `SKILL.md`, `protocols/runtime.md`, and `protocols/team.md` with root/child hierarchy semantics.
+- Add a stable governance explainer for operator use and future implementation alignment.
+- Clarify the user-facing mental model: child `$vibe` keeps discipline, not recursive top-level governance.
+
+### Wave 6: Verification, Simulation, and Proof
+- Add runtime-neutral tests for root/child packet semantics and child escalation behavior.
+- Add governed gates for:
+  - no duplicate canonical requirement surface
+  - no duplicate canonical execution-plan surface
+  - child cannot issue final completion claim
+  - specialist suggestions remain advisory until root approval
+- Run realistic delegation simulations:
+  - root `vibe` planning task with child ML lane
+  - root `vibe` debug task with child systematic-debugging lane
+  - child requesting an extra specialist not pre-approved by root
+
+### Wave 7: Rollout and Cleanup
+- Re-run targeted gates after integration.
+- Remove temporary artifacts and stale test scratch space.
+- Audit for zombie node residue.
+- Leave only intended source/docs/test changes and generated proof artifacts.
+
+## Ownership Boundaries
+- Runtime packet contract: `config/runtime-input-packet-policy.json`, `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+- Execution topology and child-lane handoff: `scripts/runtime/Invoke-PlanExecute.ps1`
+- Requirement/plan write restrictions: `scripts/runtime/Write-RequirementDoc.ps1`, `scripts/runtime/Write-XlPlan.ps1`
+- Runtime authority docs: `SKILL.md`, `protocols/runtime.md`, `protocols/team.md`
+- Stable explanatory doc: `docs/root-child-vibe-hierarchy-governance.md`
+- Verification: `tests/runtime_neutral/*`, `scripts/verify/*`
+
+## Implementation Steps
+1. Freeze the new requirement and plan.
+2. Add the stable governance explainer doc and wire it into docs navigation.
+3. Extend runtime packet policy and packet emission for root/child scope.
+4. Restrict canonical requirement/plan writes to root scope only.
+5. Add approved specialist dispatch versus local suggestion semantics.
+6. Update plan-execute so child lanes inherit context and emit subordinate receipts.
+7. Update protocol docs and public-facing authority wording.
+8. Add tests and governed gates for hierarchy invariants.
+9. Run simulation scenarios and targeted verification commands.
+10. Clean temp artifacts, audit node processes, and emit closure receipts.
+
+## Verification Commands
+- `git diff --check`
+- `python3 -m pytest tests/runtime_neutral/test_router_bridge.py tests/runtime_neutral/test_governed_runtime_bridge.py`
+- `python3 -m pytest tests/runtime_neutral -k "hierarchy or child or specialist or completion"`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-governed-runtime-contract-gate.ps1`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-benchmark-autonomous-proof-gate.ps1`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-no-silent-fallback-contract-gate.ps1`
+- new targeted gates:
+  - `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-root-child-hierarchy-gate.ps1`
+  - `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-no-duplicate-canonical-surface-gate.ps1`
+  - `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-child-specialist-escalation-gate.ps1`
+- targeted repo checks:
+  - `rg -n "governance_scope|allow_requirement_freeze|allow_plan_freeze|allow_global_dispatch|allow_completion_claim|approved_specialist_dispatch|local_specialist_suggestions" config scripts/runtime protocols tests`
+
+## Stability Proof Strategy
+- Determinism:
+  - same root input yields the same root authority fields and child-lane restrictions
+- Non-duplication:
+  - one root run cannot create more than one canonical requirement or plan
+- Boundedness:
+  - child lanes cannot widen into top-level governance
+- Recovery:
+  - escalation paths remain explicit and do not silently self-approve
+- Regression safety:
+  - existing explicit `vibe` specialist-accounting proofs continue to pass after hierarchy support lands
+
+## Usability Proof Strategy
+- Operators can explain the model in one sentence:
+  - root `vibe` governs, child `vibe` executes, specialists assist
+- Execution artifacts make authority obvious without reading chat history.
+- Child-lane receipts show inherited context and limits clearly enough for debugging and audit.
+- Failure paths produce actionable escalation surfaces instead of ambiguous re-planning.
+
+## Intelligence Proof Strategy
+- Root routing can still identify the best high-level specialist pattern without surrendering runtime authority.
+- Child lanes can still use domain-specific specialist help inside approved boundaries.
+- Ambiguous child requests produce escalation instead of unsafe self-expansion.
+- Low-signal prompts still honor fallback hazard and non-authoritative truth semantics.
+
+## Risks and Mitigations
+- Risk: child lanes accidentally reopen requirement or plan surfaces
+  - Mitigation: hard authority flags plus gates that fail on duplicate canonical surfaces
+- Risk: specialist approval and child suggestion semantics drift apart
+  - Mitigation: explicit separate fields and dedicated escalation artifacts
+- Risk: hierarchy metadata becomes verbose but unenforced
+  - Mitigation: add execution-path gates that inspect real artifacts, not docs only
+- Risk: parent/child packet inheritance breaks current explicit `vibe` proofs
+  - Mitigation: keep additive contract design and run existing governed gates before claiming completion
+
+## Rollback Rules
+- If root authority becomes ambiguous, stop and restore the last state where explicit `vibe` remained the sole runtime owner.
+- If child lanes can write canonical requirement or plan surfaces, block completion until that regression is repaired.
+- If specialist escalation cannot be kept explicit, fall back to root-approved specialist dispatch only.
+- Do not revert unrelated user changes or existing untracked docs.
+
+## Phase Cleanup Contract
+- Remove scratch artifacts created for hierarchy simulation or gate fixtures.
+- Audit and clear stale managed node processes if any appear.
+- Keep only intended source/docs/test changes and proof artifacts.
+- Emit cleanup receipts for the verification wave before claiming closure.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-28-stage-bound-specialist-dispatch-governance-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-28-stage-bound-specialist-dispatch-governance-plan.md
@@ -1,0 +1,50 @@
+# Stage-Bound Specialist Dispatch Governance
+
+## Execution Summary
+Implement the smallest coherent extension that turns specialist skills into governed, phase-bound execution contracts under `vibe`. Reuse the current canonical router and root/child hierarchy, add deterministic specialist binding metadata, place specialist units into `L` serial steps and `XL` bounded specialist lanes, and prove the result with artifact-backed tests.
+
+## Frozen Inputs
+- Requirement doc: /home/lqf/table/table5/runtime-sandboxes/verify-main-77694e8/docs/requirements/2026-03-28-stage-bound-specialist-dispatch-governance.md
+- Source task: improve specialist-skill use inside `vibe` without conflict or authority drift
+- Runtime owner invariant: explicit governed entry remains `vibe`
+
+## Internal Grade Decision
+- Grade: XL
+- The task spans config, runtime topology, docs, and test surfaces with disjoint write scopes and benefits from staged parallel investigation.
+
+## Wave Plan
+- Wave 1: freeze specialist binding policy, requirement truth, plan truth, and stable governance wording
+- Wave 2: implement runtime packet and specialist topology changes for stage-bound dispatch
+- Wave 3: upgrade manifests and delegated-lane receipts so specialist phase binding is observable
+- Wave 4: add runtime-neutral tests for `L` serial specialist steps, `XL` bounded specialist lanes, and hierarchy safety
+- Wave 5: run targeted verification, collect proof artifacts, and close with cleanup
+
+## Ownership Boundaries
+- Specialist binding policy and runtime freeze: `config/runtime-input-packet-policy.json`, `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+- Requirement and plan surfacing: `scripts/runtime/Write-RequirementDoc.ps1`, `scripts/runtime/Write-XlPlan.ps1`
+- Specialist topology and delegated execution: `scripts/runtime/VibeExecution.Common.ps1`, `scripts/runtime/Invoke-DelegatedLaneUnit.ps1`, `scripts/runtime/Invoke-PlanExecute.ps1`
+- Stable governance docs: `protocols/runtime.md`, `protocols/team.md`, `docs/root-child-vibe-hierarchy-governance.md`, `docs/specialist-dispatch-governance.md`
+- Verification: `tests/runtime_neutral/test_l_xl_native_execution_topology.py`, `tests/runtime_neutral/test_root_child_hierarchy_bridge.py`
+
+## Specialist Skill Dispatch Plan
+- Freeze each specialist recommendation as a bounded execution contract with `binding_profile`, `dispatch_phase`, `lane_policy`, `parallelizable_in_root_xl`, `write_scope`, and `review_mode`.
+- Treat `pre_execution` specialists as planning or setup support, `in_execution` specialists as bounded implementation support, `post_execution` specialists as deliverable support, and `verification` specialists as review-only support.
+- In `L`, execute specialist units as explicit serial native steps.
+- In `XL`, allow only root-approved specialist units with disjoint write scopes to enter bounded parallel windows.
+- Keep child-local new specialists advisory-first; only same-round root absorb may upgrade them.
+
+## Verification Commands
+- `git diff --check`
+- `python3 -m pytest tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py -q`
+- `pwsh -NoProfile -File scripts/verify/vibe-root-child-hierarchy-gate.ps1`
+- `pwsh -NoProfile -File scripts/verify/vibe-child-specialist-escalation-gate.ps1`
+- targeted manual replay of composite tasks with fake codex adapter for bounded native specialist execution proof
+
+## Rollback Plan
+- Revert only the specialist-dispatch governance change set if hierarchy invariants or runtime-neutral tests fail.
+- If bounded parallel specialist lanes are unstable, preserve the binding metadata and serial fallback while disabling only the parallel specialist path.
+
+## Phase Cleanup Contract
+- Remove temporary test artifacts and `.pytest_cache` after verification.
+- Audit node processes and clear only managed stale residue if present.
+- Leave the branch with intended source/docs/tests changes only.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-28-vibe-governed-project-delivery-acceptance-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-28-vibe-governed-project-delivery-acceptance-plan.md
@@ -1,0 +1,321 @@
+# Vibe-Governed Project Delivery Acceptance Plan
+
+## Execution Summary
+Shift the repository from “runtime/governance self-proof” to “downstream project delivery proof”. The smallest coherent path is not a router rewrite. It is a new acceptance layer that sits on top of the existing governed runtime: freeze downstream acceptance criteria, execute real benchmark scenarios, verify the delivered project state, and report completion truth honestly.
+
+## Frozen Inputs
+- Requirement doc: [2026-03-28-vibe-governed-project-delivery-acceptance.md](../requirements/2026-03-28-vibe-governed-project-delivery-acceptance.md)
+- Current reality:
+  - runtime/governance tests are much stronger than downstream project acceptance tests
+  - project delivery can still be under-verified even when runtime artifacts and some tests pass
+  - completion wording is too easy to overstate relative to real delivered quality
+- Invariants that must stay unchanged:
+  - canonical router remains route authority
+  - `vibe` remains runtime authority
+  - root retains canonical requirement/plan truth
+  - no second runtime/control plane is introduced
+
+## Internal Grade Decision
+- Grade: XL
+- The work spans contracts, docs, verification architecture, benchmark projects, workflow runners, release semantics, and proof methodology.
+- The design must coordinate multiple repository areas but still preserve one governed runtime model.
+
+## Design Overview
+
+### Design Principle 1: Delivery Truth Must Be Layered
+Runtime correctness is not project correctness.
+The repository must report four separate truths:
+
+- governance truth
+- engineering verification truth
+- workflow completion truth
+- product acceptance truth
+
+No lower layer may silently stand in for a higher layer.
+
+### Design Principle 2: Acceptance Must Be Frozen Up Front
+If a downstream project is to be judged honestly, acceptance criteria must be frozen in the governed requirement and plan, not improvised at the end.
+
+Required new frozen fields:
+
+- user-facing goals
+- critical functional checklist
+- failure boundaries
+- required verification commands
+- required manual spot checks
+- completion-reporting rules
+
+### Design Principle 3: Real Scenarios Beat Repository Self-Reference
+The acceptance framework must test `vibe` governing real project work in benchmark repos and scenario fixtures, not only VibeSkills exercising its own contracts.
+
+### Design Principle 4: Completion Language Must Be Evidence-Scoped
+Statuses such as `completed_with_failures`, `degraded_non_authoritative`, and `manual_actions_pending` are report states, not success synonyms.
+
+### Design Principle 5: Stability, Usability, and Intelligence Need Different Proofs
+- Stability is about repeatability and low flake.
+- Usability is about operator clarity and real user-path success.
+- Intelligence is about making good governance/execution choices, not only producing artifacts.
+
+## Target Architecture
+
+### A. Delivery Truth Model
+Introduce one machine-readable delivery report contract with at least:
+
+- `governance_truth`
+- `engineering_verification_truth`
+- `workflow_completion_truth`
+- `product_acceptance_truth`
+- `completion_language_allowed`
+- `residual_risks`
+- `manual_spot_checks`
+
+This becomes the authoritative truth surface for downstream project completion reporting.
+
+### B. Downstream Acceptance Contract Extension
+Extend governed requirement and plan surfaces so downstream project work freezes:
+
+- critical user flows
+- edge-case expectations
+- domain-specific specialist validation expectations
+- mandatory regression checks
+- manual acceptance checklist when full automation is not credible
+
+### C. Scenario Corpus
+Add a dedicated scenario family such as:
+
+- `tests/scenarios/project_delivery/`
+- `tests/scenarios/project_delivery/l-grade/`
+- `tests/scenarios/project_delivery/xl-grade/`
+- `tests/scenarios/project_delivery/specialist/`
+- `tests/scenarios/project_delivery/failure_injection/`
+
+Each scenario should include:
+
+- prompt/task
+- explicit `$vibe` usage expectation
+- expected grade
+- expected specialist set or allowance
+- frozen acceptance criteria
+- automated verification commands
+- manual spot-check checklist
+- forbidden outcomes
+
+### D. Benchmark Repositories
+Add benchmark repos under a bounded directory such as:
+
+- `benchmarks/todo-webapp`
+- `benchmarks/python-lib`
+- `benchmarks/bioinformatics-mini`
+- `benchmarks/docs-project`
+
+Purpose:
+
+- prove `vibe` can govern real downstream work
+- validate functional completeness and regression behavior
+- exercise specialist-assisted composite tasks
+
+### E. Workflow Acceptance Runner
+Add a workflow-acceptance harness, preferably runtime-neutral where possible, that:
+
+1. loads a scenario
+2. loads a benchmark repo
+3. executes the governed run or replayable simulation
+4. collects runtime/session artifacts
+5. runs project-level validations
+6. writes one delivery acceptance report
+
+Expected output families:
+
+- scenario execution receipt
+- verification command log
+- acceptance checklist result
+- residual-risk summary
+- completion-language disposition
+
+### F. Completion Semantics Hardening
+Harden runtime/reporting so the following are never flattened into “done”:
+
+- partial execution success
+- degraded specialist execution
+- pending manual actions
+- missing user-flow acceptance evidence
+
+This requires explicit mapping from execution state to allowed completion language.
+
+### G. Release Truth Gate
+Add a release-facing gate that refuses full-success release wording unless:
+
+- governance truth is passing
+- engineering verification truth is passing
+- workflow completion truth is passing
+- product acceptance truth is passing
+
+## Wave Plan
+
+### Wave 1: Freeze Delivery Truth Contract
+- Define the four-layer truth model.
+- Define report vocabulary and forbidden completion mappings.
+- Write stable governance documentation for downstream project delivery acceptance.
+
+### Wave 2: Extend Requirement / Plan Acceptance Surfaces
+- Add downstream acceptance sections to governed requirement expectations.
+- Add delivery-specific DoD, regression, and manual-check sections to governed plans.
+- Define how specialist-assisted scenarios carry domain-specific acceptance rules.
+
+### Wave 3: Create Scenario Schema And Gold Corpus
+- Design a machine-readable scenario schema.
+- Create an initial gold corpus covering:
+  - narrow feature work
+  - bugfix/regression work
+  - L staged execution
+  - XL composite work
+  - specialist-heavy work
+  - failure/drift cases
+
+### Wave 4: Add Benchmark Repositories
+- Create or import bounded benchmark repos.
+- Attach scenario-to-benchmark mappings.
+- Ensure each benchmark has a small, credible acceptance surface.
+
+### Wave 5: Implement Workflow Acceptance Runner
+- Load scenario + repo fixtures.
+- Execute governed runs or replayable harnesses.
+- Run automated acceptance checks.
+- Emit one delivery-truth report per scenario.
+
+### Wave 6: Harden Completion Reporting
+- Connect execution/reporting surfaces to the new truth model.
+- Prevent runtime-only success from being reported as full project completion.
+- Surface residual risk and manual actions in a mandatory way.
+
+### Wave 7: Prove Stability / Usability / Intelligence
+- Stability:
+  - repeated-run matrix
+  - failure injection
+  - flake accounting
+- Usability:
+  - operator-readable report audit
+  - manual spot-check contract audit
+  - benchmark user-flow walkthroughs
+- Intelligence:
+  - grade-selection sanity checks
+  - specialist-selection appropriateness checks
+  - verification-depth adequacy checks
+  - drift/escalation behavior checks
+
+### Wave 8: Release Gate Integration And Rollout
+- Add release truth gate.
+- Add operator runbook.
+- Define minimum passing suite before public completion claims or release notes can overclaim.
+
+## Detailed Test Program
+
+### 1. Functional Acceptance Tests
+- Critical user story completion
+- required outputs exist and are usable
+- changed feature behaves as specified
+
+### 2. Boundary And Error Tests
+- malformed input
+- empty input
+- conflicting requirements
+- missing dependency / provider / file / environment
+
+### 3. Regression Tests
+- reproduce prior bug
+- confirm failure before fix when possible
+- confirm pass after fix
+- preserve unrelated core behavior
+
+### 4. Workflow Tests
+- requirement freeze matches final work
+- plan steps match actual execution
+- specialist dispatch stays bounded
+- child lanes do not reopen root truth
+
+### 5. Composite XL Tests
+- multiple specialist domains
+- step-level bounded parallelism
+- disjoint write scopes
+- escalation and same-round absorption behavior
+
+### 6. Human-Like Acceptance Tests
+- manual spot checks on benchmark repos
+- artifact readability
+- result usefulness
+- final completion report honesty
+
+## Proof Strategy
+
+### Stability Proof
+- repeated execution across multiple runs
+- failure injection for selected specialist/unit paths
+- flake-rate tracking
+- deterministic artifact comparison where credible
+
+Target proof:
+- no hidden “one-pass only” success
+- clear accounting for unstable cases
+
+### Usability Proof
+- acceptance reports must be operator-readable in one pass
+- each scenario must state:
+  - what works
+  - what failed
+  - what still needs manual confirmation
+  - whether completion wording is allowed
+
+Target proof:
+- an operator can tell the true project state without reading raw logs
+
+### Intelligence Proof
+- verify that `vibe` chose a plausible grade
+- verify that specialist usage was appropriate and bounded
+- verify that verification depth matched task risk
+- verify that drift or missing evidence downgraded completion wording
+
+Target proof:
+- the system is not only active; it is choosing wisely
+
+## Ownership Boundaries
+- Contracts and policy:
+  - `config/*delivery*`
+  - runtime/reporting policy surfaces
+- Requirement/plan docs:
+  - `docs/requirements/*`
+  - `docs/plans/*`
+- Stable governance docs:
+  - `docs/*delivery*governance.md`
+- Scenario corpus:
+  - `tests/scenarios/project_delivery/*`
+- Benchmark repos:
+  - `benchmarks/*`
+- Acceptance runner and gates:
+  - `scripts/verify/runtime_neutral/*`
+  - `scripts/verify/*delivery*gate.ps1`
+
+## Verification Commands
+- `git diff --check`
+- `python3 -m pytest tests/runtime_neutral -v`
+- `python3 -m pytest tests/scenarios/project_delivery -v`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-workflow-acceptance-gate.ps1`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-release-truth-gate.ps1`
+- targeted benchmark acceptance commands per scenario
+
+## Rollback Plan
+- If the new acceptance layer causes ambiguity, keep existing runtime proof surfaces and disable only the new release-enforcement mapping.
+- If benchmark repos become too heavy, retain the scenario schema and keep a smaller gold corpus.
+- If fully automated acceptance is not credible for a scenario, force explicit manual spot-check state rather than pretending automation coverage exists.
+- Never revert unrelated user changes.
+
+## Success Metrics
+- reduced false-completion rate
+- increased scenario coverage of real project work
+- explicit accounting of residual risks
+- lower gap between “reported complete” and “user can actually use it”
+
+## Phase Cleanup Contract
+- clean temporary scenario outputs after each implementation batch
+- audit and clear managed node/python residue created by acceptance harnesses
+- preserve only intended docs, fixtures, benchmark repos, and proof artifacts
+- emit cleanup receipts before claiming a wave is closed

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-28-vibe-governor-native-specialist-skills-execution-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-28-vibe-governor-native-specialist-skills-execution-plan.md
@@ -1,0 +1,56 @@
+# Vibe Governor + Native Specialist Skills
+
+## Execution Summary
+Implement the smallest coherent extension that lets explicit `vibe` runs freeze, plan, and execute native specialist assistance without surrendering runtime authority. Reuse existing router outputs, keep `runtime_selected_skill=vibe`, add a real host adapter bridge for specialist units, and make unsupported paths degrade explicitly instead of pretending receipt-only execution is native.
+
+## Frozen Inputs
+- Requirement doc: /home/lqf/table/table5/workspace/verify-main-pr60/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
+- Source task: `vibe` governor + native specialist skills
+- Runtime authority invariant: explicit `vibe` remains the only runtime owner
+
+## Internal Grade Decision
+- Grade: XL
+- User-facing runtime remains fixed; the grade is internal only.
+- Parallel work is warranted because code, tests, and governance docs can advance on disjoint write scopes.
+
+## Wave Plan
+- Wave 1: freeze executable specialist contract, host adapter policy, and degrade contract
+- Wave 2: implement runtime-native specialist execution bridge with `codex exec` as the first adapter lane
+- Wave 3: allow child lanes to execute only root-approved specialist dispatch while keeping local suggestions escalation-only
+- Wave 4: upgrade manifests, receipts, and docs so live execution and degraded execution are clearly distinct
+- Wave 5: add fake-adapter regression tests, targeted runtime verification, and cleanup closure
+
+## Ownership Boundaries
+- Runtime packet and artifact contract: `config/runtime-input-packet-policy.json`, `config/native-specialist-execution-policy.json`, `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+- Requirement/plan surfacing: `scripts/runtime/Write-RequirementDoc.ps1`, `scripts/runtime/Write-XlPlan.ps1`
+- Execution bridge and accounting: `scripts/runtime/VibeExecution.Common.ps1`, `scripts/runtime/Invoke-DelegatedLaneUnit.ps1`, `scripts/runtime/Invoke-PlanExecute.ps1`
+- Protocol/docs authority model: `SKILL.md`, `protocols/runtime.md`, `protocols/team.md`, supporting docs
+- Verification: runtime tests and targeted gates
+- Subagent prompts must end with `$vibe`.
+
+## Specialist Skill Dispatch Plan
+- Dispatch only bounded specialist units; keep `vibe` as the sole runtime owner.
+- Preserve native specialist usage by carrying native workflow expectations, required inputs, expected outputs, and verification mode into the dispatch contract.
+- Do not auto-promote specialist recommendations into runtime ownership changes.
+- Specialist-owned lanes use visible specialist invocation plus injected hidden governance context; they are not receipt-only aliases for `$vibe`.
+- The first live bridge is `codex exec`; unsupported hosts or disabled native execution degrade explicitly to `degraded_non_authoritative`.
+- Record all specialist units in execution evidence and recover their outputs into the `vibe` manifest.
+
+## Verification Commands
+- `git diff --check`
+- `python3 -m py_compile scripts/runtime/*.ps1` is not applicable; instead validate PowerShell syntax via targeted gates and JSON schema checks
+- `python3 -m pytest tests/runtime_neutral -k "runtime_input_packet or plan_execute or specialist or requirement or plan"`
+- targeted `rg` checks for authority invariants such as `explicit_runtime_skill`, `shadow_only`, `specialist_recommendations`
+- smoke `codex exec` in a temp directory before claiming the `codex` adapter lane works
+- repo cleanliness checks and node audit after each wave
+
+## Rollback Plan
+- Revert only the governor-specialist change set if authority invariants or regression tests fail.
+- Do not revert unrelated user changes or existing untracked docs.
+- If the live host adapter bridge proves unstable, keep the executable contract and degrade explicitly to `degraded_non_authoritative` instead of silently restoring receipt-only fake native execution.
+
+## Phase Cleanup Contract
+- Remove temporary logs or scratch files created during each wave.
+- Run node audit and clean stale managed node residue when present.
+- Leave the repository with only intended source, docs, tests, and proof artifacts.
+- Emit a cleanup receipt after verification closure.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/README.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/README.md
@@ -24,6 +24,12 @@ Those surfaces live under [`../status/README.md`](../status/README.md).
 
 ### Current Entry
 
+- [`2026-03-28-root-child-vibe-hierarchy-governance-plan.md`](./2026-03-28-root-child-vibe-hierarchy-governance-plan.md): root/child `vibe` 分层治理执行计划；聚焦把 child `$vibe` 收敛为 subordinate lane，并用批准式 specialist dispatch + escalation proof 防止递归总治理。
+- [`2026-03-27-ai-governance-consolidation-plan.md`](./2026-03-27-ai-governance-consolidation-plan.md): 内置 AI 治理层收敛整理执行计划；聚焦把 active runtime、doctor、helper scripts、one-shot 入口与 bundled 镜像统一到单一路径契约。
+- [`2026-03-27-ai-governance-historical-wording-cleanup-plan.md`](./2026-03-27-ai-governance-historical-wording-cleanup-plan.md): 内置 AI 治理层历史表述清理执行计划；聚焦清理 `vibe` 范围内已退役模型键名的历史残留表述。
+- [`2026-03-27-ai-governance-openai-compatible-only-plan.md`](./2026-03-27-ai-governance-openai-compatible-only-plan.md): 内置 AI 治理层 OpenAI-compatible-only 执行计划；聚焦收口权威 provider registry、vector diff 默认面、bootstrap/setup 和安装文档中的 Ark 分支。
+- [`2026-03-27-ai-governance-install-clarity-plan.md`](./2026-03-27-ai-governance-install-clarity-plan.md): issue #57 安装澄清执行计划；聚焦用真实探针读取逻辑收口 AI 治理 advice 的配置键名、快速检查说明与安装时提示。
+- [`2026-03-27-ai-governance-single-model-key-plan.md`](./2026-03-27-ai-governance-single-model-key-plan.md): 内置 AI 治理层单模型键收敛执行计划；聚焦统一到 `VCO_RUCNLPIR_MODEL` 并清理双键口径。
 - [`2026-03-20-readme-en-detail-and-github-branding-copy-plan.md`](./2026-03-20-readme-en-detail-and-github-branding-copy-plan.md): README 英文版细化与 GitHub 品牌文案执行计划；聚焦补齐英文首页细节，并整理 `About / Topics / social preview` 设置文案。
 - [`2026-03-20-readme-emoji-layout-polish-plan.md`](./2026-03-20-readme-emoji-layout-polish-plan.md): README 中文视觉润色执行计划；聚焦少量 emoji 点缀、区块节奏优化与 GitHub-safe 的版式打磨。
 - [`2026-03-20-readme-differentiated-science-ai-strengths-plan.md`](./2026-03-20-readme-differentiated-science-ai-strengths-plan.md): README 中文差异化强化执行计划；聚焦把生命科学、科研、AI 工程三块写得更有辨识度。

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/releases/README.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/releases/README.md
@@ -10,7 +10,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ### Current Release Surface
 
-- [`v2.3.50.md`](v2.3.50.md): router AI connectivity probe / host-adapter expansion / single-entry install surface / Windows PowerShell default verification guidance
+- [`v2.3.51.md`](v2.3.51.md): main-chain delivery acceptance / specialist dispatch governance closure / Windows specialist runtime handoff fix
 
 ### Release Runtime / Proof Handoff
 
@@ -22,6 +22,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ## Recent Governed Releases
 
+- [`v2.3.51.md`](v2.3.51.md) - 2026-03-28 - main-chain delivery acceptance / specialist dispatch governance closure / Windows specialist runtime handoff fix
 - [`v2.3.50.md`](v2.3.50.md) - 2026-03-26 - router AI connectivity probe / host-adapter expansion / single-entry install surface / Windows PowerShell default verification guidance
 - [`v2.3.49.md`](v2.3.49.md) - 2026-03-23 - shallow-worktree install/check hardening / installed-runtime adapter fallback / parent-path guard convergence
 - [`v2.3.48.md`](v2.3.48.md) - 2026-03-23 - benchmark mode compatibility downgrade / governed proof alignment / adaptive-routing gate robustness

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/releases/v2.3.51.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/releases/v2.3.51.md
@@ -1,0 +1,33 @@
+# VCO Release v2.3.51
+
+- Date: 2026-03-28
+- Commit(base): 18e6b9c
+- Previous release: `v2.3.50`
+
+## Highlights
+
+- Moved downstream delivery acceptance from an external verification layer into the normal `vibe` governed runtime main chain. Governed runs now freeze product acceptance criteria, manual spot checks, completion-language policy, and a delivery-truth contract directly in the main requirement surface.
+- Extended the governed plan and closure path so `xl_plan` records a delivery-acceptance plan and `phase_cleanup` emits a per-run `delivery-acceptance-report.json`. This makes completion-language downgrades part of the real runtime path instead of a post hoc review convention.
+- Completed the recent specialist-governance sequence on `main`: stage-bound specialist dispatch, child-lane same-round auto-absorb under root approval, and stronger native-specialist failure proofing. This improves how `vibe` uses specialist help without surrendering runtime authority.
+- Fixed the Windows specialist runtime handoff so native specialist execution remains viable on current Windows environments.
+
+## What Changed Compared With v2.3.50
+
+- `v2.3.50` was mainly about install truth, router AI connectivity proofing, and host-adapter/install-surface closure.
+- `v2.3.51` shifts the center of gravity into the governed execution path itself. The main difference is that the repo no longer only says “delivery truth matters”; the normal `vibe` runtime now writes and carries that truth in its own artifacts.
+- The older release improved readiness disclosure and verification entrypoints. The new release raises the honesty bar for declaring work complete after a governed run.
+
+## Validation Notes
+
+- Main-chain delivery-acceptance coverage:
+  - `pytest -q tests/runtime_neutral/test_runtime_delivery_acceptance.py tests/runtime_neutral/test_workflow_acceptance_runner.py tests/runtime_neutral/test_release_truth_gate.py`
+- Governed runtime / hierarchy / topology coverage:
+  - `pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py`
+- Release-surface hygiene:
+  - `git diff --check`
+
+## Migration Notes
+
+- Operators should expect stricter completion wording after normal governed runs. A clean runtime/process closure is no longer treated as equivalent to proven downstream project delivery.
+- Normal `vibe` session artifacts now include a `delivery-acceptance-report.json` and companion markdown summary under `outputs/runtime/vibe-sessions/<run-id>/`.
+- This release improves truthfulness and closure semantics. It does not claim that every host UI now enforces an absolutely unskippable final text gate; the authoritative change is that the governed runtime itself now records and carries the delivery-truth result.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-26-codex-vibe-dedupe.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-26-codex-vibe-dedupe.md
@@ -1,0 +1,19 @@
+# Requirement: Codex `vibe` Duplicate Surface Fix
+
+- Date: 2026-03-26
+- Issue: `#42`
+
+## Goal
+
+Prevent Codex from exposing two `vibe` skills when either of these duplicate surfaces exist:
+
+- a legacy sibling copy under `~/.agents/skills/vibe`
+- a discoverable nested runtime mirror under `skills/vibe/bundled/skills/vibe/SKILL.md`
+
+## Acceptance
+
+- Codex default-root install quarantines the legacy `.agents/skills/vibe` duplicate instead of leaving both surfaces discoverable.
+- Installed runtime payloads hide nested runtime-mirror `SKILL.md` entrypoints while preserving runtime configs and bootstrap behavior.
+- `check.sh` and `check.ps1` fail clearly when the duplicate surface still exists.
+- Non-default custom target roots are not mutated as part of this mitigation.
+- Automated tests cover shell/PowerShell install behavior, runtime bootstrap continuity, and duplicate-surface regression checks.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-consolidation.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-consolidation.md
@@ -1,0 +1,54 @@
+# Requirement: Consolidate Built-In AI Governance to a Stable Single-Path Contract
+
+## Goal
+
+Consolidate all active built-in AI governance changes so runtime behavior, verification surfaces, bootstrap guidance, and install docs all reflect one stable contract.
+
+## User Intent
+
+The built-in AI governance layer should be:
+
+- OpenAI-compatible only
+- single-model-key only
+- correctly verifiable
+- documented without conflicting or stale active-path wording
+
+## Required Outcome
+
+The active built-in governance path must:
+
+1. support only the OpenAI-compatible provider family on the active shipped path
+2. use `VCO_RUCNLPIR_MODEL` as the only active built-in governance model key
+3. make bootstrap doctor / readiness surfaces report both credential and model readiness for the built-in governance path
+4. stop treating Ark helper modules or Ark-specific install helpers as active built-in governance surfaces
+5. keep install entry docs aligned with the same credential + base URL + model-key contract
+6. keep bundled mirrors synchronized with the corrected active source assets
+
+## In Scope
+
+- active runtime-neutral verification scripts
+- active PowerShell doctor gate
+- active bootstrap/setup docs
+- active router verification helpers
+- active shipped helper scripts for built-in governance configuration
+- bundled mirrors of the changed active assets
+
+## Out of Scope
+
+- historical release notes
+- proof bundles
+- unrelated non-vibe skills
+
+## Constraints
+
+- do not break the current OpenAI-compatible runtime path
+- do not reintroduce a second provider lane
+- preserve honest readiness reporting
+
+## Acceptance Criteria
+
+1. Active doctor outputs expose both `OPENAI_API_KEY` and `VCO_RUCNLPIR_MODEL` readiness.
+2. Active built-in governance verification scripts no longer test or clear Ark-specific built-in provider paths.
+3. Ark-specific built-in governance helper scripts are no longer present on the active shipped path.
+4. Install docs and one-shot docs consistently tell users to configure `OPENAI_API_KEY`, optional base URL, and `VCO_RUCNLPIR_MODEL`.
+5. Source and bundled mirrors stay in sync after the consolidation.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-historical-wording-cleanup.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-historical-wording-cleanup.md
@@ -1,0 +1,47 @@
+# Requirement: Clean Residual Historical Multi-Key Wording From Vibe Governance Docs
+
+## Goal
+
+Remove the remaining exact legacy model-key names from `vibe` governance history and current governance artifacts, while preserving the factual meaning of those documents.
+
+## User Intent
+
+After the active built-in governance path has converged to one model key, the repo should not keep avoidable residual old key-name strings in `vibe` documentation and planning artifacts.
+
+## Required Outcome
+
+The cleanup pass must:
+
+1. rewrite residual `vibe` historical docs so they describe the older multi-key model wording generically instead of naming the retired secondary model keys verbatim
+2. rewrite current governance requirement and plan artifacts so they describe the removed lanes generically where exact legacy names are no longer needed
+3. keep the current single-key contract unchanged:
+   - `OPENAI_API_KEY`
+   - optional `OPENAI_BASE_URL` or `OPENAI_API_BASE`
+   - `VCO_RUCNLPIR_MODEL`
+4. keep unrelated non-`vibe` skills out of scope
+5. keep bundled mirrors synchronized for any shipped `vibe` docs that change
+
+## In Scope
+
+- `docs/changes/**` entries for `vibe`
+- `docs/plans/**` legacy `vibe` planning artifacts that still spell out retired model keys
+- current `docs/requirements/**` and `docs/plans/**` artifacts created during this governance tightening run
+- bundled mirrors of changed `vibe` history docs
+
+## Out of Scope
+
+- unrelated skills outside the `vibe` shipped path
+- external examples that intentionally document generic OpenAI usage in other skills
+- rewriting unrelated historical provider notes that do not contain the retired model-key names
+
+## Constraints
+
+- preserve document meaning
+- do not reintroduce a second active model-key lane
+- do not modify unrelated skill documentation just to satisfy a broad grep
+
+## Acceptance Criteria
+
+1. Repo-wide search for the retired secondary model-key strings returns no matches inside `vibe` source docs, bundled `vibe` docs, or current governance artifacts for this run.
+2. The single-key active contract remains unchanged.
+3. Any remaining matches outside `vibe` are explicitly identified as out of scope.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-install-clarity.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-install-clarity.md
@@ -1,0 +1,71 @@
+# Requirement: Clarify AI Governance Install-Time API Configuration
+
+## Goal
+
+Remove install-time ambiguity around the AI governance online path so users can tell:
+
+- what to configure locally
+- which key names are the recommended path
+- how to verify readiness after installation
+
+## User Intent
+
+After finishing install, users should not have to guess whether:
+
+- the local install is already complete
+- the governance AI advice path is online
+- `OPENAI_*`, `ARK_*`, or `VCO_AI_PROVIDER_*` is the right configuration surface
+
+## Required Outcome
+
+The public install and configuration docs must:
+
+1. distinguish `installed locally` from `governance AI online-ready`
+2. present the common OpenAI-compatible path as:
+   - `OPENAI_API_KEY`
+   - optional `OPENAI_BASE_URL` or `OPENAI_API_BASE`
+   - the project governance model key
+3. present the Ark-compatible path as:
+   - `ARK_API_KEY`
+   - optional `ARK_BASE_URL` or `VOLC_ARK_BASE_URL`
+   - `ARK_MODEL`
+4. treat the older fallback model-key wording as legacy wording instead of the primary install-time model key
+5. stop presenting `VCO_AI_PROVIDER_URL` and `VCO_AI_PROVIDER_API_KEY` as the default local install-time guidance for quick checks
+6. explain where the quick check actually reads values from:
+   - `<target-root>/settings.json` `env`
+   - or the current process environment
+7. provide one concrete quick-check command for Windows and one for Linux/macOS
+8. align install-time console messaging with the same wording
+
+## Scope
+
+In scope:
+
+- public install docs
+- install prompts
+- install rules
+- runtime/bootstrap user-facing messages
+- quick-check guidance
+
+Out of scope:
+
+- redesigning policy schema
+- changing host adapter ownership boundaries
+- changing provider routing strategy
+
+## Constraints
+
+- do not ask users to paste secrets into chat
+- do not claim online readiness without matching local configuration
+- keep the guidance compatible with the latest GitHub version
+- keep OpenAI-compatible and Ark-compatible wording both explicit
+- preserve existing advanced policy-driven provider configuration paths where they already exist
+
+## Acceptance Criteria
+
+1. Public install docs no longer imply that `VCO_AI_PROVIDER_URL` / `VCO_AI_PROVIDER_API_KEY` is the primary local install-time path.
+2. The configuration guide matches the actual quick-check probe behavior.
+3. Install prompts tell assistants exactly which local keys to recommend after install.
+4. One-shot bootstrap messages use concrete key names instead of generic “url/apikey/model”.
+5. Quick-check next-step guidance mentions the right model/base-url keys for OpenAI-compatible and Ark-compatible paths.
+6. Updated source install docs are mirrored into both bundled install-doc trees.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-openai-compatible-only.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-openai-compatible-only.md
@@ -1,0 +1,60 @@
+# Requirement: Restrict the Built-In AI Governance Layer to OpenAI-Compatible Integration
+
+## Goal
+
+Make the built-in AI governance layer support only OpenAI-compatible integration on the active shipped path.
+
+## User Intent
+
+Users should not see, configure, or depend on multiple provider lanes for the built-in governance layer.
+
+The built-in path should stay:
+
+- one provider shape
+- one credential family
+- one model/base-url story
+
+## Required Outcome
+
+The active built-in governance path must:
+
+1. standardize on OpenAI-compatible integration for built-in advice and governance online capability
+2. stop presenting Ark-compatible configuration as an equal built-in option in install docs and prompts
+3. remove Ark-compatible provider registration from active provider authority surfaces
+4. stop using Ark-specific defaults for built-in vector diff / embeddings
+5. stop advertising or seeding Ark-specific bootstrap settings in active install/setup scripts
+6. keep the install-time distinction between:
+   - local install complete
+   - governance online-ready
+7. preserve OpenAI-compatible quick-check and doctor behavior
+
+## In Scope
+
+- active install docs
+- active configuration defaults
+- active bootstrap and doctor scripts
+- active runtime-neutral governance connectivity probe
+- active router provider registry and llm acceleration defaults
+- active bundled mirrors of the same shipped assets
+
+## Out of Scope
+
+- historical release notes
+- old archived proof bundles
+- deleting every historical Ark-related file from the repo
+
+## Constraints
+
+- do not silently widen provider support again
+- do not break the current OpenAI-compatible path
+- keep bundled mirrors synchronized with source assets
+- do not ask users to paste secrets into chat
+
+## Acceptance Criteria
+
+1. Public install docs for the built-in governance layer describe only OpenAI-compatible integration.
+2. Active bootstrap/setup output no longer suggests Ark-compatible configuration.
+3. Active policy defaults no longer use Ark-specific embedding provider settings.
+4. Active provider registry no longer advertises an Ark-compatible built-in provider lane.
+5. The router AI connectivity probe and doctor outputs align with OpenAI-compatible-only guidance.
+6. Source and bundled active assets remain in sync.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-single-model-key.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-single-model-key.md
@@ -1,0 +1,58 @@
+# Requirement: Converge the Built-In AI Governance Layer to One Model Key
+
+## Goal
+
+Make the active built-in AI governance path use one canonical model environment key only: `VCO_RUCNLPIR_MODEL`.
+
+## User Intent
+
+Users should not need to decide between multiple model-key names when configuring the built-in governance layer.
+
+The active public path should present:
+
+- one credential family
+- one base-url family
+- one model key
+
+## Required Outcome
+
+The active built-in governance path must:
+
+1. treat `VCO_RUCNLPIR_MODEL` as the only supported model environment key on the active shipped path
+2. stop presenting a second public model key as an equal configuration choice
+3. stop presenting legacy fallback model-key wording in install and quick-check guidance
+4. keep the OpenAI-compatible base URL and API key guidance unchanged
+5. preserve the distinction between:
+   - local install complete
+   - governance online-ready
+6. keep bundled mirrors synchronized with the same single-key contract
+
+## In Scope
+
+- active runtime-neutral AI connectivity probe
+- active bootstrap/setup guidance
+- active settings templates that expose built-in governance model wiring
+- active install docs and install prompts
+- active bundled mirrors of the same shipped assets
+
+## Out of Scope
+
+- rewriting historical change logs
+- deleting every historical legacy key mention from archived or superseded artifacts
+- changing the canonical OpenAI-compatible API key or base-url names
+
+## Constraints
+
+- do not break the current OpenAI-compatible governance path
+- do not silently keep a second active model-key lane
+- do not ask users to paste secrets into chat
+- keep source and bundled shipped assets in sync
+
+## Acceptance Criteria
+
+1. Active runtime guidance resolves the built-in governance model from `VCO_RUCNLPIR_MODEL` only.
+2. Active bootstrap/setup messages recommend only `VCO_RUCNLPIR_MODEL` for the model name.
+3. Public active install docs and prompts describe one model key only.
+4. Active shipped settings templates no longer advertise any retired secondary model-key lane for the built-in governance model slot.
+5. Verification output for missing model configuration points to `VCO_RUCNLPIR_MODEL` only.
+6. Source assets and bundled mirrors remain synchronized after the change.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-28-l-xl-native-execution-closure.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-28-l-xl-native-execution-closure.md
@@ -1,0 +1,104 @@
+# L / XL Native Execution Closure
+
+## Summary
+Close the gap between the documented `vibe` execution model and the current runtime implementation. Land a real `L` native serial execution path and a real `XL` native selective-parallel execution path so that `vibe` no longer only freezes governance artifacts and specialist accounting, but can actually orchestrate child lanes and native specialist work under root-controlled runtime authority.
+
+## Goal
+Implement a coherent governed execution model where:
+
+- `L` runs as a true native serial workflow inside `vibe`
+- `XL` runs as a true native multi-lane workflow inside `vibe`
+- parallelism is selective and step-scoped rather than global and always-on
+- specialist skills can be executed in their native mode as bounded work units
+- root/child governance remains single-owner, auditable, and stable
+
+## Deliverable
+A repository change set and documentation bundle that adds:
+
+- a runtime execution topology that distinguishes `M`, `L`, and `XL` in real execution behavior, not only in metadata
+- a native `L` serial orchestrator with staged subagent execution and two-stage review
+- a native `XL` selective-parallel orchestrator with root-controlled wave and step scheduling
+- executable specialist-dispatch units that preserve native specialist workflow contracts
+- tests and proof artifacts demonstrating authority preservation, stable execution, and correct bounded parallelism
+
+## Constraints
+- Do not create a second router, second requirement surface, second execution-plan surface, or second runtime authority.
+- Keep `vibe` as the runtime-selected skill for explicit governed entry.
+- Do not turn `XL` into always-parallel execution; only independent units inside a step may run concurrently.
+- Do not flatten specialist skills into generic labels; preserve native workflow, inputs, outputs, and validation style.
+- Keep root/child hierarchy rules intact: only root may freeze canonical requirement and plan truth or issue final completion claims.
+- Prefer additive execution-topology changes over broad router rewrites.
+
+## Acceptance Criteria
+- `L` execution is no longer metadata-only:
+  - runtime uses a native serial orchestrator
+  - design/plan approval remains explicit
+  - subagent units run in ordered stages
+  - two-stage review is represented in execution artifacts
+- `XL` execution is no longer metadata-only:
+  - runtime can execute child-governed units as real delegated lanes
+  - wave order stays sequential by dependency
+  - independent units inside a wave or step can run in bounded parallel
+  - scheduler policy exposes bounded concurrency rather than fixed `max_parallel_units=1`
+- specialist-dispatch execution is no longer accounting-only:
+  - approved specialist dispatch can become executable bounded units
+  - child-local specialist suggestions remain advisory until root approval
+  - execution evidence records native specialist runs and recovery into root manifest
+- proof surfaces show:
+  - one root completion authority
+  - no duplicate canonical requirement or plan surfaces
+  - child lanes cannot widen global scope silently
+  - degraded execution remains explicit and non-authoritative when the native path is unavailable
+
+## Primary Objective
+Make the documented `L` and `XL` governed execution semantics true in the runtime.
+
+## Proxy Signal
+The runtime no longer only writes plans and manifests about serial or parallel work; it actually schedules serial `L` child units, bounded `XL` parallel units, and executable native specialist dispatch under `vibe` governance.
+
+## Scope
+In scope:
+- runtime scheduler and execution-topology policy
+- `L` serial orchestrator
+- `XL` selective-parallel orchestrator
+- root/child delegated execution wiring
+- native specialist execution contracts
+- execution receipts, manifests, and proof updates
+- runtime-neutral tests and governed verification gates
+
+Out of scope:
+- redesigning canonical routing logic
+- host auto-interception of every non-`vibe` message
+- converting all specialist skills in the repository to new metadata formats
+- replacing governed runtime with a separate workflow engine
+
+## Completion
+The work is complete when explicit `vibe` runs can deliver real `L` serial native execution and real `XL` selective-parallel native execution, with specialist skills executed as bounded native helpers and with root-owned governance truth preserved end to end.
+
+## Evidence
+- runtime policy and execution code changes
+- updated protocol and stable docs
+- passing runtime-neutral tests covering `L`, `XL`, hierarchy, and specialist execution
+- governed proof artifacts showing real delegated execution rather than accounting-only shadows
+
+## Non-Goals
+- Do not make `XL` mean unconditional full parallelism.
+- Do not let child lanes become recursive top-level governors.
+- Do not let specialist skills take over runtime ownership from `vibe`.
+- Do not hide degraded or fallback paths behind success wording.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- Existing root/child hierarchy metadata is sufficient to seed a real delegated execution engine.
+- Existing specialist recommendation and dispatch fields can be extended into executable units without redesigning router scoring.
+- The current benchmark execution policy can evolve into a real governed execution-topology policy rather than remaining a repo-safe sequential proof runner only.
+- Proof quality can be preserved while moving from metadata-only semantics to actual orchestration.
+
+## Evidence Inputs
+- Source task: design a reasonable solution for the missing `L` native serial execution and `XL` selective-parallel native execution behavior
+- Current runtime gap:
+  - documented `L`/`XL` behavior is stronger than actual execution
+  - scheduler remains sequential
+  - specialist dispatch is surfaced and counted but not yet executed as native bounded units

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-28-root-child-vibe-hierarchy-governance.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-28-root-child-vibe-hierarchy-governance.md
@@ -1,0 +1,104 @@
+# Root/Child Vibe Hierarchy Governance
+
+## Summary
+Resolve the governance ambiguity introduced by recursive `vibe` usage in XL multi-agent work. Keep `vibe` as the only governed runtime authority at the root task level while allowing child agents to inherit `vibe` discipline as subordinate execution lanes instead of reopening a second top-level governed runtime.
+
+## Goal
+Design and land a hierarchy model where:
+
+- one user task has exactly one root governed `vibe` runtime
+- child agents still run under `vibe` discipline
+- child agents do not create a second requirement or plan truth
+- specialist skills remain usable as bounded native helpers without taking runtime ownership
+
+## Deliverable
+A repository change set and documentation bundle that adds:
+
+- an explicit root/child governance-scope contract inside the runtime input packet
+- subordinate child-lane rules for XL execution
+- approved specialist dispatch versus child-local suggestion separation
+- execution/accounting/proof surfaces for root-owned completion and child-owned local receipts
+- protocol, requirement, plan, and stable governance docs for the hierarchy model
+- regression tests and verification gates proving authority preservation, non-duplication of canonical surfaces, bounded specialist usage, and predictable escalation behavior
+
+## Constraints
+- Do not remove `$vibe` from child-agent prompts.
+- Do not let child agents create a second visible governed startup surface.
+- Do not let child agents freeze a second canonical requirement document or execution plan.
+- Do not let child agents make global specialist-dispatch decisions on behalf of the root run.
+- Do not let specialist skills become runtime owners or make final completion claims.
+- Preserve existing explicit `vibe` authority invariants and current canonical router ownership.
+- Prefer additive metadata and execution-policy changes over broad router rewrites.
+
+## Acceptance Criteria
+- Runtime input packet distinguishes `root` versus `child` governance scope with machine-readable authority flags.
+- Root runs are the only runs allowed to freeze canonical requirement and plan surfaces under `docs/requirements/` and `docs/plans/`.
+- Child runs inherit the frozen requirement/plan context and write only subordinate receipts or artifacts.
+- Specialist dispatch is split into:
+  - root-approved specialist dispatch
+  - child-local specialist suggestions that require escalation before becoming globally active
+- Execution manifests preserve:
+  - single root completion authority
+  - child-unit evidence
+  - approved specialist dispatch accounting
+  - escalation requests and their outcomes
+- Protocol docs explain:
+  - root-governed authority
+  - child-governed subordinate execution
+  - specialist boundedness rules
+  - conflict-prevention rules for multi-agent work
+- Tests and gates prove:
+  - no duplicate canonical requirement/plan surfaces are created
+  - child runs cannot widen scope silently
+  - child runs cannot issue final completion claims
+  - child specialist suggestions stay advisory until root approval
+  - explicit `vibe` authority remains stable during hierarchical execution
+
+## Primary Objective
+Turn recursive multi-agent `vibe` usage from a layered-governance ambiguity into a single-root, subordinate-child execution model.
+
+## Proxy Signal
+Root runs freeze the only canonical requirement and plan, child runs inherit those surfaces as subordinate lanes, and specialist skills are executed or suggested without creating second governance truth.
+
+## Scope
+In scope:
+- runtime input packet hierarchy metadata
+- plan-execution handoff contract for child lanes
+- specialist dispatch approval versus suggestion semantics
+- execution manifest and proof surfacing
+- protocol and stable-governance documentation
+- regression tests and verification gates
+
+Out of scope:
+- redesigning the full canonical router ranking system
+- host-level interception of arbitrary non-`vibe` requests
+- per-skill metadata rewrites across the whole repository
+- generalized memory-system redesign
+
+## Completion
+The work is complete when XL `vibe` orchestration can use child agents and specialist skills without creating recursive top-level governance, duplicate canonical surfaces, or ambiguous completion authority.
+
+## Evidence
+- updated runtime/config/protocol/test surfaces
+- new governed requirement/plan docs for the hierarchy change
+- new stable governance design doc
+- passing targeted tests and gates
+- explicit proof artifacts and cleanup receipts from the verification pass
+
+## Non-Goals
+- Do not make child `vibe` lanes governance-free.
+- Do not replace `vibe` with specialist skills during explicit governed entry.
+- Do not allow child lanes to silently re-plan the entire task.
+- Do not hide escalation events or specialist conflict handling from execution evidence.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- Existing explicit `vibe` runtime surfaces are already strong enough to support a root/child extension.
+- Child lanes can inherit frozen context rather than regenerate it.
+- Specialist recommendations already present in the runtime packet can be separated into approved dispatch and local suggestions without a router redesign.
+- Stable hierarchy behavior can be proven with targeted runtime-neutral tests and governed PowerShell gates.
+
+## Evidence Inputs
+- Source task: design the root/child `vibe` hierarchy model that preserves governance while allowing bounded specialist usage

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-28-stage-bound-specialist-dispatch-governance.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-28-stage-bound-specialist-dispatch-governance.md
@@ -1,0 +1,98 @@
+# Stage-Bound Specialist Dispatch Governance
+
+## Summary
+Extend the governed `vibe` runtime so specialist skills are no longer just recommended or counted, but are frozen as stage-bound execution contracts with explicit authority, phase binding, lane policy, write scope, and verification expectations. The design must preserve one runtime owner while making specialist skills materially useful during real work.
+
+## Goal
+Implement a governed specialist-dispatch model where:
+
+- `vibe` remains the sole runtime authority for requirement freeze, plan freeze, execution receipts, verification, and cleanup.
+- specialist skills are routed as candidates, approved as bounded dispatch contracts, and executed in the correct runtime phase.
+- `L` executes specialist help as explicit serial native steps.
+- `XL` executes specialist help as bounded child lanes, including parallel specialist lanes only when write scopes and governance rules allow it.
+- child `vibe` lanes can surface new specialist suggestions without gaining top-level authority.
+
+## Deliverable
+A repository change set and documentation bundle that adds:
+
+- machine-readable specialist binding policy for phase binding, lane policy, write scope, and review mode
+- frozen runtime-input specialist contracts carrying stage-bound execution metadata
+- requirement and plan surfaces that document phase-bound specialist dispatch
+- runtime topology support for `pre_execution`, `in_execution`, `post_execution`, and `verification` specialist phases
+- `L` serial specialist execution and `XL` bounded-parallel specialist lane execution
+- manifest accounting and proof surfaces that show where specialist work ran and under what authority
+- runtime-neutral tests and proof artifacts that demonstrate stability, usability, and intelligent specialist use
+
+## Constraints
+- Do not create a second router, second requirement truth, second plan truth, or second runtime owner.
+- Keep `runtime_selected_skill=vibe` for explicit governed entry.
+- Do not let specialist skills self-approve or self-upgrade into global runtime authority.
+- Preserve native specialist workflow, input contract, expected outputs, and validation style.
+- Allow parallel specialist execution only under root governance, only in `XL`, and only for disjoint write scopes.
+- Keep child local specialist suggestions advisory-first and escalation-first unless the existing same-round root auto-absorb gate approves them.
+
+## Acceptance Criteria
+- Runtime input packet recommendations carry specialist binding metadata:
+  - `binding_profile`
+  - `dispatch_phase`
+  - `execution_priority`
+  - `lane_policy`
+  - `parallelizable_in_root_xl`
+  - `write_scope`
+  - `review_mode`
+- Requirement documents surface specialist binding truth, not only skill names.
+- Execution plans surface a concrete specialist dispatch plan with phase binding, lane policy, and write scope.
+- `L` topology no longer lumps approved specialists into one generic final step; specialist units appear as phase-bound serial steps.
+- `XL` topology can place eligible specialists into bounded parallel steps while preserving serial fallback for conflicting scopes.
+- Execution manifests expose phase-binding and specialist topology evidence sufficient to prove where and how specialists ran.
+- Existing root/child hierarchy guarantees remain true:
+  - child cannot freeze canonical requirement or plan
+  - child cannot make final completion claims
+  - zero-overlap new specialist suggestions remain escalation-only
+  - same-round absorb still requires root-owned approval semantics
+
+## Primary Objective
+Make specialist skills useful inside `vibe` without letting them blur runtime ownership or fight each other.
+
+## Proxy Signal
+Specialist skills are invoked neither randomly nor only in theory. They appear in frozen runtime packets, are bound to explicit phases, execute in bounded lanes, and leave manifest evidence proving whether they ran live, degraded, serially, or in bounded parallel.
+
+## Scope
+In scope:
+- runtime-input packet specialist binding policy
+- requirement/plan surfacing
+- execution-topology specialist phase placement
+- manifest and proof accounting
+- runtime-neutral test expansion
+- stable governance documentation
+
+Out of scope:
+- redesigning canonical router scoring
+- host-wide interception of non-`vibe` entrypoints
+- granting child lanes top-level planning authority
+- unbounded automatic expert fan-out
+
+## Completion
+The work is complete when explicit `vibe` runs can freeze, plan, and execute phase-bound specialist help with artifact-backed proof that the result is stable, usable, and governed.
+
+## Evidence
+- updated config/runtime/protocol/test surfaces
+- new or updated requirement, plan, and stable governance docs
+- passing targeted runtime-neutral tests
+- replay or proof artifacts showing serial and bounded-parallel specialist execution
+
+## Non-Goals
+- Do not make every specialist recommendation executable by default.
+- Do not make `$vibe` inside child lanes mean “child may govern everything”.
+- Do not hide degraded specialist execution behind success wording.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- Existing ranked specialist recommendations are sufficient to seed deterministic phase binding.
+- Binding profiles can be kept simple and deterministic at first by classifying specialists into planning, implementation, deliverable, and verification phases.
+- Current bounded parallel scheduler already provides enough machinery to support specialist parallel lanes once dispatch units expose proper write scopes and parallel eligibility.
+
+## Evidence Inputs
+- Source task: make specialist skills useful inside `vibe` without conflict or authority drift

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-28-vibe-governed-project-delivery-acceptance.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-28-vibe-governed-project-delivery-acceptance.md
@@ -1,0 +1,111 @@
+# Vibe-Governed Project Delivery Acceptance
+
+## Summary
+Close the current gap between `vibe` runtime correctness and downstream project delivery correctness. The repository already proves many governance and runtime contracts, but it does not yet prove strongly enough that a project completed under `vibe` is functionally complete, user-usable, regression-safe, and honestly reported as such.
+
+## Goal
+Design and land a governed acceptance architecture where work completed under `vibe` is evaluated as a delivered project, not only as a correctly governed runtime session.
+
+## Deliverable
+A repository change program and documentation bundle that adds:
+
+- a delivery-truth model separating governance, engineering verification, workflow completion, and product acceptance
+- scenario-based acceptance fixtures for real project work completed under `vibe`
+- benchmark repositories and gold-task corpora that simulate real downstream work rather than only VibeSkills self-tests
+- a workflow-acceptance runner that executes governed tasks and judges project outcomes against frozen acceptance criteria
+- stronger completion semantics so `completed_with_failures`, `manual_actions_pending`, and degraded paths cannot be reported as full delivery success
+- release and operator documentation for how project delivery under `vibe` is validated and proved
+
+## Constraints
+- This project is about testing downstream work completed under `vibe`, not about host installation correctness or adapter parity by themselves.
+- Preserve existing single-router and single-runtime-owner invariants.
+- Do not create a second visible runtime, second requirement truth, or second execution-plan truth.
+- Prefer additive acceptance and proof surfaces over a disruptive router/runtime rewrite.
+- Preserve current governance evidence while making project-delivery evidence a first-class required surface.
+- Do not claim that runtime success alone proves project success.
+- Keep domain-specific expert workflows intact when the acceptance framework evaluates specialist-assisted work.
+
+## Acceptance Criteria
+- The repository defines four separate delivery truth states:
+  - governance truth
+  - engineering verification truth
+  - workflow completion truth
+  - product acceptance truth
+- `vibe`-governed requirement and plan surfaces can freeze downstream acceptance criteria for project work, not only runtime/process expectations.
+- The repository includes scenario fixtures that cover:
+  - single-skill project work
+  - L-grade staged work
+  - XL-grade composite work
+  - specialist-heavy work
+  - intentionally failing or drifting work
+- Benchmark repositories exist so the acceptance framework tests `vibe` governing other projects, not just VibeSkills governing itself.
+- A workflow-acceptance runner can:
+  - execute a governed scenario
+  - collect runtime artifacts
+  - run project-level validation
+  - produce a structured acceptance report
+- Completion/reporting rules prevent the system from presenting the following states as full success:
+  - `completed_with_failures`
+  - `degraded_non_authoritative`
+  - `manual_actions_pending`
+  - missing product acceptance evidence
+- Stability proof requires repeated scenario execution, failure injection, and flake accounting rather than a single happy-path pass.
+- Usability proof requires operator-readable acceptance reports and bounded manual spot-check contracts.
+- Intelligence proof requires evidence that `vibe` selected an appropriate execution grade, specialist usage, verification depth, and escalation behavior for the project scenario.
+
+## Primary Objective
+Make `vibe` accountable for the actual delivered quality of downstream project work, not only for the correctness of its own governance process.
+
+## Proxy Signal
+Every governed project run produces a delivery report that clearly distinguishes:
+
+- process correctness
+- code/test correctness
+- workflow completeness
+- final user-facing acceptance
+
+## Scope
+In scope:
+- delivery-truth model
+- downstream acceptance contracts
+- scenario corpus design
+- benchmark repository design
+- workflow-acceptance runner design
+- completion-language hardening
+- release proof and reporting rules
+- documentation and rollout plan
+
+Out of scope:
+- redesigning host installation flows
+- reworking the canonical router scoring model
+- replacing existing runtime artifacts with an entirely new runtime
+- promising full automation for every domain without bounded human spot-check contracts
+
+## Completion
+The work is complete when `vibe` can no longer honestly report a project as complete without downstream acceptance evidence showing that the delivered work is functionally sufficient, user-usable, and regression-aware.
+
+## Evidence
+- new or updated requirement/plan/stable governance docs
+- scenario schema and benchmark-repo design
+- verification and acceptance runner design
+- release-gate and reporting design
+- proof strategy covering stability, usability, and intelligence
+
+## Non-Goals
+- Do not reduce project delivery quality to runtime artifact existence.
+- Do not let unit tests alone stand in for downstream project acceptance.
+- Do not hide missing functionality behind broad “done” wording.
+- Do not flatten specialist-assisted tasks into generic acceptance logic that ignores domain-specific verification needs.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- Existing `vibe` requirement and plan stages are strong enough to freeze downstream acceptance criteria once the contract is extended.
+- Current runtime/session artifacts can be reused as evidence inputs rather than replaced.
+- The largest missing layer is downstream project acceptance, not basic runtime sequencing.
+- The current repository structure can host benchmark repositories and scenario fixtures without breaking canonical governance surfaces.
+
+## Evidence Inputs
+- Source task: plan a full delivery-acceptance enhancement program for work completed under `vibe`
+- Prior finding: current runtime-neutral and gate-heavy tests validate governance/runtime strongly but validate downstream project success weakly

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
@@ -1,0 +1,99 @@
+# Vibe Governor + Native Specialist Skills
+
+## Summary
+Keep `vibe` as the sole governed runtime authority while enabling it to call specialist skills as bounded native assistants through an explicit host adapter bridge. Router output must remain a single canonical routing truth, but explicit `vibe` runs should freeze specialist recommendations that can be consumed by planning and execution without handing control to a second runtime or faking native execution with receipt-only artifacts.
+
+## Goal
+Implement a minimal-change governed model where:
+
+- `vibe` remains the only runtime owner for requirement freeze, execution planning, execution receipts, verification, and cleanup.
+- specialist skills can be recommended, planned, dispatched, and verified as bounded native helpers.
+- specialist usage preserves each skill's native workflow expectations rather than flattening the skill into a label.
+- approved specialist dispatch can cross a host adapter bridge into real native execution when the active host supports it.
+- unsupported or disabled native specialist paths degrade explicitly to `degraded_non_authoritative` rather than claiming equivalent success.
+
+## Deliverable
+A repository change set that adds:
+
+- a frozen runtime packet contract for `specialist_recommendations`
+- a frozen executable contract for `approved_dispatch`
+- requirement and plan surfacing for native specialist dispatch
+- a host adapter execution bridge with an initial `codex` implementation path
+- execution-manifest support for specialist units, degraded specialist units, and their recovery into `vibe`
+- protocol and operator documentation for the governor-plus-specialists model
+- regression tests and proof artifacts demonstrating authority preservation, stability, usability, and intelligent specialist selection
+
+## Constraints
+- Do not change `runtime_selected_skill` away from `vibe` during explicit `vibe` runtime entry.
+- Do not create a second router, second requirement surface, second execution-plan surface, or second runtime authority.
+- Reuse existing router outputs and runtime artifacts as much as possible; prefer additive contract extensions over structural rewrites.
+- Preserve current host adapter boundaries; this task is a bounded runtime execution bridge project, not a host-entry auto-intercept project.
+- Specialist execution must remain bounded and must feed back into `vibe` verification and cleanup surfaces.
+- Specialist skills must retain native usage expectations, input contracts, workflow semantics, and validation style when dispatched.
+- Child lanes may execute only root-approved specialist dispatch; they may not self-approve new global specialist usage.
+
+## Acceptance Criteria
+- Runtime input packet includes machine-readable `specialist_recommendations` for explicit `vibe` runs without changing `authority_flags.explicit_runtime_skill`.
+- Runtime input packet includes machine-readable executable specialist dispatch contracts that keep `vibe` as runtime owner.
+- Requirement documents surface specialist recommendations and native-usage expectations as frozen inputs.
+- Execution plans include an explicit `Specialist Skill Dispatch Plan` section describing bounded specialist use.
+- Execution manifests record specialist unit counts, degraded specialist unit counts, execution drivers, and recovery status while keeping `vibe` as runtime owner.
+- Protocol docs define the `vibe governor + native specialist skills` model and forbid specialist takeover of runtime truth.
+- Tests prove:
+  - `vibe` authority is preserved
+  - specialist recommendations are frozen and surfaced
+  - plan/execute artifacts include specialist dispatch data
+  - root-approved child specialist dispatch can execute through the host adapter bridge
+  - degraded specialist paths remain explicit and non-authoritative when appropriate
+  - receipt-only specialist stubs are no longer presented as native execution
+
+> Fill the anti-drift fields once here. Downstream governed plan and completion surfaces should reuse them rather than restate them.
+
+## Primary Objective
+Enable `vibe` to orchestrate specialist skills natively without losing governed runtime authority.
+
+## Proxy Signal
+The system freezes specialist recommendations, plans them explicitly, executes them as bounded units, and records them in execution evidence.
+
+## Scope
+In scope:
+- runtime packet extension
+- requirement/plan surfacing
+- execution manifest specialist accounting
+- host adapter execution bridge for specialist units
+- `codex exec` as the first supported runtime-native adapter lane
+- protocol and proof documentation
+- regression tests and cleanup receipts
+
+Out of scope:
+- host auto-interception of every incoming message
+- automatic replacement of `vibe` with router-selected specialist skills
+- global redesign of the router scoring system
+- skill-by-skill metadata rewrites across the entire repository
+- blanket host-native parity for every supported install host in the first slice
+
+## Completion
+The work is complete when explicit `vibe` runs can preserve runtime authority while still planning and executing native specialist assistance with traceable evidence and passing regression coverage.
+
+## Evidence
+- code changes in runtime/config/protocol/test surfaces
+- new or updated governed requirement/plan docs
+- passing targeted tests
+- cleanup receipts and node audit output
+
+## Non-Goals
+- Do not make router-selected specialist skills authoritative runtime owners.
+- Do not silently downgrade specialist usage into generic text-only hints.
+- Do not let any specialist skill create or own a separate execution plan.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- Existing router ranking already provides enough signal to derive specialist candidates without redesigning pack scoring.
+- The current runtime packet shadow model can be extended rather than replaced.
+- A bounded host adapter bridge can be added without creating a second runtime authority.
+- `codex exec` can serve as the first real specialist-native execution lane while other hosts degrade explicitly until their adapters exist.
+
+## Evidence Inputs
+- Source task: implement `vibe` governor + native specialist skills with minimal framework change

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/README.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/README.md
@@ -19,6 +19,12 @@ Primary policy:
 
 ## Current Entry
 
+- [`2026-03-28-root-child-vibe-hierarchy-governance.md`](./2026-03-28-root-child-vibe-hierarchy-governance.md): 冻结“root/child `vibe` 分层治理”需求；聚焦把子代理 `$vibe` 收敛为从属执行态，避免递归顶层治理、重复专家分发与模糊 completion authority。
+- [`2026-03-27-ai-governance-consolidation.md`](./2026-03-27-ai-governance-consolidation.md): 冻结“内置 AI 治理层活跃路径整体收敛整理”的需求；聚焦让 runtime、doctor、install docs 与 helper surface 在 active shipped path 上完全对齐。
+- [`2026-03-27-ai-governance-historical-wording-cleanup.md`](./2026-03-27-ai-governance-historical-wording-cleanup.md): 冻结“内置 AI 治理层历史表述清理”的需求；聚焦在 `vibe` 范围内去掉退役模型键名的历史残留。
+- [`2026-03-27-ai-governance-openai-compatible-only.md`](./2026-03-27-ai-governance-openai-compatible-only.md): 冻结“内置 AI 治理层只保留 OpenAI-compatible 接入”的需求；聚焦移除 Ark 并行内置入口，统一公开安装、bootstrap、probe 与默认策略口径。
+- [`2026-03-27-ai-governance-install-clarity.md`](./2026-03-27-ai-governance-install-clarity.md): 冻结 issue #57 的安装澄清需求；聚焦把 AI 治理 advice 的 API 配置键名、快速检查口径与“本地安装完成 / 在线能力就绪”边界说清楚。
+- [`2026-03-27-ai-governance-single-model-key.md`](./2026-03-27-ai-governance-single-model-key.md): 冻结“内置 AI 治理层单模型键收敛”的需求；聚焦统一到 `VCO_RUCNLPIR_MODEL`。
 - [`2026-03-20-readme-en-detail-and-github-branding-copy.md`](./2026-03-20-readme-en-detail-and-github-branding-copy.md): 冻结英文 README 细化与 GitHub 品牌文案补充；聚焦让 `README.en.md` 与中文版接近同等细节层级，并产出 `About / Topics / social preview` 可复用文案。
 - [`2026-03-20-readme-emoji-layout-polish.md`](./2026-03-20-readme-emoji-layout-polish.md): 冻结 README 中文视觉润色；聚焦用少量 emoji 和版式节奏优化，让首页更精致、更有设计感但仍保持克制。
 - [`2026-03-20-readme-differentiated-science-ai-strengths.md`](./2026-03-20-readme-differentiated-science-ai-strengths.md): 冻结 README 中文差异化强化；聚焦把生命科学、科研、AI 工程三块写得更有冲击力，更能体现仓库强势能力区。

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/root-child-vibe-hierarchy-governance.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/root-child-vibe-hierarchy-governance.md
@@ -1,0 +1,160 @@
+# Root/Child Vibe Hierarchy Governance
+
+This document defines the stable authority model for governed multi-agent `vibe` execution.
+
+## Why This Exists
+
+Recursive use of `$vibe` inside child-agent prompts is desirable for discipline, but dangerous when each child starts behaving like a fresh top-level governed runtime. Without a hierarchy contract, the system risks:
+
+- duplicate requirement freezes
+- duplicate execution-plan surfaces
+- repeated expert re-dispatch
+- ambiguous completion authority
+- soft loss of governance despite every lane "using `vibe`"
+
+The fix is not to remove child `$vibe`.
+The fix is to distinguish root governance from child execution.
+
+## Mental Model
+
+- Root `vibe`: the only top-level governor
+- Child `vibe`: a subordinate execution lane
+- Specialist skill: a bounded native helper
+
+Short form:
+
+`root vibe governs, child vibe executes, specialists assist`
+
+## Grade Execution Alignment
+
+- `L`: serial native execution from the frozen plan (sequence-first, no blanket fan-out).
+- `XL`: wave-sequential execution, with step-level bounded parallelism only for independent units.
+- Specialist dispatch: executable as bounded native units only when root-approved in the frozen plan.
+
+## Authority Layers
+
+### Root-Governed Lane
+
+Only the root-governed lane may:
+
+- freeze the canonical requirement document
+- freeze the canonical execution plan
+- approve global specialist dispatch
+- aggregate overall execution status
+- issue final completion claims
+
+### Child-Governed Lane
+
+Child-governed lanes must:
+
+- inherit frozen requirement and plan context from the root lane
+- stay inside assigned scope and write boundaries
+- emit local receipts and proof only
+- escalate when a new specialist is needed outside approved dispatch
+
+Child-governed lanes must not:
+
+- create a second requirement truth
+- create a second plan truth
+- widen the task silently
+- make final completion claims
+
+### Specialist-Native Lane
+
+Specialists are not runtime owners.
+
+They may:
+
+- execute bounded professional subtasks
+- preserve native workflow expectations
+- preserve native input/output contracts
+- emit skill-specific verification notes
+
+They may not:
+
+- take over stage ownership
+- replace `vibe` as runtime authority
+- create separate top-level planning truth
+
+## Dispatch Model
+
+Approved specialist dispatch is phase-bound rather than “call it whenever”.
+The stable phase vocabulary is:
+
+- `pre_execution`
+- `in_execution`
+- `post_execution`
+- `verification`
+
+This keeps expert help aligned with the governed task stage instead of turning specialist calls into ad-hoc afterthoughts.
+
+### Approved Specialist Dispatch
+
+Specialist usage approved by the root-governed lane and written into the frozen plan.
+
+Properties:
+
+- executable without extra authority negotiation
+- carried into child-lane inputs
+- tracked in execution accounting
+- bound to an explicit phase, lane policy, write scope, and review mode
+
+### Local Specialist Suggestion
+
+A child lane may detect that more specialist help is useful. The frozen packet keeps that request as a suggestion first, and the root-governed execute stage may same-round auto-approve safe suggestions without handing authority to the child lane.
+
+Properties:
+
+- advisory in the frozen packet
+- executable only after root-governed approval or same-round auto-absorb
+- cannot mutate root authority by itself
+
+## Conflict Prevention Rules
+
+To prevent skills from "fighting", the system enforces:
+
+1. one runtime owner
+2. one canonical requirement surface
+3. one canonical execution-plan surface
+4. one final completion authority
+5. bounded specialist usage
+6. explicit escalation instead of silent self-expansion
+7. stage-bound dispatch instead of random specialist timing
+
+## Artifact Rules
+
+Canonical root artifacts:
+
+- `docs/requirements/YYYY-MM-DD-<topic>.md`
+- `docs/plans/YYYY-MM-DD-<topic>-execution-plan.md`
+- `outputs/runtime/vibe-sessions/<root-run-id>/...`
+
+Child artifacts:
+
+- subordinate receipts and proof nested under the root runtime session
+- no child-owned canonical docs
+
+## Safety Properties
+
+This hierarchy must preserve:
+
+- explicit `vibe` runtime authority
+- no silent fallback guarantees
+- no duplicate truth surfaces
+- specialist boundedness
+- explicit escalation for new specialist needs
+- root-owned completion claims only
+
+## What Success Looks Like
+
+When a root `vibe` task spawns children:
+
+- every child still behaves with `vibe` discipline
+- no child behaves like a second top-level governor
+- approved specialists can execute as bounded native units
+- root evidence remains the single source of completion truth
+
+## Operator Rule Of Thumb
+
+If a child needs a new expert, it may ask.
+It may not self-upgrade into a new governor.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/specialist-dispatch-governance.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/specialist-dispatch-governance.md
@@ -1,0 +1,161 @@
+# Specialist Dispatch Governance
+
+This document defines how specialist skills are used inside the governed `vibe` runtime without becoming a second runtime owner.
+
+## Mental Model
+
+- router finds candidate specialists
+- root `vibe` freezes approved specialist dispatch
+- child `vibe` executes bounded lanes
+- specialists contribute native expertise
+
+Short form:
+
+`router suggests, root vibe approves, child vibe executes, specialists assist`
+
+## Why This Exists
+
+Without a governed dispatch model, specialist skills tend to fail in one of two ways:
+
+- they stay unused even when obviously relevant
+- they are called loosely and start conflicting with runtime governance
+
+The fix is not “call more skills”.
+The fix is phase-bound specialist dispatch.
+
+## The Four Layers
+
+### 1. Governance Layer
+
+Owned by `vibe`.
+
+This layer controls:
+
+- requirement freeze
+- plan freeze
+- global dispatch approval
+- verification
+- cleanup
+- final completion authority
+
+### 2. Routing Layer
+
+Owned by the canonical router.
+
+This layer only suggests candidate specialists.
+It does not grant execution rights.
+
+### 3. Dispatch Layer
+
+Owned by root `vibe`.
+
+This layer turns suggestions into executable specialist contracts with:
+
+- `binding_profile`
+- `dispatch_phase`
+- `execution_priority`
+- `lane_policy`
+- `parallelizable_in_root_xl`
+- `write_scope`
+- `review_mode`
+
+### 4. Execution Layer
+
+Owned by bounded lanes under `vibe`.
+
+This layer runs the specialist using its native workflow while staying subordinate to the frozen requirement and plan.
+
+## Phase-Bound Specialist Model
+
+Each approved specialist belongs to one governed phase:
+
+- `pre_execution`: planning or setup support
+- `in_execution`: implementation or analysis support
+- `post_execution`: deliverable or reporting support
+- `verification`: review or audit support
+
+This prevents specialist calls from appearing randomly at the end of a task.
+
+## L / XL Behavior
+
+### `L`
+
+- specialist units are explicit serial steps
+- no blanket fan-out
+- specialist help is visible in order and remains easy to audit
+
+### `XL`
+
+- waves remain sequential by dependency
+- specialist units may become bounded parallel lanes only when:
+  - root approved them
+  - the runtime is in `XL`
+  - write scopes do not conflict
+  - the specialist lane policy allows bounded parallel execution
+
+If those conditions are not met, specialist units fall back to serial execution.
+
+## Root / Child Authority
+
+Root `vibe` may:
+
+- freeze canonical requirement truth
+- freeze canonical plan truth
+- approve global specialist dispatch
+- issue final completion claims
+
+Child `vibe` may:
+
+- inherit frozen requirement and plan context
+- execute bounded approved specialist lanes
+- surface new specialist suggestions as advisory requests
+
+Child `vibe` may not:
+
+- create a second canonical requirement surface
+- create a second canonical plan surface
+- self-approve new global specialist dispatch
+- make the root task’s final completion claim
+
+## Local Suggestion vs Approved Dispatch
+
+### Approved Dispatch
+
+Already approved by root and safe to execute.
+
+### Local Suggestion
+
+Detected by a child lane during work.
+It stays advisory until one of two things happens:
+
+- root explicitly approves it
+- the same-round root auto-absorb gate accepts it
+
+If it has no approved overlap and the gate cannot absorb it, it remains escalation-only.
+
+## Conflict Prevention
+
+The runtime prevents specialist conflicts with five rules:
+
+1. one runtime owner
+2. one canonical requirement truth
+3. one canonical plan truth
+4. write-scope-aware bounded parallelism only
+5. explicit degraded or escalation surfaces instead of silent fallback
+
+## What Proof Must Show
+
+To claim this model works, runtime evidence must show:
+
+- which specialists were recommended
+- which specialists were approved
+- which phase each specialist was bound to
+- whether each specialist ran serially, in bounded parallel, or degraded
+- whether child suggestions were auto-absorbed or escalated
+- that root completion authority stayed single-owner
+
+## Operator Rule
+
+When a specialist is relevant, make it visible, bounded, and phase-bound.
+Do not let it become invisible background magic.
+Do not let it become a second governor.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/status/README.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/status/README.md
@@ -24,6 +24,7 @@ It answers three questions:
 
 - [`protected-capability-baseline.md`](protected-capability-baseline.md): defines which surfaces must be proven before they are changed during closure work
 - [`non-regression-proof-bundle.md`](non-regression-proof-bundle.md): current cleanup and no-regression proof contract
+- [`stage-bound-specialist-dispatch-closure-2026-03-28.md`](stage-bound-specialist-dispatch-closure-2026-03-28.md): closure proof for phase-bound specialist dispatch, `L` serial specialist steps, and `XL` bounded specialist lanes under root/child governance
 - [`platform-promotion-baseline-2026-03-13.md`](platform-promotion-baseline-2026-03-13.md): current platform-promotion truth snapshot
 - [`linux-pwsh-fresh-machine-evidence-ledger-2026-03-13.md`](linux-pwsh-fresh-machine-evidence-ledger-2026-03-13.md): Linux fresh-machine evidence ledger for the promoted `Linux + pwsh` authoritative lane
 - [`single-core-dual-adaptation-baseline-2026-03-14.md`](single-core-dual-adaptation-baseline-2026-03-14.md): first adapter-contract landing status for platform-neutral target roots, installed-runtime resolution, and shell spawning

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/status/stage-bound-specialist-dispatch-closure-2026-03-28.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/status/stage-bound-specialist-dispatch-closure-2026-03-28.md
@@ -1,0 +1,112 @@
+# Stage-Bound Specialist Dispatch Closure 2026-03-28
+
+## Scope
+
+This closure proves the governed specialist-dispatch design now lands in three places at once:
+
+- frozen runtime input packets
+- frozen requirement and plan surfaces
+- executable runtime topology and receipts
+
+## Landed Design
+
+- specialist recommendations now carry binding metadata:
+  - `binding_profile`
+  - `dispatch_phase`
+  - `execution_priority`
+  - `lane_policy`
+  - `parallelizable_in_root_xl`
+  - `write_scope`
+  - `review_mode`
+- requirement and plan docs now surface phase-bound specialist truth
+- `L` can represent specialist work as explicit serial steps
+- `XL` can represent specialist work as bounded specialist parallel steps when write scopes are disjoint
+- root/child authority remained unchanged
+
+## Verification Run
+
+### Runtime-Neutral Tests
+
+Command:
+
+```bash
+pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py
+```
+
+Result:
+
+- `19 passed`
+- `38 subtests passed`
+
+What this proves:
+
+- bundled runtime mirrors stayed in sync
+- specialist binding metadata is frozen into runtime, requirement, and plan surfaces
+- `XL` can build bounded-parallel specialist steps
+- root/child hierarchy invariants still hold
+- live and degraded specialist paths still remain explicit
+
+### Governance Gates
+
+Commands:
+
+```bash
+pwsh -NoProfile -File scripts/verify/vibe-root-child-hierarchy-gate.ps1
+pwsh -NoProfile -File scripts/verify/vibe-child-specialist-escalation-gate.ps1
+```
+
+Results:
+
+- hierarchy gate: `34 assertions`, `0 failures`
+- child specialist escalation gate: `26 assertions`, `0 failures`
+
+What this proves:
+
+- explicit `vibe` authority remains single-owner
+- child specialist suggestions remain advisory-first
+- same-round auto-absorb stayed enabled and artifact-backed
+- canonical requirement / plan truth did not split
+
+### Docs Encoding
+
+Command:
+
+```bash
+pytest -q tests/runtime_neutral/test_docs_readme_encoding.py
+```
+
+Result:
+
+- `1 passed`
+
+## Stability / Usability / Intelligence Claim
+
+### Stability
+
+Claim basis:
+
+- modified runtime scripts remained mirror-consistent
+- targeted runtime-neutral suite passed end to end
+- governance gates passed without hierarchy regressions
+
+### Usability
+
+Claim basis:
+
+- specialist phase binding is now visible in requirement and plan text
+- runtime artifacts expose the same binding truth the operator sees in docs
+- `L` and `XL` no longer rely on vague “specialist may help” wording
+
+### Intelligence
+
+Claim basis:
+
+- specialist selection remains router-driven
+- specialist execution is no longer flat or last-minute; it is phase-bound
+- `XL` specialist work can now enter bounded parallel steps when safe
+
+## No-Overclaim Notes
+
+- This closure proves bounded parallel specialist steps can exist; it does not claim every composite prompt will always produce multiple parallel specialist lanes.
+- Failure-injection for malformed native specialist output is still a next-step verification gap.
+- Replay-grade proof for child escalation -> root approval -> next-run execution can still be expanded further.

--- a/bundled/skills/vibe/bundled/skills/vibe/install.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/install.ps1
@@ -134,7 +134,84 @@ function Copy-DirContent {
     return
   }
   New-Item -ItemType Directory -Force -Path $Destination | Out-Null
-  Copy-Item -Path (Join-Path $Source '*') -Destination $Destination -Recurse -Force
+    Copy-Item -Path (Join-Path $Source '*') -Destination $Destination -Recurse -Force
+}
+
+function Resolve-CodexDuplicateSkillRoot {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  if ([string]$HostId -ne 'codex') {
+    return $null
+  }
+
+  $leaf = (Split-Path -Path $TargetRoot -Leaf).ToLowerInvariant()
+  if ($leaf -ne '.codex') {
+    return $null
+  }
+
+  $parent = Get-VgoParentPath -Path $TargetRoot
+  if ([string]::IsNullOrWhiteSpace($parent)) {
+    return $null
+  }
+
+  return (Join-Path $parent '.agents\skills\vibe')
+}
+
+function Test-VibeSkillDirectory {
+  param([string]$Path)
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return $false
+  }
+
+  $skillMd = Join-Path $Path 'SKILL.md'
+  if (-not (Test-Path -LiteralPath $skillMd)) {
+    return $false
+  }
+
+  $lines = Get-Content -LiteralPath $skillMd -TotalCount 20 -Encoding UTF8
+  return [bool](@($lines | Where-Object { $_ -match '^\s*name:\s*vibe\s*$' }).Count -gt 0)
+}
+
+function Invoke-CodexDuplicateSkillQuarantine {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  $duplicateRoot = Resolve-CodexDuplicateSkillRoot -TargetRoot $TargetRoot -HostId $HostId
+  if ([string]::IsNullOrWhiteSpace($duplicateRoot) -or -not (Test-Path -LiteralPath $duplicateRoot -PathType Container)) {
+    return
+  }
+
+  $targetSkillRoot = Join-Path $TargetRoot 'skills\vibe'
+  if (-not (Test-Path -LiteralPath $targetSkillRoot -PathType Container)) {
+    return
+  }
+
+  $duplicateFull = [System.IO.Path]::GetFullPath($duplicateRoot)
+  $targetFull = [System.IO.Path]::GetFullPath($targetSkillRoot)
+  if ($duplicateFull -eq $targetFull) {
+    return
+  }
+
+  if (-not (Test-VibeSkillDirectory -Path $duplicateRoot)) {
+    throw "Duplicate Codex-discovered skill surface exists at '$duplicateRoot', but it is not a recognizable vibe skill copy. Move it out of .agents/skills manually."
+  }
+
+  $agentsHome = Get-VgoParentPath -Path (Get-VgoParentPath -Path $duplicateRoot)
+  if ([string]::IsNullOrWhiteSpace($agentsHome)) {
+    throw "Unable to resolve .agents home for duplicate skill surface: $duplicateRoot"
+  }
+
+  $quarantineRoot = Join-Path $agentsHome 'skills-disabled'
+  $quarantinePath = Join-Path $quarantineRoot ("vibe.codex-duplicate-" + (Get-Date -Format 'yyyyMMddTHHmmss'))
+  New-Item -ItemType Directory -Force -Path $quarantineRoot | Out-Null
+  Move-Item -LiteralPath $duplicateRoot -Destination $quarantinePath
+  Write-Warning ("Quarantined duplicate Codex-discovered vibe skill: {0} -> {1}" -f $duplicateRoot, $quarantinePath)
 }
 function Ensure-SkillPresent {
   param(
@@ -162,7 +239,9 @@ function Ensure-SkillPresent {
       if ([string]::IsNullOrWhiteSpace($src)) { continue }
       if (Test-Path -LiteralPath $src) {
         Write-Warning "Using external fallback source for skill '$Name': $src"
-        Copy-DirContent -Source $src -Destination (Join-Path $TargetRoot ("skills\" + $Name))
+        $destination = Join-Path $TargetRoot ("skills\" + $Name)
+        Copy-DirContent -Source $src -Destination $destination
+        Restore-SkillEntryPointIfNeeded -SkillRoot $destination
         $ExternalFallbackUsed.Add($Name) | Out-Null
         break
       }
@@ -209,6 +288,44 @@ function Sync-VibeCanonicalToTarget {
     Copy-DirContent -Source $srcDir -Destination $dstDir
   }
 }
+
+function Hide-InstalledRuntimeMirrorSkillEntryPoints {
+  param([string]$TargetRoot)
+
+  $nestedSkillsRoot = Join-Path $TargetRoot 'skills\vibe\bundled\skills'
+  if (-not (Test-Path -LiteralPath $nestedSkillsRoot -PathType Container)) {
+    return
+  }
+
+  $renamed = 0
+  foreach ($skillDir in @(Get-ChildItem -LiteralPath $nestedSkillsRoot -Directory -ErrorAction SilentlyContinue)) {
+    $skillMd = Join-Path $skillDir.FullName 'SKILL.md'
+    if (-not (Test-Path -LiteralPath $skillMd -PathType Leaf)) {
+      continue
+    }
+
+    $mirrorPath = Join-Path $skillDir.FullName 'SKILL.runtime-mirror.md'
+    Move-Item -LiteralPath $skillMd -Destination $mirrorPath -Force
+    Write-Host ("[INFO] Hid nested runtime mirror skill entrypoint: {0} -> {1}" -f $skillMd, $mirrorPath)
+    $renamed++
+  }
+
+  if ($renamed -eq 0) {
+    Write-Host "[INFO] Nested runtime mirror skill entrypoints already sanitized."
+  }
+}
+
+function Restore-SkillEntryPointIfNeeded {
+  param([string]$SkillRoot)
+
+  $skillMd = Join-Path $SkillRoot 'SKILL.md'
+  $mirrorPath = Join-Path $SkillRoot 'SKILL.runtime-mirror.md'
+  if ((Test-Path -LiteralPath $skillMd -PathType Leaf) -or -not (Test-Path -LiteralPath $mirrorPath -PathType Leaf)) {
+    return
+  }
+
+  Move-Item -LiteralPath $mirrorPath -Destination $skillMd -Force
+}
 Write-Host "=== VCO Adapter Installer ===" -ForegroundColor Cyan
 Write-Host "Host   : $HostId"
 Write-Host "Mode   : $($Adapter.install_mode)"
@@ -245,6 +362,8 @@ if ($null -ne $adapterInstallReceipt -and $adapterInstallReceipt.PSObject.Proper
     }
   }
 }
+
+Hide-InstalledRuntimeMirrorSkillEntryPoints -TargetRoot $TargetRoot
 
 if ($InstallExternal) {
   if ($Adapter.install_mode -ne 'governed') {
@@ -362,6 +481,7 @@ if ($StrictOffline) {
 } elseif ($externalFallbackUsed.Count -gt 0) {
   Write-Warning ("External fallback skills were used (non-reproducible install): " + (($externalFallbackUsed | Select-Object -Unique) -join ", "))
 }
+Invoke-CodexDuplicateSkillQuarantine -TargetRoot $TargetRoot -HostId $HostId
 Invoke-InstalledRuntimeFreshnessGate -RepoRoot $RepoRoot -TargetRoot $TargetRoot -SkipGate:$SkipRuntimeFreshnessGate
 Write-Host ""
 Write-Host "Installation complete." -ForegroundColor Green

--- a/bundled/skills/vibe/bundled/skills/vibe/install.sh
+++ b/bundled/skills/vibe/bundled/skills/vibe/install.sh
@@ -224,6 +224,70 @@ if [[ -z "${TARGET_ROOT}" ]]; then
 fi
 assert_target_root_matches_host_intent "${TARGET_ROOT}" "${HOST_ID}"
 
+resolve_codex_duplicate_skill_root() {
+  if [[ "${HOST_ID}" != "codex" ]]; then
+    return 1
+  fi
+
+  local leaf=""
+  leaf="$(basename "${TARGET_ROOT}")"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${leaf}" != ".codex" ]]; then
+    return 1
+  fi
+
+  local parent=""
+  parent="$(safe_parent_dir "${TARGET_ROOT}")"
+  if [[ -z "${parent}" ]]; then
+    return 1
+  fi
+
+  printf '%s' "${parent}/.agents/skills/vibe"
+}
+
+test_vibe_skill_dir() {
+  local root="${1:-}"
+  local skill_md="${root}/SKILL.md"
+  [[ -f "${skill_md}" ]] || return 1
+  if grep -Eq '^[[:space:]]*name:[[:space:]]*vibe[[:space:]]*$' "${skill_md}"; then
+    return 0
+  fi
+  return 1
+}
+
+quarantine_codex_duplicate_skill_surface() {
+  local duplicate_root=""
+  duplicate_root="$(resolve_codex_duplicate_skill_root || true)"
+  if [[ -z "${duplicate_root}" || ! -d "${duplicate_root}" ]]; then
+    return 0
+  fi
+
+  local target_skill_root="${TARGET_ROOT}/skills/vibe"
+  [[ -d "${target_skill_root}" ]] || return 0
+
+  local duplicate_real=""
+  local target_real=""
+  duplicate_real="$(cd "${duplicate_root}" 2>/dev/null && pwd || true)"
+  target_real="$(cd "${target_skill_root}" 2>/dev/null && pwd || true)"
+  if [[ -n "${duplicate_real}" && -n "${target_real}" && "${duplicate_real}" == "${target_real}" ]]; then
+    return 0
+  fi
+
+  if ! test_vibe_skill_dir "${duplicate_root}"; then
+    echo "[FAIL] Duplicate Codex-discovered skill surface exists at ${duplicate_root}, but it is not a recognizable vibe skill copy." >&2
+    echo "[FAIL] Move it out of .agents/skills manually before using Codex with the installed ~/.codex/skills/vibe lane." >&2
+    return 1
+  fi
+
+  local agents_root=""
+  agents_root="$(dirname "$(dirname "${duplicate_root}")")"
+  local quarantine_root="${agents_root}/skills-disabled"
+  local quarantine_path="${quarantine_root}/vibe.codex-duplicate-$(date +%Y%m%dT%H%M%S)"
+  mkdir -p "${quarantine_root}"
+  mv "${duplicate_root}" "${quarantine_path}"
+  echo "[WARN] Quarantined duplicate Codex-discovered vibe skill: ${duplicate_root} -> ${quarantine_path}"
+}
+
 CANONICAL_SKILLS_ROOT="$(safe_parent_dir "${SCRIPT_DIR}")"
 WORKSPACE_ROOT="$(safe_parent_dir "${CANONICAL_SKILLS_ROOT}")"
 WORKSPACE_SKILLS_ROOT=""
@@ -462,6 +526,34 @@ sync_vibe_canonical_to_target() {
   done
 }
 
+sanitize_installed_runtime_skill_entrypoints() {
+  local nested_skills_root="${TARGET_ROOT}/skills/vibe/bundled/skills"
+  [[ -d "${nested_skills_root}" ]] || return 0
+
+  local skill_md=""
+  local renamed=0
+  while IFS= read -r -d '' skill_md; do
+    local mirror_path="${skill_md%/SKILL.md}/SKILL.runtime-mirror.md"
+    mv "${skill_md}" "${mirror_path}"
+    echo "[INFO] Hid nested runtime mirror skill entrypoint: ${skill_md} -> ${mirror_path}"
+    renamed=$((renamed+1))
+  done < <(find "${nested_skills_root}" -mindepth 2 -maxdepth 2 -type f -name 'SKILL.md' -print0)
+
+  if [[ ${renamed} -eq 0 ]]; then
+    echo "[INFO] Nested runtime mirror skill entrypoints already sanitized."
+  fi
+}
+
+restore_skill_entrypoint_if_needed() {
+  local skill_root="$1"
+  local mirror_path="${skill_root}/SKILL.runtime-mirror.md"
+  local skill_md="${skill_root}/SKILL.md"
+  if [[ -f "${skill_md}" || ! -f "${mirror_path}" ]]; then
+    return 0
+  fi
+  mv "${mirror_path}" "${skill_md}"
+}
+
 ensure_skill_present() {
   local name="$1"
   local required="$2"
@@ -479,6 +571,7 @@ ensure_skill_present() {
       if [[ -d "${src}" ]]; then
         echo "[WARN] Using external fallback source for skill '${name}': ${src}"
         copy_dir_content "${src}" "${TARGET_ROOT}/skills/${name}"
+        restore_skill_entrypoint_if_needed "${TARGET_ROOT}/skills/${name}"
         EXTERNAL_FALLBACK_USED+=("${name}")
         break
       fi
@@ -523,6 +616,8 @@ ADAPTER_INSTALL_JSON="$("${PYTHON_BIN_FOR_ADAPTER}" "${ADAPTER_INSTALLER}" \
 if [[ -n "${ADAPTER_INSTALL_JSON}" ]]; then
   mapfile -t EXTERNAL_FALLBACK_USED < <(printf '%s\n' "${ADAPTER_INSTALL_JSON}" | "${PYTHON_BIN_FOR_ADAPTER}" -c 'import json,sys; data=json.load(sys.stdin); [print(x) for x in data.get("external_fallback_used", [])]')
 fi
+
+sanitize_installed_runtime_skill_entrypoints
 
 if [[ "${INSTALL_EXTERNAL}" == "true" ]]; then
   if [[ "${ADAPTER_INSTALL_MODE}" != "governed" ]]; then
@@ -608,6 +703,7 @@ elif [[ ${#EXTERNAL_FALLBACK_USED[@]} -gt 0 ]]; then
   echo "[WARN] External fallback skills were used (non-reproducible install): ${uniq_fallback}"
 fi
 
+quarantine_codex_duplicate_skill_surface
 run_runtime_freshness_gate
 
 echo "Install done. Run: bash check.sh --profile ${PROFILE} --target-root ${TARGET_ROOT}"

--- a/bundled/skills/vibe/bundled/skills/vibe/protocols/team.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/protocols/team.md
@@ -20,7 +20,8 @@ This protocol only activates after the requirement and plan are already frozen.
 
 ## Scope
 Activated for XL grade tasks that require:
-- Multiple agents working in parallel
+- Multi-agent coordination with dependency-aware waves
+- Step-level bounded parallelism for independent units (not blanket always-on concurrency)
 - Workflow-based execution with phases
 - Swarm or hive-mind coordination
 - Long-running iterative tasks
@@ -31,6 +32,31 @@ Codex native agent APIs manage lifecycle + task assignment (primary path).
 ruflo remains optional for workflow/memory enhancements.
 
 All spawned subagent prompts must end with `$vibe` so the governed runtime remains the active contract inside delegated work.
+
+## Root/Child Authority Model
+
+XL delegation uses two governance scopes:
+
+- `root_governed`: one lane per user task; owns canonical requirement/plan truth and final completion claims
+- `child_governed`: delegated lane; inherits frozen context and emits local execution evidence
+
+Child-governed lanes keep `vibe` discipline but are not new top-level governors.
+
+Child-governed lanes must not:
+
+- create a second canonical requirement surface
+- create a second canonical execution-plan surface
+- emit final completion claims for the full root task
+- self-approve new global specialist dispatch
+
+## Execution Topology Truth
+
+- `L` execution is handled in `do.md` as serial native execution; this protocol is not the default L executor.
+- `XL` execution is wave-sequential by dependency.
+- Parallel work in `XL` is step-scoped and bounded to independent units only.
+- Specialist dispatch can be executable as bounded units only when root-approved in the frozen plan.
+- Specialist dispatch is phase-bound: `pre_execution`, `in_execution`, `post_execution`, `verification`.
+- In `XL`, specialist lanes may join bounded parallel windows only when their write scopes are disjoint and their lane policy allows it.
 
 ### Role Division
 
@@ -59,6 +85,32 @@ Lead-agent rules:
 - subagents may surface report-only warnings, but must not invent a new hard gate,
 - if an existing approved policy or failed gate truly blocks progress, cite that exact surface,
 - aggregation must not flatten bounded-specialization outputs into generalized completion claims.
+- when a specialist skill is dispatched, keep its native workflow intact instead of rewriting it into generic lead-agent prose.
+- only root-governed aggregation may publish final completion claims for the full task.
+
+## Native Specialist Dispatch
+
+Within XL execution, a specialist skill is a bounded helper, not a replacement runtime.
+
+Rules:
+
+- `vibe` keeps final control of stage order, plan authority, and completion claims
+- specialist dispatch should be declared in the frozen plan before execution
+- each specialist receives a bounded subtask contract plus the frozen requirement context
+- specialist outputs must stay in the native format or workflow expected by that specialist skill
+- each approved specialist also carries phase binding, lane policy, write scope, and review mode
+- lead aggregation may summarize specialist output, but must not erase specialist-specific verification notes
+- a specialist recommendation is advisory until the governed plan chooses to dispatch it
+
+Hierarchy-specific dispatch semantics:
+
+- `approved_dispatch`: specialist usage approved by root and frozen in plan; child lanes may execute directly
+- `local_suggestion`: child-lane specialist suggestion; advisory until explicit root escalation approval
+
+Escalation rule:
+
+- child lanes needing non-approved specialists must emit explicit escalation evidence to root
+- no silent specialist activation is allowed in child lanes
 
 ## Orchestration Options
 
@@ -182,6 +234,7 @@ Contract rules:
 - Prefer `verification` that is command-shaped (copy/paste runnable).
 - If required info is missing, return `status=blocked` with `handoff_questions` (do not guess).
 - The same contract maps cleanly to the GSD wave contract (`entry_criteria`/`exit_criteria`/`verify_commands`).
+- If the subtask is owned by a specialist skill, keep the contract narrow enough that native specialist workflow still applies without improvising a new method.
 
 ## Shared Memory Contract (3-Tier)
 
@@ -269,7 +322,7 @@ Contract output:
   - `verify_commands`
 
 Execution semantics:
-1. Independent units run in parallel within a wave.
+1. Independent units may run in bounded parallel within a wave.
 2. Waves run sequentially by dependency.
 3. Verification gates must pass before advancing to next wave.
 4. This contract does not alter grade/task assignment.

--- a/bundled/skills/vibe/bundled/skills/vibe/protocols/think.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/protocols/think.md
@@ -143,7 +143,7 @@ Phase 2: Architecture (vibe-think)
   Gate: Architecture diagram approved
 
 Phase 3: Implementation (vibe-do)
-  Tool: superpowers:subagent-driven-development
+  Tool: native serial execution lane (bounded delegated units only when planned)
   Gate: All tests pass, code reviewed
 
 Phase 4: Security Review (vibe-review)
@@ -246,8 +246,8 @@ When task is purely research (no implementation):
 
 ## Transition to Implementation
 After design is approved:
-1. L grade: Switch to vibe-do with Superpowers subagent-driven-dev
-2. XL grade: Switch to vibe-team protocol (Codex native team + optional ruflo collaboration)
+1. L grade: Switch to vibe-do serial native execution (sequence-first; bounded delegation only when explicitly planned)
+2. XL grade: Switch to vibe-team protocol (wave-sequential execution with step-level bounded parallel units + optional ruflo collaboration)
 3. Always carry the plan document forward as context
 4. Execution must hand off into runtime stage 5 `plan_execute`, not bypass directly into ad-hoc coding
 5. Process-discipline helpers may influence how work is executed, but VCO remains the only governed runtime skeleton and artifact authority

--- a/bundled/skills/vibe/bundled/skills/vibe/references/changelog.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/references/changelog.md
@@ -1,5 +1,14 @@
 # VCO Changelog
 
+## v2.3.51 (2026-03-28)
+
+- Integrated downstream delivery acceptance into the normal `vibe` main chain so governed runs now freeze product acceptance semantics, plan delivery checks, and emit a per-run delivery-acceptance report during cleanup.
+- Completed the recent specialist-governance sequence on `main`: stage-bound specialist dispatch, child-lane same-round auto-absorb under root approval, and stronger native-specialist failure proofing.
+- Fixed Windows specialist runtime handoff so governed specialist execution stays usable on current Windows environments instead of breaking at the boundary between orchestration and native specialist lanes.
+- Added benchmark/scenario-backed workflow acceptance and release-truth helpers to support stricter completion-language honesty beyond pure runtime/process success.
+- Detailed release notes: `docs/releases/v2.3.51.md`.
+
+
 ## v2.3.50 (2026-03-26)
 
 - Added router AI connectivity proofing for the governance advice path, including a PowerShell gate, a runtime-neutral Python probe, and install-entry quick-check guidance that reports structured readiness states.

--- a/bundled/skills/vibe/bundled/skills/vibe/references/proof-bundles/openclaw-runtime-core-preview-candidate/manifest.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/references/proof-bundles/openclaw-runtime-core-preview-candidate/manifest.json
@@ -3,7 +3,7 @@
   "bundle_id": "openclaw-runtime-core-preview-candidate-2026-03-25",
   "frozen_at": "2026-03-25",
   "source_release": {
-    "version": "2.3.50",
+    "version": "2.3.51",
     "updated": "2026-03-26"
   },
   "lane_id": "openclaw/runtime-core-preview",

--- a/bundled/skills/vibe/bundled/skills/vibe/references/release-ledger.jsonl
+++ b/bundled/skills/vibe/bundled/skills/vibe/references/release-ledger.jsonl
@@ -28,3 +28,4 @@
 {"recorded_at":"2026-03-23T01:02:25","version":"2.3.48","updated":"2026-03-23","git_head":"3cd3ae2","actor":null}
 {"recorded_at":"2026-03-23T01:38:21","version":"2.3.49","updated":"2026-03-23","git_head":"dc0430d","actor":null}
 {"recorded_at":"2026-03-26T20:39:51","version":"2.3.50","updated":"2026-03-26","git_head":"d5da111","actor":null}
+{"recorded_at":"2026-03-28T00:00:00","version":"2.3.51","updated":"2026-03-28","git_head":"18e6b9c","actor":null}

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/install/Install-VgoAdapter.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/install/Install-VgoAdapter.ps1
@@ -28,6 +28,18 @@ function Copy-DirContent {
     Copy-Item -Path (Join-Path $Source '*') -Destination $Destination -Recurse -Force
 }
 
+function Restore-SkillEntryPointIfNeeded {
+    param([string]$SkillRoot)
+
+    $skillMd = Join-Path $SkillRoot 'SKILL.md'
+    $mirrorPath = Join-Path $SkillRoot 'SKILL.runtime-mirror.md'
+    if ((Test-Path -LiteralPath $skillMd -PathType Leaf) -or -not (Test-Path -LiteralPath $mirrorPath -PathType Leaf)) {
+        return
+    }
+
+    Move-Item -LiteralPath $mirrorPath -Destination $skillMd -Force
+}
+
 function Ensure-SkillPresent {
     param(
         [string]$Name,
@@ -43,7 +55,9 @@ function Ensure-SkillPresent {
         foreach ($src in $FallbackSources) {
             if ([string]::IsNullOrWhiteSpace($src)) { continue }
             if (Test-Path -LiteralPath $src) {
-                Copy-DirContent -Source $src -Destination (Join-Path $TargetRoot ("skills\" + $Name))
+                $destination = Join-Path $TargetRoot ("skills\" + $Name)
+                Copy-DirContent -Source $src -Destination $destination
+                Restore-SkillEntryPointIfNeeded -SkillRoot $destination
                 $ExternalFallbackUsed.Add($Name) | Out-Null
                 break
             }
@@ -105,6 +119,11 @@ function Install-RuntimeCorePayload {
         $src = Join-Path $RepoRoot ([string]$entry.source)
         $dst = Join-Path $TargetRoot ([string]$entry.target)
         Copy-DirContent -Source $src -Destination $dst
+        if ([string]$entry.target -eq 'skills' -and (Test-Path -LiteralPath $dst -PathType Container)) {
+            foreach ($skillDir in @(Get-ChildItem -LiteralPath $dst -Directory -ErrorAction SilentlyContinue)) {
+                Restore-SkillEntryPointIfNeeded -SkillRoot $skillDir.FullName
+            }
+        }
     }
 
     foreach ($entry in @($packaging.copy_files)) {

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/install/install_vgo_adapter.py
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/install/install_vgo_adapter.py
@@ -98,6 +98,14 @@ def copy_file(src: Path, dst: Path):
     shutil.copy2(src, dst)
 
 
+def restore_skill_entrypoint_if_needed(skill_root: Path):
+    skill_md = skill_root / "SKILL.md"
+    mirror_md = skill_root / "SKILL.runtime-mirror.md"
+    if skill_md.exists() or not mirror_md.exists():
+        return
+    mirror_md.rename(skill_md)
+
+
 def parent_dir(path: Path | None) -> Path | None:
     if path is None:
         return None
@@ -245,7 +253,9 @@ def ensure_skill_present(target_root: Path, name: str, required: bool, allow_fal
         for src in fallback_sources:
             src_path = Path(src)
             if src_path.exists():
-                copy_tree(src_path, target_root / "skills" / name)
+                destination = target_root / "skills" / name
+                copy_tree(src_path, destination)
+                restore_skill_entrypoint_if_needed(destination)
                 external_used.add(name)
                 break
     if required and not skill_md.exists():
@@ -258,6 +268,10 @@ def install_runtime_core(repo_root: Path, target_root: Path, profile: str, allow
         (target_root / rel).mkdir(parents=True, exist_ok=True)
     for entry in packaging["copy_directories"]:
         copy_tree(repo_root / entry["source"], target_root / entry["target"])
+        if entry["target"] == "skills":
+            for skill_dir in (target_root / "skills").iterdir():
+                if skill_dir.is_dir():
+                    restore_skill_entrypoint_if_needed(skill_dir)
     for entry in packaging["copy_files"]:
         src = repo_root / entry["source"]
         if not src.exists():

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/runtime_neutral/release_truth_gate.py
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/runtime_neutral/release_truth_gate.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8", newline="\n")
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8-sig") as handle:
+        return json.load(handle)
+
+
+def resolve_repo_root(start_path: Path) -> Path:
+    current = start_path.resolve()
+    if current.is_file():
+        current = current.parent
+    candidates: list[Path] = []
+    while True:
+        if (current / "config" / "version-governance.json").exists():
+            candidates.append(current)
+        if current.parent == current:
+            break
+        current = current.parent
+    if not candidates:
+        raise RuntimeError(f"Unable to resolve VCO repo root from: {start_path}")
+    git_candidates = [candidate for candidate in candidates if (candidate / ".git").exists()]
+    if git_candidates:
+        return git_candidates[-1]
+    return candidates[-1]
+
+
+def evaluate(repo_root: Path, report_paths: list[Path]) -> dict[str, Any]:
+    reports = [load_json(path) for path in report_paths]
+    failing_reports: list[str] = []
+    manual_reports: list[str] = []
+    blocked_completion_reports: list[str] = []
+
+    for report_path, report in zip(report_paths, reports):
+        summary = report.get("summary") or {}
+        gate_result = str(summary.get("gate_result") or "")
+        completion_language_allowed = bool(summary.get("completion_language_allowed"))
+        if gate_result == "FAIL":
+            failing_reports.append(str(report_path))
+        elif gate_result == "MANUAL_REVIEW_REQUIRED":
+            manual_reports.append(str(report_path))
+        if not completion_language_allowed:
+            blocked_completion_reports.append(str(report_path))
+
+    gate_result = "PASS"
+    if failing_reports:
+        gate_result = "FAIL"
+    elif manual_reports:
+        gate_result = "MANUAL_REVIEW_REQUIRED"
+
+    summary = {
+        "gate_result": gate_result,
+        "report_count": len(reports),
+        "failing_report_count": len(failing_reports),
+        "manual_review_report_count": len(manual_reports),
+        "blocked_completion_report_count": len(blocked_completion_reports),
+        "completion_language_allowed": gate_result == "PASS" and len(blocked_completion_reports) == 0,
+    }
+    return {
+        "evaluated_at": utc_now(),
+        "summary": summary,
+        "reports": [
+            {
+                "path": str(report_path),
+                "scenario_id": str((report.get("summary") or {}).get("scenario_id") or ""),
+                "task_class": str((report.get("summary") or {}).get("task_class") or ""),
+                "gate_result": str((report.get("summary") or {}).get("gate_result") or ""),
+                "completion_language_allowed": bool((report.get("summary") or {}).get("completion_language_allowed")),
+            }
+            for report_path, report in zip(report_paths, reports)
+        ],
+        "failing_reports": failing_reports,
+        "manual_review_reports": manual_reports,
+        "blocked_completion_reports": blocked_completion_reports,
+    }
+
+
+def write_artifacts(repo_root: Path, artifact: dict[str, Any], output_directory: str | None) -> None:
+    output_root = Path(output_directory) if output_directory else repo_root / "outputs" / "verify"
+    json_path = output_root / "vibe-release-truth-gate.json"
+    md_path = output_root / "vibe-release-truth-gate.md"
+    write_text(json_path, json.dumps(artifact, ensure_ascii=False, indent=2) + "\n")
+    lines = [
+        "# Vibe Release Truth Gate",
+        "",
+        f"- Gate Result: **{artifact['summary']['gate_result']}**",
+        f"- Report Count: `{artifact['summary']['report_count']}`",
+        f"- Failing Reports: `{artifact['summary']['failing_report_count']}`",
+        f"- Manual Review Reports: `{artifact['summary']['manual_review_report_count']}`",
+        f"- Completion Language Allowed: `{artifact['summary']['completion_language_allowed']}`",
+        "",
+        "## Reports",
+        "",
+    ]
+    for report in artifact["reports"]:
+        lines.append(
+            f"- `{report['scenario_id']}` task_class=`{report['task_class']}` gate_result=`{report['gate_result']}` completion_language_allowed=`{report['completion_language_allowed']}`"
+        )
+    write_text(md_path, "\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Aggregate workflow acceptance reports into a release-truth decision.")
+    parser.add_argument("--report", action="append", dest="reports", required=True, help="Path to a workflow acceptance report JSON file.")
+    parser.add_argument("--repo-root", help="Optional explicit repository root.")
+    parser.add_argument("--write-artifacts", action="store_true", help="Write JSON/Markdown artifacts.")
+    parser.add_argument("--output-directory", help="Optional output directory for artifacts.")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else resolve_repo_root(Path(__file__))
+    artifact = evaluate(repo_root, [Path(item).resolve() for item in args.reports])
+    if args.write_artifacts:
+        write_artifacts(repo_root, artifact, args.output_directory)
+    print(json.dumps(artifact, ensure_ascii=False, indent=2))
+    return 0 if artifact["summary"]["gate_result"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/runtime_neutral/workflow_acceptance_runner.py
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/runtime_neutral/workflow_acceptance_runner.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8", newline="\n")
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8-sig") as handle:
+        return json.load(handle)
+
+
+def resolve_repo_root(start_path: Path) -> Path:
+    current = start_path.resolve()
+    if current.is_file():
+        current = current.parent
+    candidates: list[Path] = []
+    while True:
+        if (current / "config" / "version-governance.json").exists():
+            candidates.append(current)
+        if current.parent == current:
+            break
+        current = current.parent
+    if not candidates:
+        raise RuntimeError(f"Unable to resolve VCO repo root from: {start_path}")
+    git_candidates = [candidate for candidate in candidates if (candidate / ".git").exists()]
+    if git_candidates:
+        return git_candidates[-1]
+    return candidates[-1]
+
+
+def _normalize_truth_state(state: str) -> str:
+    normalized = str(state or "").strip().lower()
+    aliases = {
+        "pass": "passing",
+        "passed": "passing",
+        "ok": "passing",
+        "manual": "manual_review_required",
+        "manual_required": "manual_review_required",
+        "manual_review": "manual_review_required",
+        "fail": "failing",
+        "failed": "failing",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _truth_success(contract: dict[str, Any], state: str) -> bool:
+    return bool(((contract.get("truth_states") or {}).get(state) or {}).get("counts_as_success"))
+
+
+def _truth_completion_allowed(contract: dict[str, Any], state: str) -> bool:
+    return bool(((contract.get("truth_states") or {}).get(state) or {}).get("completion_language_allowed"))
+
+
+def evaluate(repo_root: Path, scenario_path: Path) -> dict[str, Any]:
+    contract = load_json(repo_root / "config" / "project-delivery-acceptance-contract.json")
+    scenario = load_json(scenario_path)
+    benchmark_repo_rel = str(scenario.get("benchmark_repo") or "").strip()
+    benchmark_repo_path = (repo_root / benchmark_repo_rel).resolve() if benchmark_repo_rel else None
+    benchmark_manifest_path = benchmark_repo_path / "acceptance-manifest.json" if benchmark_repo_path else None
+    benchmark_manifest = load_json(benchmark_manifest_path) if benchmark_manifest_path and benchmark_manifest_path.exists() else None
+
+    truth_layers = list(contract.get("truth_layers") or [])
+    scenario_truths = scenario.get("truths") or {}
+    truth_results: dict[str, dict[str, Any]] = {}
+
+    failing_layers: list[str] = []
+    manual_layers: list[str] = []
+    incomplete_layers: list[str] = []
+
+    for layer in truth_layers:
+        layer_spec = scenario_truths.get(layer) or {}
+        state = _normalize_truth_state(layer_spec.get("state", "not_run"))
+        success = _truth_success(contract, state)
+        completion_allowed = _truth_completion_allowed(contract, state)
+        if state == "manual_review_required":
+            manual_layers.append(layer)
+        if not success:
+            incomplete_layers.append(layer)
+        if state in {"failing", "degraded", "partial", "not_run"}:
+            failing_layers.append(layer)
+        truth_results[layer] = {
+            "state": state,
+            "success": success,
+            "completion_language_allowed": completion_allowed,
+            "evidence": list(layer_spec.get("evidence") or []),
+            "notes": str(layer_spec.get("notes") or ""),
+        }
+
+    runtime_status = str((scenario.get("runtime") or {}).get("status") or "").strip()
+    readiness_state = str((scenario.get("runtime") or {}).get("readiness_state") or "").strip()
+    forbidden_hits: list[dict[str, str]] = []
+    for rule in list(contract.get("forbidden_completion_collapses") or []):
+        source = str(rule.get("source") or "")
+        value = str(rule.get("value") or "")
+        if source == "runtime_status" and runtime_status == value:
+            forbidden_hits.append({"source": source, "value": value, "reason": str(rule.get("reason") or "")})
+        if source == "readiness_state" and readiness_state == value:
+            forbidden_hits.append({"source": source, "value": value, "reason": str(rule.get("reason") or "")})
+
+    gate_result = "PASS"
+    if failing_layers or forbidden_hits:
+        gate_result = "FAIL"
+    elif manual_layers:
+        gate_result = "MANUAL_REVIEW_REQUIRED"
+
+    completion_language_allowed = gate_result == "PASS" and all(
+        truth_results[layer]["completion_language_allowed"] for layer in truth_layers
+    )
+
+    summary = {
+        "scenario_id": str(scenario.get("scenario_id") or ""),
+        "task_class": str(scenario.get("task_class") or ""),
+        "gate_result": gate_result,
+        "completion_language_allowed": completion_language_allowed,
+        "runtime_status": runtime_status,
+        "readiness_state": readiness_state,
+        "manual_review_layer_count": len(manual_layers),
+        "failing_layer_count": len(failing_layers),
+        "forbidden_completion_hit_count": len(forbidden_hits),
+        "incomplete_layers": incomplete_layers,
+        "benchmark_repo_rel": benchmark_repo_rel,
+        "benchmark_repo_exists": bool(benchmark_repo_path and benchmark_repo_path.exists()),
+        "benchmark_manifest_exists": bool(benchmark_manifest_path and benchmark_manifest_path.exists()),
+    }
+
+    if benchmark_repo_rel and not summary["benchmark_repo_exists"]:
+        summary["gate_result"] = "FAIL"
+        summary["completion_language_allowed"] = False
+        summary["incomplete_layers"] = sorted(set(summary["incomplete_layers"] + ["product_acceptance_truth"]))
+    if benchmark_repo_rel and summary["benchmark_repo_exists"] and not summary["benchmark_manifest_exists"]:
+        if summary["gate_result"] == "PASS":
+            summary["gate_result"] = "MANUAL_REVIEW_REQUIRED"
+        summary["completion_language_allowed"] = False
+        summary["incomplete_layers"] = sorted(set(summary["incomplete_layers"] + ["product_acceptance_truth"]))
+
+    manual_spot_checks = list(scenario.get("manual_spot_checks") or [])
+    residual_risks = list(scenario.get("residual_risks") or [])
+
+    return {
+        "evaluated_at": utc_now(),
+        "contract_id": str(contract.get("contract_id") or ""),
+        "contract_version": int(contract.get("version") or 0),
+        "scenario_path": str(scenario_path),
+        "summary": summary,
+        "benchmark": {
+            "repo_rel": benchmark_repo_rel,
+            "repo_path": str(benchmark_repo_path) if benchmark_repo_path else "",
+            "repo_exists": bool(benchmark_repo_path and benchmark_repo_path.exists()),
+            "manifest_path": str(benchmark_manifest_path) if benchmark_manifest_path else "",
+            "manifest_exists": bool(benchmark_manifest_path and benchmark_manifest_path.exists()),
+            "manifest": benchmark_manifest,
+        },
+        "truth_results": truth_results,
+        "forbidden_completion_hits": forbidden_hits,
+        "manual_spot_checks": manual_spot_checks,
+        "residual_risks": residual_risks,
+    }
+
+
+def write_artifacts(repo_root: Path, artifact: dict[str, Any], output_directory: str | None) -> None:
+    output_root = Path(output_directory) if output_directory else repo_root / "outputs" / "verify"
+    json_path = output_root / "vibe-workflow-acceptance-gate.json"
+    md_path = output_root / "vibe-workflow-acceptance-gate.md"
+    write_text(json_path, json.dumps(artifact, ensure_ascii=False, indent=2) + "\n")
+
+    lines = [
+        "# Vibe Workflow Acceptance Gate",
+        "",
+        f"- Scenario: `{artifact['summary']['scenario_id']}`",
+        f"- Task Class: `{artifact['summary']['task_class']}`",
+        f"- Gate Result: **{artifact['summary']['gate_result']}**",
+        f"- Completion Language Allowed: `{artifact['summary']['completion_language_allowed']}`",
+        f"- Runtime Status: `{artifact['summary']['runtime_status']}`",
+        f"- Readiness State: `{artifact['summary']['readiness_state']}`",
+        f"- Benchmark Repo: `{artifact['summary']['benchmark_repo_rel']}`",
+        f"- Benchmark Repo Exists: `{artifact['summary']['benchmark_repo_exists']}`",
+        f"- Benchmark Manifest Exists: `{artifact['summary']['benchmark_manifest_exists']}`",
+        f"- Manual Review Layers: `{artifact['summary']['manual_review_layer_count']}`",
+        f"- Failing Layers: `{artifact['summary']['failing_layer_count']}`",
+        f"- Forbidden Completion Hits: `{artifact['summary']['forbidden_completion_hit_count']}`",
+        "",
+        "## Truth Layers",
+        "",
+    ]
+    for layer, info in artifact["truth_results"].items():
+        lines.append(
+            f"- `{layer}`: state=`{info['state']}` success=`{info['success']}` completion_language_allowed=`{info['completion_language_allowed']}`"
+        )
+    if artifact["forbidden_completion_hits"]:
+        lines += ["", "## Forbidden Completion Hits", ""]
+        for hit in artifact["forbidden_completion_hits"]:
+            lines.append(f"- `{hit['source']}`=`{hit['value']}` reason=`{hit['reason']}`")
+    if artifact["benchmark"]["manifest"]:
+        lines += ["", "## Benchmark Manifest", ""]
+        manifest = artifact["benchmark"]["manifest"]
+        lines.append(f"- `benchmark_id`: `{manifest.get('benchmark_id', '')}`")
+        for flow in list(manifest.get("critical_user_flows") or []):
+            lines.append(f"- critical_user_flow: {flow}")
+    if artifact["manual_spot_checks"]:
+        lines += ["", "## Manual Spot Checks", ""]
+        for item in artifact["manual_spot_checks"]:
+            lines.append(f"- {item}")
+    if artifact["residual_risks"]:
+        lines += ["", "## Residual Risks", ""]
+        for item in artifact["residual_risks"]:
+            lines.append(f"- {item}")
+    write_text(md_path, "\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Evaluate downstream project delivery acceptance for a governed scenario.")
+    parser.add_argument("--scenario", required=True, help="Path to the scenario JSON file.")
+    parser.add_argument("--repo-root", help="Optional explicit repository root.")
+    parser.add_argument("--write-artifacts", action="store_true", help="Write JSON/Markdown artifacts.")
+    parser.add_argument("--output-directory", help="Optional output directory for artifacts.")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else resolve_repo_root(Path(__file__))
+    artifact = evaluate(repo_root, Path(args.scenario).resolve())
+    if args.write_artifacts:
+        write_artifacts(repo_root, artifact, args.output_directory)
+    print(json.dumps(artifact, ensure_ascii=False, indent=2))
+    return 0 if artifact["summary"]["gate_result"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-benchmark-autonomous-proof-gate.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-benchmark-autonomous-proof-gate.ps1
@@ -51,7 +51,7 @@ foreach ($relativePath in $requiredFiles) {
 
 $runId = "benchmark-proof-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
 $artifactRoot = Join-Path $repoRoot (".tmp\benchmark-proof-{0}" -f $runId)
-$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'benchmark autonomous proof closure' -Mode benchmark_autonomous -RunId $runId -ArtifactRoot $artifactRoot
+$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'I have a failing test and a stack trace. Help me debug systematically before proposing fixes.' -Mode benchmark_autonomous -RunId $runId -ArtifactRoot $artifactRoot
 
 $executeReceiptPath = [string]$summary.summary.artifacts.execute_receipt
 $executionManifestPath = [string]$summary.summary.artifacts.execution_manifest
@@ -74,14 +74,26 @@ Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.stage -eq
 Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.runtime_mode -eq 'interactive_governed') -Message 'runtime input packet records interactive_governed as the effective mode'
 Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$runtimeInputPacket.canonical_router.unattended) -Message 'legacy benchmark mode no longer drives unattended router execution'
 Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.provenance.proof_class -eq 'structure') -Message 'runtime input packet carries structure proof class'
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.route_snapshot.selected_skill -eq 'vibe') -Message 'runtime input packet keeps vibe as the frozen route skill for governed entry'
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'runtime input packet keeps vibe as runtime authority'
+Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$runtimeInputPacket.divergence_shadow.skill_mismatch) -Message 'runtime input packet keeps router/runtime alignment for explicit governed vibe entry'
+Add-Assertion -Results ([ref]$results) -Condition (@($runtimeInputPacket.specialist_recommendations).Count -ge 1) -Message 'runtime input packet carries specialist recommendations'
+Add-Assertion -Results ([ref]$results) -Condition ((@($runtimeInputPacket.specialist_recommendations | ForEach-Object { [string]$_.skill_id }) -contains 'systematic-debugging')) -Message 'runtime input packet carries systematic-debugging as bounded specialist recommendation'
 Add-Assertion -Results ([ref]$results) -Condition ($executeReceipt.status -ne 'execution-contract-prepared') -Message 'execute receipt is no longer receipt-only'
 Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.status -eq 'completed') -Message 'execution manifest status is completed' -Details $executionManifest.status
 Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.executed_unit_count -ge 2) -Message 'benchmark executed at least two real units' -Details $executionManifest.executed_unit_count
 Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.failed_unit_count -eq 0) -Message 'benchmark execution has zero failed units' -Details $executionManifest.failed_unit_count
 Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.proof_class -eq 'runtime') -Message 'execution manifest carries runtime proof class'
 Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath ([string]$executeReceipt.plan_shadow_path)) -Message 'plan-derived shadow manifest exists' -Details ([string]$executeReceipt.plan_shadow_path)
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executeReceipt.specialist_recommendation_count -ge 1) -Message 'execute receipt carries specialist recommendation count'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executeReceipt.specialist_dispatch_unit_count -ge 1) -Message 'execute receipt carries specialist dispatch unit count'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.specialist_accounting.recommendation_count -ge 1) -Message 'execution manifest carries specialist accounting'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.specialist_accounting.dispatch_unit_count -ge 1) -Message 'execution manifest carries specialist dispatch accounting'
+Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$executionManifest.route_runtime_alignment.skill_mismatch) -Message 'execution manifest preserves governed vibe alignment while still carrying specialist accounting'
 Add-Assertion -Results ([ref]$results) -Condition ([bool]$proofManifest.proof_passed) -Message 'benchmark proof manifest marks proof_passed=true'
 Add-Assertion -Results ([ref]$results) -Condition ($proofManifest.proof_class -eq 'runtime') -Message 'benchmark proof manifest carries runtime proof class'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$proofManifest.specialist_recommendation_count -ge 1) -Message 'benchmark proof manifest carries specialist recommendation count'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$proofManifest.specialist_dispatch_unit_count -ge 1) -Message 'benchmark proof manifest carries specialist dispatch count'
 Add-Assertion -Results ([ref]$results) -Condition ($cleanupReceipt.cleanup_mode -eq 'receipt_only') -Message 'legacy benchmark mode now uses interactive_governed cleanup defaults'
 Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$cleanupReceipt.default_bounded_cleanup_applied) -Message 'legacy benchmark mode no longer applies bounded cleanup by default'
 Add-Assertion -Results ([ref]$results) -Condition ($cleanupReceipt.proof_class -eq 'runtime') -Message 'cleanup receipt carries runtime proof class'

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-child-specialist-escalation-gate.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-child-specialist-escalation-gate.ps1
@@ -1,0 +1,202 @@
+param(
+    [switch]$WriteArtifacts,
+    [string]$OutputDirectory = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
+. (Join-Path $PSScriptRoot '..\runtime\VibeRuntime.Common.ps1')
+
+function Add-Assertion {
+    param(
+        [ref]$Results,
+        [bool]$Condition,
+        [string]$Message,
+        [string]$Details = ''
+    )
+
+    $record = [pscustomobject]@{
+        passed = [bool]$Condition
+        message = $Message
+        details = $Details
+    }
+    $Results.Value += $record
+
+    if ($Condition) {
+        Write-Host "[PASS] $Message"
+    } else {
+        Write-Host "[FAIL] $Message" -ForegroundColor Red
+        if ($Details) {
+            Write-Host "       $Details" -ForegroundColor DarkRed
+        }
+    }
+}
+
+$context = Get-VgoGovernanceContext -ScriptPath $PSCommandPath -EnforceExecutionContext
+$repoRoot = $context.repoRoot
+$results = @()
+
+$policyText = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-input-packet-policy.json') -Raw -Encoding UTF8
+foreach ($token in @('specialist_dispatch', 'local_specialist_suggestions', 'escalation_required', 'advisory_until_root_approval', 'auto_absorb_gate')) {
+    Add-Assertion -Results ([ref]$results) -Condition ($policyText.Contains($token)) -Message ("runtime input policy contains specialist escalation token: {0}" -f $token)
+}
+
+$teamText = Get-Content -LiteralPath (Join-Path $repoRoot 'protocols\team.md') -Raw -Encoding UTF8
+$stableDocText = Get-Content -LiteralPath (Join-Path $repoRoot 'docs\root-child-vibe-hierarchy-governance.md') -Raw -Encoding UTF8
+Add-Assertion -Results ([ref]$results) -Condition ($teamText.Contains('advisory until the governed plan chooses to dispatch it')) -Message 'team protocol keeps specialist recommendation advisory-first'
+Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('same-round auto-approve safe suggestions')) -Message 'stable hierarchy doc documents root-governed same-round absorb path'
+
+$runId = "child-specialist-escalation-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
+$artifactRoot = Join-Path $repoRoot (".tmp\child-specialist-escalation-{0}" -f $runId)
+
+$rootSummary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') `
+    -Task 'Root specialist dispatch seed for child escalation gate.' `
+    -Mode benchmark_autonomous `
+    -GovernanceScope root `
+    -RunId ("{0}-root" -f $runId) `
+    -ArtifactRoot $artifactRoot
+
+Add-Assertion -Results ([ref]$results) -Condition ($null -ne $rootSummary) -Message 'root specialist escalation probe returned summary payload'
+$hasRootSummary = ($null -ne $rootSummary) -and ($rootSummary.PSObject.Properties.Name -contains 'summary')
+Add-Assertion -Results ([ref]$results) -Condition $hasRootSummary -Message 'root specialist escalation probe has summary object'
+
+$approvedForChild = @()
+if ($hasRootSummary) {
+    $rootRuntimeInputPacket = Get-Content -LiteralPath $rootSummary.summary.artifacts.runtime_input_packet -Raw -Encoding UTF8 | ConvertFrom-Json
+    Add-Assertion -Results ([ref]$results) -Condition ($rootRuntimeInputPacket.governance_scope -eq 'root') -Message 'root specialist escalation probe is in root scope'
+    Add-Assertion -Results ([ref]$results) -Condition ($rootRuntimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'root specialist escalation probe keeps vibe authority'
+
+    $rootApprovedDispatch = if ($rootRuntimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch') {
+        @($rootRuntimeInputPacket.specialist_dispatch.approved_dispatch)
+    } elseif ($rootRuntimeInputPacket.PSObject.Properties.Name -contains 'approved_specialist_dispatch') {
+        @($rootRuntimeInputPacket.approved_specialist_dispatch)
+    } else {
+        @()
+    }
+    if (@($rootApprovedDispatch).Count -gt 0) {
+        $firstSkillId = [string]$rootApprovedDispatch[0].skill_id
+        if (-not [string]::IsNullOrWhiteSpace($firstSkillId)) {
+            $approvedForChild = @($firstSkillId)
+        }
+    }
+}
+
+$childSummary = $null
+if ($hasRootSummary) {
+    $childSummary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') `
+        -Task 'Child specialist escalation advisory smoke.' `
+        -Mode benchmark_autonomous `
+        -GovernanceScope child `
+        -RunId ("{0}-child" -f $runId) `
+        -RootRunId ([string]$rootSummary.summary.run_id) `
+        -ParentRunId ([string]$rootSummary.summary.run_id) `
+        -ParentUnitId 'child-specialist-escalation-unit' `
+        -InheritedRequirementDocPath ([string]$rootSummary.summary.artifacts.requirement_doc) `
+        -InheritedExecutionPlanPath ([string]$rootSummary.summary.artifacts.execution_plan) `
+        -ApprovedSpecialistSkillIds $approvedForChild `
+        -ArtifactRoot $artifactRoot
+}
+
+Add-Assertion -Results ([ref]$results) -Condition ($null -ne $childSummary) -Message 'child specialist escalation probe returned summary payload'
+$hasChildSummary = ($null -ne $childSummary) -and ($childSummary.PSObject.Properties.Name -contains 'summary')
+Add-Assertion -Results ([ref]$results) -Condition $hasChildSummary -Message 'child specialist escalation probe has summary object'
+
+$approvedDispatch = @()
+$localSuggestions = @()
+$childClaims = @()
+if ($hasChildSummary) {
+    $runtimeInputPacket = Get-Content -LiteralPath $childSummary.summary.artifacts.runtime_input_packet -Raw -Encoding UTF8 | ConvertFrom-Json
+    $executionManifest = Get-Content -LiteralPath $childSummary.summary.artifacts.execution_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    $specialistDispatch = if ($runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch') {
+        $runtimeInputPacket.specialist_dispatch
+    } else {
+        $null
+    }
+
+    $approvedDispatch = if ($null -ne $specialistDispatch -and $specialistDispatch.PSObject.Properties.Name -contains 'approved_dispatch') {
+        @($specialistDispatch.approved_dispatch)
+    } elseif ($runtimeInputPacket.PSObject.Properties.Name -contains 'approved_specialist_dispatch') {
+        @($runtimeInputPacket.approved_specialist_dispatch)
+    } else {
+        @()
+    }
+
+    $localSuggestions = if ($null -ne $specialistDispatch -and $specialistDispatch.PSObject.Properties.Name -contains 'local_specialist_suggestions') {
+        @($specialistDispatch.local_specialist_suggestions)
+    } elseif ($runtimeInputPacket.PSObject.Properties.Name -contains 'local_specialist_suggestions') {
+        @($runtimeInputPacket.local_specialist_suggestions)
+    } else {
+        @()
+    }
+
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.governance_scope -eq 'child') -Message 'specialist escalation smoke runs in child scope'
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'specialist escalation smoke keeps vibe runtime authority'
+    Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$runtimeInputPacket.authority_flags.allow_completion_claim) -Message 'child runtime input packet disallows final completion claim'
+    Add-Assertion -Results ([ref]$results) -Condition ($null -ne $specialistDispatch) -Message 'runtime packet exposes specialist dispatch surface'
+
+    if ($null -ne $specialistDispatch) {
+        Add-Assertion -Results ([ref]$results) -Condition ([string]$specialistDispatch.status -eq 'advisory_until_root_approval') -Message 'child specialist suggestions remain advisory until root approval'
+        if (@($localSuggestions).Count -gt 0) {
+            Add-Assertion -Results ([ref]$results) -Condition ([bool]$specialistDispatch.escalation_required) -Message 'child local specialist suggestions require escalation'
+            Add-Assertion -Results ([ref]$results) -Condition ([string]$specialistDispatch.escalation_status -eq 'root_approval_required') -Message 'child local specialist escalation status is root_approval_required'
+        }
+    }
+
+    $approvedSkillIds = @($approvedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    foreach ($entry in $localSuggestions) {
+        $skillId = if ($entry.PSObject.Properties.Name -contains 'skill_id') { [string]$entry.skill_id } else { 'unknown-skill' }
+        Add-Assertion -Results ([ref]$results) -Condition (-not ($approvedSkillIds -contains $skillId)) -Message ("local specialist suggestion is not approved global dispatch: {0}" -f $skillId)
+    }
+
+    Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.governance_scope -eq 'child') -Message 'execution manifest is marked child scope'
+    Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$executionManifest.authority.completion_claim_allowed) -Message 'child execution manifest cannot issue final completion claim'
+    Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.route_runtime_alignment.runtime_selected_skill -eq 'vibe') -Message 'execution manifest keeps explicit vibe authority'
+    $specialistAccounting = if ($executionManifest.PSObject.Properties.Name -contains 'specialist_accounting') { $executionManifest.specialist_accounting } else { $null }
+    if ($null -ne $specialistAccounting -and $specialistAccounting.PSObject.Properties.Name -contains 'auto_absorb_gate') {
+        Add-Assertion -Results ([ref]$results) -Condition ([bool]$specialistAccounting.auto_absorb_gate.enabled) -Message 'child execution manifest exposes enabled same-round auto-absorb gate'
+        if ($specialistAccounting.auto_absorb_gate.receipt_path) {
+            Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath ([string]$specialistAccounting.auto_absorb_gate.receipt_path)) -Message 'same-round auto-absorb gate emits receipt'
+        }
+    }
+
+    $childClaims = if ($executionManifest.PSObject.Properties.Name -contains 'child_completion_claims') { @($executionManifest.child_completion_claims) } else { @() }
+}
+
+$failureCount = @($results | Where-Object { -not $_.passed }).Count
+$gatePassed = ($failureCount -eq 0)
+$report = [pscustomobject]@{
+    generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    repo_root = $repoRoot
+    gate_passed = $gatePassed
+    assertion_count = @($results).Count
+    failure_count = $failureCount
+    runtime_summary_path = if ($null -ne $childSummary -and ($childSummary.PSObject.Properties.Name -contains 'summary_path')) { $childSummary.summary_path } else { $null }
+    approved_dispatch_count = @($approvedDispatch).Count
+    local_suggestion_count = @($localSuggestions).Count
+    child_claim_count = @($childClaims).Count
+    results = @($results)
+}
+
+if ($WriteArtifacts) {
+    $targetDir = if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        Join-Path $repoRoot 'outputs\verify\vibe-child-specialist-escalation'
+    } elseif ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+        [System.IO.Path]::GetFullPath($OutputDirectory)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDirectory))
+    }
+
+    New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    Write-VibeJsonArtifact -Path (Join-Path $targetDir 'vibe-child-specialist-escalation-gate.json') -Value $report
+} elseif (Test-Path -LiteralPath $artifactRoot) {
+    Remove-Item -LiteralPath $artifactRoot -Recurse -Force
+}
+
+if (-not $gatePassed) {
+    throw "vibe-child-specialist-escalation-gate failed with $failureCount failing assertion(s)."
+}
+
+$report

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-governed-runtime-contract-gate.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-governed-runtime-contract-gate.ps1
@@ -98,7 +98,7 @@ Add-Assertion -Results ([ref]$results) -Condition ($teamText.Contains('$vibe')) 
 
 $runId = "contract-gate-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
 $artifactRoot = Join-Path $repoRoot (".tmp\governed-runtime-contract-{0}" -f $runId)
-$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'governed runtime contract smoke proof' -Mode benchmark_autonomous -RunId $runId -ArtifactRoot $artifactRoot
+$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'I have a failing test and a stack trace. Help me debug systematically before proposing fixes.' -Mode benchmark_autonomous -RunId $runId -ArtifactRoot $artifactRoot
 
 Add-Assertion -Results ([ref]$results) -Condition ($summary.mode -eq 'interactive_governed') -Message 'runtime smoke summary normalizes legacy benchmark mode to interactive_governed'
 
@@ -120,6 +120,7 @@ foreach ($artifactPath in $artifactPaths) {
 $executeReceipt = Get-Content -LiteralPath $summary.summary.artifacts.execute_receipt -Raw -Encoding UTF8 | ConvertFrom-Json
 $executionManifest = Get-Content -LiteralPath $summary.summary.artifacts.execution_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
 $proofManifest = Get-Content -LiteralPath $summary.summary.artifacts.benchmark_proof_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+$runtimeInputPacket = Get-Content -LiteralPath $summary.summary.artifacts.runtime_input_packet -Raw -Encoding UTF8 | ConvertFrom-Json
 $generatedRequirement = Get-Content -LiteralPath $summary.summary.artifacts.requirement_doc -Raw -Encoding UTF8
 $generatedPlan = Get-Content -LiteralPath $summary.summary.artifacts.execution_plan -Raw -Encoding UTF8
 
@@ -131,6 +132,15 @@ Add-Assertion -Results ([ref]$results) -Condition ($generatedRequirement.Contain
 Add-Assertion -Results ([ref]$results) -Condition ($generatedRequirement.Contains('## Completion State')) -Message 'runtime smoke requirement doc includes anti-drift completion section'
 Add-Assertion -Results ([ref]$results) -Condition ($generatedPlan.Contains('## Anti-Proxy-Goal-Drift Controls')) -Message 'runtime smoke execution plan includes anti-drift controls section'
 Add-Assertion -Results ([ref]$results) -Condition ($generatedPlan.Contains('### Primary Objective')) -Message 'runtime smoke execution plan includes anti-drift primary objective control'
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.route_snapshot.selected_skill -eq 'vibe') -Message 'runtime smoke keeps vibe as the frozen route skill for governed entry'
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'runtime smoke keeps vibe as explicit runtime skill'
+Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$runtimeInputPacket.divergence_shadow.skill_mismatch) -Message 'runtime smoke keeps router/runtime skill alignment for explicit governed vibe entry'
+Add-Assertion -Results ([ref]$results) -Condition (@($runtimeInputPacket.specialist_recommendations).Count -ge 1) -Message 'runtime smoke freezes bounded specialist recommendations'
+Add-Assertion -Results ([ref]$results) -Condition ((@($runtimeInputPacket.specialist_recommendations | ForEach-Object { [string]$_.skill_id }) -contains 'systematic-debugging')) -Message 'runtime smoke preserves systematic-debugging as a bounded specialist recommendation'
+Add-Assertion -Results ([ref]$results) -Condition ($generatedRequirement.Contains('## Specialist Recommendations')) -Message 'runtime smoke requirement doc includes specialist recommendations section'
+Add-Assertion -Results ([ref]$results) -Condition ($generatedPlan.Contains('## Specialist Skill Dispatch Plan')) -Message 'runtime smoke execution plan includes specialist dispatch section'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.specialist_accounting.recommendation_count -ge 1) -Message 'runtime smoke execution manifest carries specialist accounting'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.plan_shadow.specialist_dispatch_unit_count -ge 1) -Message 'runtime smoke plan shadow counts specialist dispatch units'
 
 $failureCount = @($results | Where-Object { -not $_.passed }).Count
 $gatePassed = ($failureCount -eq 0)

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-no-duplicate-canonical-surface-gate.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-no-duplicate-canonical-surface-gate.ps1
@@ -1,0 +1,166 @@
+param(
+    [switch]$WriteArtifacts,
+    [string]$OutputDirectory = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
+. (Join-Path $PSScriptRoot '..\runtime\VibeRuntime.Common.ps1')
+
+function Add-Assertion {
+    param(
+        [ref]$Results,
+        [bool]$Condition,
+        [string]$Message,
+        [string]$Details = ''
+    )
+
+    $record = [pscustomobject]@{
+        passed = [bool]$Condition
+        message = $Message
+        details = $Details
+    }
+    $Results.Value += $record
+
+    if ($Condition) {
+        Write-Host "[PASS] $Message"
+    } else {
+        Write-Host "[FAIL] $Message" -ForegroundColor Red
+        if ($Details) {
+            Write-Host "       $Details" -ForegroundColor DarkRed
+        }
+    }
+}
+
+function Test-PathUnderDirectory {
+    param(
+        [Parameter(Mandatory)] [string]$CandidatePath,
+        [Parameter(Mandatory)] [string]$RootPath
+    )
+
+    $candidate = [System.IO.Path]::GetFullPath($CandidatePath)
+    $root = [System.IO.Path]::GetFullPath($RootPath)
+    if (-not $root.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
+        $root += [System.IO.Path]::DirectorySeparatorChar
+    }
+    return $candidate.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Convert-ToNormalizedPathToken {
+    param(
+        [Parameter(Mandatory)] [string]$PathValue
+    )
+
+    return ([System.IO.Path]::GetFullPath($PathValue)).Replace('\', '/')
+}
+
+$context = Get-VgoGovernanceContext -ScriptPath $PSCommandPath -EnforceExecutionContext
+$repoRoot = $context.repoRoot
+$results = @()
+
+$runId = "canonical-surface-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
+$artifactRoot = Join-Path $repoRoot (".tmp\canonical-surface-{0}" -f $runId)
+$task = "Canonical surface uniqueness probe $runId"
+$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task $task -Mode benchmark_autonomous -GovernanceScope root -RunId $runId -ArtifactRoot $artifactRoot
+
+Add-Assertion -Results ([ref]$results) -Condition ($null -ne $summary) -Message 'canonical surface probe returned summary payload'
+$hasSummary = ($null -ne $summary) -and ($summary.PSObject.Properties.Name -contains 'summary')
+Add-Assertion -Results ([ref]$results) -Condition $hasSummary -Message 'canonical surface probe has summary object'
+
+if ($hasSummary) {
+    $requirementDocPath = [string]$summary.summary.artifacts.requirement_doc
+    $executionPlanPath = [string]$summary.summary.artifacts.execution_plan
+    $runtimeInputPacketPath = [string]$summary.summary.artifacts.runtime_input_packet
+    $executionManifestPath = [string]$summary.summary.artifacts.execution_manifest
+
+    Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath $requirementDocPath) -Message 'canonical requirement artifact exists' -Details $requirementDocPath
+    Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath $executionPlanPath) -Message 'canonical execution plan artifact exists' -Details $executionPlanPath
+    $requirementPathToken = Convert-ToNormalizedPathToken -PathValue $requirementDocPath
+    $executionPlanPathToken = Convert-ToNormalizedPathToken -PathValue $executionPlanPath
+    Add-Assertion -Results ([ref]$results) -Condition (
+        $requirementPathToken.Contains('/docs/requirements/')
+    ) -Message 'canonical requirement lives under docs/requirements' -Details $requirementDocPath
+    Add-Assertion -Results ([ref]$results) -Condition (
+        $executionPlanPathToken.Contains('/docs/plans/')
+    ) -Message 'canonical execution plan lives under docs/plans' -Details $executionPlanPath
+
+    $runtimeInputPacket = Get-Content -LiteralPath $runtimeInputPacketPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.governance_scope -eq 'root') -Message 'canonical surface probe runs in root governance scope'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_requirement_freeze) -Message 'root scope keeps requirement freeze authority'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_plan_freeze) -Message 'root scope keeps plan freeze authority'
+
+    $stableDocText = Get-Content -LiteralPath (Join-Path $repoRoot 'docs\root-child-vibe-hierarchy-governance.md') -Raw -Encoding UTF8
+    Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('one canonical requirement surface')) -Message 'stable hierarchy doc forbids duplicate requirement truth'
+    Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('one canonical execution-plan surface')) -Message 'stable hierarchy doc forbids duplicate execution-plan truth'
+
+    $childRunId = "canonical-surface-child-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
+    $childSummary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') `
+        -Task ("Child canonical surface uniqueness probe {0}" -f $childRunId) `
+        -Mode benchmark_autonomous `
+        -GovernanceScope child `
+        -RunId $childRunId `
+        -RootRunId ([string]$summary.summary.run_id) `
+        -ParentRunId ([string]$summary.summary.run_id) `
+        -ParentUnitId 'canonical-surface-child-unit' `
+        -InheritedRequirementDocPath $requirementDocPath `
+        -InheritedExecutionPlanPath $executionPlanPath `
+        -ArtifactRoot $artifactRoot
+
+    Add-Assertion -Results ([ref]$results) -Condition ($null -ne $childSummary) -Message 'child canonical probe returned summary payload'
+    $hasChildSummary = ($null -ne $childSummary) -and ($childSummary.PSObject.Properties.Name -contains 'summary')
+    Add-Assertion -Results ([ref]$results) -Condition $hasChildSummary -Message 'child canonical probe has summary object'
+
+    if ($hasChildSummary) {
+        $childRequirementReceipt = Get-Content -LiteralPath $childSummary.summary.artifacts.requirement_receipt -Raw -Encoding UTF8 | ConvertFrom-Json
+        $childExecutionPlanReceipt = Get-Content -LiteralPath $childSummary.summary.artifacts.execution_plan_receipt -Raw -Encoding UTF8 | ConvertFrom-Json
+        $childExecutionManifest = Get-Content -LiteralPath $childSummary.summary.artifacts.execution_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+
+        Add-Assertion -Results ([ref]$results) -Condition ($childSummary.summary.governance_scope -eq 'child') -Message 'child canonical probe runs in child governance scope'
+        Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$childRequirementReceipt.canonical_write_allowed) -Message 'child requirement stage cannot write canonical requirement surface'
+        Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$childExecutionPlanReceipt.canonical_write_allowed) -Message 'child plan stage cannot write canonical plan surface'
+        Add-Assertion -Results ([ref]$results) -Condition (
+            [System.IO.Path]::GetFullPath([string]$childRequirementReceipt.requirement_doc_path) -eq [System.IO.Path]::GetFullPath([string]$requirementDocPath)
+        ) -Message 'child requirement stage reuses root canonical requirement path'
+        Add-Assertion -Results ([ref]$results) -Condition (
+            [System.IO.Path]::GetFullPath([string]$childExecutionPlanReceipt.execution_plan_path) -eq [System.IO.Path]::GetFullPath([string]$executionPlanPath)
+        ) -Message 'child plan stage reuses root canonical execution plan path'
+        Add-Assertion -Results ([ref]$results) -Condition ($childExecutionManifest.governance_scope -eq 'child') -Message 'child execution manifest is marked as child scope'
+        Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$childExecutionManifest.authority.completion_claim_allowed) -Message 'child execution manifest cannot issue final completion claims'
+    }
+}
+
+$failureCount = @($results | Where-Object { -not $_.passed }).Count
+$gatePassed = ($failureCount -eq 0)
+$report = [pscustomobject]@{
+    generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    repo_root = $repoRoot
+    gate_passed = $gatePassed
+    assertion_count = @($results).Count
+    failure_count = $failureCount
+    runtime_summary_path = if ($null -ne $summary -and ($summary.PSObject.Properties.Name -contains 'summary_path')) { $summary.summary_path } else { $null }
+    results = @($results)
+}
+
+if ($WriteArtifacts) {
+    $targetDir = if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        Join-Path $repoRoot 'outputs\verify\vibe-no-duplicate-canonical-surface'
+    } elseif ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+        [System.IO.Path]::GetFullPath($OutputDirectory)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDirectory))
+    }
+
+    New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    Write-VibeJsonArtifact -Path (Join-Path $targetDir 'vibe-no-duplicate-canonical-surface-gate.json') -Value $report
+} elseif (Test-Path -LiteralPath $artifactRoot) {
+    Remove-Item -LiteralPath $artifactRoot -Recurse -Force
+}
+
+if (-not $gatePassed) {
+    throw "vibe-no-duplicate-canonical-surface-gate failed with $failureCount failing assertion(s)."
+}
+
+$report

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-release-truth-gate.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-release-truth-gate.ps1
@@ -1,0 +1,49 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$ReportPath,
+    [string]$RepoRoot,
+    [string]$OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+} else {
+    $RepoRoot = (Resolve-Path $RepoRoot).Path
+}
+
+$runnerPath = Join-Path $RepoRoot 'scripts\verify\runtime_neutral\release_truth_gate.py'
+if (-not (Test-Path -LiteralPath $runnerPath)) {
+    throw "release truth runner missing: $runnerPath"
+}
+
+$pythonCommand = Get-Command python3 -ErrorAction SilentlyContinue
+if (-not $pythonCommand) {
+    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+}
+if (-not $pythonCommand) {
+    throw 'Python is required to run vibe-release-truth-gate.'
+}
+
+$args = @(
+    $runnerPath
+    '--repo-root', $RepoRoot
+    '--write-artifacts'
+)
+foreach ($path in $ReportPath) {
+    $args += @('--report', (Resolve-Path $path).Path)
+}
+if ($OutputDirectory) {
+    $args += @('--output-directory', $OutputDirectory)
+}
+
+& $pythonCommand.Source @args
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne 0) {
+    throw "vibe-release-truth-gate failed with exit code $exitCode"
+}
+
+Write-Host '[PASS] vibe-release-truth-gate passed' -ForegroundColor Green

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-root-child-hierarchy-gate.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-root-child-hierarchy-gate.ps1
@@ -1,0 +1,142 @@
+param(
+    [switch]$WriteArtifacts,
+    [string]$OutputDirectory = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
+. (Join-Path $PSScriptRoot '..\runtime\VibeRuntime.Common.ps1')
+
+function Add-Assertion {
+    param(
+        [ref]$Results,
+        [bool]$Condition,
+        [string]$Message,
+        [string]$Details = ''
+    )
+
+    $record = [pscustomobject]@{
+        passed = [bool]$Condition
+        message = $Message
+        details = $Details
+    }
+    $Results.Value += $record
+
+    if ($Condition) {
+        Write-Host "[PASS] $Message"
+    } else {
+        Write-Host "[FAIL] $Message" -ForegroundColor Red
+        if ($Details) {
+            Write-Host "       $Details" -ForegroundColor DarkRed
+        }
+    }
+}
+
+$context = Get-VgoGovernanceContext -ScriptPath $PSCommandPath -EnforceExecutionContext
+$repoRoot = $context.repoRoot
+$results = @()
+
+$requiredFiles = @(
+    'docs/root-child-vibe-hierarchy-governance.md',
+    'docs/requirements/2026-03-28-root-child-vibe-hierarchy-governance.md',
+    'docs/plans/2026-03-28-root-child-vibe-hierarchy-governance-plan.md',
+    'tests/runtime_neutral/test_root_child_hierarchy_bridge.py'
+)
+foreach ($relativePath in $requiredFiles) {
+    Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath)) -Message ("hierarchy required file exists: {0}" -f $relativePath)
+}
+
+$runtimeContract = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-contract.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeContract.entry_skill -eq 'vibe') -Message 'runtime contract entry skill remains vibe'
+
+$policyText = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-input-packet-policy.json') -Raw -Encoding UTF8
+foreach ($token in @(
+    'governance_scope',
+    'hierarchy_contract',
+    'child_specialist_suggestion_contract',
+    'allow_requirement_freeze',
+    'allow_plan_freeze',
+    'allow_global_dispatch',
+    'allow_completion_claim',
+    'specialist_dispatch',
+    'advisory_until_root_approval',
+    'escalation_required',
+    'auto_absorb_gate'
+)) {
+    Add-Assertion -Results ([ref]$results) -Condition ($policyText.Contains($token)) -Message ("runtime input policy contains hierarchy token: {0}" -f $token)
+}
+
+$runtimeText = Get-Content -LiteralPath (Join-Path $repoRoot 'protocols\runtime.md') -Raw -Encoding UTF8
+$teamText = Get-Content -LiteralPath (Join-Path $repoRoot 'protocols\team.md') -Raw -Encoding UTF8
+$stableDocText = Get-Content -LiteralPath (Join-Path $repoRoot 'docs\root-child-vibe-hierarchy-governance.md') -Raw -Encoding UTF8
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeText.Contains('runtime-selected skill stays `vibe`')) -Message 'runtime protocol documents explicit vibe authority preservation'
+Add-Assertion -Results ([ref]$results) -Condition ($teamText.Contains('`vibe` keeps final control')) -Message 'team protocol keeps vibe as final control'
+Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('root vibe governs, child vibe executes, specialists assist')) -Message 'stable hierarchy doc exposes root/child mental model'
+
+$runId = "root-child-hierarchy-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
+$artifactRoot = Join-Path $repoRoot (".tmp\root-child-hierarchy-{0}" -f $runId)
+$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'Root child hierarchy authority smoke.' -Mode benchmark_autonomous -GovernanceScope root -RunId $runId -ArtifactRoot $artifactRoot
+
+Add-Assertion -Results ([ref]$results) -Condition ($null -ne $summary) -Message 'runtime smoke returned summary payload'
+$hasSummary = ($null -ne $summary) -and ($summary.PSObject.Properties.Name -contains 'summary')
+Add-Assertion -Results ([ref]$results) -Condition $hasSummary -Message 'runtime smoke summary object exists'
+
+if ($hasSummary) {
+    $runtimeInputPacket = Get-Content -LiteralPath $summary.summary.artifacts.runtime_input_packet -Raw -Encoding UTF8 | ConvertFrom-Json
+    $executionManifest = Get-Content -LiteralPath $summary.summary.artifacts.execution_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    Add-Assertion -Results ([ref]$results) -Condition ($summary.mode -eq 'interactive_governed') -Message 'legacy benchmark mode is normalized to interactive_governed for hierarchy smoke'
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.route_snapshot.selected_skill -eq 'vibe') -Message 'root hierarchy smoke keeps vibe as frozen route skill'
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'root hierarchy smoke keeps vibe as runtime authority'
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.governance_scope -eq 'root') -Message 'runtime packet marks root governance scope'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_requirement_freeze) -Message 'root packet allows requirement freeze'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_plan_freeze) -Message 'root packet allows plan freeze'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_global_dispatch) -Message 'root packet allows global specialist dispatch'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_completion_claim) -Message 'root packet allows final completion claim'
+    $hasSpecialistDispatchSurface = ($runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch') -or ($runtimeInputPacket.PSObject.Properties.Name -contains 'approved_specialist_dispatch')
+    Add-Assertion -Results ([ref]$results) -Condition $hasSpecialistDispatchSurface -Message 'runtime packet includes specialist dispatch surface'
+    $hasEscalationSurface = ($runtimeInputPacket.PSObject.Properties.Name -contains 'escalation_required') -or (($runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch') -and ($runtimeInputPacket.specialist_dispatch.PSObject.Properties.Name -contains 'escalation_required'))
+    Add-Assertion -Results ([ref]$results) -Condition $hasEscalationSurface -Message 'runtime packet includes escalation marker surface'
+
+    $hasCompletionAuthority = ($executionManifest.PSObject.Properties.Name -contains 'authority')
+    Add-Assertion -Results ([ref]$results) -Condition $hasCompletionAuthority -Message 'execution manifest includes authority surface'
+    if ($hasCompletionAuthority) {
+        Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.governance_scope -eq 'root') -Message 'execution manifest marks root governance scope'
+        Add-Assertion -Results ([ref]$results) -Condition ([bool]$executionManifest.authority.completion_claim_allowed) -Message 'execution manifest allows final completion claim only for root scope'
+    }
+}
+
+$failureCount = @($results | Where-Object { -not $_.passed }).Count
+$gatePassed = ($failureCount -eq 0)
+$report = [pscustomobject]@{
+    generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    repo_root = $repoRoot
+    gate_passed = $gatePassed
+    assertion_count = @($results).Count
+    failure_count = $failureCount
+    runtime_summary_path = if ($null -ne $summary -and ($summary.PSObject.Properties.Name -contains 'summary_path')) { $summary.summary_path } else { $null }
+    results = @($results)
+}
+
+if ($WriteArtifacts) {
+    $targetDir = if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        Join-Path $repoRoot 'outputs\verify\vibe-root-child-hierarchy'
+    } elseif ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+        [System.IO.Path]::GetFullPath($OutputDirectory)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDirectory))
+    }
+
+    New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    Write-VibeJsonArtifact -Path (Join-Path $targetDir 'vibe-root-child-hierarchy-gate.json') -Value $report
+} elseif (Test-Path -LiteralPath $artifactRoot) {
+    Remove-Item -LiteralPath $artifactRoot -Recurse -Force
+}
+
+if (-not $gatePassed) {
+    throw "vibe-root-child-hierarchy-gate failed with $failureCount failing assertion(s)."
+}
+
+$report

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-workflow-acceptance-gate.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/vibe-workflow-acceptance-gate.ps1
@@ -1,0 +1,49 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScenarioPath,
+    [string]$RepoRoot,
+    [string]$OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+} else {
+    $RepoRoot = (Resolve-Path $RepoRoot).Path
+}
+
+$runnerPath = Join-Path $RepoRoot 'scripts\verify\runtime_neutral\workflow_acceptance_runner.py'
+if (-not (Test-Path -LiteralPath $runnerPath)) {
+    throw "workflow acceptance runner missing: $runnerPath"
+}
+
+$resolvedScenario = (Resolve-Path $ScenarioPath).Path
+
+$pythonCommand = Get-Command python3 -ErrorAction SilentlyContinue
+if (-not $pythonCommand) {
+    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+}
+if (-not $pythonCommand) {
+    throw 'Python is required to run vibe-workflow-acceptance-gate.'
+}
+
+$args = @(
+    $runnerPath
+    '--repo-root', $RepoRoot
+    '--scenario', $resolvedScenario
+    '--write-artifacts'
+)
+if ($OutputDirectory) {
+    $args += @('--output-directory', $OutputDirectory)
+}
+
+& $pythonCommand.Source @args
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne 0) {
+    throw "vibe-workflow-acceptance-gate failed with exit code $exitCode"
+}
+
+Write-Host '[PASS] vibe-workflow-acceptance-gate passed' -ForegroundColor Green

--- a/bundled/skills/vibe/check.ps1
+++ b/bundled/skills/vibe/check.ps1
@@ -136,6 +136,66 @@ function Format-OptionalValue {
   return $Value
 }
 
+function Resolve-CodexDuplicateSkillRoot {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  if ([string]$HostId -ne 'codex') {
+    return $null
+  }
+
+  $leaf = (Split-Path -Path $TargetRoot -Leaf).ToLowerInvariant()
+  if ($leaf -ne '.codex') {
+    return $null
+  }
+
+  $parent = Get-VgoParentPath -Path $TargetRoot
+  if ([string]::IsNullOrWhiteSpace($parent)) {
+    return $null
+  }
+
+  return (Join-Path $parent '.agents\skills\vibe')
+}
+
+function Test-VibeSkillDirectory {
+  param([string]$Path)
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return $false
+  }
+
+  $skillMd = Join-Path $Path 'SKILL.md'
+  if (-not (Test-Path -LiteralPath $skillMd)) {
+    return $false
+  }
+
+  $lines = Get-Content -LiteralPath $skillMd -TotalCount 20 -Encoding UTF8
+  return [bool](@($lines | Where-Object { $_ -match '^\s*name:\s*vibe\s*$' }).Count -gt 0)
+}
+
+function Check-CodexDuplicateSkillSurface {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  $duplicateRoot = Resolve-CodexDuplicateSkillRoot -TargetRoot $TargetRoot -HostId $HostId
+  if ([string]::IsNullOrWhiteSpace($duplicateRoot) -or -not (Test-Path -LiteralPath $duplicateRoot -PathType Container)) {
+    return
+  }
+
+  if (Test-VibeSkillDirectory -Path $duplicateRoot) {
+    Write-Host ("[FAIL] duplicate Codex-discovered vibe skill surface -> {0}" -f $duplicateRoot) -ForegroundColor Red
+    Write-Host '[FAIL] Re-run install.ps1 for the default Codex root to quarantine the legacy .agents copy, or move it out of .agents/skills manually.' -ForegroundColor Red
+    $script:fail++
+    return
+  }
+
+  Warn-Note -Message ("unexpected directory exists at Codex duplicate-surface path: {0}" -f $duplicateRoot)
+}
+
 function Test-ReceiptTargetFreshness {
   param(
     [string]$TargetRoot,
@@ -413,6 +473,18 @@ function Check-Path {
   }
 }
 
+function Check-PathAbsent {
+  param([string]$Label, [string]$Path)
+
+  if (Test-Path -LiteralPath $Path) {
+    Write-Host "[FAIL] $Label -> $Path" -ForegroundColor Red
+    $script:fail++
+  } else {
+    Write-Host "[OK] $Label"
+    $script:pass++
+  }
+}
+
 function Invoke-AdapterSpecificChecks {
   param(
     [psobject]$Adapter,
@@ -487,6 +559,8 @@ function Invoke-AdapterSpecificChecks {
     Check-Path -Label "vibe bundled exploration intent profiles config" -Path (Join-Path $RuntimeNestedSkillRoot 'config\exploration-intent-profiles.json') -Required:$NestedBundledRequired
     Check-Path -Label "vibe bundled exploration domain map config" -Path (Join-Path $RuntimeNestedSkillRoot 'config\exploration-domain-map.json') -Required:$NestedBundledRequired
     Check-Path -Label "vibe bundled llm acceleration policy config" -Path (Join-Path $RuntimeNestedSkillRoot 'config\llm-acceleration-policy.json') -Required:$NestedBundledRequired
+    Check-PathAbsent -Label "vibe nested bundled skill entrypoint hidden" -Path (Join-Path $RuntimeNestedSkillRoot 'SKILL.md')
+    Check-Path -Label "vibe nested bundled skill runtime mirror" -Path (Join-Path $RuntimeNestedSkillRoot 'SKILL.runtime-mirror.md') -Required:$NestedBundledRequired
   } else {
     Write-Host ("[OK] vibe nested bundled config checks skipped (target absent; policy={0})" -f $NestedBundledPresencePolicy)
     $script:pass++
@@ -552,6 +626,7 @@ if ($null -ne $startupGovernance -and $startupGovernance.PSObject.Properties.Nam
 }
 
 Invoke-AdapterSpecificChecks -Adapter $Adapter -TargetRoot $TargetRoot -RuntimeSkillRoot $runtimeSkillRoot -RuntimeNestedSkillRoot $runtimeNestedSkillRoot -NestedBundledRequired:$nestedBundledRequired -NestedBundledPresencePolicy $nestedBundledPresencePolicy
+Check-CodexDuplicateSkillSurface -TargetRoot $TargetRoot -HostId $HostId
 
 Invoke-RuntimeFreshnessCheck -RepoRoot $RepoRoot -TargetRoot $TargetRoot -SkipGate:$SkipRuntimeFreshnessGate
 Invoke-RuntimeFrontmatterCheck -RepoRoot $RepoRoot -TargetRoot $TargetRoot

--- a/bundled/skills/vibe/check.sh
+++ b/bundled/skills/vibe/check.sh
@@ -80,6 +80,17 @@ resolve_default_target_root() {
   fi
 }
 
+safe_parent_dir() {
+  local path="${1:-}"
+  [[ -n "${path}" ]] || return 0
+  local parent=""
+  parent="$(cd "${path}/.." 2>/dev/null && pwd || true)"
+  if [[ -z "${parent}" || "${parent}" == "${path}" || "${parent}" == "/" ]]; then
+    return 0
+  fi
+  printf '%s' "${parent}"
+}
+
 canonical_repo_available() {
   local current="${1:-}"
   [[ -n "${current}" ]] || return 1
@@ -204,6 +215,54 @@ if [[ -z "${TARGET_ROOT}" ]]; then
 fi
 assert_target_root_matches_host_intent "${TARGET_ROOT}" "${HOST_ID}"
 
+resolve_codex_duplicate_skill_root() {
+  if [[ "${HOST_ID}" != "codex" ]]; then
+    return 1
+  fi
+
+  local leaf=""
+  leaf="$(basename "${TARGET_ROOT}")"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${leaf}" != ".codex" ]]; then
+    return 1
+  fi
+
+  local parent=""
+  parent="$(safe_parent_dir "${TARGET_ROOT}")"
+  if [[ -z "${parent}" ]]; then
+    return 1
+  fi
+
+  printf '%s' "${parent}/.agents/skills/vibe"
+}
+
+test_vibe_skill_dir() {
+  local root="${1:-}"
+  local skill_md="${root}/SKILL.md"
+  [[ -f "${skill_md}" ]] || return 1
+  if grep -Eq '^[[:space:]]*name:[[:space:]]*vibe[[:space:]]*$' "${skill_md}"; then
+    return 0
+  fi
+  return 1
+}
+
+check_codex_duplicate_skill_surface() {
+  local duplicate_root=""
+  duplicate_root="$(resolve_codex_duplicate_skill_root || true)"
+  if [[ -z "${duplicate_root}" || ! -d "${duplicate_root}" ]]; then
+    return 0
+  fi
+
+  if test_vibe_skill_dir "${duplicate_root}"; then
+    echo "[FAIL] duplicate Codex-discovered vibe skill surface -> ${duplicate_root}"
+    echo "[FAIL] Re-run install.sh for the default Codex root to quarantine the legacy .agents copy, or move it out of .agents/skills manually."
+    FAIL=$((FAIL+1))
+    return 0
+  fi
+
+  warn_note "unexpected directory exists at Codex duplicate-surface path: ${duplicate_root}"
+}
+
 PASS=0
 FAIL=0
 WARN=0
@@ -219,6 +278,17 @@ check_path() {
   else
     echo "[WARN] $label -> $path"
     WARN=$((WARN+1))
+  fi
+}
+
+check_absent_path() {
+  local label="$1"; local path="$2"
+  if [[ -e "$path" ]]; then
+    echo "[FAIL] $label -> $path"
+    FAIL=$((FAIL+1))
+  else
+    echo "[OK] $label"
+    PASS=$((PASS+1))
   fi
 }
 
@@ -686,6 +756,7 @@ fi
 if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   check_path "plugins manifest" "${TARGET_ROOT}/config/plugins-manifest.codex.json"
 fi
+check_codex_duplicate_skill_surface
 check_path "upstream lock" "${TARGET_ROOT}/config/upstream-lock.json"
 check_path "vibe version governance config" "${TARGET_ROOT}/${runtime_target_rel}/config/version-governance.json"
 check_path "vibe release ledger" "${runtime_skill_root}/references/release-ledger.jsonl"
@@ -721,6 +792,8 @@ if [[ -d "${runtime_nested_skill_root}" ]]; then
   check_path "vibe bundled exploration intent profiles config" "${runtime_nested_skill_root}/config/exploration-intent-profiles.json"
   check_path "vibe bundled exploration domain map config" "${runtime_nested_skill_root}/config/exploration-domain-map.json"
   check_path "vibe bundled llm acceleration policy config" "${runtime_nested_skill_root}/config/llm-acceleration-policy.json"
+  check_absent_path "vibe nested bundled skill entrypoint hidden" "${runtime_nested_skill_root}/SKILL.md"
+  check_path "vibe nested bundled skill runtime mirror" "${runtime_nested_skill_root}/SKILL.runtime-mirror.md"
 else
   echo "[OK] vibe nested bundled config checks skipped (target absent; policy=optional)"
   PASS=$((PASS+1))

--- a/bundled/skills/vibe/config/benchmark-execution-policy.json
+++ b/bundled/skills/vibe/config/benchmark-execution-policy.json
@@ -30,6 +30,8 @@
             {
               "unit_id": "runtime-neutral-freshness-gate-tests",
               "kind": "python_command",
+              "parallelizable": true,
+              "write_scope": "tests/runtime_neutral",
               "command": "${VGO_PYTHON}",
               "arguments": [
                 "-m",
@@ -49,6 +51,8 @@
             {
               "unit_id": "version-consistency-gate",
               "kind": "powershell_file",
+              "parallelizable": true,
+              "write_scope": "scripts/verify",
               "script_path": "scripts/verify/vibe-version-consistency-gate.ps1",
               "arguments": [],
               "cwd": "${REPO_ROOT}",

--- a/bundled/skills/vibe/config/execution-topology-policy.json
+++ b/bundled/skills/vibe/config/execution-topology-policy.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "updated_at": "2026-03-28",
+  "default_step_execution": "sequential",
+  "default_step_parallelizable": false,
+  "default_review_mode": "none",
+  "default_specialist_execution_mode": "metadata_only",
+  "default_write_scope_prefix": "unit",
+  "grades": {
+    "M": {
+      "delegation_mode": "none",
+      "unit_execution": "sequential",
+      "max_parallel_units": 1,
+      "review_mode": "none",
+      "specialist_execution_mode": "metadata_only"
+    },
+    "L": {
+      "delegation_mode": "serial_child_lanes",
+      "unit_execution": "sequential",
+      "max_parallel_units": 1,
+      "review_mode": "two_stage_after_unit",
+      "specialist_execution_mode": "metadata_only"
+    },
+    "XL": {
+      "delegation_mode": "selective_parallel_child_lanes",
+      "unit_execution": "bounded_parallel",
+      "max_parallel_units": 2,
+      "review_mode": "checkpoint_per_step",
+      "specialist_execution_mode": "native_bounded_units"
+    }
+  }
+}

--- a/bundled/skills/vibe/config/native-specialist-execution-policy.json
+++ b/bundled/skills/vibe/config/native-specialist-execution-policy.json
@@ -1,0 +1,45 @@
+{
+  "version": 1,
+  "updated_at": "2026-03-28",
+  "enabled": true,
+  "default_adapter_id": "codex",
+  "enable_env": "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION",
+  "disable_env": "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION",
+  "default_enabled": false,
+  "default_timeout_seconds": 600,
+  "degrade_contract": {
+    "status": "degraded_non_authoritative",
+    "verification_passed": false,
+    "execution_driver": "degraded_specialist_contract_receipt",
+    "hazard_alert": "Native specialist execution is unavailable or disabled; dispatch downgraded explicitly."
+  },
+  "result_schema": {
+    "status_enum": [
+      "completed",
+      "completed_with_notes",
+      "blocked"
+    ],
+    "required_fields": [
+      "status",
+      "summary",
+      "verification_notes",
+      "changed_files",
+      "bounded_output_notes"
+    ]
+  },
+  "adapters": [
+    {
+      "id": "codex",
+      "enabled": true,
+      "executable_env": "VGO_CODEX_EXECUTABLE",
+      "command": "codex",
+      "arguments_prefix": [
+        "exec",
+        "--json",
+        "--ephemeral",
+        "--full-auto"
+      ],
+      "execution_driver": "codex_exec_native_specialist"
+    }
+  ]
+}

--- a/bundled/skills/vibe/config/project-delivery-acceptance-contract.json
+++ b/bundled/skills/vibe/config/project-delivery-acceptance-contract.json
@@ -1,0 +1,64 @@
+{
+  "contract_id": "vibe-project-delivery-acceptance-v1",
+  "version": 1,
+  "truth_layers": [
+    "governance_truth",
+    "engineering_verification_truth",
+    "workflow_completion_truth",
+    "product_acceptance_truth"
+  ],
+  "truth_states": {
+    "passing": {
+      "counts_as_success": true,
+      "completion_language_allowed": true
+    },
+    "manual_review_required": {
+      "counts_as_success": false,
+      "completion_language_allowed": false
+    },
+    "partial": {
+      "counts_as_success": false,
+      "completion_language_allowed": false
+    },
+    "degraded": {
+      "counts_as_success": false,
+      "completion_language_allowed": false
+    },
+    "failing": {
+      "counts_as_success": false,
+      "completion_language_allowed": false
+    },
+    "not_run": {
+      "counts_as_success": false,
+      "completion_language_allowed": false
+    }
+  },
+  "forbidden_completion_collapses": [
+    {
+      "source": "runtime_status",
+      "value": "completed_with_failures",
+      "reason": "partial execution cannot be reported as full downstream delivery"
+    },
+    {
+      "source": "runtime_status",
+      "value": "degraded_non_authoritative",
+      "reason": "degraded execution cannot be reported as equivalent delivery success"
+    },
+    {
+      "source": "readiness_state",
+      "value": "manual_actions_pending",
+      "reason": "pending manual actions cannot be reported as fully ready delivery"
+    }
+  ],
+  "report_requirements": {
+    "must_report_fields": [
+      "governance_truth",
+      "engineering_verification_truth",
+      "workflow_completion_truth",
+      "product_acceptance_truth",
+      "completion_language_allowed",
+      "residual_risks",
+      "manual_spot_checks"
+    ]
+  }
+}

--- a/bundled/skills/vibe/config/runtime-input-packet-policy.json
+++ b/bundled/skills/vibe/config/runtime-input-packet-policy.json
@@ -46,6 +46,12 @@
     "bounded_role": "specialist_assist",
     "native_usage_required": true,
     "must_preserve_workflow": true,
+    "dispatch_phase": "in_execution",
+    "execution_priority": 50,
+    "lane_policy": "inherit_grade",
+    "parallelizable_in_root_xl": true,
+    "write_scope_template": "specialist:{skill_id}",
+    "review_mode": "native_contract",
     "required_inputs": [
       "bounded specialist subtask contract",
       "frozen requirement context",
@@ -73,6 +79,84 @@
       "max_auto_absorb_count": 4,
       "disable_env": "VGO_DISABLE_CHILD_SPECIALIST_AUTO_ABSORB",
       "force_escalation_env": "VGO_FORCE_CHILD_SPECIALIST_ESCALATION"
+    }
+  },
+  "specialist_binding_profiles": {
+    "planning": {
+      "match_skill_patterns": [
+        "plan",
+        "architect",
+        "spec",
+        "design",
+        "roadmap",
+        "strategy"
+      ],
+      "dispatch_phase": "pre_execution",
+      "execution_priority": 10,
+      "lane_policy": "serial",
+      "parallelizable_in_root_xl": false,
+      "write_scope_template": "specialist:planning",
+      "review_mode": "native_contract"
+    },
+    "implementation": {
+      "match_skill_patterns": [
+        "pipeline",
+        "analysis",
+        "debug",
+        "bio",
+        "python",
+        "ml",
+        "model",
+        "workflow",
+        "data"
+      ],
+      "dispatch_phase": "in_execution",
+      "execution_priority": 50,
+      "lane_policy": "bounded_parallel",
+      "parallelizable_in_root_xl": true,
+      "write_scope_template": "specialist:execution:{skill_id}",
+      "review_mode": "native_contract"
+    },
+    "deliverable": {
+      "match_skill_patterns": [
+        "writing",
+        "report",
+        "publish",
+        "document",
+        "slide",
+        "poster",
+        "manuscript"
+      ],
+      "dispatch_phase": "post_execution",
+      "execution_priority": 70,
+      "lane_policy": "bounded_parallel",
+      "parallelizable_in_root_xl": true,
+      "write_scope_template": "specialist:deliverable:{skill_id}",
+      "review_mode": "checkpoint_after_step"
+    },
+    "verification": {
+      "match_skill_patterns": [
+        "review",
+        "qa",
+        "verify",
+        "assurance",
+        "audit",
+        "guard"
+      ],
+      "dispatch_phase": "verification",
+      "execution_priority": 90,
+      "lane_policy": "serial",
+      "parallelizable_in_root_xl": false,
+      "write_scope_template": "specialist:verification",
+      "review_mode": "checkpoint_after_step"
+    },
+    "default": {
+      "dispatch_phase": "in_execution",
+      "execution_priority": 50,
+      "lane_policy": "inherit_grade",
+      "parallelizable_in_root_xl": true,
+      "write_scope_template": "specialist:{skill_id}",
+      "review_mode": "native_contract"
     }
   },
   "overlay_fields": [

--- a/bundled/skills/vibe/config/version-governance.json
+++ b/bundled/skills/vibe/config/version-governance.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
   "release": {
-    "version": "2.3.50",
-    "updated": "2026-03-26",
+    "version": "2.3.51",
+    "updated": "2026-03-28",
     "channel": "stable",
-    "notes": "Adds router AI connectivity proofing, tightens llm acceleration overlay handling, expands host-adapter/install truth across OpenClaw/OpenCode/Cursor/Windsurf, and switches Windows install verification guidance to built-in PowerShell."
+    "notes": "Adds main-chain delivery acceptance under vibe, hardens stage-bound specialist dispatch and Windows specialist runtime handoff, and promotes stricter completion-language truth for governed runs."
   },
   "source_of_truth": {
     "canonical_root": ".",

--- a/bundled/skills/vibe/docs/README.md
+++ b/bundled/skills/vibe/docs/README.md
@@ -16,6 +16,9 @@
 
 - [`install/one-click-install-release-copy.md`](./install/one-click-install-release-copy.md)：面向普通用户的一键安装发布文案与 AI 助手复制提示词
 - [`install/one-click-install-release-copy.en.md`](./install/one-click-install-release-copy.en.md)：ordinary-user public release copy and copy-paste onboarding prompt
+- Governed runtime canonical surfaces live in [`../SKILL.md`](../SKILL.md), [`../protocols/runtime.md`](../protocols/runtime.md), and [`../protocols/team.md`](../protocols/team.md). Do not create a second runtime-governance truth document.
+- [`root-child-vibe-hierarchy-governance.md`](./root-child-vibe-hierarchy-governance.md)：稳定说明 root/child `vibe` 分层治理，以及 `L` 串行原生执行、`XL` 分波顺序+步骤级有界并行、批准式 specialist 可执行 bounded units 与 child escalation 规则。
+- [`specialist-dispatch-governance.md`](./specialist-dispatch-governance.md)：稳定说明 specialist skills 如何以阶段绑定、写域隔离、`L` 串行 / `XL` 有界并行的方式接入 `vibe`，避免技能荒废或互相冲突。
 
 - [`status/README.md`](./status/README.md)：当前运行态、proof 入口与阶段回执总索引。
 - [`status/current-state.md`](./status/current-state.md)：当前 closure batch 的 runtime summary。

--- a/bundled/skills/vibe/docs/plans/2026-03-26-codex-vibe-dedupe-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-26-codex-vibe-dedupe-plan.md
@@ -1,0 +1,13 @@
+# Plan: Codex `vibe` Duplicate Surface Fix
+
+- Internal grade: `M`
+- Scope: `install.sh`, `install.ps1`, `check.sh`, `check.ps1`, adapter installers, runtime-neutral install/check tests
+
+## Steps
+
+1. Detect the bounded duplicate candidate only for Codex default roots shaped like `.../.codex`.
+2. During install, quarantine legacy `.agents/skills/vibe` into `.agents/skills-disabled/`.
+3. During install, hide nested runtime-mirror `SKILL.md` entrypoints after materialization so hosts do not discover duplicate skills.
+4. Preserve bootstrap continuity by restoring `SKILL.md` when a sanitized runtime mirror is copied into a real top-level skill lane.
+5. During check, fail explicitly if the duplicate surface still exists or if nested runtime mirrors remain discoverable.
+6. Verify with targeted runtime script tests and direct shell/PowerShell checks where available.

--- a/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-consolidation-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-consolidation-plan.md
@@ -1,0 +1,35 @@
+# Plan: Consolidate Built-In AI Governance to a Stable Single-Path Contract
+
+## Internal Grade
+
+`L`
+
+## Intent
+
+Finish the built-in AI governance tightening by aligning runtime behavior, doctor/reporting surfaces, helper scripts, and install entry docs to one active OpenAI-compatible contract.
+
+## Execution Steps
+
+1. Freeze the requirement and plan for the consolidation pass.
+2. Update bootstrap doctor implementations to report both API key state and governance model state.
+3. Update one-shot and related active install entry docs so the follow-up guidance explicitly includes `VCO_RUCNLPIR_MODEL`.
+4. Remove Ark-specific built-in governance helper scripts from the active shipped path.
+5. Update active verification helpers so they no longer test Ark-specific built-in governance branches.
+6. Sync all changed active assets into both bundled mirrors.
+7. Run verification for diff hygiene, runtime behavior, residual legacy active-path matches, and mirror parity.
+
+## Verification
+
+- `git diff --check`
+- `python3 ./scripts/verify/runtime_neutral/bootstrap_doctor.py --target-root "$(mktemp -d)"`
+- `python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --target-root "$(mktemp -d)" --prefix-detected`
+- `rg -n "ARK_API_KEY|ARK_BASE_URL|VOLC_ARK_BASE_URL|02-volc-ark|persist-codex-ark-env|Invoke-VolcArkEmbeddingsCreate" config docs/install docs/one-shot-setup.md scripts/bootstrap scripts/verify scripts/router adapters/codex`
+- `cmp -s` between changed source assets and both bundled mirrors
+
+## Rollback Rule
+
+If any consolidation step makes readiness reporting less accurate or breaks the active OpenAI-compatible path, repair that regression before completion.
+
+## Cleanup Expectation
+
+Leave only the consolidated active source changes, synchronized bundled mirrors, verification evidence, and cleanup receipts.

--- a/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-historical-wording-cleanup-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-historical-wording-cleanup-plan.md
@@ -1,0 +1,31 @@
+# Plan: Clean Residual Historical Multi-Key Wording From Vibe Governance Docs
+
+## Internal Grade
+
+`M`
+
+## Intent
+
+Perform a focused cleanup pass over remaining `vibe` history and current governance artifacts so the repo no longer carries avoidable exact strings for the retired secondary model-key lanes.
+
+## Execution Steps
+
+1. Freeze the requirement and plan for the historical wording cleanup.
+2. Update residual `vibe` change logs and older planning docs to use generic legacy wording instead of the retired key names.
+3. Update current governance requirement and plan artifacts created in this run to use generic wording for removed lanes where exact names are no longer necessary.
+4. Sync any changed shipped history docs into both bundled `vibe` mirrors.
+5. Run repo-wide search to confirm the retired secondary model-key strings no longer appear in `vibe` docs or current governance artifacts.
+6. Record any remaining out-of-scope matches outside `vibe`.
+
+## Verification
+
+- `git diff --check`
+- `rg -n "<retired-secondary-model-key-pattern>" docs docs/requirements docs/plans bundled/skills/vibe`
+
+## Rollback Rule
+
+If a document becomes misleading after removing the exact legacy names, restore clarity first and only then complete the cleanup.
+
+## Cleanup Expectation
+
+Leave only the updated governance artifacts, synchronized bundled mirrors, and an explicit note for any out-of-scope non-`vibe` residue.

--- a/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-install-clarity-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-install-clarity-plan.md
@@ -1,0 +1,34 @@
+# Plan: Clarify AI Governance Install-Time API Configuration
+
+## Internal Grade
+
+`L`
+
+## Intent
+
+Unify the install-time wording, runtime hints, and quick-check guidance so the latest repo tells users one concrete story about how to bring the AI governance advice path online.
+
+## Execution Steps
+
+1. Freeze the requirement and plan for issue `#57`.
+2. Rewrite `docs/install/configuration-guide.*` around the actual probe/runtime key resolution path.
+3. Tighten the single install entry and install prompts so they tell users exactly which local keys to set after install.
+4. Update install rules and supporting install docs that still present `VCO_AI_PROVIDER_*` as the primary local guidance.
+5. Patch runtime-facing bootstrap/probe messages so install-time output matches the docs.
+6. Sync updated install docs into both bundled install-doc mirrors.
+7. Run diff/parity/keyword verification and confirm no stale primary guidance remains on the public install path.
+
+## Verification
+
+- `git diff --check -- docs/requirements/2026-03-27-ai-governance-install-clarity.md docs/plans/2026-03-27-ai-governance-install-clarity-plan.md docs/requirements/README.md docs/plans/README.md docs/install scripts/bootstrap scripts/verify/runtime_neutral/router_ai_connectivity_probe.py bundled/skills/vibe/docs/install bundled/skills/vibe/bundled/skills/vibe/docs/install`
+- `cmp -s` between each updated source install doc and both bundled mirrors
+- `rg -n "VCO_AI_PROVIDER_URL|VCO_AI_PROVIDER_API_KEY" docs/install/one-click-install-release-copy.md docs/install/one-click-install-release-copy.en.md docs/install/configuration-guide.md docs/install/configuration-guide.en.md docs/install/prompts/full-version-install.md docs/install/prompts/full-version-install.en.md docs/install/prompts/framework-only-install.md docs/install/prompts/framework-only-install.en.md docs/install/installation-rules.md docs/install/installation-rules.en.md`
+- `python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --help`
+
+## Rollback Rule
+
+If the changes weaken truthfulness around install vs online readiness, or if source and bundled docs diverge, fix that before completion.
+
+## Cleanup Expectation
+
+Leave only the new requirement/plan docs, the clarified install/runtime guidance, mirrored bundled docs, and verification evidence.

--- a/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-openai-compatible-only-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-openai-compatible-only-plan.md
@@ -1,0 +1,37 @@
+# Plan: Restrict the Built-In AI Governance Layer to OpenAI-Compatible Integration
+
+## Internal Grade
+
+`L`
+
+## Intent
+
+Close the remaining Ark-specific branches on the active built-in governance path so shipped runtime, install UX, and verification all tell one OpenAI-compatible story.
+
+## Execution Steps
+
+1. Freeze the requirement and plan for the OpenAI-compatible-only restriction.
+2. Update active governance defaults and provider authority:
+   - `config/llm-acceleration-policy.json`
+   - `config/router-provider-registry.json`
+   - active runtime/overlay scripts
+3. Update active bootstrap/setup and doctor surfaces so they no longer seed or recommend Ark-specific settings.
+4. Update public install/setup docs and prompts to remove Ark-compatible guidance from the built-in path.
+5. Update active fixtures/templates that still advertise Ark as a built-in lane.
+6. Sync the changed source assets into both bundled mirrors.
+7. Run verification for diff hygiene, mirror parity, and probe behavior.
+
+## Verification
+
+- `git diff --check`
+- `python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --target-root "$(mktemp -d)" --prefix-detected`
+- `cmp -s` between changed source assets and both bundled mirrors
+- `rg -n "ARK_API_KEY|ARK_BASE_URL|VOLC_ARK_BASE_URL|ark-compatible|volc_ark" docs/install docs/one-shot-setup.md config scripts/bootstrap scripts/verify/runtime_neutral scripts/router/modules/48-llm-acceleration-overlay.ps1 config/router-provider-registry.json config/llm-acceleration-policy.json config/settings.template.codex.json adapters/codex/settings-map.json`
+
+## Rollback Rule
+
+If the active built-in path still advertises a second provider family after the change, keep tightening before completion.
+
+## Cleanup Expectation
+
+Leave only the requirement/plan docs, the OpenAI-compatible-only source changes, the synced bundled mirrors, and the verification evidence.

--- a/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-single-model-key-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-27-ai-governance-single-model-key-plan.md
@@ -1,0 +1,62 @@
+# Plan: Converge the Built-In AI Governance Layer to One Model Key
+
+## Internal Grade
+
+`L`
+
+## Intent
+
+Finish the install-clarity tightening by removing the remaining multi-key model guidance from the active built-in governance path and standardizing on `VCO_RUCNLPIR_MODEL`.
+
+## Wave Structure
+
+### Wave 1: Freeze
+
+1. Freeze the requirement and plan for the single-model-key convergence.
+2. Record the active surfaces that still mention retired secondary model-key wording.
+
+### Wave 2: Runtime and Setup
+
+1. Update the runtime-neutral AI connectivity probe to read and recommend `VCO_RUCNLPIR_MODEL` only.
+2. Update bootstrap/setup guidance so the built-in governance path recommends one model key only.
+3. Update active settings templates so the built-in governance model slot uses the same key.
+
+### Wave 3: Public Docs
+
+1. Update active Chinese and English install docs to document only `VCO_RUCNLPIR_MODEL`.
+2. Update install/update prompt templates to use the same one-key wording.
+3. Remove active wording that still presents a retired fallback model key on the public path.
+
+### Wave 4: Mirrors and Proof
+
+1. Sync the changed active source assets into both bundled mirrors.
+2. Run verification for diff hygiene, runtime behavior, text references, and mirror parity.
+3. Emit cleanup receipts and leave the worktree free of temporary artifacts.
+
+## Ownership Boundaries
+
+- Runtime and verification behavior: `scripts/verify/runtime_neutral/router_ai_connectivity_probe.py`
+- Bootstrap/setup guidance: `scripts/bootstrap/one-shot-setup.sh`, `scripts/bootstrap/one-shot-setup.ps1`
+- Active shipped templates: `config/settings.template.claude.json`, related source assets
+- Public install docs and prompts: `docs/install/**`
+- Bundled shipped mirrors: `bundled/skills/vibe/**` and `bundled/skills/vibe/bundled/skills/vibe/**`
+
+## Verification
+
+- `git diff --check`
+- `python3 ./scripts/verify/runtime_neutral/router_ai_connectivity_probe.py --target-root "$(mktemp -d)" --prefix-detected`
+- `rg -n "<retired-secondary-model-key-pattern>" docs/install docs/one-shot-setup.md scripts/bootstrap scripts/verify/runtime_neutral scripts/verify/vibe-bootstrap-doctor-gate.ps1 config adapters/codex`
+- `cmp -s` between changed source assets and both bundled mirrors
+
+## Rollback Rule
+
+If the active shipped path still exposes a second model-key lane after the change, keep tightening before claiming completion.
+
+## Cleanup Expectation
+
+Leave only:
+
+- the frozen requirement and plan docs
+- the active source changes for the one-key contract
+- synchronized bundled mirrors
+- verification evidence and cleanup receipts

--- a/bundled/skills/vibe/docs/plans/2026-03-28-l-xl-native-execution-closure-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-28-l-xl-native-execution-closure-plan.md
@@ -1,0 +1,234 @@
+# L / XL Native Execution Closure Plan
+
+## Execution Summary
+Align runtime truth with public and protocol truth. The current repository already has governance packets, hierarchy semantics, specialist recommendation contracts, and proof accounting. What is still missing is the actual orchestrator. This plan lands that orchestrator in the smallest coherent way: first `L` native serial execution, then `XL` selective-parallel execution, then executable native specialist dispatch, all under the existing single-root `vibe` authority model.
+
+## Frozen Inputs
+- Requirement doc: /home/lqf/table/table5/workspace/release-v2.3.50-main/docs/requirements/2026-03-28-l-xl-native-execution-closure.md
+- Current mismatch:
+  - protocol and README promise stronger `L` / `XL` execution semantics than runtime currently performs
+  - scheduler policy is still sequential with `max_parallel_units=1`
+  - plan execution currently runs proof units directly rather than child-lane orchestration
+  - specialist dispatch is mostly surfaced as plan-shadow accounting
+- Authority invariants that must remain unchanged:
+  - canonical router owns route selection
+  - `vibe` owns runtime authority
+  - root owns canonical requirement and plan truth
+  - child lanes stay subordinate
+
+## Internal Grade Decision
+- Grade: XL
+- The work changes runtime topology, policy, hierarchy execution, specialist execution, proofs, and verification.
+- Parallel implementation is justified by disjoint write scopes, but the resulting runtime must use selective bounded parallelism, not blanket concurrency.
+
+## Design Overview
+
+### Design Principle 1: Separate Governance From Scheduling
+- Governance already exists and should stay stable.
+- What needs to be added is a scheduler/orchestrator layer under stage 5 `plan_execute`.
+- The router still decides the route.
+- `vibe` still freezes requirement and plan truth.
+- The new execution layer only decides how frozen units are executed.
+
+### Design Principle 2: One Execution Topology Policy, Three Runtime Grades
+- `M`: single-lane execution
+- `L`: serial child-lane execution with review checkpoints
+- `XL`: wave-sequential, step-selective parallel child-lane execution
+- Remove the current implicit assumption that all governed execution can use one sequential benchmark profile.
+
+### Design Principle 3: Step-Scoped Parallelism Only
+- A wave may contain multiple steps.
+- Steps run sequentially by dependency.
+- A step may contain multiple units.
+- Only units marked `parallelizable=true` and with disjoint write scopes may execute concurrently.
+- This directly answers the current gap: parallelism should happen when useful inside the `vibe` serial workflow, not as an always-on mode.
+
+### Design Principle 4: Specialist Skills Become Executable Bounded Units
+- `approved_dispatch` should be convertible into real execution units.
+- `local_specialist_suggestions` remain advisory until root approval.
+- A specialist unit carries:
+  - native skill id
+  - bounded goal
+  - required inputs
+  - expected outputs
+  - verification expectation
+  - write-scope boundary
+- Specialist execution results must feed back into the root execution manifest and verification bundle.
+
+## Target Runtime Architecture
+
+### A. Execution Topology Policy
+Replace the current repo-safe benchmark-only scheduler interpretation with a topology policy that supports:
+
+- `wave_execution`: sequential
+- `step_execution`: sequential
+- `unit_execution`: sequential or bounded_parallel
+- `max_parallel_units`: configurable and greater than 1 only for `XL`
+- `delegation_mode`: `none`, `serial_child_lanes`, `selective_parallel_child_lanes`
+- `specialist_execution_mode`: `metadata_only`, `native_bounded_units`
+
+### B. Plan Artifact Evolution
+Extend the frozen plan to express executable topology:
+
+- wave
+- step
+- unit
+- owner
+- write_scope
+- parallelizable
+- requires_root_approval
+- specialist_skill_id when applicable
+- review_stage
+
+This should remain one canonical plan surface, not a second planner.
+
+### C. L Native Serial Orchestrator
+`L` should execute as:
+
+1. root freezes requirement and plan
+2. root emits ordered child units
+3. each child unit runs as a real child-governed lane
+4. lead performs stage review after each child unit or small batch
+5. final two-stage review is recorded before completion
+
+This makes `L` truly “serial native execution”, not just a line in docs.
+
+### D. XL Selective-Parallel Orchestrator
+`XL` should execute as:
+
+1. root freezes requirement and plan
+2. root walks waves sequentially
+3. inside each wave, root walks steps sequentially
+4. for a step marked parallelizable, root dispatches independent child lanes concurrently
+5. root waits, aggregates evidence, resolves escalations, then advances to the next step
+
+This makes parallelism local, bounded, and intelligible.
+
+### E. Root/Child Specialist Coordination
+- Root-approved specialists may execute directly inside child lanes if already frozen in the plan.
+- Child lanes may suggest additional specialists.
+- New specialists discovered by child lanes produce escalation artifacts, not silent activation.
+- Root may accept and append them to the active dispatch surface only through explicit governed update logic.
+
+## Wave Plan
+
+### Wave 1: Freeze Execution-Topology Contract
+- Create a dedicated execution-topology policy schema and config surface.
+- Define the runtime distinction between wave, step, and unit.
+- Define `parallelizable`, `write_scope`, and `review_stage` fields.
+- Preserve current single-root authority semantics.
+
+### Wave 2: Refactor Plan Generation For Executable Topology
+- Update `Write-XlPlan.ps1` so the plan can express executable step/unit structure instead of only narrative bullets.
+- Keep the current human-readable plan, but add machine-readable companion data for stage 5.
+- Ensure specialist dispatch is represented as executable bounded units when approved.
+
+### Wave 3: Land L Native Serial Execution
+- Introduce an `L` execution path in `Invoke-PlanExecute.ps1`.
+- Convert the documented `subagent execution → two-stage review` sequence into actual runtime behavior.
+- Child units should be real delegated runs with inherited frozen context and subordinate receipts.
+- Add explicit review receipts so `L` is not just “serial execution”, but “serial governed execution”.
+
+### Wave 4: Land XL Selective-Parallel Execution
+- Introduce a scheduler that can execute a step in bounded parallel only when:
+  - units are marked parallelizable
+  - write scopes do not overlap
+  - global specialist approval constraints are satisfied
+- Keep wave order sequential.
+- Keep root aggregation and checkpoint review mandatory between steps.
+
+### Wave 5: Convert Specialist Dispatch From Metadata To Execution
+- Add an executable specialist-unit adapter shape.
+- For approved dispatch:
+  - spawn bounded child unit
+  - preserve native specialist contract
+  - collect specialist-specific outputs and verification notes
+- For local suggestions:
+  - emit escalation artifact
+  - do not execute until root approval
+
+### Wave 6: Proof And Verification Upgrade
+- Extend tests to prove actual delegated execution behavior:
+  - `L` child units execute in order
+  - `XL` parallel step executes more than one unit when allowed
+  - non-parallel steps remain sequential
+  - overlapping write scopes block parallel execution
+  - specialist units execute only when approved
+- Upgrade manifests and proof bundles to distinguish:
+  - metadata-only dispatch
+  - executed specialist dispatch
+  - serial child-lane execution
+  - bounded parallel child-lane execution
+
+### Wave 7: Cleanup And Documentation Closure
+- Update `SKILL.md`, `protocols/runtime.md`, `protocols/do.md`, `protocols/team.md`, and README wording so public truth matches runtime truth.
+- Remove any wording that overstates behavior before the new orchestrator ships.
+- Re-run node audit and clear temp artifacts produced by the implementation wave.
+
+## Ownership Boundaries
+- Execution policy and topology config:
+  - `config/benchmark-execution-policy.json`
+  - new or adjacent topology policy files
+- Runtime packet and dispatch metadata:
+  - `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+  - `config/runtime-input-packet-policy.json`
+- Plan generation:
+  - `scripts/runtime/Write-XlPlan.ps1`
+- Execution engine:
+  - `scripts/runtime/Invoke-PlanExecute.ps1`
+  - `scripts/runtime/invoke-vibe-runtime.ps1`
+- Hierarchy and docs:
+  - `SKILL.md`
+  - `protocols/runtime.md`
+  - `protocols/do.md`
+  - `protocols/team.md`
+  - `README.md`
+  - `README.zh.md`
+- Verification:
+  - `tests/runtime_neutral/*`
+  - governed `scripts/verify/*` gates
+
+## Verification Commands
+- `git diff --check`
+- `python3 -m pytest tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py -v`
+- `python3 -m pytest tests/runtime_neutral -k "specialist or hierarchy or runtime or plan_execute" -v`
+- `rg -n "spawn_agent|send_input|wait_agent|close_agent|parallelizable|write_scope|review_stage" scripts/runtime protocols docs README*`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-governed-runtime-contract-gate.ps1`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-child-specialist-escalation-gate.ps1`
+
+## Rollback Plan
+- If real delegated execution threatens root-owned authority, revert to the last state where hierarchy metadata is correct and execution remains explicit.
+- If selective parallelism causes scope overlap or artifact races, keep the topology contract but temporarily force affected steps back to serial mode.
+- If native specialist execution proves unstable, degrade explicitly to metadata-only specialist dispatch rather than silently pretending execution occurred.
+- Never revert unrelated user changes.
+
+## Stability Proof Strategy
+- Authority:
+  - only root may freeze canonical requirement and plan truth
+  - only root may issue final completion claims
+- Scheduling:
+  - `L` remains ordered
+  - `XL` runs only approved bounded parallel steps
+  - overlapping scopes are blocked from concurrent execution
+- Specialist safety:
+  - approved specialists may execute
+  - unapproved specialists remain escalation-only
+- Observability:
+  - manifests prove what actually executed, not only what was recommended
+
+## Usability Proof Strategy
+- Operators can explain the runtime in one sentence:
+  - `L` is serial governed execution; `XL` is wave-sequential with step-level bounded parallelism.
+- Plans show where concurrency happens and where it does not.
+- Specialists remain understandable as bounded helpers, not hidden runtime replacements.
+
+## Intelligence Proof Strategy
+- The system should choose concurrency only where the dependency graph allows it.
+- The system should preserve specialist expertise without losing `vibe` sovereignty.
+- Complex composite tasks can be decomposed into sequential macro-steps with local parallel micro-steps.
+
+## Phase Cleanup Contract
+- Remove scratch artifacts, temporary logs, and simulation outputs created during the implementation wave.
+- Audit managed node processes and clear stale residue after each implementation batch.
+- Preserve only intended source, docs, tests, and proof artifacts.
+- Emit cleanup receipts before any completion claim.

--- a/bundled/skills/vibe/docs/plans/2026-03-28-root-child-vibe-hierarchy-governance-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-28-root-child-vibe-hierarchy-governance-plan.md
@@ -1,0 +1,184 @@
+# Root/Child Vibe Hierarchy Governance Plan
+
+## Execution Summary
+Land a hierarchy model for XL governed execution so one user task has one root `vibe` runtime, child agents inherit `vibe` as subordinate execution lanes, and specialist skills remain bounded assistants rather than recursive governance owners. The design must preserve current explicit `vibe` authority, prevent duplicate canonical surfaces, and produce proof that the new hierarchy is stable, usable, and intelligent under realistic task delegation flows.
+
+## Frozen Inputs
+- Requirement doc: /home/lqf/table/table5/workspace/issue-57-ai-governance/docs/requirements/2026-03-28-root-child-vibe-hierarchy-governance.md
+- Problem statement: recursive child-agent `vibe` use currently risks layered governance, repeated specialist dispatch, and ambiguous completion authority
+- Existing authority invariants:
+  - canonical router keeps route authority
+  - explicit `vibe` remains runtime owner
+  - no second requirement truth
+  - no second execution-plan truth
+
+## Internal Grade Decision
+- Grade: XL
+- The change spans runtime packet policy, execution topology, manifests, protocol docs, and proof gates.
+- Parallel implementation is justified, but final authority semantics must be integrated and verified as one coherent contract.
+
+## Design Overview
+
+### Target Model
+- `root_governed`: the only runtime allowed to freeze canonical requirement and plan surfaces and make final completion claims
+- `child_governed`: a subordinate `vibe` lane that inherits frozen context, keeps verification/cleanup discipline, and emits local receipts only
+- `specialist_native`: a bounded helper execution style that can be root-approved for direct use or child-suggested for escalation
+
+### Runtime Packet Additions
+- `governance_scope`: `root` or `child`
+- `root_run_id`
+- `parent_run_id`
+- `parent_unit_id`
+- `inherited_requirement_doc_path`
+- `inherited_execution_plan_path`
+- `allow_requirement_freeze`
+- `allow_plan_freeze`
+- `allow_global_dispatch`
+- `allow_completion_claim`
+- `approved_specialist_dispatch`
+- `local_specialist_suggestions`
+- `escalation_required`
+
+### Authority Split
+- Root owns:
+  - requirement freeze
+  - plan freeze
+  - global specialist approval
+  - overall completion claim
+  - root execution manifest
+- Child owns:
+  - bounded execution inside assigned scope
+  - local receipts and proof
+  - escalation requests when approved specialist coverage is insufficient
+- Specialists own:
+  - native workflow execution only
+  - skill-specific validation notes and outputs
+  - no runtime ownership and no top-level completion claims
+
+## Wave Plan
+
+### Wave 1: Contract Freeze
+- Update requirement, plan, and stable governance docs to define the hierarchy model.
+- Freeze naming for root versus child governance scope and approved dispatch versus local suggestion surfaces.
+- Confirm which existing runtime packet fields can be extended without breaking current proofs.
+
+### Wave 2: Runtime Packet and Policy
+- Extend `config/runtime-input-packet-policy.json` with hierarchy fields and scope-specific authority flags.
+- Update `scripts/runtime/Freeze-RuntimeInputPacket.ps1` to emit root or child packets.
+- Ensure explicit `vibe` authority remains the runtime-selected skill for both scopes.
+
+### Wave 3: Execution Topology and Artifact Boundaries
+- Update `scripts/runtime/Invoke-PlanExecute.ps1` to spawn child lanes as subordinate runs instead of fresh top-level governed runs.
+- Ensure child lanes inherit frozen requirement/plan paths and cannot write canonical docs.
+- Add child receipt and escalation artifact surfaces under root-owned runtime outputs.
+
+### Wave 4: Specialist Dispatch Semantics
+- Split specialist data into:
+  - root-approved dispatch
+  - child-local suggestion
+- Prevent child lanes from activating new global specialists without escalation approval.
+- Preserve native specialist workflow, inputs, outputs, and verification expectations.
+
+### Wave 5: Protocol and Operator Documentation
+- Update `SKILL.md`, `protocols/runtime.md`, and `protocols/team.md` with root/child hierarchy semantics.
+- Add a stable governance explainer for operator use and future implementation alignment.
+- Clarify the user-facing mental model: child `$vibe` keeps discipline, not recursive top-level governance.
+
+### Wave 6: Verification, Simulation, and Proof
+- Add runtime-neutral tests for root/child packet semantics and child escalation behavior.
+- Add governed gates for:
+  - no duplicate canonical requirement surface
+  - no duplicate canonical execution-plan surface
+  - child cannot issue final completion claim
+  - specialist suggestions remain advisory until root approval
+- Run realistic delegation simulations:
+  - root `vibe` planning task with child ML lane
+  - root `vibe` debug task with child systematic-debugging lane
+  - child requesting an extra specialist not pre-approved by root
+
+### Wave 7: Rollout and Cleanup
+- Re-run targeted gates after integration.
+- Remove temporary artifacts and stale test scratch space.
+- Audit for zombie node residue.
+- Leave only intended source/docs/test changes and generated proof artifacts.
+
+## Ownership Boundaries
+- Runtime packet contract: `config/runtime-input-packet-policy.json`, `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+- Execution topology and child-lane handoff: `scripts/runtime/Invoke-PlanExecute.ps1`
+- Requirement/plan write restrictions: `scripts/runtime/Write-RequirementDoc.ps1`, `scripts/runtime/Write-XlPlan.ps1`
+- Runtime authority docs: `SKILL.md`, `protocols/runtime.md`, `protocols/team.md`
+- Stable explanatory doc: `docs/root-child-vibe-hierarchy-governance.md`
+- Verification: `tests/runtime_neutral/*`, `scripts/verify/*`
+
+## Implementation Steps
+1. Freeze the new requirement and plan.
+2. Add the stable governance explainer doc and wire it into docs navigation.
+3. Extend runtime packet policy and packet emission for root/child scope.
+4. Restrict canonical requirement/plan writes to root scope only.
+5. Add approved specialist dispatch versus local suggestion semantics.
+6. Update plan-execute so child lanes inherit context and emit subordinate receipts.
+7. Update protocol docs and public-facing authority wording.
+8. Add tests and governed gates for hierarchy invariants.
+9. Run simulation scenarios and targeted verification commands.
+10. Clean temp artifacts, audit node processes, and emit closure receipts.
+
+## Verification Commands
+- `git diff --check`
+- `python3 -m pytest tests/runtime_neutral/test_router_bridge.py tests/runtime_neutral/test_governed_runtime_bridge.py`
+- `python3 -m pytest tests/runtime_neutral -k "hierarchy or child or specialist or completion"`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-governed-runtime-contract-gate.ps1`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-benchmark-autonomous-proof-gate.ps1`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-no-silent-fallback-contract-gate.ps1`
+- new targeted gates:
+  - `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-root-child-hierarchy-gate.ps1`
+  - `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-no-duplicate-canonical-surface-gate.ps1`
+  - `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-child-specialist-escalation-gate.ps1`
+- targeted repo checks:
+  - `rg -n "governance_scope|allow_requirement_freeze|allow_plan_freeze|allow_global_dispatch|allow_completion_claim|approved_specialist_dispatch|local_specialist_suggestions" config scripts/runtime protocols tests`
+
+## Stability Proof Strategy
+- Determinism:
+  - same root input yields the same root authority fields and child-lane restrictions
+- Non-duplication:
+  - one root run cannot create more than one canonical requirement or plan
+- Boundedness:
+  - child lanes cannot widen into top-level governance
+- Recovery:
+  - escalation paths remain explicit and do not silently self-approve
+- Regression safety:
+  - existing explicit `vibe` specialist-accounting proofs continue to pass after hierarchy support lands
+
+## Usability Proof Strategy
+- Operators can explain the model in one sentence:
+  - root `vibe` governs, child `vibe` executes, specialists assist
+- Execution artifacts make authority obvious without reading chat history.
+- Child-lane receipts show inherited context and limits clearly enough for debugging and audit.
+- Failure paths produce actionable escalation surfaces instead of ambiguous re-planning.
+
+## Intelligence Proof Strategy
+- Root routing can still identify the best high-level specialist pattern without surrendering runtime authority.
+- Child lanes can still use domain-specific specialist help inside approved boundaries.
+- Ambiguous child requests produce escalation instead of unsafe self-expansion.
+- Low-signal prompts still honor fallback hazard and non-authoritative truth semantics.
+
+## Risks and Mitigations
+- Risk: child lanes accidentally reopen requirement or plan surfaces
+  - Mitigation: hard authority flags plus gates that fail on duplicate canonical surfaces
+- Risk: specialist approval and child suggestion semantics drift apart
+  - Mitigation: explicit separate fields and dedicated escalation artifacts
+- Risk: hierarchy metadata becomes verbose but unenforced
+  - Mitigation: add execution-path gates that inspect real artifacts, not docs only
+- Risk: parent/child packet inheritance breaks current explicit `vibe` proofs
+  - Mitigation: keep additive contract design and run existing governed gates before claiming completion
+
+## Rollback Rules
+- If root authority becomes ambiguous, stop and restore the last state where explicit `vibe` remained the sole runtime owner.
+- If child lanes can write canonical requirement or plan surfaces, block completion until that regression is repaired.
+- If specialist escalation cannot be kept explicit, fall back to root-approved specialist dispatch only.
+- Do not revert unrelated user changes or existing untracked docs.
+
+## Phase Cleanup Contract
+- Remove scratch artifacts created for hierarchy simulation or gate fixtures.
+- Audit and clear stale managed node processes if any appear.
+- Keep only intended source/docs/test changes and proof artifacts.
+- Emit cleanup receipts for the verification wave before claiming closure.

--- a/bundled/skills/vibe/docs/plans/2026-03-28-stage-bound-specialist-dispatch-governance-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-28-stage-bound-specialist-dispatch-governance-plan.md
@@ -1,0 +1,50 @@
+# Stage-Bound Specialist Dispatch Governance
+
+## Execution Summary
+Implement the smallest coherent extension that turns specialist skills into governed, phase-bound execution contracts under `vibe`. Reuse the current canonical router and root/child hierarchy, add deterministic specialist binding metadata, place specialist units into `L` serial steps and `XL` bounded specialist lanes, and prove the result with artifact-backed tests.
+
+## Frozen Inputs
+- Requirement doc: /home/lqf/table/table5/runtime-sandboxes/verify-main-77694e8/docs/requirements/2026-03-28-stage-bound-specialist-dispatch-governance.md
+- Source task: improve specialist-skill use inside `vibe` without conflict or authority drift
+- Runtime owner invariant: explicit governed entry remains `vibe`
+
+## Internal Grade Decision
+- Grade: XL
+- The task spans config, runtime topology, docs, and test surfaces with disjoint write scopes and benefits from staged parallel investigation.
+
+## Wave Plan
+- Wave 1: freeze specialist binding policy, requirement truth, plan truth, and stable governance wording
+- Wave 2: implement runtime packet and specialist topology changes for stage-bound dispatch
+- Wave 3: upgrade manifests and delegated-lane receipts so specialist phase binding is observable
+- Wave 4: add runtime-neutral tests for `L` serial specialist steps, `XL` bounded specialist lanes, and hierarchy safety
+- Wave 5: run targeted verification, collect proof artifacts, and close with cleanup
+
+## Ownership Boundaries
+- Specialist binding policy and runtime freeze: `config/runtime-input-packet-policy.json`, `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+- Requirement and plan surfacing: `scripts/runtime/Write-RequirementDoc.ps1`, `scripts/runtime/Write-XlPlan.ps1`
+- Specialist topology and delegated execution: `scripts/runtime/VibeExecution.Common.ps1`, `scripts/runtime/Invoke-DelegatedLaneUnit.ps1`, `scripts/runtime/Invoke-PlanExecute.ps1`
+- Stable governance docs: `protocols/runtime.md`, `protocols/team.md`, `docs/root-child-vibe-hierarchy-governance.md`, `docs/specialist-dispatch-governance.md`
+- Verification: `tests/runtime_neutral/test_l_xl_native_execution_topology.py`, `tests/runtime_neutral/test_root_child_hierarchy_bridge.py`
+
+## Specialist Skill Dispatch Plan
+- Freeze each specialist recommendation as a bounded execution contract with `binding_profile`, `dispatch_phase`, `lane_policy`, `parallelizable_in_root_xl`, `write_scope`, and `review_mode`.
+- Treat `pre_execution` specialists as planning or setup support, `in_execution` specialists as bounded implementation support, `post_execution` specialists as deliverable support, and `verification` specialists as review-only support.
+- In `L`, execute specialist units as explicit serial native steps.
+- In `XL`, allow only root-approved specialist units with disjoint write scopes to enter bounded parallel windows.
+- Keep child-local new specialists advisory-first; only same-round root absorb may upgrade them.
+
+## Verification Commands
+- `git diff --check`
+- `python3 -m pytest tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py -q`
+- `pwsh -NoProfile -File scripts/verify/vibe-root-child-hierarchy-gate.ps1`
+- `pwsh -NoProfile -File scripts/verify/vibe-child-specialist-escalation-gate.ps1`
+- targeted manual replay of composite tasks with fake codex adapter for bounded native specialist execution proof
+
+## Rollback Plan
+- Revert only the specialist-dispatch governance change set if hierarchy invariants or runtime-neutral tests fail.
+- If bounded parallel specialist lanes are unstable, preserve the binding metadata and serial fallback while disabling only the parallel specialist path.
+
+## Phase Cleanup Contract
+- Remove temporary test artifacts and `.pytest_cache` after verification.
+- Audit node processes and clear only managed stale residue if present.
+- Leave the branch with intended source/docs/tests changes only.

--- a/bundled/skills/vibe/docs/plans/2026-03-28-vibe-governed-project-delivery-acceptance-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-28-vibe-governed-project-delivery-acceptance-plan.md
@@ -1,0 +1,321 @@
+# Vibe-Governed Project Delivery Acceptance Plan
+
+## Execution Summary
+Shift the repository from “runtime/governance self-proof” to “downstream project delivery proof”. The smallest coherent path is not a router rewrite. It is a new acceptance layer that sits on top of the existing governed runtime: freeze downstream acceptance criteria, execute real benchmark scenarios, verify the delivered project state, and report completion truth honestly.
+
+## Frozen Inputs
+- Requirement doc: [2026-03-28-vibe-governed-project-delivery-acceptance.md](../requirements/2026-03-28-vibe-governed-project-delivery-acceptance.md)
+- Current reality:
+  - runtime/governance tests are much stronger than downstream project acceptance tests
+  - project delivery can still be under-verified even when runtime artifacts and some tests pass
+  - completion wording is too easy to overstate relative to real delivered quality
+- Invariants that must stay unchanged:
+  - canonical router remains route authority
+  - `vibe` remains runtime authority
+  - root retains canonical requirement/plan truth
+  - no second runtime/control plane is introduced
+
+## Internal Grade Decision
+- Grade: XL
+- The work spans contracts, docs, verification architecture, benchmark projects, workflow runners, release semantics, and proof methodology.
+- The design must coordinate multiple repository areas but still preserve one governed runtime model.
+
+## Design Overview
+
+### Design Principle 1: Delivery Truth Must Be Layered
+Runtime correctness is not project correctness.
+The repository must report four separate truths:
+
+- governance truth
+- engineering verification truth
+- workflow completion truth
+- product acceptance truth
+
+No lower layer may silently stand in for a higher layer.
+
+### Design Principle 2: Acceptance Must Be Frozen Up Front
+If a downstream project is to be judged honestly, acceptance criteria must be frozen in the governed requirement and plan, not improvised at the end.
+
+Required new frozen fields:
+
+- user-facing goals
+- critical functional checklist
+- failure boundaries
+- required verification commands
+- required manual spot checks
+- completion-reporting rules
+
+### Design Principle 3: Real Scenarios Beat Repository Self-Reference
+The acceptance framework must test `vibe` governing real project work in benchmark repos and scenario fixtures, not only VibeSkills exercising its own contracts.
+
+### Design Principle 4: Completion Language Must Be Evidence-Scoped
+Statuses such as `completed_with_failures`, `degraded_non_authoritative`, and `manual_actions_pending` are report states, not success synonyms.
+
+### Design Principle 5: Stability, Usability, and Intelligence Need Different Proofs
+- Stability is about repeatability and low flake.
+- Usability is about operator clarity and real user-path success.
+- Intelligence is about making good governance/execution choices, not only producing artifacts.
+
+## Target Architecture
+
+### A. Delivery Truth Model
+Introduce one machine-readable delivery report contract with at least:
+
+- `governance_truth`
+- `engineering_verification_truth`
+- `workflow_completion_truth`
+- `product_acceptance_truth`
+- `completion_language_allowed`
+- `residual_risks`
+- `manual_spot_checks`
+
+This becomes the authoritative truth surface for downstream project completion reporting.
+
+### B. Downstream Acceptance Contract Extension
+Extend governed requirement and plan surfaces so downstream project work freezes:
+
+- critical user flows
+- edge-case expectations
+- domain-specific specialist validation expectations
+- mandatory regression checks
+- manual acceptance checklist when full automation is not credible
+
+### C. Scenario Corpus
+Add a dedicated scenario family such as:
+
+- `tests/scenarios/project_delivery/`
+- `tests/scenarios/project_delivery/l-grade/`
+- `tests/scenarios/project_delivery/xl-grade/`
+- `tests/scenarios/project_delivery/specialist/`
+- `tests/scenarios/project_delivery/failure_injection/`
+
+Each scenario should include:
+
+- prompt/task
+- explicit `$vibe` usage expectation
+- expected grade
+- expected specialist set or allowance
+- frozen acceptance criteria
+- automated verification commands
+- manual spot-check checklist
+- forbidden outcomes
+
+### D. Benchmark Repositories
+Add benchmark repos under a bounded directory such as:
+
+- `benchmarks/todo-webapp`
+- `benchmarks/python-lib`
+- `benchmarks/bioinformatics-mini`
+- `benchmarks/docs-project`
+
+Purpose:
+
+- prove `vibe` can govern real downstream work
+- validate functional completeness and regression behavior
+- exercise specialist-assisted composite tasks
+
+### E. Workflow Acceptance Runner
+Add a workflow-acceptance harness, preferably runtime-neutral where possible, that:
+
+1. loads a scenario
+2. loads a benchmark repo
+3. executes the governed run or replayable simulation
+4. collects runtime/session artifacts
+5. runs project-level validations
+6. writes one delivery acceptance report
+
+Expected output families:
+
+- scenario execution receipt
+- verification command log
+- acceptance checklist result
+- residual-risk summary
+- completion-language disposition
+
+### F. Completion Semantics Hardening
+Harden runtime/reporting so the following are never flattened into “done”:
+
+- partial execution success
+- degraded specialist execution
+- pending manual actions
+- missing user-flow acceptance evidence
+
+This requires explicit mapping from execution state to allowed completion language.
+
+### G. Release Truth Gate
+Add a release-facing gate that refuses full-success release wording unless:
+
+- governance truth is passing
+- engineering verification truth is passing
+- workflow completion truth is passing
+- product acceptance truth is passing
+
+## Wave Plan
+
+### Wave 1: Freeze Delivery Truth Contract
+- Define the four-layer truth model.
+- Define report vocabulary and forbidden completion mappings.
+- Write stable governance documentation for downstream project delivery acceptance.
+
+### Wave 2: Extend Requirement / Plan Acceptance Surfaces
+- Add downstream acceptance sections to governed requirement expectations.
+- Add delivery-specific DoD, regression, and manual-check sections to governed plans.
+- Define how specialist-assisted scenarios carry domain-specific acceptance rules.
+
+### Wave 3: Create Scenario Schema And Gold Corpus
+- Design a machine-readable scenario schema.
+- Create an initial gold corpus covering:
+  - narrow feature work
+  - bugfix/regression work
+  - L staged execution
+  - XL composite work
+  - specialist-heavy work
+  - failure/drift cases
+
+### Wave 4: Add Benchmark Repositories
+- Create or import bounded benchmark repos.
+- Attach scenario-to-benchmark mappings.
+- Ensure each benchmark has a small, credible acceptance surface.
+
+### Wave 5: Implement Workflow Acceptance Runner
+- Load scenario + repo fixtures.
+- Execute governed runs or replayable harnesses.
+- Run automated acceptance checks.
+- Emit one delivery-truth report per scenario.
+
+### Wave 6: Harden Completion Reporting
+- Connect execution/reporting surfaces to the new truth model.
+- Prevent runtime-only success from being reported as full project completion.
+- Surface residual risk and manual actions in a mandatory way.
+
+### Wave 7: Prove Stability / Usability / Intelligence
+- Stability:
+  - repeated-run matrix
+  - failure injection
+  - flake accounting
+- Usability:
+  - operator-readable report audit
+  - manual spot-check contract audit
+  - benchmark user-flow walkthroughs
+- Intelligence:
+  - grade-selection sanity checks
+  - specialist-selection appropriateness checks
+  - verification-depth adequacy checks
+  - drift/escalation behavior checks
+
+### Wave 8: Release Gate Integration And Rollout
+- Add release truth gate.
+- Add operator runbook.
+- Define minimum passing suite before public completion claims or release notes can overclaim.
+
+## Detailed Test Program
+
+### 1. Functional Acceptance Tests
+- Critical user story completion
+- required outputs exist and are usable
+- changed feature behaves as specified
+
+### 2. Boundary And Error Tests
+- malformed input
+- empty input
+- conflicting requirements
+- missing dependency / provider / file / environment
+
+### 3. Regression Tests
+- reproduce prior bug
+- confirm failure before fix when possible
+- confirm pass after fix
+- preserve unrelated core behavior
+
+### 4. Workflow Tests
+- requirement freeze matches final work
+- plan steps match actual execution
+- specialist dispatch stays bounded
+- child lanes do not reopen root truth
+
+### 5. Composite XL Tests
+- multiple specialist domains
+- step-level bounded parallelism
+- disjoint write scopes
+- escalation and same-round absorption behavior
+
+### 6. Human-Like Acceptance Tests
+- manual spot checks on benchmark repos
+- artifact readability
+- result usefulness
+- final completion report honesty
+
+## Proof Strategy
+
+### Stability Proof
+- repeated execution across multiple runs
+- failure injection for selected specialist/unit paths
+- flake-rate tracking
+- deterministic artifact comparison where credible
+
+Target proof:
+- no hidden “one-pass only” success
+- clear accounting for unstable cases
+
+### Usability Proof
+- acceptance reports must be operator-readable in one pass
+- each scenario must state:
+  - what works
+  - what failed
+  - what still needs manual confirmation
+  - whether completion wording is allowed
+
+Target proof:
+- an operator can tell the true project state without reading raw logs
+
+### Intelligence Proof
+- verify that `vibe` chose a plausible grade
+- verify that specialist usage was appropriate and bounded
+- verify that verification depth matched task risk
+- verify that drift or missing evidence downgraded completion wording
+
+Target proof:
+- the system is not only active; it is choosing wisely
+
+## Ownership Boundaries
+- Contracts and policy:
+  - `config/*delivery*`
+  - runtime/reporting policy surfaces
+- Requirement/plan docs:
+  - `docs/requirements/*`
+  - `docs/plans/*`
+- Stable governance docs:
+  - `docs/*delivery*governance.md`
+- Scenario corpus:
+  - `tests/scenarios/project_delivery/*`
+- Benchmark repos:
+  - `benchmarks/*`
+- Acceptance runner and gates:
+  - `scripts/verify/runtime_neutral/*`
+  - `scripts/verify/*delivery*gate.ps1`
+
+## Verification Commands
+- `git diff --check`
+- `python3 -m pytest tests/runtime_neutral -v`
+- `python3 -m pytest tests/scenarios/project_delivery -v`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-workflow-acceptance-gate.ps1`
+- `pwsh -NoLogo -NoProfile -File scripts/verify/vibe-release-truth-gate.ps1`
+- targeted benchmark acceptance commands per scenario
+
+## Rollback Plan
+- If the new acceptance layer causes ambiguity, keep existing runtime proof surfaces and disable only the new release-enforcement mapping.
+- If benchmark repos become too heavy, retain the scenario schema and keep a smaller gold corpus.
+- If fully automated acceptance is not credible for a scenario, force explicit manual spot-check state rather than pretending automation coverage exists.
+- Never revert unrelated user changes.
+
+## Success Metrics
+- reduced false-completion rate
+- increased scenario coverage of real project work
+- explicit accounting of residual risks
+- lower gap between “reported complete” and “user can actually use it”
+
+## Phase Cleanup Contract
+- clean temporary scenario outputs after each implementation batch
+- audit and clear managed node/python residue created by acceptance harnesses
+- preserve only intended docs, fixtures, benchmark repos, and proof artifacts
+- emit cleanup receipts before claiming a wave is closed

--- a/bundled/skills/vibe/docs/plans/2026-03-28-vibe-governor-native-specialist-skills-execution-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-28-vibe-governor-native-specialist-skills-execution-plan.md
@@ -1,0 +1,56 @@
+# Vibe Governor + Native Specialist Skills
+
+## Execution Summary
+Implement the smallest coherent extension that lets explicit `vibe` runs freeze, plan, and execute native specialist assistance without surrendering runtime authority. Reuse existing router outputs, keep `runtime_selected_skill=vibe`, add a real host adapter bridge for specialist units, and make unsupported paths degrade explicitly instead of pretending receipt-only execution is native.
+
+## Frozen Inputs
+- Requirement doc: /home/lqf/table/table5/workspace/verify-main-pr60/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
+- Source task: `vibe` governor + native specialist skills
+- Runtime authority invariant: explicit `vibe` remains the only runtime owner
+
+## Internal Grade Decision
+- Grade: XL
+- User-facing runtime remains fixed; the grade is internal only.
+- Parallel work is warranted because code, tests, and governance docs can advance on disjoint write scopes.
+
+## Wave Plan
+- Wave 1: freeze executable specialist contract, host adapter policy, and degrade contract
+- Wave 2: implement runtime-native specialist execution bridge with `codex exec` as the first adapter lane
+- Wave 3: allow child lanes to execute only root-approved specialist dispatch while keeping local suggestions escalation-only
+- Wave 4: upgrade manifests, receipts, and docs so live execution and degraded execution are clearly distinct
+- Wave 5: add fake-adapter regression tests, targeted runtime verification, and cleanup closure
+
+## Ownership Boundaries
+- Runtime packet and artifact contract: `config/runtime-input-packet-policy.json`, `config/native-specialist-execution-policy.json`, `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+- Requirement/plan surfacing: `scripts/runtime/Write-RequirementDoc.ps1`, `scripts/runtime/Write-XlPlan.ps1`
+- Execution bridge and accounting: `scripts/runtime/VibeExecution.Common.ps1`, `scripts/runtime/Invoke-DelegatedLaneUnit.ps1`, `scripts/runtime/Invoke-PlanExecute.ps1`
+- Protocol/docs authority model: `SKILL.md`, `protocols/runtime.md`, `protocols/team.md`, supporting docs
+- Verification: runtime tests and targeted gates
+- Subagent prompts must end with `$vibe`.
+
+## Specialist Skill Dispatch Plan
+- Dispatch only bounded specialist units; keep `vibe` as the sole runtime owner.
+- Preserve native specialist usage by carrying native workflow expectations, required inputs, expected outputs, and verification mode into the dispatch contract.
+- Do not auto-promote specialist recommendations into runtime ownership changes.
+- Specialist-owned lanes use visible specialist invocation plus injected hidden governance context; they are not receipt-only aliases for `$vibe`.
+- The first live bridge is `codex exec`; unsupported hosts or disabled native execution degrade explicitly to `degraded_non_authoritative`.
+- Record all specialist units in execution evidence and recover their outputs into the `vibe` manifest.
+
+## Verification Commands
+- `git diff --check`
+- `python3 -m py_compile scripts/runtime/*.ps1` is not applicable; instead validate PowerShell syntax via targeted gates and JSON schema checks
+- `python3 -m pytest tests/runtime_neutral -k "runtime_input_packet or plan_execute or specialist or requirement or plan"`
+- targeted `rg` checks for authority invariants such as `explicit_runtime_skill`, `shadow_only`, `specialist_recommendations`
+- smoke `codex exec` in a temp directory before claiming the `codex` adapter lane works
+- repo cleanliness checks and node audit after each wave
+
+## Rollback Plan
+- Revert only the governor-specialist change set if authority invariants or regression tests fail.
+- Do not revert unrelated user changes or existing untracked docs.
+- If the live host adapter bridge proves unstable, keep the executable contract and degrade explicitly to `degraded_non_authoritative` instead of silently restoring receipt-only fake native execution.
+
+## Phase Cleanup Contract
+- Remove temporary logs or scratch files created during each wave.
+- Run node audit and clean stale managed node residue when present.
+- Leave the repository with only intended source, docs, tests, and proof artifacts.
+- Emit a cleanup receipt after verification closure.

--- a/bundled/skills/vibe/docs/plans/README.md
+++ b/bundled/skills/vibe/docs/plans/README.md
@@ -24,6 +24,12 @@ Those surfaces live under [`../status/README.md`](../status/README.md).
 
 ### Current Entry
 
+- [`2026-03-28-root-child-vibe-hierarchy-governance-plan.md`](./2026-03-28-root-child-vibe-hierarchy-governance-plan.md): root/child `vibe` 分层治理执行计划；聚焦把 child `$vibe` 收敛为 subordinate lane，并用批准式 specialist dispatch + escalation proof 防止递归总治理。
+- [`2026-03-27-ai-governance-consolidation-plan.md`](./2026-03-27-ai-governance-consolidation-plan.md): 内置 AI 治理层收敛整理执行计划；聚焦把 active runtime、doctor、helper scripts、one-shot 入口与 bundled 镜像统一到单一路径契约。
+- [`2026-03-27-ai-governance-historical-wording-cleanup-plan.md`](./2026-03-27-ai-governance-historical-wording-cleanup-plan.md): 内置 AI 治理层历史表述清理执行计划；聚焦清理 `vibe` 范围内已退役模型键名的历史残留表述。
+- [`2026-03-27-ai-governance-openai-compatible-only-plan.md`](./2026-03-27-ai-governance-openai-compatible-only-plan.md): 内置 AI 治理层 OpenAI-compatible-only 执行计划；聚焦收口权威 provider registry、vector diff 默认面、bootstrap/setup 和安装文档中的 Ark 分支。
+- [`2026-03-27-ai-governance-install-clarity-plan.md`](./2026-03-27-ai-governance-install-clarity-plan.md): issue #57 安装澄清执行计划；聚焦用真实探针读取逻辑收口 AI 治理 advice 的配置键名、快速检查说明与安装时提示。
+- [`2026-03-27-ai-governance-single-model-key-plan.md`](./2026-03-27-ai-governance-single-model-key-plan.md): 内置 AI 治理层单模型键收敛执行计划；聚焦统一到 `VCO_RUCNLPIR_MODEL` 并清理双键口径。
 - [`2026-03-20-readme-en-detail-and-github-branding-copy-plan.md`](./2026-03-20-readme-en-detail-and-github-branding-copy-plan.md): README 英文版细化与 GitHub 品牌文案执行计划；聚焦补齐英文首页细节，并整理 `About / Topics / social preview` 设置文案。
 - [`2026-03-20-readme-emoji-layout-polish-plan.md`](./2026-03-20-readme-emoji-layout-polish-plan.md): README 中文视觉润色执行计划；聚焦少量 emoji 点缀、区块节奏优化与 GitHub-safe 的版式打磨。
 - [`2026-03-20-readme-differentiated-science-ai-strengths-plan.md`](./2026-03-20-readme-differentiated-science-ai-strengths-plan.md): README 中文差异化强化执行计划；聚焦把生命科学、科研、AI 工程三块写得更有辨识度。

--- a/bundled/skills/vibe/docs/releases/README.md
+++ b/bundled/skills/vibe/docs/releases/README.md
@@ -10,7 +10,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ### Current Release Surface
 
-- [`v2.3.50.md`](v2.3.50.md): router AI connectivity probe / host-adapter expansion / single-entry install surface / Windows PowerShell default verification guidance
+- [`v2.3.51.md`](v2.3.51.md): main-chain delivery acceptance / specialist dispatch governance closure / Windows specialist runtime handoff fix
 
 ### Release Runtime / Proof Handoff
 
@@ -22,6 +22,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ## Recent Governed Releases
 
+- [`v2.3.51.md`](v2.3.51.md) - 2026-03-28 - main-chain delivery acceptance / specialist dispatch governance closure / Windows specialist runtime handoff fix
 - [`v2.3.50.md`](v2.3.50.md) - 2026-03-26 - router AI connectivity probe / host-adapter expansion / single-entry install surface / Windows PowerShell default verification guidance
 - [`v2.3.49.md`](v2.3.49.md) - 2026-03-23 - shallow-worktree install/check hardening / installed-runtime adapter fallback / parent-path guard convergence
 - [`v2.3.48.md`](v2.3.48.md) - 2026-03-23 - benchmark mode compatibility downgrade / governed proof alignment / adaptive-routing gate robustness

--- a/bundled/skills/vibe/docs/releases/v2.3.51.md
+++ b/bundled/skills/vibe/docs/releases/v2.3.51.md
@@ -1,0 +1,33 @@
+# VCO Release v2.3.51
+
+- Date: 2026-03-28
+- Commit(base): 18e6b9c
+- Previous release: `v2.3.50`
+
+## Highlights
+
+- Moved downstream delivery acceptance from an external verification layer into the normal `vibe` governed runtime main chain. Governed runs now freeze product acceptance criteria, manual spot checks, completion-language policy, and a delivery-truth contract directly in the main requirement surface.
+- Extended the governed plan and closure path so `xl_plan` records a delivery-acceptance plan and `phase_cleanup` emits a per-run `delivery-acceptance-report.json`. This makes completion-language downgrades part of the real runtime path instead of a post hoc review convention.
+- Completed the recent specialist-governance sequence on `main`: stage-bound specialist dispatch, child-lane same-round auto-absorb under root approval, and stronger native-specialist failure proofing. This improves how `vibe` uses specialist help without surrendering runtime authority.
+- Fixed the Windows specialist runtime handoff so native specialist execution remains viable on current Windows environments.
+
+## What Changed Compared With v2.3.50
+
+- `v2.3.50` was mainly about install truth, router AI connectivity proofing, and host-adapter/install-surface closure.
+- `v2.3.51` shifts the center of gravity into the governed execution path itself. The main difference is that the repo no longer only says “delivery truth matters”; the normal `vibe` runtime now writes and carries that truth in its own artifacts.
+- The older release improved readiness disclosure and verification entrypoints. The new release raises the honesty bar for declaring work complete after a governed run.
+
+## Validation Notes
+
+- Main-chain delivery-acceptance coverage:
+  - `pytest -q tests/runtime_neutral/test_runtime_delivery_acceptance.py tests/runtime_neutral/test_workflow_acceptance_runner.py tests/runtime_neutral/test_release_truth_gate.py`
+- Governed runtime / hierarchy / topology coverage:
+  - `pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py`
+- Release-surface hygiene:
+  - `git diff --check`
+
+## Migration Notes
+
+- Operators should expect stricter completion wording after normal governed runs. A clean runtime/process closure is no longer treated as equivalent to proven downstream project delivery.
+- Normal `vibe` session artifacts now include a `delivery-acceptance-report.json` and companion markdown summary under `outputs/runtime/vibe-sessions/<run-id>/`.
+- This release improves truthfulness and closure semantics. It does not claim that every host UI now enforces an absolutely unskippable final text gate; the authoritative change is that the governed runtime itself now records and carries the delivery-truth result.

--- a/bundled/skills/vibe/docs/requirements/2026-03-26-codex-vibe-dedupe.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-26-codex-vibe-dedupe.md
@@ -1,0 +1,19 @@
+# Requirement: Codex `vibe` Duplicate Surface Fix
+
+- Date: 2026-03-26
+- Issue: `#42`
+
+## Goal
+
+Prevent Codex from exposing two `vibe` skills when either of these duplicate surfaces exist:
+
+- a legacy sibling copy under `~/.agents/skills/vibe`
+- a discoverable nested runtime mirror under `skills/vibe/bundled/skills/vibe/SKILL.md`
+
+## Acceptance
+
+- Codex default-root install quarantines the legacy `.agents/skills/vibe` duplicate instead of leaving both surfaces discoverable.
+- Installed runtime payloads hide nested runtime-mirror `SKILL.md` entrypoints while preserving runtime configs and bootstrap behavior.
+- `check.sh` and `check.ps1` fail clearly when the duplicate surface still exists.
+- Non-default custom target roots are not mutated as part of this mitigation.
+- Automated tests cover shell/PowerShell install behavior, runtime bootstrap continuity, and duplicate-surface regression checks.

--- a/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-consolidation.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-consolidation.md
@@ -1,0 +1,54 @@
+# Requirement: Consolidate Built-In AI Governance to a Stable Single-Path Contract
+
+## Goal
+
+Consolidate all active built-in AI governance changes so runtime behavior, verification surfaces, bootstrap guidance, and install docs all reflect one stable contract.
+
+## User Intent
+
+The built-in AI governance layer should be:
+
+- OpenAI-compatible only
+- single-model-key only
+- correctly verifiable
+- documented without conflicting or stale active-path wording
+
+## Required Outcome
+
+The active built-in governance path must:
+
+1. support only the OpenAI-compatible provider family on the active shipped path
+2. use `VCO_RUCNLPIR_MODEL` as the only active built-in governance model key
+3. make bootstrap doctor / readiness surfaces report both credential and model readiness for the built-in governance path
+4. stop treating Ark helper modules or Ark-specific install helpers as active built-in governance surfaces
+5. keep install entry docs aligned with the same credential + base URL + model-key contract
+6. keep bundled mirrors synchronized with the corrected active source assets
+
+## In Scope
+
+- active runtime-neutral verification scripts
+- active PowerShell doctor gate
+- active bootstrap/setup docs
+- active router verification helpers
+- active shipped helper scripts for built-in governance configuration
+- bundled mirrors of the changed active assets
+
+## Out of Scope
+
+- historical release notes
+- proof bundles
+- unrelated non-vibe skills
+
+## Constraints
+
+- do not break the current OpenAI-compatible runtime path
+- do not reintroduce a second provider lane
+- preserve honest readiness reporting
+
+## Acceptance Criteria
+
+1. Active doctor outputs expose both `OPENAI_API_KEY` and `VCO_RUCNLPIR_MODEL` readiness.
+2. Active built-in governance verification scripts no longer test or clear Ark-specific built-in provider paths.
+3. Ark-specific built-in governance helper scripts are no longer present on the active shipped path.
+4. Install docs and one-shot docs consistently tell users to configure `OPENAI_API_KEY`, optional base URL, and `VCO_RUCNLPIR_MODEL`.
+5. Source and bundled mirrors stay in sync after the consolidation.

--- a/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-historical-wording-cleanup.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-historical-wording-cleanup.md
@@ -1,0 +1,47 @@
+# Requirement: Clean Residual Historical Multi-Key Wording From Vibe Governance Docs
+
+## Goal
+
+Remove the remaining exact legacy model-key names from `vibe` governance history and current governance artifacts, while preserving the factual meaning of those documents.
+
+## User Intent
+
+After the active built-in governance path has converged to one model key, the repo should not keep avoidable residual old key-name strings in `vibe` documentation and planning artifacts.
+
+## Required Outcome
+
+The cleanup pass must:
+
+1. rewrite residual `vibe` historical docs so they describe the older multi-key model wording generically instead of naming the retired secondary model keys verbatim
+2. rewrite current governance requirement and plan artifacts so they describe the removed lanes generically where exact legacy names are no longer needed
+3. keep the current single-key contract unchanged:
+   - `OPENAI_API_KEY`
+   - optional `OPENAI_BASE_URL` or `OPENAI_API_BASE`
+   - `VCO_RUCNLPIR_MODEL`
+4. keep unrelated non-`vibe` skills out of scope
+5. keep bundled mirrors synchronized for any shipped `vibe` docs that change
+
+## In Scope
+
+- `docs/changes/**` entries for `vibe`
+- `docs/plans/**` legacy `vibe` planning artifacts that still spell out retired model keys
+- current `docs/requirements/**` and `docs/plans/**` artifacts created during this governance tightening run
+- bundled mirrors of changed `vibe` history docs
+
+## Out of Scope
+
+- unrelated skills outside the `vibe` shipped path
+- external examples that intentionally document generic OpenAI usage in other skills
+- rewriting unrelated historical provider notes that do not contain the retired model-key names
+
+## Constraints
+
+- preserve document meaning
+- do not reintroduce a second active model-key lane
+- do not modify unrelated skill documentation just to satisfy a broad grep
+
+## Acceptance Criteria
+
+1. Repo-wide search for the retired secondary model-key strings returns no matches inside `vibe` source docs, bundled `vibe` docs, or current governance artifacts for this run.
+2. The single-key active contract remains unchanged.
+3. Any remaining matches outside `vibe` are explicitly identified as out of scope.

--- a/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-install-clarity.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-install-clarity.md
@@ -1,0 +1,71 @@
+# Requirement: Clarify AI Governance Install-Time API Configuration
+
+## Goal
+
+Remove install-time ambiguity around the AI governance online path so users can tell:
+
+- what to configure locally
+- which key names are the recommended path
+- how to verify readiness after installation
+
+## User Intent
+
+After finishing install, users should not have to guess whether:
+
+- the local install is already complete
+- the governance AI advice path is online
+- `OPENAI_*`, `ARK_*`, or `VCO_AI_PROVIDER_*` is the right configuration surface
+
+## Required Outcome
+
+The public install and configuration docs must:
+
+1. distinguish `installed locally` from `governance AI online-ready`
+2. present the common OpenAI-compatible path as:
+   - `OPENAI_API_KEY`
+   - optional `OPENAI_BASE_URL` or `OPENAI_API_BASE`
+   - the project governance model key
+3. present the Ark-compatible path as:
+   - `ARK_API_KEY`
+   - optional `ARK_BASE_URL` or `VOLC_ARK_BASE_URL`
+   - `ARK_MODEL`
+4. treat the older fallback model-key wording as legacy wording instead of the primary install-time model key
+5. stop presenting `VCO_AI_PROVIDER_URL` and `VCO_AI_PROVIDER_API_KEY` as the default local install-time guidance for quick checks
+6. explain where the quick check actually reads values from:
+   - `<target-root>/settings.json` `env`
+   - or the current process environment
+7. provide one concrete quick-check command for Windows and one for Linux/macOS
+8. align install-time console messaging with the same wording
+
+## Scope
+
+In scope:
+
+- public install docs
+- install prompts
+- install rules
+- runtime/bootstrap user-facing messages
+- quick-check guidance
+
+Out of scope:
+
+- redesigning policy schema
+- changing host adapter ownership boundaries
+- changing provider routing strategy
+
+## Constraints
+
+- do not ask users to paste secrets into chat
+- do not claim online readiness without matching local configuration
+- keep the guidance compatible with the latest GitHub version
+- keep OpenAI-compatible and Ark-compatible wording both explicit
+- preserve existing advanced policy-driven provider configuration paths where they already exist
+
+## Acceptance Criteria
+
+1. Public install docs no longer imply that `VCO_AI_PROVIDER_URL` / `VCO_AI_PROVIDER_API_KEY` is the primary local install-time path.
+2. The configuration guide matches the actual quick-check probe behavior.
+3. Install prompts tell assistants exactly which local keys to recommend after install.
+4. One-shot bootstrap messages use concrete key names instead of generic “url/apikey/model”.
+5. Quick-check next-step guidance mentions the right model/base-url keys for OpenAI-compatible and Ark-compatible paths.
+6. Updated source install docs are mirrored into both bundled install-doc trees.

--- a/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-openai-compatible-only.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-openai-compatible-only.md
@@ -1,0 +1,60 @@
+# Requirement: Restrict the Built-In AI Governance Layer to OpenAI-Compatible Integration
+
+## Goal
+
+Make the built-in AI governance layer support only OpenAI-compatible integration on the active shipped path.
+
+## User Intent
+
+Users should not see, configure, or depend on multiple provider lanes for the built-in governance layer.
+
+The built-in path should stay:
+
+- one provider shape
+- one credential family
+- one model/base-url story
+
+## Required Outcome
+
+The active built-in governance path must:
+
+1. standardize on OpenAI-compatible integration for built-in advice and governance online capability
+2. stop presenting Ark-compatible configuration as an equal built-in option in install docs and prompts
+3. remove Ark-compatible provider registration from active provider authority surfaces
+4. stop using Ark-specific defaults for built-in vector diff / embeddings
+5. stop advertising or seeding Ark-specific bootstrap settings in active install/setup scripts
+6. keep the install-time distinction between:
+   - local install complete
+   - governance online-ready
+7. preserve OpenAI-compatible quick-check and doctor behavior
+
+## In Scope
+
+- active install docs
+- active configuration defaults
+- active bootstrap and doctor scripts
+- active runtime-neutral governance connectivity probe
+- active router provider registry and llm acceleration defaults
+- active bundled mirrors of the same shipped assets
+
+## Out of Scope
+
+- historical release notes
+- old archived proof bundles
+- deleting every historical Ark-related file from the repo
+
+## Constraints
+
+- do not silently widen provider support again
+- do not break the current OpenAI-compatible path
+- keep bundled mirrors synchronized with source assets
+- do not ask users to paste secrets into chat
+
+## Acceptance Criteria
+
+1. Public install docs for the built-in governance layer describe only OpenAI-compatible integration.
+2. Active bootstrap/setup output no longer suggests Ark-compatible configuration.
+3. Active policy defaults no longer use Ark-specific embedding provider settings.
+4. Active provider registry no longer advertises an Ark-compatible built-in provider lane.
+5. The router AI connectivity probe and doctor outputs align with OpenAI-compatible-only guidance.
+6. Source and bundled active assets remain in sync.

--- a/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-single-model-key.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-27-ai-governance-single-model-key.md
@@ -1,0 +1,58 @@
+# Requirement: Converge the Built-In AI Governance Layer to One Model Key
+
+## Goal
+
+Make the active built-in AI governance path use one canonical model environment key only: `VCO_RUCNLPIR_MODEL`.
+
+## User Intent
+
+Users should not need to decide between multiple model-key names when configuring the built-in governance layer.
+
+The active public path should present:
+
+- one credential family
+- one base-url family
+- one model key
+
+## Required Outcome
+
+The active built-in governance path must:
+
+1. treat `VCO_RUCNLPIR_MODEL` as the only supported model environment key on the active shipped path
+2. stop presenting a second public model key as an equal configuration choice
+3. stop presenting legacy fallback model-key wording in install and quick-check guidance
+4. keep the OpenAI-compatible base URL and API key guidance unchanged
+5. preserve the distinction between:
+   - local install complete
+   - governance online-ready
+6. keep bundled mirrors synchronized with the same single-key contract
+
+## In Scope
+
+- active runtime-neutral AI connectivity probe
+- active bootstrap/setup guidance
+- active settings templates that expose built-in governance model wiring
+- active install docs and install prompts
+- active bundled mirrors of the same shipped assets
+
+## Out of Scope
+
+- rewriting historical change logs
+- deleting every historical legacy key mention from archived or superseded artifacts
+- changing the canonical OpenAI-compatible API key or base-url names
+
+## Constraints
+
+- do not break the current OpenAI-compatible governance path
+- do not silently keep a second active model-key lane
+- do not ask users to paste secrets into chat
+- keep source and bundled shipped assets in sync
+
+## Acceptance Criteria
+
+1. Active runtime guidance resolves the built-in governance model from `VCO_RUCNLPIR_MODEL` only.
+2. Active bootstrap/setup messages recommend only `VCO_RUCNLPIR_MODEL` for the model name.
+3. Public active install docs and prompts describe one model key only.
+4. Active shipped settings templates no longer advertise any retired secondary model-key lane for the built-in governance model slot.
+5. Verification output for missing model configuration points to `VCO_RUCNLPIR_MODEL` only.
+6. Source assets and bundled mirrors remain synchronized after the change.

--- a/bundled/skills/vibe/docs/requirements/2026-03-28-l-xl-native-execution-closure.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-28-l-xl-native-execution-closure.md
@@ -1,0 +1,104 @@
+# L / XL Native Execution Closure
+
+## Summary
+Close the gap between the documented `vibe` execution model and the current runtime implementation. Land a real `L` native serial execution path and a real `XL` native selective-parallel execution path so that `vibe` no longer only freezes governance artifacts and specialist accounting, but can actually orchestrate child lanes and native specialist work under root-controlled runtime authority.
+
+## Goal
+Implement a coherent governed execution model where:
+
+- `L` runs as a true native serial workflow inside `vibe`
+- `XL` runs as a true native multi-lane workflow inside `vibe`
+- parallelism is selective and step-scoped rather than global and always-on
+- specialist skills can be executed in their native mode as bounded work units
+- root/child governance remains single-owner, auditable, and stable
+
+## Deliverable
+A repository change set and documentation bundle that adds:
+
+- a runtime execution topology that distinguishes `M`, `L`, and `XL` in real execution behavior, not only in metadata
+- a native `L` serial orchestrator with staged subagent execution and two-stage review
+- a native `XL` selective-parallel orchestrator with root-controlled wave and step scheduling
+- executable specialist-dispatch units that preserve native specialist workflow contracts
+- tests and proof artifacts demonstrating authority preservation, stable execution, and correct bounded parallelism
+
+## Constraints
+- Do not create a second router, second requirement surface, second execution-plan surface, or second runtime authority.
+- Keep `vibe` as the runtime-selected skill for explicit governed entry.
+- Do not turn `XL` into always-parallel execution; only independent units inside a step may run concurrently.
+- Do not flatten specialist skills into generic labels; preserve native workflow, inputs, outputs, and validation style.
+- Keep root/child hierarchy rules intact: only root may freeze canonical requirement and plan truth or issue final completion claims.
+- Prefer additive execution-topology changes over broad router rewrites.
+
+## Acceptance Criteria
+- `L` execution is no longer metadata-only:
+  - runtime uses a native serial orchestrator
+  - design/plan approval remains explicit
+  - subagent units run in ordered stages
+  - two-stage review is represented in execution artifacts
+- `XL` execution is no longer metadata-only:
+  - runtime can execute child-governed units as real delegated lanes
+  - wave order stays sequential by dependency
+  - independent units inside a wave or step can run in bounded parallel
+  - scheduler policy exposes bounded concurrency rather than fixed `max_parallel_units=1`
+- specialist-dispatch execution is no longer accounting-only:
+  - approved specialist dispatch can become executable bounded units
+  - child-local specialist suggestions remain advisory until root approval
+  - execution evidence records native specialist runs and recovery into root manifest
+- proof surfaces show:
+  - one root completion authority
+  - no duplicate canonical requirement or plan surfaces
+  - child lanes cannot widen global scope silently
+  - degraded execution remains explicit and non-authoritative when the native path is unavailable
+
+## Primary Objective
+Make the documented `L` and `XL` governed execution semantics true in the runtime.
+
+## Proxy Signal
+The runtime no longer only writes plans and manifests about serial or parallel work; it actually schedules serial `L` child units, bounded `XL` parallel units, and executable native specialist dispatch under `vibe` governance.
+
+## Scope
+In scope:
+- runtime scheduler and execution-topology policy
+- `L` serial orchestrator
+- `XL` selective-parallel orchestrator
+- root/child delegated execution wiring
+- native specialist execution contracts
+- execution receipts, manifests, and proof updates
+- runtime-neutral tests and governed verification gates
+
+Out of scope:
+- redesigning canonical routing logic
+- host auto-interception of every non-`vibe` message
+- converting all specialist skills in the repository to new metadata formats
+- replacing governed runtime with a separate workflow engine
+
+## Completion
+The work is complete when explicit `vibe` runs can deliver real `L` serial native execution and real `XL` selective-parallel native execution, with specialist skills executed as bounded native helpers and with root-owned governance truth preserved end to end.
+
+## Evidence
+- runtime policy and execution code changes
+- updated protocol and stable docs
+- passing runtime-neutral tests covering `L`, `XL`, hierarchy, and specialist execution
+- governed proof artifacts showing real delegated execution rather than accounting-only shadows
+
+## Non-Goals
+- Do not make `XL` mean unconditional full parallelism.
+- Do not let child lanes become recursive top-level governors.
+- Do not let specialist skills take over runtime ownership from `vibe`.
+- Do not hide degraded or fallback paths behind success wording.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- Existing root/child hierarchy metadata is sufficient to seed a real delegated execution engine.
+- Existing specialist recommendation and dispatch fields can be extended into executable units without redesigning router scoring.
+- The current benchmark execution policy can evolve into a real governed execution-topology policy rather than remaining a repo-safe sequential proof runner only.
+- Proof quality can be preserved while moving from metadata-only semantics to actual orchestration.
+
+## Evidence Inputs
+- Source task: design a reasonable solution for the missing `L` native serial execution and `XL` selective-parallel native execution behavior
+- Current runtime gap:
+  - documented `L`/`XL` behavior is stronger than actual execution
+  - scheduler remains sequential
+  - specialist dispatch is surfaced and counted but not yet executed as native bounded units

--- a/bundled/skills/vibe/docs/requirements/2026-03-28-root-child-vibe-hierarchy-governance.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-28-root-child-vibe-hierarchy-governance.md
@@ -1,0 +1,104 @@
+# Root/Child Vibe Hierarchy Governance
+
+## Summary
+Resolve the governance ambiguity introduced by recursive `vibe` usage in XL multi-agent work. Keep `vibe` as the only governed runtime authority at the root task level while allowing child agents to inherit `vibe` discipline as subordinate execution lanes instead of reopening a second top-level governed runtime.
+
+## Goal
+Design and land a hierarchy model where:
+
+- one user task has exactly one root governed `vibe` runtime
+- child agents still run under `vibe` discipline
+- child agents do not create a second requirement or plan truth
+- specialist skills remain usable as bounded native helpers without taking runtime ownership
+
+## Deliverable
+A repository change set and documentation bundle that adds:
+
+- an explicit root/child governance-scope contract inside the runtime input packet
+- subordinate child-lane rules for XL execution
+- approved specialist dispatch versus child-local suggestion separation
+- execution/accounting/proof surfaces for root-owned completion and child-owned local receipts
+- protocol, requirement, plan, and stable governance docs for the hierarchy model
+- regression tests and verification gates proving authority preservation, non-duplication of canonical surfaces, bounded specialist usage, and predictable escalation behavior
+
+## Constraints
+- Do not remove `$vibe` from child-agent prompts.
+- Do not let child agents create a second visible governed startup surface.
+- Do not let child agents freeze a second canonical requirement document or execution plan.
+- Do not let child agents make global specialist-dispatch decisions on behalf of the root run.
+- Do not let specialist skills become runtime owners or make final completion claims.
+- Preserve existing explicit `vibe` authority invariants and current canonical router ownership.
+- Prefer additive metadata and execution-policy changes over broad router rewrites.
+
+## Acceptance Criteria
+- Runtime input packet distinguishes `root` versus `child` governance scope with machine-readable authority flags.
+- Root runs are the only runs allowed to freeze canonical requirement and plan surfaces under `docs/requirements/` and `docs/plans/`.
+- Child runs inherit the frozen requirement/plan context and write only subordinate receipts or artifacts.
+- Specialist dispatch is split into:
+  - root-approved specialist dispatch
+  - child-local specialist suggestions that require escalation before becoming globally active
+- Execution manifests preserve:
+  - single root completion authority
+  - child-unit evidence
+  - approved specialist dispatch accounting
+  - escalation requests and their outcomes
+- Protocol docs explain:
+  - root-governed authority
+  - child-governed subordinate execution
+  - specialist boundedness rules
+  - conflict-prevention rules for multi-agent work
+- Tests and gates prove:
+  - no duplicate canonical requirement/plan surfaces are created
+  - child runs cannot widen scope silently
+  - child runs cannot issue final completion claims
+  - child specialist suggestions stay advisory until root approval
+  - explicit `vibe` authority remains stable during hierarchical execution
+
+## Primary Objective
+Turn recursive multi-agent `vibe` usage from a layered-governance ambiguity into a single-root, subordinate-child execution model.
+
+## Proxy Signal
+Root runs freeze the only canonical requirement and plan, child runs inherit those surfaces as subordinate lanes, and specialist skills are executed or suggested without creating second governance truth.
+
+## Scope
+In scope:
+- runtime input packet hierarchy metadata
+- plan-execution handoff contract for child lanes
+- specialist dispatch approval versus suggestion semantics
+- execution manifest and proof surfacing
+- protocol and stable-governance documentation
+- regression tests and verification gates
+
+Out of scope:
+- redesigning the full canonical router ranking system
+- host-level interception of arbitrary non-`vibe` requests
+- per-skill metadata rewrites across the whole repository
+- generalized memory-system redesign
+
+## Completion
+The work is complete when XL `vibe` orchestration can use child agents and specialist skills without creating recursive top-level governance, duplicate canonical surfaces, or ambiguous completion authority.
+
+## Evidence
+- updated runtime/config/protocol/test surfaces
+- new governed requirement/plan docs for the hierarchy change
+- new stable governance design doc
+- passing targeted tests and gates
+- explicit proof artifacts and cleanup receipts from the verification pass
+
+## Non-Goals
+- Do not make child `vibe` lanes governance-free.
+- Do not replace `vibe` with specialist skills during explicit governed entry.
+- Do not allow child lanes to silently re-plan the entire task.
+- Do not hide escalation events or specialist conflict handling from execution evidence.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- Existing explicit `vibe` runtime surfaces are already strong enough to support a root/child extension.
+- Child lanes can inherit frozen context rather than regenerate it.
+- Specialist recommendations already present in the runtime packet can be separated into approved dispatch and local suggestions without a router redesign.
+- Stable hierarchy behavior can be proven with targeted runtime-neutral tests and governed PowerShell gates.
+
+## Evidence Inputs
+- Source task: design the root/child `vibe` hierarchy model that preserves governance while allowing bounded specialist usage

--- a/bundled/skills/vibe/docs/requirements/2026-03-28-stage-bound-specialist-dispatch-governance.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-28-stage-bound-specialist-dispatch-governance.md
@@ -1,0 +1,98 @@
+# Stage-Bound Specialist Dispatch Governance
+
+## Summary
+Extend the governed `vibe` runtime so specialist skills are no longer just recommended or counted, but are frozen as stage-bound execution contracts with explicit authority, phase binding, lane policy, write scope, and verification expectations. The design must preserve one runtime owner while making specialist skills materially useful during real work.
+
+## Goal
+Implement a governed specialist-dispatch model where:
+
+- `vibe` remains the sole runtime authority for requirement freeze, plan freeze, execution receipts, verification, and cleanup.
+- specialist skills are routed as candidates, approved as bounded dispatch contracts, and executed in the correct runtime phase.
+- `L` executes specialist help as explicit serial native steps.
+- `XL` executes specialist help as bounded child lanes, including parallel specialist lanes only when write scopes and governance rules allow it.
+- child `vibe` lanes can surface new specialist suggestions without gaining top-level authority.
+
+## Deliverable
+A repository change set and documentation bundle that adds:
+
+- machine-readable specialist binding policy for phase binding, lane policy, write scope, and review mode
+- frozen runtime-input specialist contracts carrying stage-bound execution metadata
+- requirement and plan surfaces that document phase-bound specialist dispatch
+- runtime topology support for `pre_execution`, `in_execution`, `post_execution`, and `verification` specialist phases
+- `L` serial specialist execution and `XL` bounded-parallel specialist lane execution
+- manifest accounting and proof surfaces that show where specialist work ran and under what authority
+- runtime-neutral tests and proof artifacts that demonstrate stability, usability, and intelligent specialist use
+
+## Constraints
+- Do not create a second router, second requirement truth, second plan truth, or second runtime owner.
+- Keep `runtime_selected_skill=vibe` for explicit governed entry.
+- Do not let specialist skills self-approve or self-upgrade into global runtime authority.
+- Preserve native specialist workflow, input contract, expected outputs, and validation style.
+- Allow parallel specialist execution only under root governance, only in `XL`, and only for disjoint write scopes.
+- Keep child local specialist suggestions advisory-first and escalation-first unless the existing same-round root auto-absorb gate approves them.
+
+## Acceptance Criteria
+- Runtime input packet recommendations carry specialist binding metadata:
+  - `binding_profile`
+  - `dispatch_phase`
+  - `execution_priority`
+  - `lane_policy`
+  - `parallelizable_in_root_xl`
+  - `write_scope`
+  - `review_mode`
+- Requirement documents surface specialist binding truth, not only skill names.
+- Execution plans surface a concrete specialist dispatch plan with phase binding, lane policy, and write scope.
+- `L` topology no longer lumps approved specialists into one generic final step; specialist units appear as phase-bound serial steps.
+- `XL` topology can place eligible specialists into bounded parallel steps while preserving serial fallback for conflicting scopes.
+- Execution manifests expose phase-binding and specialist topology evidence sufficient to prove where and how specialists ran.
+- Existing root/child hierarchy guarantees remain true:
+  - child cannot freeze canonical requirement or plan
+  - child cannot make final completion claims
+  - zero-overlap new specialist suggestions remain escalation-only
+  - same-round absorb still requires root-owned approval semantics
+
+## Primary Objective
+Make specialist skills useful inside `vibe` without letting them blur runtime ownership or fight each other.
+
+## Proxy Signal
+Specialist skills are invoked neither randomly nor only in theory. They appear in frozen runtime packets, are bound to explicit phases, execute in bounded lanes, and leave manifest evidence proving whether they ran live, degraded, serially, or in bounded parallel.
+
+## Scope
+In scope:
+- runtime-input packet specialist binding policy
+- requirement/plan surfacing
+- execution-topology specialist phase placement
+- manifest and proof accounting
+- runtime-neutral test expansion
+- stable governance documentation
+
+Out of scope:
+- redesigning canonical router scoring
+- host-wide interception of non-`vibe` entrypoints
+- granting child lanes top-level planning authority
+- unbounded automatic expert fan-out
+
+## Completion
+The work is complete when explicit `vibe` runs can freeze, plan, and execute phase-bound specialist help with artifact-backed proof that the result is stable, usable, and governed.
+
+## Evidence
+- updated config/runtime/protocol/test surfaces
+- new or updated requirement, plan, and stable governance docs
+- passing targeted runtime-neutral tests
+- replay or proof artifacts showing serial and bounded-parallel specialist execution
+
+## Non-Goals
+- Do not make every specialist recommendation executable by default.
+- Do not make `$vibe` inside child lanes mean “child may govern everything”.
+- Do not hide degraded specialist execution behind success wording.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- Existing ranked specialist recommendations are sufficient to seed deterministic phase binding.
+- Binding profiles can be kept simple and deterministic at first by classifying specialists into planning, implementation, deliverable, and verification phases.
+- Current bounded parallel scheduler already provides enough machinery to support specialist parallel lanes once dispatch units expose proper write scopes and parallel eligibility.
+
+## Evidence Inputs
+- Source task: make specialist skills useful inside `vibe` without conflict or authority drift

--- a/bundled/skills/vibe/docs/requirements/2026-03-28-vibe-governed-project-delivery-acceptance.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-28-vibe-governed-project-delivery-acceptance.md
@@ -1,0 +1,111 @@
+# Vibe-Governed Project Delivery Acceptance
+
+## Summary
+Close the current gap between `vibe` runtime correctness and downstream project delivery correctness. The repository already proves many governance and runtime contracts, but it does not yet prove strongly enough that a project completed under `vibe` is functionally complete, user-usable, regression-safe, and honestly reported as such.
+
+## Goal
+Design and land a governed acceptance architecture where work completed under `vibe` is evaluated as a delivered project, not only as a correctly governed runtime session.
+
+## Deliverable
+A repository change program and documentation bundle that adds:
+
+- a delivery-truth model separating governance, engineering verification, workflow completion, and product acceptance
+- scenario-based acceptance fixtures for real project work completed under `vibe`
+- benchmark repositories and gold-task corpora that simulate real downstream work rather than only VibeSkills self-tests
+- a workflow-acceptance runner that executes governed tasks and judges project outcomes against frozen acceptance criteria
+- stronger completion semantics so `completed_with_failures`, `manual_actions_pending`, and degraded paths cannot be reported as full delivery success
+- release and operator documentation for how project delivery under `vibe` is validated and proved
+
+## Constraints
+- This project is about testing downstream work completed under `vibe`, not about host installation correctness or adapter parity by themselves.
+- Preserve existing single-router and single-runtime-owner invariants.
+- Do not create a second visible runtime, second requirement truth, or second execution-plan truth.
+- Prefer additive acceptance and proof surfaces over a disruptive router/runtime rewrite.
+- Preserve current governance evidence while making project-delivery evidence a first-class required surface.
+- Do not claim that runtime success alone proves project success.
+- Keep domain-specific expert workflows intact when the acceptance framework evaluates specialist-assisted work.
+
+## Acceptance Criteria
+- The repository defines four separate delivery truth states:
+  - governance truth
+  - engineering verification truth
+  - workflow completion truth
+  - product acceptance truth
+- `vibe`-governed requirement and plan surfaces can freeze downstream acceptance criteria for project work, not only runtime/process expectations.
+- The repository includes scenario fixtures that cover:
+  - single-skill project work
+  - L-grade staged work
+  - XL-grade composite work
+  - specialist-heavy work
+  - intentionally failing or drifting work
+- Benchmark repositories exist so the acceptance framework tests `vibe` governing other projects, not just VibeSkills governing itself.
+- A workflow-acceptance runner can:
+  - execute a governed scenario
+  - collect runtime artifacts
+  - run project-level validation
+  - produce a structured acceptance report
+- Completion/reporting rules prevent the system from presenting the following states as full success:
+  - `completed_with_failures`
+  - `degraded_non_authoritative`
+  - `manual_actions_pending`
+  - missing product acceptance evidence
+- Stability proof requires repeated scenario execution, failure injection, and flake accounting rather than a single happy-path pass.
+- Usability proof requires operator-readable acceptance reports and bounded manual spot-check contracts.
+- Intelligence proof requires evidence that `vibe` selected an appropriate execution grade, specialist usage, verification depth, and escalation behavior for the project scenario.
+
+## Primary Objective
+Make `vibe` accountable for the actual delivered quality of downstream project work, not only for the correctness of its own governance process.
+
+## Proxy Signal
+Every governed project run produces a delivery report that clearly distinguishes:
+
+- process correctness
+- code/test correctness
+- workflow completeness
+- final user-facing acceptance
+
+## Scope
+In scope:
+- delivery-truth model
+- downstream acceptance contracts
+- scenario corpus design
+- benchmark repository design
+- workflow-acceptance runner design
+- completion-language hardening
+- release proof and reporting rules
+- documentation and rollout plan
+
+Out of scope:
+- redesigning host installation flows
+- reworking the canonical router scoring model
+- replacing existing runtime artifacts with an entirely new runtime
+- promising full automation for every domain without bounded human spot-check contracts
+
+## Completion
+The work is complete when `vibe` can no longer honestly report a project as complete without downstream acceptance evidence showing that the delivered work is functionally sufficient, user-usable, and regression-aware.
+
+## Evidence
+- new or updated requirement/plan/stable governance docs
+- scenario schema and benchmark-repo design
+- verification and acceptance runner design
+- release-gate and reporting design
+- proof strategy covering stability, usability, and intelligence
+
+## Non-Goals
+- Do not reduce project delivery quality to runtime artifact existence.
+- Do not let unit tests alone stand in for downstream project acceptance.
+- Do not hide missing functionality behind broad “done” wording.
+- Do not flatten specialist-assisted tasks into generic acceptance logic that ignores domain-specific verification needs.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- Existing `vibe` requirement and plan stages are strong enough to freeze downstream acceptance criteria once the contract is extended.
+- Current runtime/session artifacts can be reused as evidence inputs rather than replaced.
+- The largest missing layer is downstream project acceptance, not basic runtime sequencing.
+- The current repository structure can host benchmark repositories and scenario fixtures without breaking canonical governance surfaces.
+
+## Evidence Inputs
+- Source task: plan a full delivery-acceptance enhancement program for work completed under `vibe`
+- Prior finding: current runtime-neutral and gate-heavy tests validate governance/runtime strongly but validate downstream project success weakly

--- a/bundled/skills/vibe/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-28-vibe-governor-native-specialist-skills.md
@@ -1,0 +1,99 @@
+# Vibe Governor + Native Specialist Skills
+
+## Summary
+Keep `vibe` as the sole governed runtime authority while enabling it to call specialist skills as bounded native assistants through an explicit host adapter bridge. Router output must remain a single canonical routing truth, but explicit `vibe` runs should freeze specialist recommendations that can be consumed by planning and execution without handing control to a second runtime or faking native execution with receipt-only artifacts.
+
+## Goal
+Implement a minimal-change governed model where:
+
+- `vibe` remains the only runtime owner for requirement freeze, execution planning, execution receipts, verification, and cleanup.
+- specialist skills can be recommended, planned, dispatched, and verified as bounded native helpers.
+- specialist usage preserves each skill's native workflow expectations rather than flattening the skill into a label.
+- approved specialist dispatch can cross a host adapter bridge into real native execution when the active host supports it.
+- unsupported or disabled native specialist paths degrade explicitly to `degraded_non_authoritative` rather than claiming equivalent success.
+
+## Deliverable
+A repository change set that adds:
+
+- a frozen runtime packet contract for `specialist_recommendations`
+- a frozen executable contract for `approved_dispatch`
+- requirement and plan surfacing for native specialist dispatch
+- a host adapter execution bridge with an initial `codex` implementation path
+- execution-manifest support for specialist units, degraded specialist units, and their recovery into `vibe`
+- protocol and operator documentation for the governor-plus-specialists model
+- regression tests and proof artifacts demonstrating authority preservation, stability, usability, and intelligent specialist selection
+
+## Constraints
+- Do not change `runtime_selected_skill` away from `vibe` during explicit `vibe` runtime entry.
+- Do not create a second router, second requirement surface, second execution-plan surface, or second runtime authority.
+- Reuse existing router outputs and runtime artifacts as much as possible; prefer additive contract extensions over structural rewrites.
+- Preserve current host adapter boundaries; this task is a bounded runtime execution bridge project, not a host-entry auto-intercept project.
+- Specialist execution must remain bounded and must feed back into `vibe` verification and cleanup surfaces.
+- Specialist skills must retain native usage expectations, input contracts, workflow semantics, and validation style when dispatched.
+- Child lanes may execute only root-approved specialist dispatch; they may not self-approve new global specialist usage.
+
+## Acceptance Criteria
+- Runtime input packet includes machine-readable `specialist_recommendations` for explicit `vibe` runs without changing `authority_flags.explicit_runtime_skill`.
+- Runtime input packet includes machine-readable executable specialist dispatch contracts that keep `vibe` as runtime owner.
+- Requirement documents surface specialist recommendations and native-usage expectations as frozen inputs.
+- Execution plans include an explicit `Specialist Skill Dispatch Plan` section describing bounded specialist use.
+- Execution manifests record specialist unit counts, degraded specialist unit counts, execution drivers, and recovery status while keeping `vibe` as runtime owner.
+- Protocol docs define the `vibe governor + native specialist skills` model and forbid specialist takeover of runtime truth.
+- Tests prove:
+  - `vibe` authority is preserved
+  - specialist recommendations are frozen and surfaced
+  - plan/execute artifacts include specialist dispatch data
+  - root-approved child specialist dispatch can execute through the host adapter bridge
+  - degraded specialist paths remain explicit and non-authoritative when appropriate
+  - receipt-only specialist stubs are no longer presented as native execution
+
+> Fill the anti-drift fields once here. Downstream governed plan and completion surfaces should reuse them rather than restate them.
+
+## Primary Objective
+Enable `vibe` to orchestrate specialist skills natively without losing governed runtime authority.
+
+## Proxy Signal
+The system freezes specialist recommendations, plans them explicitly, executes them as bounded units, and records them in execution evidence.
+
+## Scope
+In scope:
+- runtime packet extension
+- requirement/plan surfacing
+- execution manifest specialist accounting
+- host adapter execution bridge for specialist units
+- `codex exec` as the first supported runtime-native adapter lane
+- protocol and proof documentation
+- regression tests and cleanup receipts
+
+Out of scope:
+- host auto-interception of every incoming message
+- automatic replacement of `vibe` with router-selected specialist skills
+- global redesign of the router scoring system
+- skill-by-skill metadata rewrites across the entire repository
+- blanket host-native parity for every supported install host in the first slice
+
+## Completion
+The work is complete when explicit `vibe` runs can preserve runtime authority while still planning and executing native specialist assistance with traceable evidence and passing regression coverage.
+
+## Evidence
+- code changes in runtime/config/protocol/test surfaces
+- new or updated governed requirement/plan docs
+- passing targeted tests
+- cleanup receipts and node audit output
+
+## Non-Goals
+- Do not make router-selected specialist skills authoritative runtime owners.
+- Do not silently downgrade specialist usage into generic text-only hints.
+- Do not let any specialist skill create or own a separate execution plan.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- Existing router ranking already provides enough signal to derive specialist candidates without redesigning pack scoring.
+- The current runtime packet shadow model can be extended rather than replaced.
+- A bounded host adapter bridge can be added without creating a second runtime authority.
+- `codex exec` can serve as the first real specialist-native execution lane while other hosts degrade explicitly until their adapters exist.
+
+## Evidence Inputs
+- Source task: implement `vibe` governor + native specialist skills with minimal framework change

--- a/bundled/skills/vibe/docs/requirements/README.md
+++ b/bundled/skills/vibe/docs/requirements/README.md
@@ -19,6 +19,12 @@ Primary policy:
 
 ## Current Entry
 
+- [`2026-03-28-root-child-vibe-hierarchy-governance.md`](./2026-03-28-root-child-vibe-hierarchy-governance.md): 冻结“root/child `vibe` 分层治理”需求；聚焦把子代理 `$vibe` 收敛为从属执行态，避免递归顶层治理、重复专家分发与模糊 completion authority。
+- [`2026-03-27-ai-governance-consolidation.md`](./2026-03-27-ai-governance-consolidation.md): 冻结“内置 AI 治理层活跃路径整体收敛整理”的需求；聚焦让 runtime、doctor、install docs 与 helper surface 在 active shipped path 上完全对齐。
+- [`2026-03-27-ai-governance-historical-wording-cleanup.md`](./2026-03-27-ai-governance-historical-wording-cleanup.md): 冻结“内置 AI 治理层历史表述清理”的需求；聚焦在 `vibe` 范围内去掉退役模型键名的历史残留。
+- [`2026-03-27-ai-governance-openai-compatible-only.md`](./2026-03-27-ai-governance-openai-compatible-only.md): 冻结“内置 AI 治理层只保留 OpenAI-compatible 接入”的需求；聚焦移除 Ark 并行内置入口，统一公开安装、bootstrap、probe 与默认策略口径。
+- [`2026-03-27-ai-governance-install-clarity.md`](./2026-03-27-ai-governance-install-clarity.md): 冻结 issue #57 的安装澄清需求；聚焦把 AI 治理 advice 的 API 配置键名、快速检查口径与“本地安装完成 / 在线能力就绪”边界说清楚。
+- [`2026-03-27-ai-governance-single-model-key.md`](./2026-03-27-ai-governance-single-model-key.md): 冻结“内置 AI 治理层单模型键收敛”的需求；聚焦统一到 `VCO_RUCNLPIR_MODEL`。
 - [`2026-03-20-readme-en-detail-and-github-branding-copy.md`](./2026-03-20-readme-en-detail-and-github-branding-copy.md): 冻结英文 README 细化与 GitHub 品牌文案补充；聚焦让 `README.en.md` 与中文版接近同等细节层级，并产出 `About / Topics / social preview` 可复用文案。
 - [`2026-03-20-readme-emoji-layout-polish.md`](./2026-03-20-readme-emoji-layout-polish.md): 冻结 README 中文视觉润色；聚焦用少量 emoji 和版式节奏优化，让首页更精致、更有设计感但仍保持克制。
 - [`2026-03-20-readme-differentiated-science-ai-strengths.md`](./2026-03-20-readme-differentiated-science-ai-strengths.md): 冻结 README 中文差异化强化；聚焦把生命科学、科研、AI 工程三块写得更有冲击力，更能体现仓库强势能力区。

--- a/bundled/skills/vibe/docs/root-child-vibe-hierarchy-governance.md
+++ b/bundled/skills/vibe/docs/root-child-vibe-hierarchy-governance.md
@@ -1,0 +1,160 @@
+# Root/Child Vibe Hierarchy Governance
+
+This document defines the stable authority model for governed multi-agent `vibe` execution.
+
+## Why This Exists
+
+Recursive use of `$vibe` inside child-agent prompts is desirable for discipline, but dangerous when each child starts behaving like a fresh top-level governed runtime. Without a hierarchy contract, the system risks:
+
+- duplicate requirement freezes
+- duplicate execution-plan surfaces
+- repeated expert re-dispatch
+- ambiguous completion authority
+- soft loss of governance despite every lane "using `vibe`"
+
+The fix is not to remove child `$vibe`.
+The fix is to distinguish root governance from child execution.
+
+## Mental Model
+
+- Root `vibe`: the only top-level governor
+- Child `vibe`: a subordinate execution lane
+- Specialist skill: a bounded native helper
+
+Short form:
+
+`root vibe governs, child vibe executes, specialists assist`
+
+## Grade Execution Alignment
+
+- `L`: serial native execution from the frozen plan (sequence-first, no blanket fan-out).
+- `XL`: wave-sequential execution, with step-level bounded parallelism only for independent units.
+- Specialist dispatch: executable as bounded native units only when root-approved in the frozen plan.
+
+## Authority Layers
+
+### Root-Governed Lane
+
+Only the root-governed lane may:
+
+- freeze the canonical requirement document
+- freeze the canonical execution plan
+- approve global specialist dispatch
+- aggregate overall execution status
+- issue final completion claims
+
+### Child-Governed Lane
+
+Child-governed lanes must:
+
+- inherit frozen requirement and plan context from the root lane
+- stay inside assigned scope and write boundaries
+- emit local receipts and proof only
+- escalate when a new specialist is needed outside approved dispatch
+
+Child-governed lanes must not:
+
+- create a second requirement truth
+- create a second plan truth
+- widen the task silently
+- make final completion claims
+
+### Specialist-Native Lane
+
+Specialists are not runtime owners.
+
+They may:
+
+- execute bounded professional subtasks
+- preserve native workflow expectations
+- preserve native input/output contracts
+- emit skill-specific verification notes
+
+They may not:
+
+- take over stage ownership
+- replace `vibe` as runtime authority
+- create separate top-level planning truth
+
+## Dispatch Model
+
+Approved specialist dispatch is phase-bound rather than “call it whenever”.
+The stable phase vocabulary is:
+
+- `pre_execution`
+- `in_execution`
+- `post_execution`
+- `verification`
+
+This keeps expert help aligned with the governed task stage instead of turning specialist calls into ad-hoc afterthoughts.
+
+### Approved Specialist Dispatch
+
+Specialist usage approved by the root-governed lane and written into the frozen plan.
+
+Properties:
+
+- executable without extra authority negotiation
+- carried into child-lane inputs
+- tracked in execution accounting
+- bound to an explicit phase, lane policy, write scope, and review mode
+
+### Local Specialist Suggestion
+
+A child lane may detect that more specialist help is useful. The frozen packet keeps that request as a suggestion first, and the root-governed execute stage may same-round auto-approve safe suggestions without handing authority to the child lane.
+
+Properties:
+
+- advisory in the frozen packet
+- executable only after root-governed approval or same-round auto-absorb
+- cannot mutate root authority by itself
+
+## Conflict Prevention Rules
+
+To prevent skills from "fighting", the system enforces:
+
+1. one runtime owner
+2. one canonical requirement surface
+3. one canonical execution-plan surface
+4. one final completion authority
+5. bounded specialist usage
+6. explicit escalation instead of silent self-expansion
+7. stage-bound dispatch instead of random specialist timing
+
+## Artifact Rules
+
+Canonical root artifacts:
+
+- `docs/requirements/YYYY-MM-DD-<topic>.md`
+- `docs/plans/YYYY-MM-DD-<topic>-execution-plan.md`
+- `outputs/runtime/vibe-sessions/<root-run-id>/...`
+
+Child artifacts:
+
+- subordinate receipts and proof nested under the root runtime session
+- no child-owned canonical docs
+
+## Safety Properties
+
+This hierarchy must preserve:
+
+- explicit `vibe` runtime authority
+- no silent fallback guarantees
+- no duplicate truth surfaces
+- specialist boundedness
+- explicit escalation for new specialist needs
+- root-owned completion claims only
+
+## What Success Looks Like
+
+When a root `vibe` task spawns children:
+
+- every child still behaves with `vibe` discipline
+- no child behaves like a second top-level governor
+- approved specialists can execute as bounded native units
+- root evidence remains the single source of completion truth
+
+## Operator Rule Of Thumb
+
+If a child needs a new expert, it may ask.
+It may not self-upgrade into a new governor.

--- a/bundled/skills/vibe/docs/specialist-dispatch-governance.md
+++ b/bundled/skills/vibe/docs/specialist-dispatch-governance.md
@@ -1,0 +1,161 @@
+# Specialist Dispatch Governance
+
+This document defines how specialist skills are used inside the governed `vibe` runtime without becoming a second runtime owner.
+
+## Mental Model
+
+- router finds candidate specialists
+- root `vibe` freezes approved specialist dispatch
+- child `vibe` executes bounded lanes
+- specialists contribute native expertise
+
+Short form:
+
+`router suggests, root vibe approves, child vibe executes, specialists assist`
+
+## Why This Exists
+
+Without a governed dispatch model, specialist skills tend to fail in one of two ways:
+
+- they stay unused even when obviously relevant
+- they are called loosely and start conflicting with runtime governance
+
+The fix is not “call more skills”.
+The fix is phase-bound specialist dispatch.
+
+## The Four Layers
+
+### 1. Governance Layer
+
+Owned by `vibe`.
+
+This layer controls:
+
+- requirement freeze
+- plan freeze
+- global dispatch approval
+- verification
+- cleanup
+- final completion authority
+
+### 2. Routing Layer
+
+Owned by the canonical router.
+
+This layer only suggests candidate specialists.
+It does not grant execution rights.
+
+### 3. Dispatch Layer
+
+Owned by root `vibe`.
+
+This layer turns suggestions into executable specialist contracts with:
+
+- `binding_profile`
+- `dispatch_phase`
+- `execution_priority`
+- `lane_policy`
+- `parallelizable_in_root_xl`
+- `write_scope`
+- `review_mode`
+
+### 4. Execution Layer
+
+Owned by bounded lanes under `vibe`.
+
+This layer runs the specialist using its native workflow while staying subordinate to the frozen requirement and plan.
+
+## Phase-Bound Specialist Model
+
+Each approved specialist belongs to one governed phase:
+
+- `pre_execution`: planning or setup support
+- `in_execution`: implementation or analysis support
+- `post_execution`: deliverable or reporting support
+- `verification`: review or audit support
+
+This prevents specialist calls from appearing randomly at the end of a task.
+
+## L / XL Behavior
+
+### `L`
+
+- specialist units are explicit serial steps
+- no blanket fan-out
+- specialist help is visible in order and remains easy to audit
+
+### `XL`
+
+- waves remain sequential by dependency
+- specialist units may become bounded parallel lanes only when:
+  - root approved them
+  - the runtime is in `XL`
+  - write scopes do not conflict
+  - the specialist lane policy allows bounded parallel execution
+
+If those conditions are not met, specialist units fall back to serial execution.
+
+## Root / Child Authority
+
+Root `vibe` may:
+
+- freeze canonical requirement truth
+- freeze canonical plan truth
+- approve global specialist dispatch
+- issue final completion claims
+
+Child `vibe` may:
+
+- inherit frozen requirement and plan context
+- execute bounded approved specialist lanes
+- surface new specialist suggestions as advisory requests
+
+Child `vibe` may not:
+
+- create a second canonical requirement surface
+- create a second canonical plan surface
+- self-approve new global specialist dispatch
+- make the root task’s final completion claim
+
+## Local Suggestion vs Approved Dispatch
+
+### Approved Dispatch
+
+Already approved by root and safe to execute.
+
+### Local Suggestion
+
+Detected by a child lane during work.
+It stays advisory until one of two things happens:
+
+- root explicitly approves it
+- the same-round root auto-absorb gate accepts it
+
+If it has no approved overlap and the gate cannot absorb it, it remains escalation-only.
+
+## Conflict Prevention
+
+The runtime prevents specialist conflicts with five rules:
+
+1. one runtime owner
+2. one canonical requirement truth
+3. one canonical plan truth
+4. write-scope-aware bounded parallelism only
+5. explicit degraded or escalation surfaces instead of silent fallback
+
+## What Proof Must Show
+
+To claim this model works, runtime evidence must show:
+
+- which specialists were recommended
+- which specialists were approved
+- which phase each specialist was bound to
+- whether each specialist ran serially, in bounded parallel, or degraded
+- whether child suggestions were auto-absorbed or escalated
+- that root completion authority stayed single-owner
+
+## Operator Rule
+
+When a specialist is relevant, make it visible, bounded, and phase-bound.
+Do not let it become invisible background magic.
+Do not let it become a second governor.

--- a/bundled/skills/vibe/docs/status/README.md
+++ b/bundled/skills/vibe/docs/status/README.md
@@ -24,6 +24,7 @@ It answers three questions:
 
 - [`protected-capability-baseline.md`](protected-capability-baseline.md): defines which surfaces must be proven before they are changed during closure work
 - [`non-regression-proof-bundle.md`](non-regression-proof-bundle.md): current cleanup and no-regression proof contract
+- [`stage-bound-specialist-dispatch-closure-2026-03-28.md`](stage-bound-specialist-dispatch-closure-2026-03-28.md): closure proof for phase-bound specialist dispatch, `L` serial specialist steps, and `XL` bounded specialist lanes under root/child governance
 - [`platform-promotion-baseline-2026-03-13.md`](platform-promotion-baseline-2026-03-13.md): current platform-promotion truth snapshot
 - [`linux-pwsh-fresh-machine-evidence-ledger-2026-03-13.md`](linux-pwsh-fresh-machine-evidence-ledger-2026-03-13.md): Linux fresh-machine evidence ledger for the promoted `Linux + pwsh` authoritative lane
 - [`single-core-dual-adaptation-baseline-2026-03-14.md`](single-core-dual-adaptation-baseline-2026-03-14.md): first adapter-contract landing status for platform-neutral target roots, installed-runtime resolution, and shell spawning

--- a/bundled/skills/vibe/docs/status/stage-bound-specialist-dispatch-closure-2026-03-28.md
+++ b/bundled/skills/vibe/docs/status/stage-bound-specialist-dispatch-closure-2026-03-28.md
@@ -1,0 +1,112 @@
+# Stage-Bound Specialist Dispatch Closure 2026-03-28
+
+## Scope
+
+This closure proves the governed specialist-dispatch design now lands in three places at once:
+
+- frozen runtime input packets
+- frozen requirement and plan surfaces
+- executable runtime topology and receipts
+
+## Landed Design
+
+- specialist recommendations now carry binding metadata:
+  - `binding_profile`
+  - `dispatch_phase`
+  - `execution_priority`
+  - `lane_policy`
+  - `parallelizable_in_root_xl`
+  - `write_scope`
+  - `review_mode`
+- requirement and plan docs now surface phase-bound specialist truth
+- `L` can represent specialist work as explicit serial steps
+- `XL` can represent specialist work as bounded specialist parallel steps when write scopes are disjoint
+- root/child authority remained unchanged
+
+## Verification Run
+
+### Runtime-Neutral Tests
+
+Command:
+
+```bash
+pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py
+```
+
+Result:
+
+- `19 passed`
+- `38 subtests passed`
+
+What this proves:
+
+- bundled runtime mirrors stayed in sync
+- specialist binding metadata is frozen into runtime, requirement, and plan surfaces
+- `XL` can build bounded-parallel specialist steps
+- root/child hierarchy invariants still hold
+- live and degraded specialist paths still remain explicit
+
+### Governance Gates
+
+Commands:
+
+```bash
+pwsh -NoProfile -File scripts/verify/vibe-root-child-hierarchy-gate.ps1
+pwsh -NoProfile -File scripts/verify/vibe-child-specialist-escalation-gate.ps1
+```
+
+Results:
+
+- hierarchy gate: `34 assertions`, `0 failures`
+- child specialist escalation gate: `26 assertions`, `0 failures`
+
+What this proves:
+
+- explicit `vibe` authority remains single-owner
+- child specialist suggestions remain advisory-first
+- same-round auto-absorb stayed enabled and artifact-backed
+- canonical requirement / plan truth did not split
+
+### Docs Encoding
+
+Command:
+
+```bash
+pytest -q tests/runtime_neutral/test_docs_readme_encoding.py
+```
+
+Result:
+
+- `1 passed`
+
+## Stability / Usability / Intelligence Claim
+
+### Stability
+
+Claim basis:
+
+- modified runtime scripts remained mirror-consistent
+- targeted runtime-neutral suite passed end to end
+- governance gates passed without hierarchy regressions
+
+### Usability
+
+Claim basis:
+
+- specialist phase binding is now visible in requirement and plan text
+- runtime artifacts expose the same binding truth the operator sees in docs
+- `L` and `XL` no longer rely on vague “specialist may help” wording
+
+### Intelligence
+
+Claim basis:
+
+- specialist selection remains router-driven
+- specialist execution is no longer flat or last-minute; it is phase-bound
+- `XL` specialist work can now enter bounded parallel steps when safe
+
+## No-Overclaim Notes
+
+- This closure proves bounded parallel specialist steps can exist; it does not claim every composite prompt will always produce multiple parallel specialist lanes.
+- Failure-injection for malformed native specialist output is still a next-step verification gap.
+- Replay-grade proof for child escalation -> root approval -> next-run execution can still be expanded further.

--- a/bundled/skills/vibe/install.ps1
+++ b/bundled/skills/vibe/install.ps1
@@ -134,7 +134,84 @@ function Copy-DirContent {
     return
   }
   New-Item -ItemType Directory -Force -Path $Destination | Out-Null
-  Copy-Item -Path (Join-Path $Source '*') -Destination $Destination -Recurse -Force
+    Copy-Item -Path (Join-Path $Source '*') -Destination $Destination -Recurse -Force
+}
+
+function Resolve-CodexDuplicateSkillRoot {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  if ([string]$HostId -ne 'codex') {
+    return $null
+  }
+
+  $leaf = (Split-Path -Path $TargetRoot -Leaf).ToLowerInvariant()
+  if ($leaf -ne '.codex') {
+    return $null
+  }
+
+  $parent = Get-VgoParentPath -Path $TargetRoot
+  if ([string]::IsNullOrWhiteSpace($parent)) {
+    return $null
+  }
+
+  return (Join-Path $parent '.agents\skills\vibe')
+}
+
+function Test-VibeSkillDirectory {
+  param([string]$Path)
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return $false
+  }
+
+  $skillMd = Join-Path $Path 'SKILL.md'
+  if (-not (Test-Path -LiteralPath $skillMd)) {
+    return $false
+  }
+
+  $lines = Get-Content -LiteralPath $skillMd -TotalCount 20 -Encoding UTF8
+  return [bool](@($lines | Where-Object { $_ -match '^\s*name:\s*vibe\s*$' }).Count -gt 0)
+}
+
+function Invoke-CodexDuplicateSkillQuarantine {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  $duplicateRoot = Resolve-CodexDuplicateSkillRoot -TargetRoot $TargetRoot -HostId $HostId
+  if ([string]::IsNullOrWhiteSpace($duplicateRoot) -or -not (Test-Path -LiteralPath $duplicateRoot -PathType Container)) {
+    return
+  }
+
+  $targetSkillRoot = Join-Path $TargetRoot 'skills\vibe'
+  if (-not (Test-Path -LiteralPath $targetSkillRoot -PathType Container)) {
+    return
+  }
+
+  $duplicateFull = [System.IO.Path]::GetFullPath($duplicateRoot)
+  $targetFull = [System.IO.Path]::GetFullPath($targetSkillRoot)
+  if ($duplicateFull -eq $targetFull) {
+    return
+  }
+
+  if (-not (Test-VibeSkillDirectory -Path $duplicateRoot)) {
+    throw "Duplicate Codex-discovered skill surface exists at '$duplicateRoot', but it is not a recognizable vibe skill copy. Move it out of .agents/skills manually."
+  }
+
+  $agentsHome = Get-VgoParentPath -Path (Get-VgoParentPath -Path $duplicateRoot)
+  if ([string]::IsNullOrWhiteSpace($agentsHome)) {
+    throw "Unable to resolve .agents home for duplicate skill surface: $duplicateRoot"
+  }
+
+  $quarantineRoot = Join-Path $agentsHome 'skills-disabled'
+  $quarantinePath = Join-Path $quarantineRoot ("vibe.codex-duplicate-" + (Get-Date -Format 'yyyyMMddTHHmmss'))
+  New-Item -ItemType Directory -Force -Path $quarantineRoot | Out-Null
+  Move-Item -LiteralPath $duplicateRoot -Destination $quarantinePath
+  Write-Warning ("Quarantined duplicate Codex-discovered vibe skill: {0} -> {1}" -f $duplicateRoot, $quarantinePath)
 }
 function Ensure-SkillPresent {
   param(
@@ -162,7 +239,9 @@ function Ensure-SkillPresent {
       if ([string]::IsNullOrWhiteSpace($src)) { continue }
       if (Test-Path -LiteralPath $src) {
         Write-Warning "Using external fallback source for skill '$Name': $src"
-        Copy-DirContent -Source $src -Destination (Join-Path $TargetRoot ("skills\" + $Name))
+        $destination = Join-Path $TargetRoot ("skills\" + $Name)
+        Copy-DirContent -Source $src -Destination $destination
+        Restore-SkillEntryPointIfNeeded -SkillRoot $destination
         $ExternalFallbackUsed.Add($Name) | Out-Null
         break
       }
@@ -209,6 +288,44 @@ function Sync-VibeCanonicalToTarget {
     Copy-DirContent -Source $srcDir -Destination $dstDir
   }
 }
+
+function Hide-InstalledRuntimeMirrorSkillEntryPoints {
+  param([string]$TargetRoot)
+
+  $nestedSkillsRoot = Join-Path $TargetRoot 'skills\vibe\bundled\skills'
+  if (-not (Test-Path -LiteralPath $nestedSkillsRoot -PathType Container)) {
+    return
+  }
+
+  $renamed = 0
+  foreach ($skillDir in @(Get-ChildItem -LiteralPath $nestedSkillsRoot -Directory -ErrorAction SilentlyContinue)) {
+    $skillMd = Join-Path $skillDir.FullName 'SKILL.md'
+    if (-not (Test-Path -LiteralPath $skillMd -PathType Leaf)) {
+      continue
+    }
+
+    $mirrorPath = Join-Path $skillDir.FullName 'SKILL.runtime-mirror.md'
+    Move-Item -LiteralPath $skillMd -Destination $mirrorPath -Force
+    Write-Host ("[INFO] Hid nested runtime mirror skill entrypoint: {0} -> {1}" -f $skillMd, $mirrorPath)
+    $renamed++
+  }
+
+  if ($renamed -eq 0) {
+    Write-Host "[INFO] Nested runtime mirror skill entrypoints already sanitized."
+  }
+}
+
+function Restore-SkillEntryPointIfNeeded {
+  param([string]$SkillRoot)
+
+  $skillMd = Join-Path $SkillRoot 'SKILL.md'
+  $mirrorPath = Join-Path $SkillRoot 'SKILL.runtime-mirror.md'
+  if ((Test-Path -LiteralPath $skillMd -PathType Leaf) -or -not (Test-Path -LiteralPath $mirrorPath -PathType Leaf)) {
+    return
+  }
+
+  Move-Item -LiteralPath $mirrorPath -Destination $skillMd -Force
+}
 Write-Host "=== VCO Adapter Installer ===" -ForegroundColor Cyan
 Write-Host "Host   : $HostId"
 Write-Host "Mode   : $($Adapter.install_mode)"
@@ -245,6 +362,8 @@ if ($null -ne $adapterInstallReceipt -and $adapterInstallReceipt.PSObject.Proper
     }
   }
 }
+
+Hide-InstalledRuntimeMirrorSkillEntryPoints -TargetRoot $TargetRoot
 
 if ($InstallExternal) {
   if ($Adapter.install_mode -ne 'governed') {
@@ -362,6 +481,7 @@ if ($StrictOffline) {
 } elseif ($externalFallbackUsed.Count -gt 0) {
   Write-Warning ("External fallback skills were used (non-reproducible install): " + (($externalFallbackUsed | Select-Object -Unique) -join ", "))
 }
+Invoke-CodexDuplicateSkillQuarantine -TargetRoot $TargetRoot -HostId $HostId
 Invoke-InstalledRuntimeFreshnessGate -RepoRoot $RepoRoot -TargetRoot $TargetRoot -SkipGate:$SkipRuntimeFreshnessGate
 Write-Host ""
 Write-Host "Installation complete." -ForegroundColor Green

--- a/bundled/skills/vibe/install.sh
+++ b/bundled/skills/vibe/install.sh
@@ -224,6 +224,70 @@ if [[ -z "${TARGET_ROOT}" ]]; then
 fi
 assert_target_root_matches_host_intent "${TARGET_ROOT}" "${HOST_ID}"
 
+resolve_codex_duplicate_skill_root() {
+  if [[ "${HOST_ID}" != "codex" ]]; then
+    return 1
+  fi
+
+  local leaf=""
+  leaf="$(basename "${TARGET_ROOT}")"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${leaf}" != ".codex" ]]; then
+    return 1
+  fi
+
+  local parent=""
+  parent="$(safe_parent_dir "${TARGET_ROOT}")"
+  if [[ -z "${parent}" ]]; then
+    return 1
+  fi
+
+  printf '%s' "${parent}/.agents/skills/vibe"
+}
+
+test_vibe_skill_dir() {
+  local root="${1:-}"
+  local skill_md="${root}/SKILL.md"
+  [[ -f "${skill_md}" ]] || return 1
+  if grep -Eq '^[[:space:]]*name:[[:space:]]*vibe[[:space:]]*$' "${skill_md}"; then
+    return 0
+  fi
+  return 1
+}
+
+quarantine_codex_duplicate_skill_surface() {
+  local duplicate_root=""
+  duplicate_root="$(resolve_codex_duplicate_skill_root || true)"
+  if [[ -z "${duplicate_root}" || ! -d "${duplicate_root}" ]]; then
+    return 0
+  fi
+
+  local target_skill_root="${TARGET_ROOT}/skills/vibe"
+  [[ -d "${target_skill_root}" ]] || return 0
+
+  local duplicate_real=""
+  local target_real=""
+  duplicate_real="$(cd "${duplicate_root}" 2>/dev/null && pwd || true)"
+  target_real="$(cd "${target_skill_root}" 2>/dev/null && pwd || true)"
+  if [[ -n "${duplicate_real}" && -n "${target_real}" && "${duplicate_real}" == "${target_real}" ]]; then
+    return 0
+  fi
+
+  if ! test_vibe_skill_dir "${duplicate_root}"; then
+    echo "[FAIL] Duplicate Codex-discovered skill surface exists at ${duplicate_root}, but it is not a recognizable vibe skill copy." >&2
+    echo "[FAIL] Move it out of .agents/skills manually before using Codex with the installed ~/.codex/skills/vibe lane." >&2
+    return 1
+  fi
+
+  local agents_root=""
+  agents_root="$(dirname "$(dirname "${duplicate_root}")")"
+  local quarantine_root="${agents_root}/skills-disabled"
+  local quarantine_path="${quarantine_root}/vibe.codex-duplicate-$(date +%Y%m%dT%H%M%S)"
+  mkdir -p "${quarantine_root}"
+  mv "${duplicate_root}" "${quarantine_path}"
+  echo "[WARN] Quarantined duplicate Codex-discovered vibe skill: ${duplicate_root} -> ${quarantine_path}"
+}
+
 CANONICAL_SKILLS_ROOT="$(safe_parent_dir "${SCRIPT_DIR}")"
 WORKSPACE_ROOT="$(safe_parent_dir "${CANONICAL_SKILLS_ROOT}")"
 WORKSPACE_SKILLS_ROOT=""
@@ -462,6 +526,34 @@ sync_vibe_canonical_to_target() {
   done
 }
 
+sanitize_installed_runtime_skill_entrypoints() {
+  local nested_skills_root="${TARGET_ROOT}/skills/vibe/bundled/skills"
+  [[ -d "${nested_skills_root}" ]] || return 0
+
+  local skill_md=""
+  local renamed=0
+  while IFS= read -r -d '' skill_md; do
+    local mirror_path="${skill_md%/SKILL.md}/SKILL.runtime-mirror.md"
+    mv "${skill_md}" "${mirror_path}"
+    echo "[INFO] Hid nested runtime mirror skill entrypoint: ${skill_md} -> ${mirror_path}"
+    renamed=$((renamed+1))
+  done < <(find "${nested_skills_root}" -mindepth 2 -maxdepth 2 -type f -name 'SKILL.md' -print0)
+
+  if [[ ${renamed} -eq 0 ]]; then
+    echo "[INFO] Nested runtime mirror skill entrypoints already sanitized."
+  fi
+}
+
+restore_skill_entrypoint_if_needed() {
+  local skill_root="$1"
+  local mirror_path="${skill_root}/SKILL.runtime-mirror.md"
+  local skill_md="${skill_root}/SKILL.md"
+  if [[ -f "${skill_md}" || ! -f "${mirror_path}" ]]; then
+    return 0
+  fi
+  mv "${mirror_path}" "${skill_md}"
+}
+
 ensure_skill_present() {
   local name="$1"
   local required="$2"
@@ -479,6 +571,7 @@ ensure_skill_present() {
       if [[ -d "${src}" ]]; then
         echo "[WARN] Using external fallback source for skill '${name}': ${src}"
         copy_dir_content "${src}" "${TARGET_ROOT}/skills/${name}"
+        restore_skill_entrypoint_if_needed "${TARGET_ROOT}/skills/${name}"
         EXTERNAL_FALLBACK_USED+=("${name}")
         break
       fi
@@ -523,6 +616,8 @@ ADAPTER_INSTALL_JSON="$("${PYTHON_BIN_FOR_ADAPTER}" "${ADAPTER_INSTALLER}" \
 if [[ -n "${ADAPTER_INSTALL_JSON}" ]]; then
   mapfile -t EXTERNAL_FALLBACK_USED < <(printf '%s\n' "${ADAPTER_INSTALL_JSON}" | "${PYTHON_BIN_FOR_ADAPTER}" -c 'import json,sys; data=json.load(sys.stdin); [print(x) for x in data.get("external_fallback_used", [])]')
 fi
+
+sanitize_installed_runtime_skill_entrypoints
 
 if [[ "${INSTALL_EXTERNAL}" == "true" ]]; then
   if [[ "${ADAPTER_INSTALL_MODE}" != "governed" ]]; then
@@ -608,6 +703,7 @@ elif [[ ${#EXTERNAL_FALLBACK_USED[@]} -gt 0 ]]; then
   echo "[WARN] External fallback skills were used (non-reproducible install): ${uniq_fallback}"
 fi
 
+quarantine_codex_duplicate_skill_surface
 run_runtime_freshness_gate
 
 echo "Install done. Run: bash check.sh --profile ${PROFILE} --target-root ${TARGET_ROOT}"

--- a/bundled/skills/vibe/protocols/team.md
+++ b/bundled/skills/vibe/protocols/team.md
@@ -20,7 +20,8 @@ This protocol only activates after the requirement and plan are already frozen.
 
 ## Scope
 Activated for XL grade tasks that require:
-- Multiple agents working in parallel
+- Multi-agent coordination with dependency-aware waves
+- Step-level bounded parallelism for independent units (not blanket always-on concurrency)
 - Workflow-based execution with phases
 - Swarm or hive-mind coordination
 - Long-running iterative tasks
@@ -31,6 +32,31 @@ Codex native agent APIs manage lifecycle + task assignment (primary path).
 ruflo remains optional for workflow/memory enhancements.
 
 All spawned subagent prompts must end with `$vibe` so the governed runtime remains the active contract inside delegated work.
+
+## Root/Child Authority Model
+
+XL delegation uses two governance scopes:
+
+- `root_governed`: one lane per user task; owns canonical requirement/plan truth and final completion claims
+- `child_governed`: delegated lane; inherits frozen context and emits local execution evidence
+
+Child-governed lanes keep `vibe` discipline but are not new top-level governors.
+
+Child-governed lanes must not:
+
+- create a second canonical requirement surface
+- create a second canonical execution-plan surface
+- emit final completion claims for the full root task
+- self-approve new global specialist dispatch
+
+## Execution Topology Truth
+
+- `L` execution is handled in `do.md` as serial native execution; this protocol is not the default L executor.
+- `XL` execution is wave-sequential by dependency.
+- Parallel work in `XL` is step-scoped and bounded to independent units only.
+- Specialist dispatch can be executable as bounded units only when root-approved in the frozen plan.
+- Specialist dispatch is phase-bound: `pre_execution`, `in_execution`, `post_execution`, `verification`.
+- In `XL`, specialist lanes may join bounded parallel windows only when their write scopes are disjoint and their lane policy allows it.
 
 ### Role Division
 
@@ -59,6 +85,32 @@ Lead-agent rules:
 - subagents may surface report-only warnings, but must not invent a new hard gate,
 - if an existing approved policy or failed gate truly blocks progress, cite that exact surface,
 - aggregation must not flatten bounded-specialization outputs into generalized completion claims.
+- when a specialist skill is dispatched, keep its native workflow intact instead of rewriting it into generic lead-agent prose.
+- only root-governed aggregation may publish final completion claims for the full task.
+
+## Native Specialist Dispatch
+
+Within XL execution, a specialist skill is a bounded helper, not a replacement runtime.
+
+Rules:
+
+- `vibe` keeps final control of stage order, plan authority, and completion claims
+- specialist dispatch should be declared in the frozen plan before execution
+- each specialist receives a bounded subtask contract plus the frozen requirement context
+- specialist outputs must stay in the native format or workflow expected by that specialist skill
+- each approved specialist also carries phase binding, lane policy, write scope, and review mode
+- lead aggregation may summarize specialist output, but must not erase specialist-specific verification notes
+- a specialist recommendation is advisory until the governed plan chooses to dispatch it
+
+Hierarchy-specific dispatch semantics:
+
+- `approved_dispatch`: specialist usage approved by root and frozen in plan; child lanes may execute directly
+- `local_suggestion`: child-lane specialist suggestion; advisory until explicit root escalation approval
+
+Escalation rule:
+
+- child lanes needing non-approved specialists must emit explicit escalation evidence to root
+- no silent specialist activation is allowed in child lanes
 
 ## Orchestration Options
 
@@ -182,6 +234,7 @@ Contract rules:
 - Prefer `verification` that is command-shaped (copy/paste runnable).
 - If required info is missing, return `status=blocked` with `handoff_questions` (do not guess).
 - The same contract maps cleanly to the GSD wave contract (`entry_criteria`/`exit_criteria`/`verify_commands`).
+- If the subtask is owned by a specialist skill, keep the contract narrow enough that native specialist workflow still applies without improvising a new method.
 
 ## Shared Memory Contract (3-Tier)
 
@@ -269,7 +322,7 @@ Contract output:
   - `verify_commands`
 
 Execution semantics:
-1. Independent units run in parallel within a wave.
+1. Independent units may run in bounded parallel within a wave.
 2. Waves run sequentially by dependency.
 3. Verification gates must pass before advancing to next wave.
 4. This contract does not alter grade/task assignment.

--- a/bundled/skills/vibe/protocols/think.md
+++ b/bundled/skills/vibe/protocols/think.md
@@ -143,7 +143,7 @@ Phase 2: Architecture (vibe-think)
   Gate: Architecture diagram approved
 
 Phase 3: Implementation (vibe-do)
-  Tool: superpowers:subagent-driven-development
+  Tool: native serial execution lane (bounded delegated units only when planned)
   Gate: All tests pass, code reviewed
 
 Phase 4: Security Review (vibe-review)
@@ -246,8 +246,8 @@ When task is purely research (no implementation):
 
 ## Transition to Implementation
 After design is approved:
-1. L grade: Switch to vibe-do with Superpowers subagent-driven-dev
-2. XL grade: Switch to vibe-team protocol (Codex native team + optional ruflo collaboration)
+1. L grade: Switch to vibe-do serial native execution (sequence-first; bounded delegation only when explicitly planned)
+2. XL grade: Switch to vibe-team protocol (wave-sequential execution with step-level bounded parallel units + optional ruflo collaboration)
 3. Always carry the plan document forward as context
 4. Execution must hand off into runtime stage 5 `plan_execute`, not bypass directly into ad-hoc coding
 5. Process-discipline helpers may influence how work is executed, but VCO remains the only governed runtime skeleton and artifact authority

--- a/bundled/skills/vibe/references/changelog.md
+++ b/bundled/skills/vibe/references/changelog.md
@@ -1,5 +1,14 @@
 # VCO Changelog
 
+## v2.3.51 (2026-03-28)
+
+- Integrated downstream delivery acceptance into the normal `vibe` main chain so governed runs now freeze product acceptance semantics, plan delivery checks, and emit a per-run delivery-acceptance report during cleanup.
+- Completed the recent specialist-governance sequence on `main`: stage-bound specialist dispatch, child-lane same-round auto-absorb under root approval, and stronger native-specialist failure proofing.
+- Fixed Windows specialist runtime handoff so governed specialist execution stays usable on current Windows environments instead of breaking at the boundary between orchestration and native specialist lanes.
+- Added benchmark/scenario-backed workflow acceptance and release-truth helpers to support stricter completion-language honesty beyond pure runtime/process success.
+- Detailed release notes: `docs/releases/v2.3.51.md`.
+
+
 ## v2.3.50 (2026-03-26)
 
 - Added router AI connectivity proofing for the governance advice path, including a PowerShell gate, a runtime-neutral Python probe, and install-entry quick-check guidance that reports structured readiness states.

--- a/bundled/skills/vibe/references/proof-bundles/openclaw-runtime-core-preview-candidate/manifest.json
+++ b/bundled/skills/vibe/references/proof-bundles/openclaw-runtime-core-preview-candidate/manifest.json
@@ -3,7 +3,7 @@
   "bundle_id": "openclaw-runtime-core-preview-candidate-2026-03-25",
   "frozen_at": "2026-03-25",
   "source_release": {
-    "version": "2.3.50",
+    "version": "2.3.51",
     "updated": "2026-03-26"
   },
   "lane_id": "openclaw/runtime-core-preview",

--- a/bundled/skills/vibe/references/release-ledger.jsonl
+++ b/bundled/skills/vibe/references/release-ledger.jsonl
@@ -28,3 +28,4 @@
 {"recorded_at":"2026-03-23T01:02:25","version":"2.3.48","updated":"2026-03-23","git_head":"3cd3ae2","actor":null}
 {"recorded_at":"2026-03-23T01:38:21","version":"2.3.49","updated":"2026-03-23","git_head":"dc0430d","actor":null}
 {"recorded_at":"2026-03-26T20:39:51","version":"2.3.50","updated":"2026-03-26","git_head":"d5da111","actor":null}
+{"recorded_at":"2026-03-28T00:00:00","version":"2.3.51","updated":"2026-03-28","git_head":"18e6b9c","actor":null}

--- a/bundled/skills/vibe/scripts/install/Install-VgoAdapter.ps1
+++ b/bundled/skills/vibe/scripts/install/Install-VgoAdapter.ps1
@@ -28,6 +28,18 @@ function Copy-DirContent {
     Copy-Item -Path (Join-Path $Source '*') -Destination $Destination -Recurse -Force
 }
 
+function Restore-SkillEntryPointIfNeeded {
+    param([string]$SkillRoot)
+
+    $skillMd = Join-Path $SkillRoot 'SKILL.md'
+    $mirrorPath = Join-Path $SkillRoot 'SKILL.runtime-mirror.md'
+    if ((Test-Path -LiteralPath $skillMd -PathType Leaf) -or -not (Test-Path -LiteralPath $mirrorPath -PathType Leaf)) {
+        return
+    }
+
+    Move-Item -LiteralPath $mirrorPath -Destination $skillMd -Force
+}
+
 function Ensure-SkillPresent {
     param(
         [string]$Name,
@@ -43,7 +55,9 @@ function Ensure-SkillPresent {
         foreach ($src in $FallbackSources) {
             if ([string]::IsNullOrWhiteSpace($src)) { continue }
             if (Test-Path -LiteralPath $src) {
-                Copy-DirContent -Source $src -Destination (Join-Path $TargetRoot ("skills\" + $Name))
+                $destination = Join-Path $TargetRoot ("skills\" + $Name)
+                Copy-DirContent -Source $src -Destination $destination
+                Restore-SkillEntryPointIfNeeded -SkillRoot $destination
                 $ExternalFallbackUsed.Add($Name) | Out-Null
                 break
             }
@@ -105,6 +119,11 @@ function Install-RuntimeCorePayload {
         $src = Join-Path $RepoRoot ([string]$entry.source)
         $dst = Join-Path $TargetRoot ([string]$entry.target)
         Copy-DirContent -Source $src -Destination $dst
+        if ([string]$entry.target -eq 'skills' -and (Test-Path -LiteralPath $dst -PathType Container)) {
+            foreach ($skillDir in @(Get-ChildItem -LiteralPath $dst -Directory -ErrorAction SilentlyContinue)) {
+                Restore-SkillEntryPointIfNeeded -SkillRoot $skillDir.FullName
+            }
+        }
     }
 
     foreach ($entry in @($packaging.copy_files)) {

--- a/bundled/skills/vibe/scripts/install/install_vgo_adapter.py
+++ b/bundled/skills/vibe/scripts/install/install_vgo_adapter.py
@@ -98,6 +98,14 @@ def copy_file(src: Path, dst: Path):
     shutil.copy2(src, dst)
 
 
+def restore_skill_entrypoint_if_needed(skill_root: Path):
+    skill_md = skill_root / "SKILL.md"
+    mirror_md = skill_root / "SKILL.runtime-mirror.md"
+    if skill_md.exists() or not mirror_md.exists():
+        return
+    mirror_md.rename(skill_md)
+
+
 def parent_dir(path: Path | None) -> Path | None:
     if path is None:
         return None
@@ -245,7 +253,9 @@ def ensure_skill_present(target_root: Path, name: str, required: bool, allow_fal
         for src in fallback_sources:
             src_path = Path(src)
             if src_path.exists():
-                copy_tree(src_path, target_root / "skills" / name)
+                destination = target_root / "skills" / name
+                copy_tree(src_path, destination)
+                restore_skill_entrypoint_if_needed(destination)
                 external_used.add(name)
                 break
     if required and not skill_md.exists():
@@ -258,6 +268,10 @@ def install_runtime_core(repo_root: Path, target_root: Path, profile: str, allow
         (target_root / rel).mkdir(parents=True, exist_ok=True)
     for entry in packaging["copy_directories"]:
         copy_tree(repo_root / entry["source"], target_root / entry["target"])
+        if entry["target"] == "skills":
+            for skill_dir in (target_root / "skills").iterdir():
+                if skill_dir.is_dir():
+                    restore_skill_entrypoint_if_needed(skill_dir)
     for entry in packaging["copy_files"]:
         src = repo_root / entry["source"]
         if not src.exists():

--- a/bundled/skills/vibe/scripts/verify/runtime_neutral/release_truth_gate.py
+++ b/bundled/skills/vibe/scripts/verify/runtime_neutral/release_truth_gate.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8", newline="\n")
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8-sig") as handle:
+        return json.load(handle)
+
+
+def resolve_repo_root(start_path: Path) -> Path:
+    current = start_path.resolve()
+    if current.is_file():
+        current = current.parent
+    candidates: list[Path] = []
+    while True:
+        if (current / "config" / "version-governance.json").exists():
+            candidates.append(current)
+        if current.parent == current:
+            break
+        current = current.parent
+    if not candidates:
+        raise RuntimeError(f"Unable to resolve VCO repo root from: {start_path}")
+    git_candidates = [candidate for candidate in candidates if (candidate / ".git").exists()]
+    if git_candidates:
+        return git_candidates[-1]
+    return candidates[-1]
+
+
+def evaluate(repo_root: Path, report_paths: list[Path]) -> dict[str, Any]:
+    reports = [load_json(path) for path in report_paths]
+    failing_reports: list[str] = []
+    manual_reports: list[str] = []
+    blocked_completion_reports: list[str] = []
+
+    for report_path, report in zip(report_paths, reports):
+        summary = report.get("summary") or {}
+        gate_result = str(summary.get("gate_result") or "")
+        completion_language_allowed = bool(summary.get("completion_language_allowed"))
+        if gate_result == "FAIL":
+            failing_reports.append(str(report_path))
+        elif gate_result == "MANUAL_REVIEW_REQUIRED":
+            manual_reports.append(str(report_path))
+        if not completion_language_allowed:
+            blocked_completion_reports.append(str(report_path))
+
+    gate_result = "PASS"
+    if failing_reports:
+        gate_result = "FAIL"
+    elif manual_reports:
+        gate_result = "MANUAL_REVIEW_REQUIRED"
+
+    summary = {
+        "gate_result": gate_result,
+        "report_count": len(reports),
+        "failing_report_count": len(failing_reports),
+        "manual_review_report_count": len(manual_reports),
+        "blocked_completion_report_count": len(blocked_completion_reports),
+        "completion_language_allowed": gate_result == "PASS" and len(blocked_completion_reports) == 0,
+    }
+    return {
+        "evaluated_at": utc_now(),
+        "summary": summary,
+        "reports": [
+            {
+                "path": str(report_path),
+                "scenario_id": str((report.get("summary") or {}).get("scenario_id") or ""),
+                "task_class": str((report.get("summary") or {}).get("task_class") or ""),
+                "gate_result": str((report.get("summary") or {}).get("gate_result") or ""),
+                "completion_language_allowed": bool((report.get("summary") or {}).get("completion_language_allowed")),
+            }
+            for report_path, report in zip(report_paths, reports)
+        ],
+        "failing_reports": failing_reports,
+        "manual_review_reports": manual_reports,
+        "blocked_completion_reports": blocked_completion_reports,
+    }
+
+
+def write_artifacts(repo_root: Path, artifact: dict[str, Any], output_directory: str | None) -> None:
+    output_root = Path(output_directory) if output_directory else repo_root / "outputs" / "verify"
+    json_path = output_root / "vibe-release-truth-gate.json"
+    md_path = output_root / "vibe-release-truth-gate.md"
+    write_text(json_path, json.dumps(artifact, ensure_ascii=False, indent=2) + "\n")
+    lines = [
+        "# Vibe Release Truth Gate",
+        "",
+        f"- Gate Result: **{artifact['summary']['gate_result']}**",
+        f"- Report Count: `{artifact['summary']['report_count']}`",
+        f"- Failing Reports: `{artifact['summary']['failing_report_count']}`",
+        f"- Manual Review Reports: `{artifact['summary']['manual_review_report_count']}`",
+        f"- Completion Language Allowed: `{artifact['summary']['completion_language_allowed']}`",
+        "",
+        "## Reports",
+        "",
+    ]
+    for report in artifact["reports"]:
+        lines.append(
+            f"- `{report['scenario_id']}` task_class=`{report['task_class']}` gate_result=`{report['gate_result']}` completion_language_allowed=`{report['completion_language_allowed']}`"
+        )
+    write_text(md_path, "\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Aggregate workflow acceptance reports into a release-truth decision.")
+    parser.add_argument("--report", action="append", dest="reports", required=True, help="Path to a workflow acceptance report JSON file.")
+    parser.add_argument("--repo-root", help="Optional explicit repository root.")
+    parser.add_argument("--write-artifacts", action="store_true", help="Write JSON/Markdown artifacts.")
+    parser.add_argument("--output-directory", help="Optional output directory for artifacts.")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else resolve_repo_root(Path(__file__))
+    artifact = evaluate(repo_root, [Path(item).resolve() for item in args.reports])
+    if args.write_artifacts:
+        write_artifacts(repo_root, artifact, args.output_directory)
+    print(json.dumps(artifact, ensure_ascii=False, indent=2))
+    return 0 if artifact["summary"]["gate_result"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bundled/skills/vibe/scripts/verify/runtime_neutral/workflow_acceptance_runner.py
+++ b/bundled/skills/vibe/scripts/verify/runtime_neutral/workflow_acceptance_runner.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8", newline="\n")
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8-sig") as handle:
+        return json.load(handle)
+
+
+def resolve_repo_root(start_path: Path) -> Path:
+    current = start_path.resolve()
+    if current.is_file():
+        current = current.parent
+    candidates: list[Path] = []
+    while True:
+        if (current / "config" / "version-governance.json").exists():
+            candidates.append(current)
+        if current.parent == current:
+            break
+        current = current.parent
+    if not candidates:
+        raise RuntimeError(f"Unable to resolve VCO repo root from: {start_path}")
+    git_candidates = [candidate for candidate in candidates if (candidate / ".git").exists()]
+    if git_candidates:
+        return git_candidates[-1]
+    return candidates[-1]
+
+
+def _normalize_truth_state(state: str) -> str:
+    normalized = str(state or "").strip().lower()
+    aliases = {
+        "pass": "passing",
+        "passed": "passing",
+        "ok": "passing",
+        "manual": "manual_review_required",
+        "manual_required": "manual_review_required",
+        "manual_review": "manual_review_required",
+        "fail": "failing",
+        "failed": "failing",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _truth_success(contract: dict[str, Any], state: str) -> bool:
+    return bool(((contract.get("truth_states") or {}).get(state) or {}).get("counts_as_success"))
+
+
+def _truth_completion_allowed(contract: dict[str, Any], state: str) -> bool:
+    return bool(((contract.get("truth_states") or {}).get(state) or {}).get("completion_language_allowed"))
+
+
+def evaluate(repo_root: Path, scenario_path: Path) -> dict[str, Any]:
+    contract = load_json(repo_root / "config" / "project-delivery-acceptance-contract.json")
+    scenario = load_json(scenario_path)
+    benchmark_repo_rel = str(scenario.get("benchmark_repo") or "").strip()
+    benchmark_repo_path = (repo_root / benchmark_repo_rel).resolve() if benchmark_repo_rel else None
+    benchmark_manifest_path = benchmark_repo_path / "acceptance-manifest.json" if benchmark_repo_path else None
+    benchmark_manifest = load_json(benchmark_manifest_path) if benchmark_manifest_path and benchmark_manifest_path.exists() else None
+
+    truth_layers = list(contract.get("truth_layers") or [])
+    scenario_truths = scenario.get("truths") or {}
+    truth_results: dict[str, dict[str, Any]] = {}
+
+    failing_layers: list[str] = []
+    manual_layers: list[str] = []
+    incomplete_layers: list[str] = []
+
+    for layer in truth_layers:
+        layer_spec = scenario_truths.get(layer) or {}
+        state = _normalize_truth_state(layer_spec.get("state", "not_run"))
+        success = _truth_success(contract, state)
+        completion_allowed = _truth_completion_allowed(contract, state)
+        if state == "manual_review_required":
+            manual_layers.append(layer)
+        if not success:
+            incomplete_layers.append(layer)
+        if state in {"failing", "degraded", "partial", "not_run"}:
+            failing_layers.append(layer)
+        truth_results[layer] = {
+            "state": state,
+            "success": success,
+            "completion_language_allowed": completion_allowed,
+            "evidence": list(layer_spec.get("evidence") or []),
+            "notes": str(layer_spec.get("notes") or ""),
+        }
+
+    runtime_status = str((scenario.get("runtime") or {}).get("status") or "").strip()
+    readiness_state = str((scenario.get("runtime") or {}).get("readiness_state") or "").strip()
+    forbidden_hits: list[dict[str, str]] = []
+    for rule in list(contract.get("forbidden_completion_collapses") or []):
+        source = str(rule.get("source") or "")
+        value = str(rule.get("value") or "")
+        if source == "runtime_status" and runtime_status == value:
+            forbidden_hits.append({"source": source, "value": value, "reason": str(rule.get("reason") or "")})
+        if source == "readiness_state" and readiness_state == value:
+            forbidden_hits.append({"source": source, "value": value, "reason": str(rule.get("reason") or "")})
+
+    gate_result = "PASS"
+    if failing_layers or forbidden_hits:
+        gate_result = "FAIL"
+    elif manual_layers:
+        gate_result = "MANUAL_REVIEW_REQUIRED"
+
+    completion_language_allowed = gate_result == "PASS" and all(
+        truth_results[layer]["completion_language_allowed"] for layer in truth_layers
+    )
+
+    summary = {
+        "scenario_id": str(scenario.get("scenario_id") or ""),
+        "task_class": str(scenario.get("task_class") or ""),
+        "gate_result": gate_result,
+        "completion_language_allowed": completion_language_allowed,
+        "runtime_status": runtime_status,
+        "readiness_state": readiness_state,
+        "manual_review_layer_count": len(manual_layers),
+        "failing_layer_count": len(failing_layers),
+        "forbidden_completion_hit_count": len(forbidden_hits),
+        "incomplete_layers": incomplete_layers,
+        "benchmark_repo_rel": benchmark_repo_rel,
+        "benchmark_repo_exists": bool(benchmark_repo_path and benchmark_repo_path.exists()),
+        "benchmark_manifest_exists": bool(benchmark_manifest_path and benchmark_manifest_path.exists()),
+    }
+
+    if benchmark_repo_rel and not summary["benchmark_repo_exists"]:
+        summary["gate_result"] = "FAIL"
+        summary["completion_language_allowed"] = False
+        summary["incomplete_layers"] = sorted(set(summary["incomplete_layers"] + ["product_acceptance_truth"]))
+    if benchmark_repo_rel and summary["benchmark_repo_exists"] and not summary["benchmark_manifest_exists"]:
+        if summary["gate_result"] == "PASS":
+            summary["gate_result"] = "MANUAL_REVIEW_REQUIRED"
+        summary["completion_language_allowed"] = False
+        summary["incomplete_layers"] = sorted(set(summary["incomplete_layers"] + ["product_acceptance_truth"]))
+
+    manual_spot_checks = list(scenario.get("manual_spot_checks") or [])
+    residual_risks = list(scenario.get("residual_risks") or [])
+
+    return {
+        "evaluated_at": utc_now(),
+        "contract_id": str(contract.get("contract_id") or ""),
+        "contract_version": int(contract.get("version") or 0),
+        "scenario_path": str(scenario_path),
+        "summary": summary,
+        "benchmark": {
+            "repo_rel": benchmark_repo_rel,
+            "repo_path": str(benchmark_repo_path) if benchmark_repo_path else "",
+            "repo_exists": bool(benchmark_repo_path and benchmark_repo_path.exists()),
+            "manifest_path": str(benchmark_manifest_path) if benchmark_manifest_path else "",
+            "manifest_exists": bool(benchmark_manifest_path and benchmark_manifest_path.exists()),
+            "manifest": benchmark_manifest,
+        },
+        "truth_results": truth_results,
+        "forbidden_completion_hits": forbidden_hits,
+        "manual_spot_checks": manual_spot_checks,
+        "residual_risks": residual_risks,
+    }
+
+
+def write_artifacts(repo_root: Path, artifact: dict[str, Any], output_directory: str | None) -> None:
+    output_root = Path(output_directory) if output_directory else repo_root / "outputs" / "verify"
+    json_path = output_root / "vibe-workflow-acceptance-gate.json"
+    md_path = output_root / "vibe-workflow-acceptance-gate.md"
+    write_text(json_path, json.dumps(artifact, ensure_ascii=False, indent=2) + "\n")
+
+    lines = [
+        "# Vibe Workflow Acceptance Gate",
+        "",
+        f"- Scenario: `{artifact['summary']['scenario_id']}`",
+        f"- Task Class: `{artifact['summary']['task_class']}`",
+        f"- Gate Result: **{artifact['summary']['gate_result']}**",
+        f"- Completion Language Allowed: `{artifact['summary']['completion_language_allowed']}`",
+        f"- Runtime Status: `{artifact['summary']['runtime_status']}`",
+        f"- Readiness State: `{artifact['summary']['readiness_state']}`",
+        f"- Benchmark Repo: `{artifact['summary']['benchmark_repo_rel']}`",
+        f"- Benchmark Repo Exists: `{artifact['summary']['benchmark_repo_exists']}`",
+        f"- Benchmark Manifest Exists: `{artifact['summary']['benchmark_manifest_exists']}`",
+        f"- Manual Review Layers: `{artifact['summary']['manual_review_layer_count']}`",
+        f"- Failing Layers: `{artifact['summary']['failing_layer_count']}`",
+        f"- Forbidden Completion Hits: `{artifact['summary']['forbidden_completion_hit_count']}`",
+        "",
+        "## Truth Layers",
+        "",
+    ]
+    for layer, info in artifact["truth_results"].items():
+        lines.append(
+            f"- `{layer}`: state=`{info['state']}` success=`{info['success']}` completion_language_allowed=`{info['completion_language_allowed']}`"
+        )
+    if artifact["forbidden_completion_hits"]:
+        lines += ["", "## Forbidden Completion Hits", ""]
+        for hit in artifact["forbidden_completion_hits"]:
+            lines.append(f"- `{hit['source']}`=`{hit['value']}` reason=`{hit['reason']}`")
+    if artifact["benchmark"]["manifest"]:
+        lines += ["", "## Benchmark Manifest", ""]
+        manifest = artifact["benchmark"]["manifest"]
+        lines.append(f"- `benchmark_id`: `{manifest.get('benchmark_id', '')}`")
+        for flow in list(manifest.get("critical_user_flows") or []):
+            lines.append(f"- critical_user_flow: {flow}")
+    if artifact["manual_spot_checks"]:
+        lines += ["", "## Manual Spot Checks", ""]
+        for item in artifact["manual_spot_checks"]:
+            lines.append(f"- {item}")
+    if artifact["residual_risks"]:
+        lines += ["", "## Residual Risks", ""]
+        for item in artifact["residual_risks"]:
+            lines.append(f"- {item}")
+    write_text(md_path, "\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Evaluate downstream project delivery acceptance for a governed scenario.")
+    parser.add_argument("--scenario", required=True, help="Path to the scenario JSON file.")
+    parser.add_argument("--repo-root", help="Optional explicit repository root.")
+    parser.add_argument("--write-artifacts", action="store_true", help="Write JSON/Markdown artifacts.")
+    parser.add_argument("--output-directory", help="Optional output directory for artifacts.")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else resolve_repo_root(Path(__file__))
+    artifact = evaluate(repo_root, Path(args.scenario).resolve())
+    if args.write_artifacts:
+        write_artifacts(repo_root, artifact, args.output_directory)
+    print(json.dumps(artifact, ensure_ascii=False, indent=2))
+    return 0 if artifact["summary"]["gate_result"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bundled/skills/vibe/scripts/verify/vibe-benchmark-autonomous-proof-gate.ps1
+++ b/bundled/skills/vibe/scripts/verify/vibe-benchmark-autonomous-proof-gate.ps1
@@ -51,7 +51,7 @@ foreach ($relativePath in $requiredFiles) {
 
 $runId = "benchmark-proof-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
 $artifactRoot = Join-Path $repoRoot (".tmp\benchmark-proof-{0}" -f $runId)
-$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'benchmark autonomous proof closure' -Mode benchmark_autonomous -RunId $runId -ArtifactRoot $artifactRoot
+$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'I have a failing test and a stack trace. Help me debug systematically before proposing fixes.' -Mode benchmark_autonomous -RunId $runId -ArtifactRoot $artifactRoot
 
 $executeReceiptPath = [string]$summary.summary.artifacts.execute_receipt
 $executionManifestPath = [string]$summary.summary.artifacts.execution_manifest
@@ -74,14 +74,26 @@ Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.stage -eq
 Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.runtime_mode -eq 'interactive_governed') -Message 'runtime input packet records interactive_governed as the effective mode'
 Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$runtimeInputPacket.canonical_router.unattended) -Message 'legacy benchmark mode no longer drives unattended router execution'
 Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.provenance.proof_class -eq 'structure') -Message 'runtime input packet carries structure proof class'
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.route_snapshot.selected_skill -eq 'vibe') -Message 'runtime input packet keeps vibe as the frozen route skill for governed entry'
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'runtime input packet keeps vibe as runtime authority'
+Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$runtimeInputPacket.divergence_shadow.skill_mismatch) -Message 'runtime input packet keeps router/runtime alignment for explicit governed vibe entry'
+Add-Assertion -Results ([ref]$results) -Condition (@($runtimeInputPacket.specialist_recommendations).Count -ge 1) -Message 'runtime input packet carries specialist recommendations'
+Add-Assertion -Results ([ref]$results) -Condition ((@($runtimeInputPacket.specialist_recommendations | ForEach-Object { [string]$_.skill_id }) -contains 'systematic-debugging')) -Message 'runtime input packet carries systematic-debugging as bounded specialist recommendation'
 Add-Assertion -Results ([ref]$results) -Condition ($executeReceipt.status -ne 'execution-contract-prepared') -Message 'execute receipt is no longer receipt-only'
 Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.status -eq 'completed') -Message 'execution manifest status is completed' -Details $executionManifest.status
 Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.executed_unit_count -ge 2) -Message 'benchmark executed at least two real units' -Details $executionManifest.executed_unit_count
 Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.failed_unit_count -eq 0) -Message 'benchmark execution has zero failed units' -Details $executionManifest.failed_unit_count
 Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.proof_class -eq 'runtime') -Message 'execution manifest carries runtime proof class'
 Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath ([string]$executeReceipt.plan_shadow_path)) -Message 'plan-derived shadow manifest exists' -Details ([string]$executeReceipt.plan_shadow_path)
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executeReceipt.specialist_recommendation_count -ge 1) -Message 'execute receipt carries specialist recommendation count'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executeReceipt.specialist_dispatch_unit_count -ge 1) -Message 'execute receipt carries specialist dispatch unit count'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.specialist_accounting.recommendation_count -ge 1) -Message 'execution manifest carries specialist accounting'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.specialist_accounting.dispatch_unit_count -ge 1) -Message 'execution manifest carries specialist dispatch accounting'
+Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$executionManifest.route_runtime_alignment.skill_mismatch) -Message 'execution manifest preserves governed vibe alignment while still carrying specialist accounting'
 Add-Assertion -Results ([ref]$results) -Condition ([bool]$proofManifest.proof_passed) -Message 'benchmark proof manifest marks proof_passed=true'
 Add-Assertion -Results ([ref]$results) -Condition ($proofManifest.proof_class -eq 'runtime') -Message 'benchmark proof manifest carries runtime proof class'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$proofManifest.specialist_recommendation_count -ge 1) -Message 'benchmark proof manifest carries specialist recommendation count'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$proofManifest.specialist_dispatch_unit_count -ge 1) -Message 'benchmark proof manifest carries specialist dispatch count'
 Add-Assertion -Results ([ref]$results) -Condition ($cleanupReceipt.cleanup_mode -eq 'receipt_only') -Message 'legacy benchmark mode now uses interactive_governed cleanup defaults'
 Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$cleanupReceipt.default_bounded_cleanup_applied) -Message 'legacy benchmark mode no longer applies bounded cleanup by default'
 Add-Assertion -Results ([ref]$results) -Condition ($cleanupReceipt.proof_class -eq 'runtime') -Message 'cleanup receipt carries runtime proof class'

--- a/bundled/skills/vibe/scripts/verify/vibe-child-specialist-escalation-gate.ps1
+++ b/bundled/skills/vibe/scripts/verify/vibe-child-specialist-escalation-gate.ps1
@@ -1,0 +1,202 @@
+param(
+    [switch]$WriteArtifacts,
+    [string]$OutputDirectory = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
+. (Join-Path $PSScriptRoot '..\runtime\VibeRuntime.Common.ps1')
+
+function Add-Assertion {
+    param(
+        [ref]$Results,
+        [bool]$Condition,
+        [string]$Message,
+        [string]$Details = ''
+    )
+
+    $record = [pscustomobject]@{
+        passed = [bool]$Condition
+        message = $Message
+        details = $Details
+    }
+    $Results.Value += $record
+
+    if ($Condition) {
+        Write-Host "[PASS] $Message"
+    } else {
+        Write-Host "[FAIL] $Message" -ForegroundColor Red
+        if ($Details) {
+            Write-Host "       $Details" -ForegroundColor DarkRed
+        }
+    }
+}
+
+$context = Get-VgoGovernanceContext -ScriptPath $PSCommandPath -EnforceExecutionContext
+$repoRoot = $context.repoRoot
+$results = @()
+
+$policyText = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-input-packet-policy.json') -Raw -Encoding UTF8
+foreach ($token in @('specialist_dispatch', 'local_specialist_suggestions', 'escalation_required', 'advisory_until_root_approval', 'auto_absorb_gate')) {
+    Add-Assertion -Results ([ref]$results) -Condition ($policyText.Contains($token)) -Message ("runtime input policy contains specialist escalation token: {0}" -f $token)
+}
+
+$teamText = Get-Content -LiteralPath (Join-Path $repoRoot 'protocols\team.md') -Raw -Encoding UTF8
+$stableDocText = Get-Content -LiteralPath (Join-Path $repoRoot 'docs\root-child-vibe-hierarchy-governance.md') -Raw -Encoding UTF8
+Add-Assertion -Results ([ref]$results) -Condition ($teamText.Contains('advisory until the governed plan chooses to dispatch it')) -Message 'team protocol keeps specialist recommendation advisory-first'
+Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('same-round auto-approve safe suggestions')) -Message 'stable hierarchy doc documents root-governed same-round absorb path'
+
+$runId = "child-specialist-escalation-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
+$artifactRoot = Join-Path $repoRoot (".tmp\child-specialist-escalation-{0}" -f $runId)
+
+$rootSummary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') `
+    -Task 'Root specialist dispatch seed for child escalation gate.' `
+    -Mode benchmark_autonomous `
+    -GovernanceScope root `
+    -RunId ("{0}-root" -f $runId) `
+    -ArtifactRoot $artifactRoot
+
+Add-Assertion -Results ([ref]$results) -Condition ($null -ne $rootSummary) -Message 'root specialist escalation probe returned summary payload'
+$hasRootSummary = ($null -ne $rootSummary) -and ($rootSummary.PSObject.Properties.Name -contains 'summary')
+Add-Assertion -Results ([ref]$results) -Condition $hasRootSummary -Message 'root specialist escalation probe has summary object'
+
+$approvedForChild = @()
+if ($hasRootSummary) {
+    $rootRuntimeInputPacket = Get-Content -LiteralPath $rootSummary.summary.artifacts.runtime_input_packet -Raw -Encoding UTF8 | ConvertFrom-Json
+    Add-Assertion -Results ([ref]$results) -Condition ($rootRuntimeInputPacket.governance_scope -eq 'root') -Message 'root specialist escalation probe is in root scope'
+    Add-Assertion -Results ([ref]$results) -Condition ($rootRuntimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'root specialist escalation probe keeps vibe authority'
+
+    $rootApprovedDispatch = if ($rootRuntimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch') {
+        @($rootRuntimeInputPacket.specialist_dispatch.approved_dispatch)
+    } elseif ($rootRuntimeInputPacket.PSObject.Properties.Name -contains 'approved_specialist_dispatch') {
+        @($rootRuntimeInputPacket.approved_specialist_dispatch)
+    } else {
+        @()
+    }
+    if (@($rootApprovedDispatch).Count -gt 0) {
+        $firstSkillId = [string]$rootApprovedDispatch[0].skill_id
+        if (-not [string]::IsNullOrWhiteSpace($firstSkillId)) {
+            $approvedForChild = @($firstSkillId)
+        }
+    }
+}
+
+$childSummary = $null
+if ($hasRootSummary) {
+    $childSummary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') `
+        -Task 'Child specialist escalation advisory smoke.' `
+        -Mode benchmark_autonomous `
+        -GovernanceScope child `
+        -RunId ("{0}-child" -f $runId) `
+        -RootRunId ([string]$rootSummary.summary.run_id) `
+        -ParentRunId ([string]$rootSummary.summary.run_id) `
+        -ParentUnitId 'child-specialist-escalation-unit' `
+        -InheritedRequirementDocPath ([string]$rootSummary.summary.artifacts.requirement_doc) `
+        -InheritedExecutionPlanPath ([string]$rootSummary.summary.artifacts.execution_plan) `
+        -ApprovedSpecialistSkillIds $approvedForChild `
+        -ArtifactRoot $artifactRoot
+}
+
+Add-Assertion -Results ([ref]$results) -Condition ($null -ne $childSummary) -Message 'child specialist escalation probe returned summary payload'
+$hasChildSummary = ($null -ne $childSummary) -and ($childSummary.PSObject.Properties.Name -contains 'summary')
+Add-Assertion -Results ([ref]$results) -Condition $hasChildSummary -Message 'child specialist escalation probe has summary object'
+
+$approvedDispatch = @()
+$localSuggestions = @()
+$childClaims = @()
+if ($hasChildSummary) {
+    $runtimeInputPacket = Get-Content -LiteralPath $childSummary.summary.artifacts.runtime_input_packet -Raw -Encoding UTF8 | ConvertFrom-Json
+    $executionManifest = Get-Content -LiteralPath $childSummary.summary.artifacts.execution_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    $specialistDispatch = if ($runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch') {
+        $runtimeInputPacket.specialist_dispatch
+    } else {
+        $null
+    }
+
+    $approvedDispatch = if ($null -ne $specialistDispatch -and $specialistDispatch.PSObject.Properties.Name -contains 'approved_dispatch') {
+        @($specialistDispatch.approved_dispatch)
+    } elseif ($runtimeInputPacket.PSObject.Properties.Name -contains 'approved_specialist_dispatch') {
+        @($runtimeInputPacket.approved_specialist_dispatch)
+    } else {
+        @()
+    }
+
+    $localSuggestions = if ($null -ne $specialistDispatch -and $specialistDispatch.PSObject.Properties.Name -contains 'local_specialist_suggestions') {
+        @($specialistDispatch.local_specialist_suggestions)
+    } elseif ($runtimeInputPacket.PSObject.Properties.Name -contains 'local_specialist_suggestions') {
+        @($runtimeInputPacket.local_specialist_suggestions)
+    } else {
+        @()
+    }
+
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.governance_scope -eq 'child') -Message 'specialist escalation smoke runs in child scope'
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'specialist escalation smoke keeps vibe runtime authority'
+    Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$runtimeInputPacket.authority_flags.allow_completion_claim) -Message 'child runtime input packet disallows final completion claim'
+    Add-Assertion -Results ([ref]$results) -Condition ($null -ne $specialistDispatch) -Message 'runtime packet exposes specialist dispatch surface'
+
+    if ($null -ne $specialistDispatch) {
+        Add-Assertion -Results ([ref]$results) -Condition ([string]$specialistDispatch.status -eq 'advisory_until_root_approval') -Message 'child specialist suggestions remain advisory until root approval'
+        if (@($localSuggestions).Count -gt 0) {
+            Add-Assertion -Results ([ref]$results) -Condition ([bool]$specialistDispatch.escalation_required) -Message 'child local specialist suggestions require escalation'
+            Add-Assertion -Results ([ref]$results) -Condition ([string]$specialistDispatch.escalation_status -eq 'root_approval_required') -Message 'child local specialist escalation status is root_approval_required'
+        }
+    }
+
+    $approvedSkillIds = @($approvedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    foreach ($entry in $localSuggestions) {
+        $skillId = if ($entry.PSObject.Properties.Name -contains 'skill_id') { [string]$entry.skill_id } else { 'unknown-skill' }
+        Add-Assertion -Results ([ref]$results) -Condition (-not ($approvedSkillIds -contains $skillId)) -Message ("local specialist suggestion is not approved global dispatch: {0}" -f $skillId)
+    }
+
+    Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.governance_scope -eq 'child') -Message 'execution manifest is marked child scope'
+    Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$executionManifest.authority.completion_claim_allowed) -Message 'child execution manifest cannot issue final completion claim'
+    Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.route_runtime_alignment.runtime_selected_skill -eq 'vibe') -Message 'execution manifest keeps explicit vibe authority'
+    $specialistAccounting = if ($executionManifest.PSObject.Properties.Name -contains 'specialist_accounting') { $executionManifest.specialist_accounting } else { $null }
+    if ($null -ne $specialistAccounting -and $specialistAccounting.PSObject.Properties.Name -contains 'auto_absorb_gate') {
+        Add-Assertion -Results ([ref]$results) -Condition ([bool]$specialistAccounting.auto_absorb_gate.enabled) -Message 'child execution manifest exposes enabled same-round auto-absorb gate'
+        if ($specialistAccounting.auto_absorb_gate.receipt_path) {
+            Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath ([string]$specialistAccounting.auto_absorb_gate.receipt_path)) -Message 'same-round auto-absorb gate emits receipt'
+        }
+    }
+
+    $childClaims = if ($executionManifest.PSObject.Properties.Name -contains 'child_completion_claims') { @($executionManifest.child_completion_claims) } else { @() }
+}
+
+$failureCount = @($results | Where-Object { -not $_.passed }).Count
+$gatePassed = ($failureCount -eq 0)
+$report = [pscustomobject]@{
+    generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    repo_root = $repoRoot
+    gate_passed = $gatePassed
+    assertion_count = @($results).Count
+    failure_count = $failureCount
+    runtime_summary_path = if ($null -ne $childSummary -and ($childSummary.PSObject.Properties.Name -contains 'summary_path')) { $childSummary.summary_path } else { $null }
+    approved_dispatch_count = @($approvedDispatch).Count
+    local_suggestion_count = @($localSuggestions).Count
+    child_claim_count = @($childClaims).Count
+    results = @($results)
+}
+
+if ($WriteArtifacts) {
+    $targetDir = if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        Join-Path $repoRoot 'outputs\verify\vibe-child-specialist-escalation'
+    } elseif ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+        [System.IO.Path]::GetFullPath($OutputDirectory)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDirectory))
+    }
+
+    New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    Write-VibeJsonArtifact -Path (Join-Path $targetDir 'vibe-child-specialist-escalation-gate.json') -Value $report
+} elseif (Test-Path -LiteralPath $artifactRoot) {
+    Remove-Item -LiteralPath $artifactRoot -Recurse -Force
+}
+
+if (-not $gatePassed) {
+    throw "vibe-child-specialist-escalation-gate failed with $failureCount failing assertion(s)."
+}
+
+$report

--- a/bundled/skills/vibe/scripts/verify/vibe-governed-runtime-contract-gate.ps1
+++ b/bundled/skills/vibe/scripts/verify/vibe-governed-runtime-contract-gate.ps1
@@ -98,7 +98,7 @@ Add-Assertion -Results ([ref]$results) -Condition ($teamText.Contains('$vibe')) 
 
 $runId = "contract-gate-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
 $artifactRoot = Join-Path $repoRoot (".tmp\governed-runtime-contract-{0}" -f $runId)
-$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'governed runtime contract smoke proof' -Mode benchmark_autonomous -RunId $runId -ArtifactRoot $artifactRoot
+$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'I have a failing test and a stack trace. Help me debug systematically before proposing fixes.' -Mode benchmark_autonomous -RunId $runId -ArtifactRoot $artifactRoot
 
 Add-Assertion -Results ([ref]$results) -Condition ($summary.mode -eq 'interactive_governed') -Message 'runtime smoke summary normalizes legacy benchmark mode to interactive_governed'
 
@@ -120,6 +120,7 @@ foreach ($artifactPath in $artifactPaths) {
 $executeReceipt = Get-Content -LiteralPath $summary.summary.artifacts.execute_receipt -Raw -Encoding UTF8 | ConvertFrom-Json
 $executionManifest = Get-Content -LiteralPath $summary.summary.artifacts.execution_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
 $proofManifest = Get-Content -LiteralPath $summary.summary.artifacts.benchmark_proof_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+$runtimeInputPacket = Get-Content -LiteralPath $summary.summary.artifacts.runtime_input_packet -Raw -Encoding UTF8 | ConvertFrom-Json
 $generatedRequirement = Get-Content -LiteralPath $summary.summary.artifacts.requirement_doc -Raw -Encoding UTF8
 $generatedPlan = Get-Content -LiteralPath $summary.summary.artifacts.execution_plan -Raw -Encoding UTF8
 
@@ -131,6 +132,15 @@ Add-Assertion -Results ([ref]$results) -Condition ($generatedRequirement.Contain
 Add-Assertion -Results ([ref]$results) -Condition ($generatedRequirement.Contains('## Completion State')) -Message 'runtime smoke requirement doc includes anti-drift completion section'
 Add-Assertion -Results ([ref]$results) -Condition ($generatedPlan.Contains('## Anti-Proxy-Goal-Drift Controls')) -Message 'runtime smoke execution plan includes anti-drift controls section'
 Add-Assertion -Results ([ref]$results) -Condition ($generatedPlan.Contains('### Primary Objective')) -Message 'runtime smoke execution plan includes anti-drift primary objective control'
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.route_snapshot.selected_skill -eq 'vibe') -Message 'runtime smoke keeps vibe as the frozen route skill for governed entry'
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'runtime smoke keeps vibe as explicit runtime skill'
+Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$runtimeInputPacket.divergence_shadow.skill_mismatch) -Message 'runtime smoke keeps router/runtime skill alignment for explicit governed vibe entry'
+Add-Assertion -Results ([ref]$results) -Condition (@($runtimeInputPacket.specialist_recommendations).Count -ge 1) -Message 'runtime smoke freezes bounded specialist recommendations'
+Add-Assertion -Results ([ref]$results) -Condition ((@($runtimeInputPacket.specialist_recommendations | ForEach-Object { [string]$_.skill_id }) -contains 'systematic-debugging')) -Message 'runtime smoke preserves systematic-debugging as a bounded specialist recommendation'
+Add-Assertion -Results ([ref]$results) -Condition ($generatedRequirement.Contains('## Specialist Recommendations')) -Message 'runtime smoke requirement doc includes specialist recommendations section'
+Add-Assertion -Results ([ref]$results) -Condition ($generatedPlan.Contains('## Specialist Skill Dispatch Plan')) -Message 'runtime smoke execution plan includes specialist dispatch section'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.specialist_accounting.recommendation_count -ge 1) -Message 'runtime smoke execution manifest carries specialist accounting'
+Add-Assertion -Results ([ref]$results) -Condition ([int]$executionManifest.plan_shadow.specialist_dispatch_unit_count -ge 1) -Message 'runtime smoke plan shadow counts specialist dispatch units'
 
 $failureCount = @($results | Where-Object { -not $_.passed }).Count
 $gatePassed = ($failureCount -eq 0)

--- a/bundled/skills/vibe/scripts/verify/vibe-no-duplicate-canonical-surface-gate.ps1
+++ b/bundled/skills/vibe/scripts/verify/vibe-no-duplicate-canonical-surface-gate.ps1
@@ -1,0 +1,166 @@
+param(
+    [switch]$WriteArtifacts,
+    [string]$OutputDirectory = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
+. (Join-Path $PSScriptRoot '..\runtime\VibeRuntime.Common.ps1')
+
+function Add-Assertion {
+    param(
+        [ref]$Results,
+        [bool]$Condition,
+        [string]$Message,
+        [string]$Details = ''
+    )
+
+    $record = [pscustomobject]@{
+        passed = [bool]$Condition
+        message = $Message
+        details = $Details
+    }
+    $Results.Value += $record
+
+    if ($Condition) {
+        Write-Host "[PASS] $Message"
+    } else {
+        Write-Host "[FAIL] $Message" -ForegroundColor Red
+        if ($Details) {
+            Write-Host "       $Details" -ForegroundColor DarkRed
+        }
+    }
+}
+
+function Test-PathUnderDirectory {
+    param(
+        [Parameter(Mandatory)] [string]$CandidatePath,
+        [Parameter(Mandatory)] [string]$RootPath
+    )
+
+    $candidate = [System.IO.Path]::GetFullPath($CandidatePath)
+    $root = [System.IO.Path]::GetFullPath($RootPath)
+    if (-not $root.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
+        $root += [System.IO.Path]::DirectorySeparatorChar
+    }
+    return $candidate.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Convert-ToNormalizedPathToken {
+    param(
+        [Parameter(Mandatory)] [string]$PathValue
+    )
+
+    return ([System.IO.Path]::GetFullPath($PathValue)).Replace('\', '/')
+}
+
+$context = Get-VgoGovernanceContext -ScriptPath $PSCommandPath -EnforceExecutionContext
+$repoRoot = $context.repoRoot
+$results = @()
+
+$runId = "canonical-surface-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
+$artifactRoot = Join-Path $repoRoot (".tmp\canonical-surface-{0}" -f $runId)
+$task = "Canonical surface uniqueness probe $runId"
+$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task $task -Mode benchmark_autonomous -GovernanceScope root -RunId $runId -ArtifactRoot $artifactRoot
+
+Add-Assertion -Results ([ref]$results) -Condition ($null -ne $summary) -Message 'canonical surface probe returned summary payload'
+$hasSummary = ($null -ne $summary) -and ($summary.PSObject.Properties.Name -contains 'summary')
+Add-Assertion -Results ([ref]$results) -Condition $hasSummary -Message 'canonical surface probe has summary object'
+
+if ($hasSummary) {
+    $requirementDocPath = [string]$summary.summary.artifacts.requirement_doc
+    $executionPlanPath = [string]$summary.summary.artifacts.execution_plan
+    $runtimeInputPacketPath = [string]$summary.summary.artifacts.runtime_input_packet
+    $executionManifestPath = [string]$summary.summary.artifacts.execution_manifest
+
+    Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath $requirementDocPath) -Message 'canonical requirement artifact exists' -Details $requirementDocPath
+    Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath $executionPlanPath) -Message 'canonical execution plan artifact exists' -Details $executionPlanPath
+    $requirementPathToken = Convert-ToNormalizedPathToken -PathValue $requirementDocPath
+    $executionPlanPathToken = Convert-ToNormalizedPathToken -PathValue $executionPlanPath
+    Add-Assertion -Results ([ref]$results) -Condition (
+        $requirementPathToken.Contains('/docs/requirements/')
+    ) -Message 'canonical requirement lives under docs/requirements' -Details $requirementDocPath
+    Add-Assertion -Results ([ref]$results) -Condition (
+        $executionPlanPathToken.Contains('/docs/plans/')
+    ) -Message 'canonical execution plan lives under docs/plans' -Details $executionPlanPath
+
+    $runtimeInputPacket = Get-Content -LiteralPath $runtimeInputPacketPath -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.governance_scope -eq 'root') -Message 'canonical surface probe runs in root governance scope'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_requirement_freeze) -Message 'root scope keeps requirement freeze authority'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_plan_freeze) -Message 'root scope keeps plan freeze authority'
+
+    $stableDocText = Get-Content -LiteralPath (Join-Path $repoRoot 'docs\root-child-vibe-hierarchy-governance.md') -Raw -Encoding UTF8
+    Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('one canonical requirement surface')) -Message 'stable hierarchy doc forbids duplicate requirement truth'
+    Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('one canonical execution-plan surface')) -Message 'stable hierarchy doc forbids duplicate execution-plan truth'
+
+    $childRunId = "canonical-surface-child-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
+    $childSummary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') `
+        -Task ("Child canonical surface uniqueness probe {0}" -f $childRunId) `
+        -Mode benchmark_autonomous `
+        -GovernanceScope child `
+        -RunId $childRunId `
+        -RootRunId ([string]$summary.summary.run_id) `
+        -ParentRunId ([string]$summary.summary.run_id) `
+        -ParentUnitId 'canonical-surface-child-unit' `
+        -InheritedRequirementDocPath $requirementDocPath `
+        -InheritedExecutionPlanPath $executionPlanPath `
+        -ArtifactRoot $artifactRoot
+
+    Add-Assertion -Results ([ref]$results) -Condition ($null -ne $childSummary) -Message 'child canonical probe returned summary payload'
+    $hasChildSummary = ($null -ne $childSummary) -and ($childSummary.PSObject.Properties.Name -contains 'summary')
+    Add-Assertion -Results ([ref]$results) -Condition $hasChildSummary -Message 'child canonical probe has summary object'
+
+    if ($hasChildSummary) {
+        $childRequirementReceipt = Get-Content -LiteralPath $childSummary.summary.artifacts.requirement_receipt -Raw -Encoding UTF8 | ConvertFrom-Json
+        $childExecutionPlanReceipt = Get-Content -LiteralPath $childSummary.summary.artifacts.execution_plan_receipt -Raw -Encoding UTF8 | ConvertFrom-Json
+        $childExecutionManifest = Get-Content -LiteralPath $childSummary.summary.artifacts.execution_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+
+        Add-Assertion -Results ([ref]$results) -Condition ($childSummary.summary.governance_scope -eq 'child') -Message 'child canonical probe runs in child governance scope'
+        Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$childRequirementReceipt.canonical_write_allowed) -Message 'child requirement stage cannot write canonical requirement surface'
+        Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$childExecutionPlanReceipt.canonical_write_allowed) -Message 'child plan stage cannot write canonical plan surface'
+        Add-Assertion -Results ([ref]$results) -Condition (
+            [System.IO.Path]::GetFullPath([string]$childRequirementReceipt.requirement_doc_path) -eq [System.IO.Path]::GetFullPath([string]$requirementDocPath)
+        ) -Message 'child requirement stage reuses root canonical requirement path'
+        Add-Assertion -Results ([ref]$results) -Condition (
+            [System.IO.Path]::GetFullPath([string]$childExecutionPlanReceipt.execution_plan_path) -eq [System.IO.Path]::GetFullPath([string]$executionPlanPath)
+        ) -Message 'child plan stage reuses root canonical execution plan path'
+        Add-Assertion -Results ([ref]$results) -Condition ($childExecutionManifest.governance_scope -eq 'child') -Message 'child execution manifest is marked as child scope'
+        Add-Assertion -Results ([ref]$results) -Condition (-not [bool]$childExecutionManifest.authority.completion_claim_allowed) -Message 'child execution manifest cannot issue final completion claims'
+    }
+}
+
+$failureCount = @($results | Where-Object { -not $_.passed }).Count
+$gatePassed = ($failureCount -eq 0)
+$report = [pscustomobject]@{
+    generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    repo_root = $repoRoot
+    gate_passed = $gatePassed
+    assertion_count = @($results).Count
+    failure_count = $failureCount
+    runtime_summary_path = if ($null -ne $summary -and ($summary.PSObject.Properties.Name -contains 'summary_path')) { $summary.summary_path } else { $null }
+    results = @($results)
+}
+
+if ($WriteArtifacts) {
+    $targetDir = if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        Join-Path $repoRoot 'outputs\verify\vibe-no-duplicate-canonical-surface'
+    } elseif ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+        [System.IO.Path]::GetFullPath($OutputDirectory)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDirectory))
+    }
+
+    New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    Write-VibeJsonArtifact -Path (Join-Path $targetDir 'vibe-no-duplicate-canonical-surface-gate.json') -Value $report
+} elseif (Test-Path -LiteralPath $artifactRoot) {
+    Remove-Item -LiteralPath $artifactRoot -Recurse -Force
+}
+
+if (-not $gatePassed) {
+    throw "vibe-no-duplicate-canonical-surface-gate failed with $failureCount failing assertion(s)."
+}
+
+$report

--- a/bundled/skills/vibe/scripts/verify/vibe-release-truth-gate.ps1
+++ b/bundled/skills/vibe/scripts/verify/vibe-release-truth-gate.ps1
@@ -1,0 +1,49 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$ReportPath,
+    [string]$RepoRoot,
+    [string]$OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+} else {
+    $RepoRoot = (Resolve-Path $RepoRoot).Path
+}
+
+$runnerPath = Join-Path $RepoRoot 'scripts\verify\runtime_neutral\release_truth_gate.py'
+if (-not (Test-Path -LiteralPath $runnerPath)) {
+    throw "release truth runner missing: $runnerPath"
+}
+
+$pythonCommand = Get-Command python3 -ErrorAction SilentlyContinue
+if (-not $pythonCommand) {
+    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+}
+if (-not $pythonCommand) {
+    throw 'Python is required to run vibe-release-truth-gate.'
+}
+
+$args = @(
+    $runnerPath
+    '--repo-root', $RepoRoot
+    '--write-artifacts'
+)
+foreach ($path in $ReportPath) {
+    $args += @('--report', (Resolve-Path $path).Path)
+}
+if ($OutputDirectory) {
+    $args += @('--output-directory', $OutputDirectory)
+}
+
+& $pythonCommand.Source @args
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne 0) {
+    throw "vibe-release-truth-gate failed with exit code $exitCode"
+}
+
+Write-Host '[PASS] vibe-release-truth-gate passed' -ForegroundColor Green

--- a/bundled/skills/vibe/scripts/verify/vibe-root-child-hierarchy-gate.ps1
+++ b/bundled/skills/vibe/scripts/verify/vibe-root-child-hierarchy-gate.ps1
@@ -1,0 +1,142 @@
+param(
+    [switch]$WriteArtifacts,
+    [string]$OutputDirectory = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
+. (Join-Path $PSScriptRoot '..\runtime\VibeRuntime.Common.ps1')
+
+function Add-Assertion {
+    param(
+        [ref]$Results,
+        [bool]$Condition,
+        [string]$Message,
+        [string]$Details = ''
+    )
+
+    $record = [pscustomobject]@{
+        passed = [bool]$Condition
+        message = $Message
+        details = $Details
+    }
+    $Results.Value += $record
+
+    if ($Condition) {
+        Write-Host "[PASS] $Message"
+    } else {
+        Write-Host "[FAIL] $Message" -ForegroundColor Red
+        if ($Details) {
+            Write-Host "       $Details" -ForegroundColor DarkRed
+        }
+    }
+}
+
+$context = Get-VgoGovernanceContext -ScriptPath $PSCommandPath -EnforceExecutionContext
+$repoRoot = $context.repoRoot
+$results = @()
+
+$requiredFiles = @(
+    'docs/root-child-vibe-hierarchy-governance.md',
+    'docs/requirements/2026-03-28-root-child-vibe-hierarchy-governance.md',
+    'docs/plans/2026-03-28-root-child-vibe-hierarchy-governance-plan.md',
+    'tests/runtime_neutral/test_root_child_hierarchy_bridge.py'
+)
+foreach ($relativePath in $requiredFiles) {
+    Add-Assertion -Results ([ref]$results) -Condition (Test-Path -LiteralPath (Join-Path $repoRoot $relativePath)) -Message ("hierarchy required file exists: {0}" -f $relativePath)
+}
+
+$runtimeContract = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-contract.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeContract.entry_skill -eq 'vibe') -Message 'runtime contract entry skill remains vibe'
+
+$policyText = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-input-packet-policy.json') -Raw -Encoding UTF8
+foreach ($token in @(
+    'governance_scope',
+    'hierarchy_contract',
+    'child_specialist_suggestion_contract',
+    'allow_requirement_freeze',
+    'allow_plan_freeze',
+    'allow_global_dispatch',
+    'allow_completion_claim',
+    'specialist_dispatch',
+    'advisory_until_root_approval',
+    'escalation_required',
+    'auto_absorb_gate'
+)) {
+    Add-Assertion -Results ([ref]$results) -Condition ($policyText.Contains($token)) -Message ("runtime input policy contains hierarchy token: {0}" -f $token)
+}
+
+$runtimeText = Get-Content -LiteralPath (Join-Path $repoRoot 'protocols\runtime.md') -Raw -Encoding UTF8
+$teamText = Get-Content -LiteralPath (Join-Path $repoRoot 'protocols\team.md') -Raw -Encoding UTF8
+$stableDocText = Get-Content -LiteralPath (Join-Path $repoRoot 'docs\root-child-vibe-hierarchy-governance.md') -Raw -Encoding UTF8
+Add-Assertion -Results ([ref]$results) -Condition ($runtimeText.Contains('runtime-selected skill stays `vibe`')) -Message 'runtime protocol documents explicit vibe authority preservation'
+Add-Assertion -Results ([ref]$results) -Condition ($teamText.Contains('`vibe` keeps final control')) -Message 'team protocol keeps vibe as final control'
+Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('root vibe governs, child vibe executes, specialists assist')) -Message 'stable hierarchy doc exposes root/child mental model'
+
+$runId = "root-child-hierarchy-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
+$artifactRoot = Join-Path $repoRoot (".tmp\root-child-hierarchy-{0}" -f $runId)
+$summary = & (Join-Path $repoRoot 'scripts\runtime\invoke-vibe-runtime.ps1') -Task 'Root child hierarchy authority smoke.' -Mode benchmark_autonomous -GovernanceScope root -RunId $runId -ArtifactRoot $artifactRoot
+
+Add-Assertion -Results ([ref]$results) -Condition ($null -ne $summary) -Message 'runtime smoke returned summary payload'
+$hasSummary = ($null -ne $summary) -and ($summary.PSObject.Properties.Name -contains 'summary')
+Add-Assertion -Results ([ref]$results) -Condition $hasSummary -Message 'runtime smoke summary object exists'
+
+if ($hasSummary) {
+    $runtimeInputPacket = Get-Content -LiteralPath $summary.summary.artifacts.runtime_input_packet -Raw -Encoding UTF8 | ConvertFrom-Json
+    $executionManifest = Get-Content -LiteralPath $summary.summary.artifacts.execution_manifest -Raw -Encoding UTF8 | ConvertFrom-Json
+
+    Add-Assertion -Results ([ref]$results) -Condition ($summary.mode -eq 'interactive_governed') -Message 'legacy benchmark mode is normalized to interactive_governed for hierarchy smoke'
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.route_snapshot.selected_skill -eq 'vibe') -Message 'root hierarchy smoke keeps vibe as frozen route skill'
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.authority_flags.explicit_runtime_skill -eq 'vibe') -Message 'root hierarchy smoke keeps vibe as runtime authority'
+    Add-Assertion -Results ([ref]$results) -Condition ($runtimeInputPacket.governance_scope -eq 'root') -Message 'runtime packet marks root governance scope'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_requirement_freeze) -Message 'root packet allows requirement freeze'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_plan_freeze) -Message 'root packet allows plan freeze'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_global_dispatch) -Message 'root packet allows global specialist dispatch'
+    Add-Assertion -Results ([ref]$results) -Condition ([bool]$runtimeInputPacket.authority_flags.allow_completion_claim) -Message 'root packet allows final completion claim'
+    $hasSpecialistDispatchSurface = ($runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch') -or ($runtimeInputPacket.PSObject.Properties.Name -contains 'approved_specialist_dispatch')
+    Add-Assertion -Results ([ref]$results) -Condition $hasSpecialistDispatchSurface -Message 'runtime packet includes specialist dispatch surface'
+    $hasEscalationSurface = ($runtimeInputPacket.PSObject.Properties.Name -contains 'escalation_required') -or (($runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch') -and ($runtimeInputPacket.specialist_dispatch.PSObject.Properties.Name -contains 'escalation_required'))
+    Add-Assertion -Results ([ref]$results) -Condition $hasEscalationSurface -Message 'runtime packet includes escalation marker surface'
+
+    $hasCompletionAuthority = ($executionManifest.PSObject.Properties.Name -contains 'authority')
+    Add-Assertion -Results ([ref]$results) -Condition $hasCompletionAuthority -Message 'execution manifest includes authority surface'
+    if ($hasCompletionAuthority) {
+        Add-Assertion -Results ([ref]$results) -Condition ($executionManifest.governance_scope -eq 'root') -Message 'execution manifest marks root governance scope'
+        Add-Assertion -Results ([ref]$results) -Condition ([bool]$executionManifest.authority.completion_claim_allowed) -Message 'execution manifest allows final completion claim only for root scope'
+    }
+}
+
+$failureCount = @($results | Where-Object { -not $_.passed }).Count
+$gatePassed = ($failureCount -eq 0)
+$report = [pscustomobject]@{
+    generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    repo_root = $repoRoot
+    gate_passed = $gatePassed
+    assertion_count = @($results).Count
+    failure_count = $failureCount
+    runtime_summary_path = if ($null -ne $summary -and ($summary.PSObject.Properties.Name -contains 'summary_path')) { $summary.summary_path } else { $null }
+    results = @($results)
+}
+
+if ($WriteArtifacts) {
+    $targetDir = if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+        Join-Path $repoRoot 'outputs\verify\vibe-root-child-hierarchy'
+    } elseif ([System.IO.Path]::IsPathRooted($OutputDirectory)) {
+        [System.IO.Path]::GetFullPath($OutputDirectory)
+    } else {
+        [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDirectory))
+    }
+
+    New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    Write-VibeJsonArtifact -Path (Join-Path $targetDir 'vibe-root-child-hierarchy-gate.json') -Value $report
+} elseif (Test-Path -LiteralPath $artifactRoot) {
+    Remove-Item -LiteralPath $artifactRoot -Recurse -Force
+}
+
+if (-not $gatePassed) {
+    throw "vibe-root-child-hierarchy-gate failed with $failureCount failing assertion(s)."
+}
+
+$report

--- a/bundled/skills/vibe/scripts/verify/vibe-workflow-acceptance-gate.ps1
+++ b/bundled/skills/vibe/scripts/verify/vibe-workflow-acceptance-gate.ps1
@@ -1,0 +1,49 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScenarioPath,
+    [string]$RepoRoot,
+    [string]$OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+} else {
+    $RepoRoot = (Resolve-Path $RepoRoot).Path
+}
+
+$runnerPath = Join-Path $RepoRoot 'scripts\verify\runtime_neutral\workflow_acceptance_runner.py'
+if (-not (Test-Path -LiteralPath $runnerPath)) {
+    throw "workflow acceptance runner missing: $runnerPath"
+}
+
+$resolvedScenario = (Resolve-Path $ScenarioPath).Path
+
+$pythonCommand = Get-Command python3 -ErrorAction SilentlyContinue
+if (-not $pythonCommand) {
+    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+}
+if (-not $pythonCommand) {
+    throw 'Python is required to run vibe-workflow-acceptance-gate.'
+}
+
+$args = @(
+    $runnerPath
+    '--repo-root', $RepoRoot
+    '--scenario', $resolvedScenario
+    '--write-artifacts'
+)
+if ($OutputDirectory) {
+    $args += @('--output-directory', $OutputDirectory)
+}
+
+& $pythonCommand.Source @args
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne 0) {
+    throw "vibe-workflow-acceptance-gate failed with exit code $exitCode"
+}
+
+Write-Host '[PASS] vibe-workflow-acceptance-gate passed' -ForegroundColor Green

--- a/config/version-governance.json
+++ b/config/version-governance.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
   "release": {
-    "version": "2.3.50",
-    "updated": "2026-03-26",
+    "version": "2.3.51",
+    "updated": "2026-03-28",
     "channel": "stable",
-    "notes": "Adds router AI connectivity proofing, tightens llm acceleration overlay handling, expands host-adapter/install truth across OpenClaw/OpenCode/Cursor/Windsurf, and switches Windows install verification guidance to built-in PowerShell."
+    "notes": "Adds main-chain delivery acceptance under vibe, hardens stage-bound specialist dispatch and Windows specialist runtime handoff, and promotes stricter completion-language truth for governed runs."
   },
   "source_of_truth": {
     "canonical_root": ".",

--- a/dist/core/manifest.json
+++ b/dist/core/manifest.json
@@ -4,7 +4,7 @@
   "lane_kind": "universal-core",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.50",
+    "version": "2.3.51",
     "updated": "2026-03-26"
   },
   "summary": "Universal contracts only. No install/check runtime closure is promised by this lane.",

--- a/dist/host-claude-code/manifest.json
+++ b/dist/host-claude-code/manifest.json
@@ -5,7 +5,7 @@
   "host_id": "claude-code",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.50",
+    "version": "2.3.51",
     "updated": "2026-03-26"
   },
   "summary": "Claude Code host adapter preview. The repo can now scaffold preview artifacts and run preview health checks, but still does not claim full governed closure.",

--- a/dist/host-codex/manifest.json
+++ b/dist/host-codex/manifest.json
@@ -5,7 +5,7 @@
   "host_id": "codex",
   "stability": "supported-with-constraints",
   "source_release": {
-    "version": "2.3.50",
+    "version": "2.3.51",
     "updated": "2026-03-26"
   },
   "summary": "Codex host adapter lane. Uses the official runtime entrypoints, but remains honest about host-managed plugin and credential surfaces.",

--- a/dist/host-cursor/manifest.json
+++ b/dist/host-cursor/manifest.json
@@ -5,7 +5,7 @@
   "host_id": "cursor",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.50",
+    "version": "2.3.51",
     "updated": "2026-03-26"
   },
   "summary": "Cursor host adapter preview. The repository can expose runtime-core payload and preview health checks, but does not claim full governed closure yet.",

--- a/dist/host-openclaw/manifest.json
+++ b/dist/host-openclaw/manifest.json
@@ -5,7 +5,7 @@
   "host_id": "openclaw",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.50",
+    "version": "2.3.51",
     "updated": "2026-03-26"
   },
   "summary": "OpenClaw host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",

--- a/dist/host-opencode/manifest.json
+++ b/dist/host-opencode/manifest.json
@@ -5,7 +5,7 @@
   "host_id": "opencode",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.50",
+    "version": "2.3.51",
     "updated": "2026-03-26"
   },
   "summary": "OpenCode host adapter preview. The repo can install runtime-core plus OpenCode-native command and agent wrapper payload into OpenCode roots, but final host config and platform closure remain incomplete.",

--- a/dist/host-windsurf/manifest.json
+++ b/dist/host-windsurf/manifest.json
@@ -5,7 +5,7 @@
   "host_id": "windsurf",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.50",
+    "version": "2.3.51",
     "updated": "2026-03-26"
   },
   "summary": "Windsurf host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",

--- a/dist/official-runtime/manifest.json
+++ b/dist/official-runtime/manifest.json
@@ -4,7 +4,7 @@
   "lane_kind": "tier-1-official-runtime",
   "stability": "tier-1",
   "source_release": {
-    "version": "2.3.50",
+    "version": "2.3.51",
     "updated": "2026-03-26"
   },
   "summary": "Reference lane for the current governed official runtime. This dist pack points to it and must not rewrite it.",

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -10,7 +10,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ### Current Release Surface
 
-- [`v2.3.50.md`](v2.3.50.md): router AI connectivity probe / host-adapter expansion / single-entry install surface / Windows PowerShell default verification guidance
+- [`v2.3.51.md`](v2.3.51.md): main-chain delivery acceptance / specialist dispatch governance closure / Windows specialist runtime handoff fix
 
 ### Release Runtime / Proof Handoff
 
@@ -22,6 +22,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ## Recent Governed Releases
 
+- [`v2.3.51.md`](v2.3.51.md) - 2026-03-28 - main-chain delivery acceptance / specialist dispatch governance closure / Windows specialist runtime handoff fix
 - [`v2.3.50.md`](v2.3.50.md) - 2026-03-26 - router AI connectivity probe / host-adapter expansion / single-entry install surface / Windows PowerShell default verification guidance
 - [`v2.3.49.md`](v2.3.49.md) - 2026-03-23 - shallow-worktree install/check hardening / installed-runtime adapter fallback / parent-path guard convergence
 - [`v2.3.48.md`](v2.3.48.md) - 2026-03-23 - benchmark mode compatibility downgrade / governed proof alignment / adaptive-routing gate robustness

--- a/docs/releases/v2.3.51.md
+++ b/docs/releases/v2.3.51.md
@@ -1,0 +1,33 @@
+# VCO Release v2.3.51
+
+- Date: 2026-03-28
+- Commit(base): 18e6b9c
+- Previous release: `v2.3.50`
+
+## Highlights
+
+- Moved downstream delivery acceptance from an external verification layer into the normal `vibe` governed runtime main chain. Governed runs now freeze product acceptance criteria, manual spot checks, completion-language policy, and a delivery-truth contract directly in the main requirement surface.
+- Extended the governed plan and closure path so `xl_plan` records a delivery-acceptance plan and `phase_cleanup` emits a per-run `delivery-acceptance-report.json`. This makes completion-language downgrades part of the real runtime path instead of a post hoc review convention.
+- Completed the recent specialist-governance sequence on `main`: stage-bound specialist dispatch, child-lane same-round auto-absorb under root approval, and stronger native-specialist failure proofing. This improves how `vibe` uses specialist help without surrendering runtime authority.
+- Fixed the Windows specialist runtime handoff so native specialist execution remains viable on current Windows environments.
+
+## What Changed Compared With v2.3.50
+
+- `v2.3.50` was mainly about install truth, router AI connectivity proofing, and host-adapter/install-surface closure.
+- `v2.3.51` shifts the center of gravity into the governed execution path itself. The main difference is that the repo no longer only says “delivery truth matters”; the normal `vibe` runtime now writes and carries that truth in its own artifacts.
+- The older release improved readiness disclosure and verification entrypoints. The new release raises the honesty bar for declaring work complete after a governed run.
+
+## Validation Notes
+
+- Main-chain delivery-acceptance coverage:
+  - `pytest -q tests/runtime_neutral/test_runtime_delivery_acceptance.py tests/runtime_neutral/test_workflow_acceptance_runner.py tests/runtime_neutral/test_release_truth_gate.py`
+- Governed runtime / hierarchy / topology coverage:
+  - `pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py`
+- Release-surface hygiene:
+  - `git diff --check`
+
+## Migration Notes
+
+- Operators should expect stricter completion wording after normal governed runs. A clean runtime/process closure is no longer treated as equivalent to proven downstream project delivery.
+- Normal `vibe` session artifacts now include a `delivery-acceptance-report.json` and companion markdown summary under `outputs/runtime/vibe-sessions/<run-id>/`.
+- This release improves truthfulness and closure semantics. It does not claim that every host UI now enforces an absolutely unskippable final text gate; the authoritative change is that the governed runtime itself now records and carries the delivery-truth result.

--- a/references/changelog.md
+++ b/references/changelog.md
@@ -1,5 +1,14 @@
 # VCO Changelog
 
+## v2.3.51 (2026-03-28)
+
+- Integrated downstream delivery acceptance into the normal `vibe` main chain so governed runs now freeze product acceptance semantics, plan delivery checks, and emit a per-run delivery-acceptance report during cleanup.
+- Completed the recent specialist-governance sequence on `main`: stage-bound specialist dispatch, child-lane same-round auto-absorb under root approval, and stronger native-specialist failure proofing.
+- Fixed Windows specialist runtime handoff so governed specialist execution stays usable on current Windows environments instead of breaking at the boundary between orchestration and native specialist lanes.
+- Added benchmark/scenario-backed workflow acceptance and release-truth helpers to support stricter completion-language honesty beyond pure runtime/process success.
+- Detailed release notes: `docs/releases/v2.3.51.md`.
+
+
 ## v2.3.50 (2026-03-26)
 
 - Added router AI connectivity proofing for the governance advice path, including a PowerShell gate, a runtime-neutral Python probe, and install-entry quick-check guidance that reports structured readiness states.

--- a/references/proof-bundles/openclaw-runtime-core-preview-candidate/manifest.json
+++ b/references/proof-bundles/openclaw-runtime-core-preview-candidate/manifest.json
@@ -3,7 +3,7 @@
   "bundle_id": "openclaw-runtime-core-preview-candidate-2026-03-25",
   "frozen_at": "2026-03-25",
   "source_release": {
-    "version": "2.3.50",
+    "version": "2.3.51",
     "updated": "2026-03-26"
   },
   "lane_id": "openclaw/runtime-core-preview",

--- a/references/release-ledger.jsonl
+++ b/references/release-ledger.jsonl
@@ -28,3 +28,4 @@
 {"recorded_at":"2026-03-23T01:02:25","version":"2.3.48","updated":"2026-03-23","git_head":"3cd3ae2","actor":null}
 {"recorded_at":"2026-03-23T01:38:21","version":"2.3.49","updated":"2026-03-23","git_head":"dc0430d","actor":null}
 {"recorded_at":"2026-03-26T20:39:51","version":"2.3.50","updated":"2026-03-26","git_head":"d5da111","actor":null}
+{"recorded_at":"2026-03-28T00:00:00","version":"2.3.51","updated":"2026-03-28","git_head":"18e6b9c","actor":null}


### PR DESCRIPTION
This PR prepares the `v2.3.51` release on top of the current `main` branch.

Compared with `v2.3.50`, this release is centered much more on governed execution truth than on install-surface truth. The previous release mainly improved router AI connectivity probing, host-adapter/install closure, and Windows verification entry guidance. The new release keeps that foundation, but moves the center of gravity into the normal `vibe` runtime itself.

The main user-visible change is that downstream delivery acceptance is now part of the normal `vibe` main chain. Governed runs now freeze product acceptance semantics directly in the requirement doc, record a delivery-acceptance plan in the governed plan surface, and emit a per-run delivery-acceptance report during cleanup. This makes completion-language downgrades part of the actual runtime path instead of a purely external reporting convention.

This release also bundles the recent specialist-governance sequence that landed on `main`: stage-bound specialist dispatch governance, child-lane same-round specialist auto-absorb under root approval, stronger native-specialist failure proofing, and the Windows specialist runtime handoff fix.

In addition to the version bump itself, this PR updates governed release docs, changelog and ledger surfaces, dist manifests, proof-bundle manifests, and syncs the canonical packaging surface back into the bundled and nested bundled mirrors so the release packaging gate passes again.

Validation performed:

- `git diff --check`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/verify/vibe-version-consistency-gate.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/verify/vibe-version-packaging-gate.ps1`
