### PR TITLE
Add stage-aware memory runtime activation

### DIFF
--- a/bundled/skills/vibe/bundled/skills/vibe/config/memory-retrieval-budget-policy.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/memory-retrieval-budget-policy.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "updated": "2026-03-28",
+  "defaults": {
+    "top_k": 3,
+    "max_tokens": 120,
+    "max_chars_per_item": 240
+  },
+  "stages": {
+    "skeleton_check": {
+      "top_k": 3,
+      "max_tokens": 96,
+      "max_chars_per_item": 220
+    },
+    "requirement_doc": {
+      "top_k": 2,
+      "max_tokens": 120,
+      "max_chars_per_item": 260
+    },
+    "phase_cleanup": {
+      "top_k": 2,
+      "max_tokens": 160,
+      "max_chars_per_item": 320
+    }
+  }
+}

--- a/bundled/skills/vibe/bundled/skills/vibe/config/memory-stage-activation-policy.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/memory-stage-activation-policy.json
@@ -1,0 +1,76 @@
+{
+  "version": 1,
+  "updated": "2026-03-28",
+  "enabled": true,
+  "fallback_mode": "local_first_audited",
+  "stages": [
+    {
+      "stage": "skeleton_check",
+      "read_actions": [
+        {
+          "owner": "state_store",
+          "status": "fallback_local_digest",
+          "artifact_kind": "local_digest"
+        }
+      ],
+      "write_actions": []
+    },
+    {
+      "stage": "deep_interview",
+      "read_actions": [
+        {
+          "owner": "serena",
+          "status_if_missing_project_key": "deferred_no_project_key",
+          "project_key_env": [
+            "VIBE_SERENA_PROJECT_KEY",
+            "SERENA_PROJECT_KEY"
+          ]
+        }
+      ],
+      "write_actions": []
+    },
+    {
+      "stage": "requirement_doc",
+      "read_actions": [
+        {
+          "owner": "state_store",
+          "status": "bounded_context_injection",
+          "artifact_kind": "context_pack"
+        }
+      ],
+      "write_actions": []
+    },
+    {
+      "stage": "xl_plan",
+      "read_actions": [],
+      "write_actions": []
+    },
+    {
+      "stage": "plan_execute",
+      "read_actions": [],
+      "write_actions": [
+        {
+          "owner": "state_store",
+          "status": "fallback_local_artifact",
+          "artifact_kind": "execution_handoff_card"
+        }
+      ]
+    },
+    {
+      "stage": "phase_cleanup",
+      "read_actions": [],
+      "write_actions": [
+        {
+          "owner": "serena",
+          "status": "guarded_no_write",
+          "artifact_kind": "project_decision_gate"
+        },
+        {
+          "owner": "state_store",
+          "status": "generated_local_fold",
+          "artifact_kind": "memory_fold"
+        }
+      ]
+    }
+  ]
+}

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/common/vibe-governance-helpers.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/common/vibe-governance-helpers.ps1
@@ -1038,6 +1038,38 @@ function Get-VgoLegacySourceOfTruthCompatibility {
     }
 }
 
+function Test-VgoInstalledRuntimeMaterialization {
+    param(
+        [AllowEmptyString()] [string]$RepoRoot,
+        [AllowNull()] [psobject]$RuntimeConfig
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RepoRoot) -or $null -eq $RuntimeConfig) {
+        return $false
+    }
+
+    $requiredMarkers = @()
+    if ($RuntimeConfig.PSObject.Properties.Name -contains 'required_runtime_markers' -and $null -ne $RuntimeConfig.required_runtime_markers) {
+        $requiredMarkers = @($RuntimeConfig.required_runtime_markers)
+    }
+    if (@($requiredMarkers).Count -eq 0) {
+        return $false
+    }
+
+    foreach ($marker in @($requiredMarkers)) {
+        if ([string]::IsNullOrWhiteSpace([string]$marker)) {
+            continue
+        }
+
+        $markerPath = Join-Path $RepoRoot ([string]$marker)
+        if (-not (Test-Path -LiteralPath $markerPath)) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
 function Assert-VgoCanonicalExecutionContext {
     param(
         [Parameter(Mandatory)] [psobject]$Context
@@ -1056,7 +1088,9 @@ function Assert-VgoCanonicalExecutionContext {
         }
     }
 
-    if ($requireOuterGitRoot -and -not (Test-Path -LiteralPath (Join-Path $Context.repoRoot '.git'))) {
+    $hasOuterGitRoot = (Test-Path -LiteralPath (Join-Path $Context.repoRoot '.git'))
+    $hasInstalledRuntimeMaterialization = Test-VgoInstalledRuntimeMaterialization -RepoRoot ([string]$Context.repoRoot) -RuntimeConfig $Context.runtimeConfig
+    if ($requireOuterGitRoot -and -not $hasOuterGitRoot -and -not $hasInstalledRuntimeMaterialization) {
         throw "Execution-context lock failed: resolved repo root is not the outer git root -> $($Context.repoRoot)"
     }
 

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/VibeMemoryActivation.Common.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/VibeMemoryActivation.Common.ps1
@@ -1,0 +1,469 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-VibeMemoryArtifactsRoot {
+    param(
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $path = Join-Path $SessionRoot 'memory-activation'
+    New-Item -ItemType Directory -Path $path -Force | Out-Null
+    return $path
+}
+
+function Get-VibeMemoryBudgetSpec {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [string]$Stage
+    )
+
+    $defaults = $Runtime.memory_retrieval_budget_policy.defaults
+    $topK = [int]$defaults.top_k
+    $maxTokens = [int]$defaults.max_tokens
+    $maxCharsPerItem = [int]$defaults.max_chars_per_item
+
+    if ($Runtime.memory_retrieval_budget_policy.stages.PSObject.Properties.Name -contains $Stage) {
+        $stageBudget = $Runtime.memory_retrieval_budget_policy.stages.$Stage
+        if ($null -ne $stageBudget.top_k) {
+            $topK = [int]$stageBudget.top_k
+        }
+        if ($null -ne $stageBudget.max_tokens) {
+            $maxTokens = [int]$stageBudget.max_tokens
+        }
+        if ($null -ne $stageBudget.max_chars_per_item) {
+            $maxCharsPerItem = [int]$stageBudget.max_chars_per_item
+        }
+    }
+
+    return [pscustomobject]@{
+        top_k = $topK
+        max_tokens = $maxTokens
+        max_chars_per_item = $maxCharsPerItem
+    }
+}
+
+function Get-VibeMemoryCanonicalOwners {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime
+    )
+
+    $owners = $Runtime.memory_runtime_v3_policy.canonical_owners
+    return [ordered]@{
+        session = [string]$owners.session
+        project_decision = switch ([string]$owners.project_decision) {
+            'serena' { 'Serena' }
+            default { [string]$owners.project_decision }
+        }
+        short_term_semantic = [string]$owners.short_term_semantic
+        long_term_graph = switch ([string]$owners.long_term_graph) {
+            'cognee' { 'Cognee' }
+            default { [string]$owners.long_term_graph }
+        }
+    }
+}
+
+function Get-VibeMemoryStagePolicy {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [string]$Stage
+    )
+
+    foreach ($stagePolicy in @($Runtime.memory_stage_activation_policy.stages)) {
+        if ([string]$stagePolicy.stage -eq $Stage) {
+            return $stagePolicy
+        }
+    }
+
+    throw "Missing memory stage policy for stage: $Stage"
+}
+
+function Get-VibeBoundedMemoryItems {
+    param(
+        [AllowEmptyCollection()] [string[]]$Items = @(),
+        [Parameter(Mandatory)] [object]$Budget
+    )
+
+    $bounded = [System.Collections.Generic.List[string]]::new()
+    foreach ($item in @($Items)) {
+        if ([string]::IsNullOrWhiteSpace($item)) {
+            continue
+        }
+        if ($bounded.Count -ge [int]$Budget.top_k) {
+            break
+        }
+
+        $text = [string]$item
+        if ($text.Length -gt [int]$Budget.max_chars_per_item) {
+            $text = $text.Substring(0, [int]$Budget.max_chars_per_item).TrimEnd() + '...'
+        }
+        $bounded.Add($text) | Out-Null
+    }
+    return @($bounded)
+}
+
+function Get-VibeEstimatedTokenCount {
+    param(
+        [AllowEmptyCollection()] [string[]]$Items = @()
+    )
+
+    $charCount = 0
+    foreach ($item in @($Items)) {
+        $charCount += ([string]$item).Length
+    }
+
+    if ($charCount -le 0) {
+        return 0
+    }
+
+    return [int][Math]::Ceiling($charCount / 4.0)
+}
+
+function New-VibeSkeletonMemoryDigest {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [object]$Skeleton,
+        [Parameter(Mandatory)] [string]$Task,
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $budget = Get-VibeMemoryBudgetSpec -Runtime $Runtime -Stage 'skeleton_check'
+    $receipt = $Skeleton.receipt
+    $missingPaths = @($receipt.required_paths | Where-Object { -not [bool]$_.exists } | ForEach-Object { [string]$_.path })
+    $requirementDocs = @($receipt.existing_requirement_docs | Select-Object -First 5)
+    $planDocs = @($receipt.existing_plan_docs | Select-Object -First 5)
+
+    $items = @()
+    $items += ('Task focus: {0}' -f $Task)
+    $items += ('Git branch: {0}' -f [string]$receipt.git_branch)
+    if (@($missingPaths).Count -gt 0) {
+        $items += 'Missing runtime prerequisites: ' + (@($missingPaths) -join ', ')
+    } else {
+        $items += 'All required governed runtime prerequisite paths are present.'
+    }
+    if (@($requirementDocs).Count -gt 0) {
+        $items += 'Existing requirement docs: ' + (@($requirementDocs) -join ', ')
+    } else {
+        $items += 'Existing requirement docs: none'
+    }
+    if (@($planDocs).Count -gt 0) {
+        $items += 'Existing plan docs: ' + (@($planDocs) -join ', ')
+    } else {
+        $items += 'Existing plan docs: none'
+    }
+
+    $boundedItems = Get-VibeBoundedMemoryItems -Items $items -Budget $budget
+    $artifactPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'skeleton-local-digest.json'
+    $artifact = [pscustomobject]@{
+        stage = 'skeleton_check'
+        owner = 'state_store'
+        status = 'fallback_local_digest'
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        source_receipt_path = [string]$Skeleton.receipt_path
+        items = @($boundedItems)
+        budget = $budget
+    }
+    Write-VibeJsonArtifact -Path $artifactPath -Value $artifact
+
+    return [pscustomobject]@{
+        owner = 'state_store'
+        status = 'fallback_local_digest'
+        item_count = @($boundedItems).Count
+        items = @($boundedItems)
+        artifact_path = $artifactPath
+        budget = $budget
+    }
+}
+
+function Get-VibeDeepInterviewMemoryReadAction {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime
+    )
+
+    $stagePolicy = Get-VibeMemoryStagePolicy -Runtime $Runtime -Stage 'deep_interview'
+    $readPolicy = @($stagePolicy.read_actions)[0]
+    $projectKeyEnv = @($readPolicy.project_key_env)
+    $projectKeyName = $null
+    foreach ($envName in $projectKeyEnv) {
+        $value = [Environment]::GetEnvironmentVariable([string]$envName)
+        if (-not [string]::IsNullOrWhiteSpace($value)) {
+            $projectKeyName = [string]$envName
+            break
+        }
+    }
+
+    return [pscustomobject]@{
+        owner = 'Serena'
+        status = if ($null -eq $projectKeyName) { [string]$readPolicy.status_if_missing_project_key } else { 'backend_key_available' }
+        item_count = 0
+        items = @()
+        project_key_env = if ($null -eq $projectKeyName) { $null } else { $projectKeyName }
+    }
+}
+
+function New-VibeRequirementContextPack {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [object]$SkeletonDigestAction,
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $budget = Get-VibeMemoryBudgetSpec -Runtime $Runtime -Stage 'requirement_doc'
+    $boundedItems = Get-VibeBoundedMemoryItems -Items @($SkeletonDigestAction.items) -Budget $budget
+    $estimatedTokens = Get-VibeEstimatedTokenCount -Items @($boundedItems)
+    $artifactPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'requirement-context-pack.json'
+    $artifact = [pscustomobject]@{
+        stage = 'requirement_doc'
+        source_stage = 'skeleton_check'
+        owner = 'state_store'
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        items = @($boundedItems)
+        estimated_tokens = $estimatedTokens
+        budget = $budget
+    }
+    Write-VibeJsonArtifact -Path $artifactPath -Value $artifact
+
+    return [pscustomobject]@{
+        context_path = $artifactPath
+        injected_item_count = @($boundedItems).Count
+        estimated_tokens = $estimatedTokens
+        budget = $budget
+        items = @($boundedItems)
+    }
+}
+
+function New-VibeExecutionMemoryWriteAction {
+    param(
+        [Parameter(Mandatory)] [string]$ExecutionManifestPath,
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $manifest = Get-Content -LiteralPath $ExecutionManifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $items = @(
+        ('Execution status: {0}' -f [string]$manifest.status),
+        ('Executed units: {0}; failures: {1}' -f [int]$manifest.executed_unit_count, [int]$manifest.failed_unit_count),
+        ('Specialist execution status: {0}' -f [string]$manifest.specialist_accounting.effective_execution_status)
+    )
+    $artifactPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'execution-handoff-card.json'
+    $artifact = [pscustomobject]@{
+        stage = 'plan_execute'
+        owner = 'state_store'
+        status = 'fallback_local_artifact'
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        source_execution_manifest = $ExecutionManifestPath
+        items = @($items)
+    }
+    Write-VibeJsonArtifact -Path $artifactPath -Value $artifact
+
+    return [pscustomobject]@{
+        owner = 'state_store'
+        status = 'fallback_local_artifact'
+        item_count = @($items).Count
+        items = @($items)
+        artifact_path = $artifactPath
+    }
+}
+
+function Get-VibeCleanupDecisionWriteAction {
+    param(
+        [Parameter(Mandatory)] [string]$RequirementDocPath,
+        [Parameter(Mandatory)] [string]$ExecutionPlanPath
+    )
+
+    $requirementText = if (Test-Path -LiteralPath $RequirementDocPath) {
+        Get-Content -LiteralPath $RequirementDocPath -Raw -Encoding UTF8
+    } else {
+        ''
+    }
+    $planText = if (Test-Path -LiteralPath $ExecutionPlanPath) {
+        Get-Content -LiteralPath $ExecutionPlanPath -Raw -Encoding UTF8
+    } else {
+        ''
+    }
+    $combined = "$requirementText`n$planText"
+    $hasExplicitDecision = $combined -match 'approved decision|decision record|adr-|## decision'
+
+    return [pscustomobject]@{
+        owner = 'Serena'
+        status = if ($hasExplicitDecision) { 'backend_write_candidate' } else { 'guarded_no_write' }
+        item_count = 0
+        items = @()
+        artifact_path = $null
+        reason = if ($hasExplicitDecision) { 'explicit decision markers detected' } else { 'no explicit approved decision markers detected in frozen requirement/plan surfaces' }
+    }
+}
+
+function New-VibeCleanupMemoryFold {
+    param(
+        [Parameter(Mandatory)] [string]$RequirementDocPath,
+        [Parameter(Mandatory)] [string]$ExecutionPlanPath,
+        [Parameter(Mandatory)] [string]$ExecutionManifestPath,
+        [Parameter(Mandatory)] [string]$CleanupReceiptPath,
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $manifest = Get-Content -LiteralPath $ExecutionManifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $fold = [pscustomobject]@{
+        stage = 'phase_cleanup'
+        fold_kind = 'deepagent_memory_fold_local'
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        working_memory = @(
+            ('Requirement doc: {0}' -f $RequirementDocPath),
+            ('Execution plan: {0}' -f $ExecutionPlanPath),
+            ('Runtime status: {0}' -f [string]$manifest.status)
+        )
+        tool_memory = @(
+            ('Execution manifest: {0}' -f $ExecutionManifestPath),
+            ('Cleanup receipt: {0}' -f $CleanupReceiptPath)
+        )
+        evidence_anchors = @(
+            $RequirementDocPath,
+            $ExecutionPlanPath,
+            $ExecutionManifestPath,
+            $CleanupReceiptPath
+        )
+    }
+    $artifactPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'phase-cleanup-memory-fold.json'
+    Write-VibeJsonArtifact -Path $artifactPath -Value $fold
+
+    return [pscustomobject]@{
+        owner = 'state_store'
+        status = 'generated_local_fold'
+        item_count = @($fold.working_memory).Count + @($fold.tool_memory).Count
+        items = @($fold.working_memory + $fold.tool_memory)
+        artifact_path = $artifactPath
+    }
+}
+
+function New-VibeMemoryActivationReport {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [string]$RunId,
+        [Parameter(Mandatory)] [string]$SessionRoot,
+        [Parameter(Mandatory)] [object]$SkeletonDigestAction,
+        [Parameter(Mandatory)] [object]$DeepInterviewReadAction,
+        [Parameter(Mandatory)] [object]$RequirementContextPack,
+        [Parameter(Mandatory)] [object]$ExecuteWriteAction,
+        [Parameter(Mandatory)] [object]$CleanupDecisionAction,
+        [Parameter(Mandatory)] [object]$CleanupFoldAction
+    )
+
+    $stages = @(
+        [pscustomobject]@{
+            stage = 'skeleton_check'
+            read_actions = @($SkeletonDigestAction)
+            context_injection = $null
+            write_actions = @()
+        },
+        [pscustomobject]@{
+            stage = 'deep_interview'
+            read_actions = @($DeepInterviewReadAction)
+            context_injection = $null
+            write_actions = @()
+        },
+        [pscustomobject]@{
+            stage = 'requirement_doc'
+            read_actions = @()
+            context_injection = [pscustomobject]@{
+                injected_item_count = [int]$RequirementContextPack.injected_item_count
+                estimated_tokens = [int]$RequirementContextPack.estimated_tokens
+                budget = $RequirementContextPack.budget
+                artifact_path = [string]$RequirementContextPack.context_path
+            }
+            write_actions = @()
+        },
+        [pscustomobject]@{
+            stage = 'xl_plan'
+            read_actions = @()
+            context_injection = $null
+            write_actions = @()
+        },
+        [pscustomobject]@{
+            stage = 'plan_execute'
+            read_actions = @()
+            context_injection = $null
+            write_actions = @($ExecuteWriteAction)
+        },
+        [pscustomobject]@{
+            stage = 'phase_cleanup'
+            read_actions = @()
+            context_injection = $null
+            write_actions = @($CleanupDecisionAction, $CleanupFoldAction)
+        }
+    )
+
+    $artifactPaths = [System.Collections.Generic.List[string]]::new()
+    $fallbackEventCount = 0
+    $budgetGuardRespected = $true
+    foreach ($stage in @($stages)) {
+        foreach ($readAction in @($stage.read_actions)) {
+            if ($readAction.PSObject.Properties.Name -contains 'artifact_path' -and -not [string]::IsNullOrWhiteSpace([string]$readAction.artifact_path)) {
+                $artifactPaths.Add([string]$readAction.artifact_path) | Out-Null
+            }
+            if ([string]$readAction.status -match 'fallback|deferred|guarded|generated') {
+                $fallbackEventCount += 1
+            }
+            if ($readAction.PSObject.Properties.Name -contains 'budget' -and $readAction.PSObject.Properties.Name -contains 'items') {
+                if (@($readAction.items).Count -gt [int]$readAction.budget.top_k) {
+                    $budgetGuardRespected = $false
+                }
+            }
+        }
+
+        if ($null -ne $stage.context_injection) {
+            if (-not [string]::IsNullOrWhiteSpace([string]$stage.context_injection.artifact_path)) {
+                $artifactPaths.Add([string]$stage.context_injection.artifact_path) | Out-Null
+            }
+            if ([int]$stage.context_injection.estimated_tokens -gt [int]$stage.context_injection.budget.max_tokens) {
+                $budgetGuardRespected = $false
+            }
+        }
+
+        foreach ($writeAction in @($stage.write_actions)) {
+            if ($writeAction.PSObject.Properties.Name -contains 'artifact_path' -and -not [string]::IsNullOrWhiteSpace([string]$writeAction.artifact_path)) {
+                $artifactPaths.Add([string]$writeAction.artifact_path) | Out-Null
+            }
+            if ([string]$writeAction.status -match 'fallback|deferred|guarded|generated') {
+                $fallbackEventCount += 1
+            }
+        }
+    }
+
+    $owners = Get-VibeMemoryCanonicalOwners -Runtime $Runtime
+    $report = [pscustomobject]@{
+        run_id = $RunId
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        policy = [pscustomobject]@{
+            mode = [string]$Runtime.memory_runtime_v3_policy.mode
+            routing_contract = [string]$Runtime.memory_runtime_v3_policy.routing_contract
+            canonical_owners = [pscustomobject]$owners
+        }
+        stages = @($stages)
+        summary = [pscustomobject]@{
+            stage_count = @($stages).Count
+            fallback_event_count = $fallbackEventCount
+            artifact_count = @($artifactPaths | Select-Object -Unique).Count
+            budget_guard_respected = [bool]$budgetGuardRespected
+        }
+    }
+
+    $reportPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'memory-activation-report.json'
+    $markdownPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'memory-activation-report.md'
+    Write-VibeJsonArtifact -Path $reportPath -Value $report
+    Write-VibeMarkdownArtifact -Path $markdownPath -Lines @(
+        '# Memory Activation Report',
+        '',
+        ('- run_id: `{0}`' -f $RunId),
+        ('- mode: `{0}`' -f [string]$Runtime.memory_runtime_v3_policy.mode),
+        ('- routing_contract: `{0}`' -f [string]$Runtime.memory_runtime_v3_policy.routing_contract),
+        ('- fallback_event_count: `{0}`' -f [int]$report.summary.fallback_event_count),
+        ('- artifact_count: `{0}`' -f [int]$report.summary.artifact_count),
+        ('- budget_guard_respected: `{0}`' -f [bool]$report.summary.budget_guard_respected),
+        ''
+    )
+
+    return [pscustomobject]@{
+        report = $report
+        report_path = $reportPath
+        markdown_path = $markdownPath
+    }
+}

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/VibeRuntime.Common.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/VibeRuntime.Common.ps1
@@ -24,6 +24,11 @@ function Get-VibeRuntimeContext {
         benchmark_execution_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\benchmark-execution-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         cleanup_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\phase-cleanup-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         proof_class_registry = Get-Content -LiteralPath (Join-Path $repoRoot 'config\proof-class-registry.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_governance = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-governance.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_tier_router = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-tier-router.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_runtime_v3_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-runtime-v3-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_stage_activation_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-stage-activation-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_retrieval_budget_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-retrieval-budget-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
     }
 }
 

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Write-RequirementDoc.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Write-RequirementDoc.ps1
@@ -4,6 +4,7 @@ param(
     [string]$RunId = '',
     [string]$IntentContractPath = '',
     [string]$RuntimeInputPacketPath = '',
+    [string]$MemoryContextPath = '',
     [string]$ArtifactRoot = '',
     [AllowEmptyString()] [string]$GovernanceScope = '',
     [AllowEmptyString()] [string]$RootRunId = '',
@@ -120,6 +121,11 @@ $runtimeInputPacket = if (-not [string]::IsNullOrWhiteSpace($RuntimeInputPacketP
 } else {
     $null
 }
+$memoryContextPack = if (-not [string]::IsNullOrWhiteSpace($MemoryContextPath) -and (Test-Path -LiteralPath $MemoryContextPath)) {
+    Get-Content -LiteralPath $MemoryContextPath -Raw -Encoding UTF8 | ConvertFrom-Json
+} else {
+    $null
+}
 $lines = @(
     "# $($intentContract.title)",
     '',
@@ -224,6 +230,15 @@ if ($runtimeInputPacket) {
     }
 }
 
+if ($memoryContextPack -and @($memoryContextPack.items).Count -gt 0) {
+    $lines += @(
+        '',
+        '## Memory Context',
+        'Bounded stage-aware memory context injected into requirement freezing:'
+    )
+    $lines += @($memoryContextPack.items | ForEach-Object { "- $_" })
+}
+
 $childHandoffPath = $null
 if ($isChildScope) {
     if (-not (Test-Path -LiteralPath $docPath)) {
@@ -258,6 +273,9 @@ $receipt = [pscustomobject]@{
     canonical_write_allowed = -not $isChildScope
     inherited_requirement_doc_path = if ($isChildScope) { $docPath } else { $null }
     runtime_input_packet_path = $RuntimeInputPacketPath
+    memory_context_path = if ($memoryContextPack) { $MemoryContextPath } else { $null }
+    memory_context_item_count = if ($memoryContextPack) { @($memoryContextPack.items).Count } else { 0 }
+    memory_context_estimated_tokens = if ($memoryContextPack) { [int]$memoryContextPack.estimated_tokens } else { 0 }
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 }
 $receiptPath = Join-Path $sessionRoot 'requirement-doc-receipt.json'

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/invoke-vibe-runtime.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/invoke-vibe-runtime.ps1
@@ -18,6 +18,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'VibeRuntime.Common.ps1')
+. (Join-Path $PSScriptRoot 'VibeMemoryActivation.Common.ps1')
 
 function Wait-VibeArtifactSet {
     param(
@@ -105,6 +106,8 @@ if (-not [string]::IsNullOrWhiteSpace([string]$hierarchyState.inherited_executio
 }
 
 $skeleton = & (Join-Path $PSScriptRoot 'Invoke-SkeletonCheck.ps1') -Task $Task -Mode $Mode -RunId $RunId -ArtifactRoot $ArtifactRoot
+$memorySkeletonDigest = New-VibeSkeletonMemoryDigest -Runtime $runtime -Skeleton $skeleton -Task $Task -SessionRoot ([string]$skeleton.session_root)
+$requirementMemoryContext = New-VibeRequirementContextPack -Runtime $runtime -SkeletonDigestAction $memorySkeletonDigest -SessionRoot ([string]$skeleton.session_root)
 $freezeArgs = @{
     Task = $Task
     Mode = $Mode
@@ -123,6 +126,7 @@ $requirementArgs = @{
     RunId = $RunId
     IntentContractPath = $interview.receipt_path
     RuntimeInputPacketPath = $runtimeInput.packet_path
+    MemoryContextPath = $requirementMemoryContext.context_path
     ArtifactRoot = $ArtifactRoot
 }
 foreach ($key in @($hierarchyArgs.Keys)) {
@@ -158,6 +162,25 @@ foreach ($key in @('GovernanceScope', 'RootRunId', 'ParentRunId', 'ParentUnitId'
 }
 $execute = & (Join-Path $PSScriptRoot 'Invoke-PlanExecute.ps1') @executeArgs
 $cleanup = & (Join-Path $PSScriptRoot 'Invoke-PhaseCleanup.ps1') -Task $Task -Mode $Mode -RunId $RunId -ArtifactRoot $ArtifactRoot -ExecuteGovernanceCleanup:$ExecuteGovernanceCleanup -ApplyManagedNodeCleanup:$ApplyManagedNodeCleanup
+$memoryDeepInterviewRead = Get-VibeDeepInterviewMemoryReadAction -Runtime $runtime
+$memoryExecuteWrite = New-VibeExecutionMemoryWriteAction -ExecutionManifestPath ([string]$execute.execution_manifest_path) -SessionRoot ([string]$skeleton.session_root)
+$memoryCleanupDecision = Get-VibeCleanupDecisionWriteAction -RequirementDocPath ([string]$requirement.requirement_doc_path) -ExecutionPlanPath ([string]$plan.execution_plan_path)
+$memoryCleanupFold = New-VibeCleanupMemoryFold `
+    -RequirementDocPath ([string]$requirement.requirement_doc_path) `
+    -ExecutionPlanPath ([string]$plan.execution_plan_path) `
+    -ExecutionManifestPath ([string]$execute.execution_manifest_path) `
+    -CleanupReceiptPath ([string]$cleanup.receipt_path) `
+    -SessionRoot ([string]$skeleton.session_root)
+$memoryActivation = New-VibeMemoryActivationReport `
+    -Runtime $runtime `
+    -RunId $RunId `
+    -SessionRoot ([string]$skeleton.session_root) `
+    -SkeletonDigestAction $memorySkeletonDigest `
+    -DeepInterviewReadAction $memoryDeepInterviewRead `
+    -RequirementContextPack $requirementMemoryContext `
+    -ExecuteWriteAction $memoryExecuteWrite `
+    -CleanupDecisionAction $memoryCleanupDecision `
+    -CleanupFoldAction $memoryCleanupFold
 $deliveryAcceptanceReportPath = Join-Path $skeleton.session_root 'delivery-acceptance-report.json'
 $deliveryAcceptanceMarkdownPath = Join-Path $skeleton.session_root 'delivery-acceptance-report.md'
 
@@ -174,7 +197,9 @@ $artifactReadiness = Wait-VibeArtifactSet -Paths @(
     [string]$execute.execution_topology_path,
     [string]$execute.benchmark_proof_manifest_path,
     [string]$cleanup.receipt_path,
-    [string]$deliveryAcceptanceReportPath
+    [string]$deliveryAcceptanceReportPath,
+    [string]$memoryActivation.report_path,
+    [string]$memoryActivation.markdown_path
 )
 
 if (-not $artifactReadiness.ready) {
@@ -196,6 +221,8 @@ $relativeArtifacts = [ordered]@{
     cleanup_receipt = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$cleanup.receipt_path)
     delivery_acceptance_report = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$deliveryAcceptanceReportPath)
     delivery_acceptance_markdown = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$deliveryAcceptanceMarkdownPath)
+    memory_activation_report = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$memoryActivation.report_path)
+    memory_activation_markdown = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$memoryActivation.markdown_path)
 }
 
 $deliveryAcceptanceReport = if (Test-Path -LiteralPath $deliveryAcceptanceReportPath) {
@@ -243,6 +270,15 @@ $summary = [pscustomobject]@{
         cleanup_receipt = $cleanup.receipt_path
         delivery_acceptance_report = $deliveryAcceptanceReportPath
         delivery_acceptance_markdown = $deliveryAcceptanceMarkdownPath
+        memory_activation_report = $memoryActivation.report_path
+        memory_activation_markdown = $memoryActivation.markdown_path
+    }
+    memory_activation = [pscustomobject]@{
+        policy_mode = [string]$memoryActivation.report.policy.mode
+        routing_contract = [string]$memoryActivation.report.policy.routing_contract
+        fallback_event_count = [int]$memoryActivation.report.summary.fallback_event_count
+        artifact_count = [int]$memoryActivation.report.summary.artifact_count
+        budget_guard_respected = [bool]$memoryActivation.report.summary.budget_guard_respected
     }
     delivery_acceptance = if ($deliveryAcceptanceReport) {
         [pscustomobject]@{

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/runtime_neutral/freshness_gate.py
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/verify/runtime_neutral/freshness_gate.py
@@ -211,11 +211,22 @@ def runtime_config(governance: dict[str, Any]) -> dict[str, Any]:
     return merged
 
 
+def installed_runtime_materialized(repo_root: Path, runtime_cfg: dict[str, Any]) -> bool:
+    required_markers = list(runtime_cfg.get("required_runtime_markers") or [])
+    if not required_markers:
+        return False
+    return all((repo_root / marker).exists() for marker in required_markers)
+
+
 def enforce_execution_context(context: GovernanceContext, script_path: Path) -> None:
     policy = context.governance.get("execution_context_policy") or {}
     require_outer_git_root = bool(policy.get("require_outer_git_root", True))
     fail_if_under_mirror = bool(policy.get("fail_if_script_path_is_under_mirror_root", True))
-    if require_outer_git_root and not (context.repo_root / ".git").exists():
+    if (
+        require_outer_git_root
+        and not (context.repo_root / ".git").exists()
+        and not installed_runtime_materialized(context.repo_root, context.runtime_config)
+    ):
         raise RuntimeError(
             f"Execution-context lock failed: resolved repo root is not the outer git root -> {context.repo_root}"
         )

--- a/bundled/skills/vibe/config/memory-retrieval-budget-policy.json
+++ b/bundled/skills/vibe/config/memory-retrieval-budget-policy.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "updated": "2026-03-28",
+  "defaults": {
+    "top_k": 3,
+    "max_tokens": 120,
+    "max_chars_per_item": 240
+  },
+  "stages": {
+    "skeleton_check": {
+      "top_k": 3,
+      "max_tokens": 96,
+      "max_chars_per_item": 220
+    },
+    "requirement_doc": {
+      "top_k": 2,
+      "max_tokens": 120,
+      "max_chars_per_item": 260
+    },
+    "phase_cleanup": {
+      "top_k": 2,
+      "max_tokens": 160,
+      "max_chars_per_item": 320
+    }
+  }
+}

--- a/bundled/skills/vibe/config/memory-stage-activation-policy.json
+++ b/bundled/skills/vibe/config/memory-stage-activation-policy.json
@@ -1,0 +1,76 @@
+{
+  "version": 1,
+  "updated": "2026-03-28",
+  "enabled": true,
+  "fallback_mode": "local_first_audited",
+  "stages": [
+    {
+      "stage": "skeleton_check",
+      "read_actions": [
+        {
+          "owner": "state_store",
+          "status": "fallback_local_digest",
+          "artifact_kind": "local_digest"
+        }
+      ],
+      "write_actions": []
+    },
+    {
+      "stage": "deep_interview",
+      "read_actions": [
+        {
+          "owner": "serena",
+          "status_if_missing_project_key": "deferred_no_project_key",
+          "project_key_env": [
+            "VIBE_SERENA_PROJECT_KEY",
+            "SERENA_PROJECT_KEY"
+          ]
+        }
+      ],
+      "write_actions": []
+    },
+    {
+      "stage": "requirement_doc",
+      "read_actions": [
+        {
+          "owner": "state_store",
+          "status": "bounded_context_injection",
+          "artifact_kind": "context_pack"
+        }
+      ],
+      "write_actions": []
+    },
+    {
+      "stage": "xl_plan",
+      "read_actions": [],
+      "write_actions": []
+    },
+    {
+      "stage": "plan_execute",
+      "read_actions": [],
+      "write_actions": [
+        {
+          "owner": "state_store",
+          "status": "fallback_local_artifact",
+          "artifact_kind": "execution_handoff_card"
+        }
+      ]
+    },
+    {
+      "stage": "phase_cleanup",
+      "read_actions": [],
+      "write_actions": [
+        {
+          "owner": "serena",
+          "status": "guarded_no_write",
+          "artifact_kind": "project_decision_gate"
+        },
+        {
+          "owner": "state_store",
+          "status": "generated_local_fold",
+          "artifact_kind": "memory_fold"
+        }
+      ]
+    }
+  ]
+}

--- a/bundled/skills/vibe/scripts/common/vibe-governance-helpers.ps1
+++ b/bundled/skills/vibe/scripts/common/vibe-governance-helpers.ps1
@@ -1038,6 +1038,38 @@ function Get-VgoLegacySourceOfTruthCompatibility {
     }
 }
 
+function Test-VgoInstalledRuntimeMaterialization {
+    param(
+        [AllowEmptyString()] [string]$RepoRoot,
+        [AllowNull()] [psobject]$RuntimeConfig
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RepoRoot) -or $null -eq $RuntimeConfig) {
+        return $false
+    }
+
+    $requiredMarkers = @()
+    if ($RuntimeConfig.PSObject.Properties.Name -contains 'required_runtime_markers' -and $null -ne $RuntimeConfig.required_runtime_markers) {
+        $requiredMarkers = @($RuntimeConfig.required_runtime_markers)
+    }
+    if (@($requiredMarkers).Count -eq 0) {
+        return $false
+    }
+
+    foreach ($marker in @($requiredMarkers)) {
+        if ([string]::IsNullOrWhiteSpace([string]$marker)) {
+            continue
+        }
+
+        $markerPath = Join-Path $RepoRoot ([string]$marker)
+        if (-not (Test-Path -LiteralPath $markerPath)) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
 function Assert-VgoCanonicalExecutionContext {
     param(
         [Parameter(Mandatory)] [psobject]$Context
@@ -1056,7 +1088,9 @@ function Assert-VgoCanonicalExecutionContext {
         }
     }
 
-    if ($requireOuterGitRoot -and -not (Test-Path -LiteralPath (Join-Path $Context.repoRoot '.git'))) {
+    $hasOuterGitRoot = (Test-Path -LiteralPath (Join-Path $Context.repoRoot '.git'))
+    $hasInstalledRuntimeMaterialization = Test-VgoInstalledRuntimeMaterialization -RepoRoot ([string]$Context.repoRoot) -RuntimeConfig $Context.runtimeConfig
+    if ($requireOuterGitRoot -and -not $hasOuterGitRoot -and -not $hasInstalledRuntimeMaterialization) {
         throw "Execution-context lock failed: resolved repo root is not the outer git root -> $($Context.repoRoot)"
     }
 

--- a/bundled/skills/vibe/scripts/runtime/VibeMemoryActivation.Common.ps1
+++ b/bundled/skills/vibe/scripts/runtime/VibeMemoryActivation.Common.ps1
@@ -1,0 +1,469 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-VibeMemoryArtifactsRoot {
+    param(
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $path = Join-Path $SessionRoot 'memory-activation'
+    New-Item -ItemType Directory -Path $path -Force | Out-Null
+    return $path
+}
+
+function Get-VibeMemoryBudgetSpec {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [string]$Stage
+    )
+
+    $defaults = $Runtime.memory_retrieval_budget_policy.defaults
+    $topK = [int]$defaults.top_k
+    $maxTokens = [int]$defaults.max_tokens
+    $maxCharsPerItem = [int]$defaults.max_chars_per_item
+
+    if ($Runtime.memory_retrieval_budget_policy.stages.PSObject.Properties.Name -contains $Stage) {
+        $stageBudget = $Runtime.memory_retrieval_budget_policy.stages.$Stage
+        if ($null -ne $stageBudget.top_k) {
+            $topK = [int]$stageBudget.top_k
+        }
+        if ($null -ne $stageBudget.max_tokens) {
+            $maxTokens = [int]$stageBudget.max_tokens
+        }
+        if ($null -ne $stageBudget.max_chars_per_item) {
+            $maxCharsPerItem = [int]$stageBudget.max_chars_per_item
+        }
+    }
+
+    return [pscustomobject]@{
+        top_k = $topK
+        max_tokens = $maxTokens
+        max_chars_per_item = $maxCharsPerItem
+    }
+}
+
+function Get-VibeMemoryCanonicalOwners {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime
+    )
+
+    $owners = $Runtime.memory_runtime_v3_policy.canonical_owners
+    return [ordered]@{
+        session = [string]$owners.session
+        project_decision = switch ([string]$owners.project_decision) {
+            'serena' { 'Serena' }
+            default { [string]$owners.project_decision }
+        }
+        short_term_semantic = [string]$owners.short_term_semantic
+        long_term_graph = switch ([string]$owners.long_term_graph) {
+            'cognee' { 'Cognee' }
+            default { [string]$owners.long_term_graph }
+        }
+    }
+}
+
+function Get-VibeMemoryStagePolicy {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [string]$Stage
+    )
+
+    foreach ($stagePolicy in @($Runtime.memory_stage_activation_policy.stages)) {
+        if ([string]$stagePolicy.stage -eq $Stage) {
+            return $stagePolicy
+        }
+    }
+
+    throw "Missing memory stage policy for stage: $Stage"
+}
+
+function Get-VibeBoundedMemoryItems {
+    param(
+        [AllowEmptyCollection()] [string[]]$Items = @(),
+        [Parameter(Mandatory)] [object]$Budget
+    )
+
+    $bounded = [System.Collections.Generic.List[string]]::new()
+    foreach ($item in @($Items)) {
+        if ([string]::IsNullOrWhiteSpace($item)) {
+            continue
+        }
+        if ($bounded.Count -ge [int]$Budget.top_k) {
+            break
+        }
+
+        $text = [string]$item
+        if ($text.Length -gt [int]$Budget.max_chars_per_item) {
+            $text = $text.Substring(0, [int]$Budget.max_chars_per_item).TrimEnd() + '...'
+        }
+        $bounded.Add($text) | Out-Null
+    }
+    return @($bounded)
+}
+
+function Get-VibeEstimatedTokenCount {
+    param(
+        [AllowEmptyCollection()] [string[]]$Items = @()
+    )
+
+    $charCount = 0
+    foreach ($item in @($Items)) {
+        $charCount += ([string]$item).Length
+    }
+
+    if ($charCount -le 0) {
+        return 0
+    }
+
+    return [int][Math]::Ceiling($charCount / 4.0)
+}
+
+function New-VibeSkeletonMemoryDigest {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [object]$Skeleton,
+        [Parameter(Mandatory)] [string]$Task,
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $budget = Get-VibeMemoryBudgetSpec -Runtime $Runtime -Stage 'skeleton_check'
+    $receipt = $Skeleton.receipt
+    $missingPaths = @($receipt.required_paths | Where-Object { -not [bool]$_.exists } | ForEach-Object { [string]$_.path })
+    $requirementDocs = @($receipt.existing_requirement_docs | Select-Object -First 5)
+    $planDocs = @($receipt.existing_plan_docs | Select-Object -First 5)
+
+    $items = @()
+    $items += ('Task focus: {0}' -f $Task)
+    $items += ('Git branch: {0}' -f [string]$receipt.git_branch)
+    if (@($missingPaths).Count -gt 0) {
+        $items += 'Missing runtime prerequisites: ' + (@($missingPaths) -join ', ')
+    } else {
+        $items += 'All required governed runtime prerequisite paths are present.'
+    }
+    if (@($requirementDocs).Count -gt 0) {
+        $items += 'Existing requirement docs: ' + (@($requirementDocs) -join ', ')
+    } else {
+        $items += 'Existing requirement docs: none'
+    }
+    if (@($planDocs).Count -gt 0) {
+        $items += 'Existing plan docs: ' + (@($planDocs) -join ', ')
+    } else {
+        $items += 'Existing plan docs: none'
+    }
+
+    $boundedItems = Get-VibeBoundedMemoryItems -Items $items -Budget $budget
+    $artifactPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'skeleton-local-digest.json'
+    $artifact = [pscustomobject]@{
+        stage = 'skeleton_check'
+        owner = 'state_store'
+        status = 'fallback_local_digest'
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        source_receipt_path = [string]$Skeleton.receipt_path
+        items = @($boundedItems)
+        budget = $budget
+    }
+    Write-VibeJsonArtifact -Path $artifactPath -Value $artifact
+
+    return [pscustomobject]@{
+        owner = 'state_store'
+        status = 'fallback_local_digest'
+        item_count = @($boundedItems).Count
+        items = @($boundedItems)
+        artifact_path = $artifactPath
+        budget = $budget
+    }
+}
+
+function Get-VibeDeepInterviewMemoryReadAction {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime
+    )
+
+    $stagePolicy = Get-VibeMemoryStagePolicy -Runtime $Runtime -Stage 'deep_interview'
+    $readPolicy = @($stagePolicy.read_actions)[0]
+    $projectKeyEnv = @($readPolicy.project_key_env)
+    $projectKeyName = $null
+    foreach ($envName in $projectKeyEnv) {
+        $value = [Environment]::GetEnvironmentVariable([string]$envName)
+        if (-not [string]::IsNullOrWhiteSpace($value)) {
+            $projectKeyName = [string]$envName
+            break
+        }
+    }
+
+    return [pscustomobject]@{
+        owner = 'Serena'
+        status = if ($null -eq $projectKeyName) { [string]$readPolicy.status_if_missing_project_key } else { 'backend_key_available' }
+        item_count = 0
+        items = @()
+        project_key_env = if ($null -eq $projectKeyName) { $null } else { $projectKeyName }
+    }
+}
+
+function New-VibeRequirementContextPack {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [object]$SkeletonDigestAction,
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $budget = Get-VibeMemoryBudgetSpec -Runtime $Runtime -Stage 'requirement_doc'
+    $boundedItems = Get-VibeBoundedMemoryItems -Items @($SkeletonDigestAction.items) -Budget $budget
+    $estimatedTokens = Get-VibeEstimatedTokenCount -Items @($boundedItems)
+    $artifactPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'requirement-context-pack.json'
+    $artifact = [pscustomobject]@{
+        stage = 'requirement_doc'
+        source_stage = 'skeleton_check'
+        owner = 'state_store'
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        items = @($boundedItems)
+        estimated_tokens = $estimatedTokens
+        budget = $budget
+    }
+    Write-VibeJsonArtifact -Path $artifactPath -Value $artifact
+
+    return [pscustomobject]@{
+        context_path = $artifactPath
+        injected_item_count = @($boundedItems).Count
+        estimated_tokens = $estimatedTokens
+        budget = $budget
+        items = @($boundedItems)
+    }
+}
+
+function New-VibeExecutionMemoryWriteAction {
+    param(
+        [Parameter(Mandatory)] [string]$ExecutionManifestPath,
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $manifest = Get-Content -LiteralPath $ExecutionManifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $items = @(
+        ('Execution status: {0}' -f [string]$manifest.status),
+        ('Executed units: {0}; failures: {1}' -f [int]$manifest.executed_unit_count, [int]$manifest.failed_unit_count),
+        ('Specialist execution status: {0}' -f [string]$manifest.specialist_accounting.effective_execution_status)
+    )
+    $artifactPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'execution-handoff-card.json'
+    $artifact = [pscustomobject]@{
+        stage = 'plan_execute'
+        owner = 'state_store'
+        status = 'fallback_local_artifact'
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        source_execution_manifest = $ExecutionManifestPath
+        items = @($items)
+    }
+    Write-VibeJsonArtifact -Path $artifactPath -Value $artifact
+
+    return [pscustomobject]@{
+        owner = 'state_store'
+        status = 'fallback_local_artifact'
+        item_count = @($items).Count
+        items = @($items)
+        artifact_path = $artifactPath
+    }
+}
+
+function Get-VibeCleanupDecisionWriteAction {
+    param(
+        [Parameter(Mandatory)] [string]$RequirementDocPath,
+        [Parameter(Mandatory)] [string]$ExecutionPlanPath
+    )
+
+    $requirementText = if (Test-Path -LiteralPath $RequirementDocPath) {
+        Get-Content -LiteralPath $RequirementDocPath -Raw -Encoding UTF8
+    } else {
+        ''
+    }
+    $planText = if (Test-Path -LiteralPath $ExecutionPlanPath) {
+        Get-Content -LiteralPath $ExecutionPlanPath -Raw -Encoding UTF8
+    } else {
+        ''
+    }
+    $combined = "$requirementText`n$planText"
+    $hasExplicitDecision = $combined -match 'approved decision|decision record|adr-|## decision'
+
+    return [pscustomobject]@{
+        owner = 'Serena'
+        status = if ($hasExplicitDecision) { 'backend_write_candidate' } else { 'guarded_no_write' }
+        item_count = 0
+        items = @()
+        artifact_path = $null
+        reason = if ($hasExplicitDecision) { 'explicit decision markers detected' } else { 'no explicit approved decision markers detected in frozen requirement/plan surfaces' }
+    }
+}
+
+function New-VibeCleanupMemoryFold {
+    param(
+        [Parameter(Mandatory)] [string]$RequirementDocPath,
+        [Parameter(Mandatory)] [string]$ExecutionPlanPath,
+        [Parameter(Mandatory)] [string]$ExecutionManifestPath,
+        [Parameter(Mandatory)] [string]$CleanupReceiptPath,
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $manifest = Get-Content -LiteralPath $ExecutionManifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $fold = [pscustomobject]@{
+        stage = 'phase_cleanup'
+        fold_kind = 'deepagent_memory_fold_local'
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        working_memory = @(
+            ('Requirement doc: {0}' -f $RequirementDocPath),
+            ('Execution plan: {0}' -f $ExecutionPlanPath),
+            ('Runtime status: {0}' -f [string]$manifest.status)
+        )
+        tool_memory = @(
+            ('Execution manifest: {0}' -f $ExecutionManifestPath),
+            ('Cleanup receipt: {0}' -f $CleanupReceiptPath)
+        )
+        evidence_anchors = @(
+            $RequirementDocPath,
+            $ExecutionPlanPath,
+            $ExecutionManifestPath,
+            $CleanupReceiptPath
+        )
+    }
+    $artifactPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'phase-cleanup-memory-fold.json'
+    Write-VibeJsonArtifact -Path $artifactPath -Value $fold
+
+    return [pscustomobject]@{
+        owner = 'state_store'
+        status = 'generated_local_fold'
+        item_count = @($fold.working_memory).Count + @($fold.tool_memory).Count
+        items = @($fold.working_memory + $fold.tool_memory)
+        artifact_path = $artifactPath
+    }
+}
+
+function New-VibeMemoryActivationReport {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [string]$RunId,
+        [Parameter(Mandatory)] [string]$SessionRoot,
+        [Parameter(Mandatory)] [object]$SkeletonDigestAction,
+        [Parameter(Mandatory)] [object]$DeepInterviewReadAction,
+        [Parameter(Mandatory)] [object]$RequirementContextPack,
+        [Parameter(Mandatory)] [object]$ExecuteWriteAction,
+        [Parameter(Mandatory)] [object]$CleanupDecisionAction,
+        [Parameter(Mandatory)] [object]$CleanupFoldAction
+    )
+
+    $stages = @(
+        [pscustomobject]@{
+            stage = 'skeleton_check'
+            read_actions = @($SkeletonDigestAction)
+            context_injection = $null
+            write_actions = @()
+        },
+        [pscustomobject]@{
+            stage = 'deep_interview'
+            read_actions = @($DeepInterviewReadAction)
+            context_injection = $null
+            write_actions = @()
+        },
+        [pscustomobject]@{
+            stage = 'requirement_doc'
+            read_actions = @()
+            context_injection = [pscustomobject]@{
+                injected_item_count = [int]$RequirementContextPack.injected_item_count
+                estimated_tokens = [int]$RequirementContextPack.estimated_tokens
+                budget = $RequirementContextPack.budget
+                artifact_path = [string]$RequirementContextPack.context_path
+            }
+            write_actions = @()
+        },
+        [pscustomobject]@{
+            stage = 'xl_plan'
+            read_actions = @()
+            context_injection = $null
+            write_actions = @()
+        },
+        [pscustomobject]@{
+            stage = 'plan_execute'
+            read_actions = @()
+            context_injection = $null
+            write_actions = @($ExecuteWriteAction)
+        },
+        [pscustomobject]@{
+            stage = 'phase_cleanup'
+            read_actions = @()
+            context_injection = $null
+            write_actions = @($CleanupDecisionAction, $CleanupFoldAction)
+        }
+    )
+
+    $artifactPaths = [System.Collections.Generic.List[string]]::new()
+    $fallbackEventCount = 0
+    $budgetGuardRespected = $true
+    foreach ($stage in @($stages)) {
+        foreach ($readAction in @($stage.read_actions)) {
+            if ($readAction.PSObject.Properties.Name -contains 'artifact_path' -and -not [string]::IsNullOrWhiteSpace([string]$readAction.artifact_path)) {
+                $artifactPaths.Add([string]$readAction.artifact_path) | Out-Null
+            }
+            if ([string]$readAction.status -match 'fallback|deferred|guarded|generated') {
+                $fallbackEventCount += 1
+            }
+            if ($readAction.PSObject.Properties.Name -contains 'budget' -and $readAction.PSObject.Properties.Name -contains 'items') {
+                if (@($readAction.items).Count -gt [int]$readAction.budget.top_k) {
+                    $budgetGuardRespected = $false
+                }
+            }
+        }
+
+        if ($null -ne $stage.context_injection) {
+            if (-not [string]::IsNullOrWhiteSpace([string]$stage.context_injection.artifact_path)) {
+                $artifactPaths.Add([string]$stage.context_injection.artifact_path) | Out-Null
+            }
+            if ([int]$stage.context_injection.estimated_tokens -gt [int]$stage.context_injection.budget.max_tokens) {
+                $budgetGuardRespected = $false
+            }
+        }
+
+        foreach ($writeAction in @($stage.write_actions)) {
+            if ($writeAction.PSObject.Properties.Name -contains 'artifact_path' -and -not [string]::IsNullOrWhiteSpace([string]$writeAction.artifact_path)) {
+                $artifactPaths.Add([string]$writeAction.artifact_path) | Out-Null
+            }
+            if ([string]$writeAction.status -match 'fallback|deferred|guarded|generated') {
+                $fallbackEventCount += 1
+            }
+        }
+    }
+
+    $owners = Get-VibeMemoryCanonicalOwners -Runtime $Runtime
+    $report = [pscustomobject]@{
+        run_id = $RunId
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        policy = [pscustomobject]@{
+            mode = [string]$Runtime.memory_runtime_v3_policy.mode
+            routing_contract = [string]$Runtime.memory_runtime_v3_policy.routing_contract
+            canonical_owners = [pscustomobject]$owners
+        }
+        stages = @($stages)
+        summary = [pscustomobject]@{
+            stage_count = @($stages).Count
+            fallback_event_count = $fallbackEventCount
+            artifact_count = @($artifactPaths | Select-Object -Unique).Count
+            budget_guard_respected = [bool]$budgetGuardRespected
+        }
+    }
+
+    $reportPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'memory-activation-report.json'
+    $markdownPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'memory-activation-report.md'
+    Write-VibeJsonArtifact -Path $reportPath -Value $report
+    Write-VibeMarkdownArtifact -Path $markdownPath -Lines @(
+        '# Memory Activation Report',
+        '',
+        ('- run_id: `{0}`' -f $RunId),
+        ('- mode: `{0}`' -f [string]$Runtime.memory_runtime_v3_policy.mode),
+        ('- routing_contract: `{0}`' -f [string]$Runtime.memory_runtime_v3_policy.routing_contract),
+        ('- fallback_event_count: `{0}`' -f [int]$report.summary.fallback_event_count),
+        ('- artifact_count: `{0}`' -f [int]$report.summary.artifact_count),
+        ('- budget_guard_respected: `{0}`' -f [bool]$report.summary.budget_guard_respected),
+        ''
+    )
+
+    return [pscustomobject]@{
+        report = $report
+        report_path = $reportPath
+        markdown_path = $markdownPath
+    }
+}

--- a/bundled/skills/vibe/scripts/runtime/VibeRuntime.Common.ps1
+++ b/bundled/skills/vibe/scripts/runtime/VibeRuntime.Common.ps1
@@ -24,6 +24,11 @@ function Get-VibeRuntimeContext {
         benchmark_execution_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\benchmark-execution-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         cleanup_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\phase-cleanup-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         proof_class_registry = Get-Content -LiteralPath (Join-Path $repoRoot 'config\proof-class-registry.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_governance = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-governance.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_tier_router = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-tier-router.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_runtime_v3_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-runtime-v3-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_stage_activation_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-stage-activation-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_retrieval_budget_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-retrieval-budget-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
     }
 }
 

--- a/bundled/skills/vibe/scripts/runtime/Write-RequirementDoc.ps1
+++ b/bundled/skills/vibe/scripts/runtime/Write-RequirementDoc.ps1
@@ -4,6 +4,7 @@ param(
     [string]$RunId = '',
     [string]$IntentContractPath = '',
     [string]$RuntimeInputPacketPath = '',
+    [string]$MemoryContextPath = '',
     [string]$ArtifactRoot = '',
     [AllowEmptyString()] [string]$GovernanceScope = '',
     [AllowEmptyString()] [string]$RootRunId = '',
@@ -120,6 +121,11 @@ $runtimeInputPacket = if (-not [string]::IsNullOrWhiteSpace($RuntimeInputPacketP
 } else {
     $null
 }
+$memoryContextPack = if (-not [string]::IsNullOrWhiteSpace($MemoryContextPath) -and (Test-Path -LiteralPath $MemoryContextPath)) {
+    Get-Content -LiteralPath $MemoryContextPath -Raw -Encoding UTF8 | ConvertFrom-Json
+} else {
+    $null
+}
 $lines = @(
     "# $($intentContract.title)",
     '',
@@ -224,6 +230,15 @@ if ($runtimeInputPacket) {
     }
 }
 
+if ($memoryContextPack -and @($memoryContextPack.items).Count -gt 0) {
+    $lines += @(
+        '',
+        '## Memory Context',
+        'Bounded stage-aware memory context injected into requirement freezing:'
+    )
+    $lines += @($memoryContextPack.items | ForEach-Object { "- $_" })
+}
+
 $childHandoffPath = $null
 if ($isChildScope) {
     if (-not (Test-Path -LiteralPath $docPath)) {
@@ -258,6 +273,9 @@ $receipt = [pscustomobject]@{
     canonical_write_allowed = -not $isChildScope
     inherited_requirement_doc_path = if ($isChildScope) { $docPath } else { $null }
     runtime_input_packet_path = $RuntimeInputPacketPath
+    memory_context_path = if ($memoryContextPack) { $MemoryContextPath } else { $null }
+    memory_context_item_count = if ($memoryContextPack) { @($memoryContextPack.items).Count } else { 0 }
+    memory_context_estimated_tokens = if ($memoryContextPack) { [int]$memoryContextPack.estimated_tokens } else { 0 }
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 }
 $receiptPath = Join-Path $sessionRoot 'requirement-doc-receipt.json'

--- a/bundled/skills/vibe/scripts/runtime/invoke-vibe-runtime.ps1
+++ b/bundled/skills/vibe/scripts/runtime/invoke-vibe-runtime.ps1
@@ -18,6 +18,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'VibeRuntime.Common.ps1')
+. (Join-Path $PSScriptRoot 'VibeMemoryActivation.Common.ps1')
 
 function Wait-VibeArtifactSet {
     param(
@@ -105,6 +106,8 @@ if (-not [string]::IsNullOrWhiteSpace([string]$hierarchyState.inherited_executio
 }
 
 $skeleton = & (Join-Path $PSScriptRoot 'Invoke-SkeletonCheck.ps1') -Task $Task -Mode $Mode -RunId $RunId -ArtifactRoot $ArtifactRoot
+$memorySkeletonDigest = New-VibeSkeletonMemoryDigest -Runtime $runtime -Skeleton $skeleton -Task $Task -SessionRoot ([string]$skeleton.session_root)
+$requirementMemoryContext = New-VibeRequirementContextPack -Runtime $runtime -SkeletonDigestAction $memorySkeletonDigest -SessionRoot ([string]$skeleton.session_root)
 $freezeArgs = @{
     Task = $Task
     Mode = $Mode
@@ -123,6 +126,7 @@ $requirementArgs = @{
     RunId = $RunId
     IntentContractPath = $interview.receipt_path
     RuntimeInputPacketPath = $runtimeInput.packet_path
+    MemoryContextPath = $requirementMemoryContext.context_path
     ArtifactRoot = $ArtifactRoot
 }
 foreach ($key in @($hierarchyArgs.Keys)) {
@@ -158,6 +162,25 @@ foreach ($key in @('GovernanceScope', 'RootRunId', 'ParentRunId', 'ParentUnitId'
 }
 $execute = & (Join-Path $PSScriptRoot 'Invoke-PlanExecute.ps1') @executeArgs
 $cleanup = & (Join-Path $PSScriptRoot 'Invoke-PhaseCleanup.ps1') -Task $Task -Mode $Mode -RunId $RunId -ArtifactRoot $ArtifactRoot -ExecuteGovernanceCleanup:$ExecuteGovernanceCleanup -ApplyManagedNodeCleanup:$ApplyManagedNodeCleanup
+$memoryDeepInterviewRead = Get-VibeDeepInterviewMemoryReadAction -Runtime $runtime
+$memoryExecuteWrite = New-VibeExecutionMemoryWriteAction -ExecutionManifestPath ([string]$execute.execution_manifest_path) -SessionRoot ([string]$skeleton.session_root)
+$memoryCleanupDecision = Get-VibeCleanupDecisionWriteAction -RequirementDocPath ([string]$requirement.requirement_doc_path) -ExecutionPlanPath ([string]$plan.execution_plan_path)
+$memoryCleanupFold = New-VibeCleanupMemoryFold `
+    -RequirementDocPath ([string]$requirement.requirement_doc_path) `
+    -ExecutionPlanPath ([string]$plan.execution_plan_path) `
+    -ExecutionManifestPath ([string]$execute.execution_manifest_path) `
+    -CleanupReceiptPath ([string]$cleanup.receipt_path) `
+    -SessionRoot ([string]$skeleton.session_root)
+$memoryActivation = New-VibeMemoryActivationReport `
+    -Runtime $runtime `
+    -RunId $RunId `
+    -SessionRoot ([string]$skeleton.session_root) `
+    -SkeletonDigestAction $memorySkeletonDigest `
+    -DeepInterviewReadAction $memoryDeepInterviewRead `
+    -RequirementContextPack $requirementMemoryContext `
+    -ExecuteWriteAction $memoryExecuteWrite `
+    -CleanupDecisionAction $memoryCleanupDecision `
+    -CleanupFoldAction $memoryCleanupFold
 $deliveryAcceptanceReportPath = Join-Path $skeleton.session_root 'delivery-acceptance-report.json'
 $deliveryAcceptanceMarkdownPath = Join-Path $skeleton.session_root 'delivery-acceptance-report.md'
 
@@ -174,7 +197,9 @@ $artifactReadiness = Wait-VibeArtifactSet -Paths @(
     [string]$execute.execution_topology_path,
     [string]$execute.benchmark_proof_manifest_path,
     [string]$cleanup.receipt_path,
-    [string]$deliveryAcceptanceReportPath
+    [string]$deliveryAcceptanceReportPath,
+    [string]$memoryActivation.report_path,
+    [string]$memoryActivation.markdown_path
 )
 
 if (-not $artifactReadiness.ready) {
@@ -196,6 +221,8 @@ $relativeArtifacts = [ordered]@{
     cleanup_receipt = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$cleanup.receipt_path)
     delivery_acceptance_report = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$deliveryAcceptanceReportPath)
     delivery_acceptance_markdown = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$deliveryAcceptanceMarkdownPath)
+    memory_activation_report = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$memoryActivation.report_path)
+    memory_activation_markdown = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$memoryActivation.markdown_path)
 }
 
 $deliveryAcceptanceReport = if (Test-Path -LiteralPath $deliveryAcceptanceReportPath) {
@@ -243,6 +270,15 @@ $summary = [pscustomobject]@{
         cleanup_receipt = $cleanup.receipt_path
         delivery_acceptance_report = $deliveryAcceptanceReportPath
         delivery_acceptance_markdown = $deliveryAcceptanceMarkdownPath
+        memory_activation_report = $memoryActivation.report_path
+        memory_activation_markdown = $memoryActivation.markdown_path
+    }
+    memory_activation = [pscustomobject]@{
+        policy_mode = [string]$memoryActivation.report.policy.mode
+        routing_contract = [string]$memoryActivation.report.policy.routing_contract
+        fallback_event_count = [int]$memoryActivation.report.summary.fallback_event_count
+        artifact_count = [int]$memoryActivation.report.summary.artifact_count
+        budget_guard_respected = [bool]$memoryActivation.report.summary.budget_guard_respected
     }
     delivery_acceptance = if ($deliveryAcceptanceReport) {
         [pscustomobject]@{

--- a/bundled/skills/vibe/scripts/verify/runtime_neutral/freshness_gate.py
+++ b/bundled/skills/vibe/scripts/verify/runtime_neutral/freshness_gate.py
@@ -211,11 +211,22 @@ def runtime_config(governance: dict[str, Any]) -> dict[str, Any]:
     return merged
 
 
+def installed_runtime_materialized(repo_root: Path, runtime_cfg: dict[str, Any]) -> bool:
+    required_markers = list(runtime_cfg.get("required_runtime_markers") or [])
+    if not required_markers:
+        return False
+    return all((repo_root / marker).exists() for marker in required_markers)
+
+
 def enforce_execution_context(context: GovernanceContext, script_path: Path) -> None:
     policy = context.governance.get("execution_context_policy") or {}
     require_outer_git_root = bool(policy.get("require_outer_git_root", True))
     fail_if_under_mirror = bool(policy.get("fail_if_script_path_is_under_mirror_root", True))
-    if require_outer_git_root and not (context.repo_root / ".git").exists():
+    if (
+        require_outer_git_root
+        and not (context.repo_root / ".git").exists()
+        and not installed_runtime_materialized(context.repo_root, context.runtime_config)
+    ):
         raise RuntimeError(
             f"Execution-context lock failed: resolved repo root is not the outer git root -> {context.repo_root}"
         )

--- a/config/memory-retrieval-budget-policy.json
+++ b/config/memory-retrieval-budget-policy.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "updated": "2026-03-28",
+  "defaults": {
+    "top_k": 3,
+    "max_tokens": 120,
+    "max_chars_per_item": 240
+  },
+  "stages": {
+    "skeleton_check": {
+      "top_k": 3,
+      "max_tokens": 96,
+      "max_chars_per_item": 220
+    },
+    "requirement_doc": {
+      "top_k": 2,
+      "max_tokens": 120,
+      "max_chars_per_item": 260
+    },
+    "phase_cleanup": {
+      "top_k": 2,
+      "max_tokens": 160,
+      "max_chars_per_item": 320
+    }
+  }
+}

--- a/config/memory-stage-activation-policy.json
+++ b/config/memory-stage-activation-policy.json
@@ -1,0 +1,76 @@
+{
+  "version": 1,
+  "updated": "2026-03-28",
+  "enabled": true,
+  "fallback_mode": "local_first_audited",
+  "stages": [
+    {
+      "stage": "skeleton_check",
+      "read_actions": [
+        {
+          "owner": "state_store",
+          "status": "fallback_local_digest",
+          "artifact_kind": "local_digest"
+        }
+      ],
+      "write_actions": []
+    },
+    {
+      "stage": "deep_interview",
+      "read_actions": [
+        {
+          "owner": "serena",
+          "status_if_missing_project_key": "deferred_no_project_key",
+          "project_key_env": [
+            "VIBE_SERENA_PROJECT_KEY",
+            "SERENA_PROJECT_KEY"
+          ]
+        }
+      ],
+      "write_actions": []
+    },
+    {
+      "stage": "requirement_doc",
+      "read_actions": [
+        {
+          "owner": "state_store",
+          "status": "bounded_context_injection",
+          "artifact_kind": "context_pack"
+        }
+      ],
+      "write_actions": []
+    },
+    {
+      "stage": "xl_plan",
+      "read_actions": [],
+      "write_actions": []
+    },
+    {
+      "stage": "plan_execute",
+      "read_actions": [],
+      "write_actions": [
+        {
+          "owner": "state_store",
+          "status": "fallback_local_artifact",
+          "artifact_kind": "execution_handoff_card"
+        }
+      ]
+    },
+    {
+      "stage": "phase_cleanup",
+      "read_actions": [],
+      "write_actions": [
+        {
+          "owner": "serena",
+          "status": "guarded_no_write",
+          "artifact_kind": "project_decision_gate"
+        },
+        {
+          "owner": "state_store",
+          "status": "generated_local_fold",
+          "artifact_kind": "memory_fold"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/plans/2026-03-28-vibe-memory-runtime-activation-closure-plan.md
+++ b/docs/plans/2026-03-28-vibe-memory-runtime-activation-closure-plan.md
@@ -1,0 +1,358 @@
+# Vibe Memory Runtime Activation Closure Plan
+
+## Execution Summary
+The repository already has the right owner-boundary model for memory. The smallest coherent path is not to widen memory authority. It is to convert the current governance-only memory plane into a stage-aware runtime activation model with strict write admission, retrieval gating, prompt-budget controls, and fallback-safe runtime hooks. The design goal is to keep memory useful, sparse, and auditable.
+
+## Frozen Inputs
+- Requirement doc: [2026-03-28-vibe-memory-runtime-activation-closure.md](../requirements/2026-03-28-vibe-memory-runtime-activation-closure.md)
+- Current reality:
+  - `state_store` is the only reliably active default memory lane
+  - `Serena`, `ruflo`, and `Cognee` are mostly defined in governance and protocol surfaces, not yet fully wired into normal `vibe` runtime execution
+  - `knowledge-steward` and `deepagent-memory-fold` are real skills, but they are explicit or keyword-triggered rather than systematically stage-bound
+  - `memory-runtime-v3` remains `shadow` and `advisory_first_post_route_only`
+- Invariants that must stay unchanged:
+  - canonical router remains route authority
+  - `vibe` remains runtime authority
+  - memory stays post-route and subordinate to runtime governance
+  - canonical owners remain `state_store`, `Serena`, `ruflo`, and `Cognee`
+
+## Internal Grade Decision
+- Grade: XL
+- The work spans runtime integration, config contracts, test harnesses, rollout policy, prompt-budget rules, operator documentation, and failure proof.
+- The design must coordinate router metadata, runtime stages, retro surfaces, and benchmark evaluation without creating a parallel control plane.
+
+## Design Overview
+
+### Design Principle 1: Memory Must Be Stage-Bound
+Memory activation should depend on the runtime stage, not on generic availability.
+
+Required behavior:
+- `skeleton_check`: light background recall only
+- `deep_interview`: minimum decision recall only
+- `requirement_doc`: citeable acceptance-relevant recall only
+- `xl_plan`: planning-relevant recall only
+- `plan_execute`: bounded milestone and handoff memory only
+- `phase_cleanup`: persistence and fold cleanup only
+
+### Design Principle 2: Write Admission Must Be Narrower Than Recall
+The system must reject most candidate writes.
+Memory quality comes from selective persistence, not from large-volume storage.
+
+Required write shapes:
+- `state_store`: run-local progress and artifacts
+- `Serena`: explicit approved project decisions only
+- `ruflo`: short-horizon milestone cards and handoff cards only
+- `Cognee`: entities and relations only
+- `knowledge-steward`: explicit user-requested durable capture only
+- `deepagent-memory-fold`: structured compaction object only
+
+### Design Principle 3: Retrieval Must Be Budgeted
+Memory should return cards, not transcripts.
+Every recall lane requires:
+- trigger condition
+- top-k cap
+- token budget
+- replacement vs append semantics
+
+### Design Principle 4: Fallback Must Preserve Continuity
+Backend outages must not break `vibe`.
+The runtime must degrade to:
+- `state_store`
+- local session artifacts
+- requirement/plan/handoff outputs
+
+### Design Principle 5: Intelligence Must Be Proven, Not Assumed
+A memory lane is intelligent only if it:
+- reduces repeated clarification or lost context
+- improves handoff continuity
+- avoids irrelevant recall
+- stays within prompt budget
+
+## Target Architecture
+
+### A. Stage-Aware Memory Trigger Matrix
+Add one canonical trigger matrix document and config contract that maps memory actions to `vibe` stages.
+
+Expected stage actions:
+
+#### `skeleton_check`
+- Read:
+  - `Serena` decision digest: allowed
+  - `Cognee` small relationship digest: allowed
+- Write: none
+- Budget:
+  - max 3 decision cards
+  - max 1 graph digest block
+- Failure behavior:
+  - fallback to local docs and `state_store`
+
+#### `deep_interview`
+- Read:
+  - `Serena` only if the same project already has approved conventions
+- Write: none
+- Budget:
+  - max 2 decision cards
+- Goal:
+  - avoid re-asking settled project conventions
+
+#### `requirement_doc`
+- Read:
+  - only citeable constraints and approved decisions
+- Write:
+  - candidate decisions staged locally, not yet persisted to `Serena`
+- Budget:
+  - max 3 cited memory anchors
+
+#### `xl_plan`
+- Read:
+  - `Serena` decision digest
+  - bounded `Cognee` relationship digest for cross-module dependencies
+- Write:
+  - none to long-term stores
+  - optional local `state_store` planning memo
+
+#### `plan_execute`
+- `M`:
+  - use `state_store` only
+- `L`:
+  - use `state_store`; no default `ruflo`
+- `XL`:
+  - optional `ruflo` milestone cards
+  - optional `ruflo` handoff summaries
+  - no raw transcript storage
+- Specialist lanes:
+  - child lanes receive only root-approved handoff digests
+
+#### `phase_cleanup`
+- Write:
+  - `Serena`: only approved decisions
+  - `Cognee`: only approved entities/relations
+  - `deepagent-memory-fold`: only when context-pressure or handoff criteria were met
+  - `knowledge-steward`: only on explicit user request
+- Read:
+  - none unless required for retro comparison
+
+### B. Write Admission Contracts
+Add explicit config or reference contracts for:
+- `serena-write-admission.json`
+- `ruflo-card-contract.json`
+- `cognee-entity-relation-contract.json`
+- `memory-fold-trigger-policy.json`
+
+Each contract must define:
+- allowed payload classes
+- forbidden payload classes
+- required metadata
+- retention policy
+- rollback behavior
+
+### C. Retrieval Budget Contracts
+Add one canonical budget contract, for example:
+- `config/memory-retrieval-budget-policy.json`
+
+Minimum fields:
+- stage
+- lane
+- `top_k`
+- `max_tokens`
+- `replacement_mode`
+- `inject_as`
+- `fallback_mode`
+
+Required semantics:
+- recall injects compact cards or digests only
+- full raw stored content stays out of prompt context
+- folded memory replaces old context instead of appending
+
+### D. Runtime Integration Hooks
+Add bounded runtime hook points inside the existing stage implementation:
+
+- `Invoke-SkeletonCheck`:
+  - optional pre-run recall receipts
+- `Write-RequirementDoc`:
+  - citeable memory anchors only
+- `Write-XlPlan`:
+  - bounded dependency recall only
+- `Invoke-PlanExecute`:
+  - XL milestone/handoff store and search
+- `Invoke-PhaseCleanup`:
+  - durable persistence receipts
+  - optional fold receipt
+
+Every hook must emit:
+- attempted lane
+- action type
+- success/fallback
+- payload count
+- token budget used
+
+### E. Intelligence Guardrails
+Introduce runtime guardrails that block low-quality memory usage:
+- no memory read if stage is out of scope
+- no memory write if payload lacks required type metadata
+- no recall when relevance score is below threshold
+- no injection if budget would be exceeded
+- no fold append on top of full historical context
+
+### F. Proof Surface
+Add one memory activation report family under:
+- `outputs/runtime/vibe-sessions/<run-id>/memory-activation.json`
+- `outputs/runtime/vibe-sessions/<run-id>/memory-activation.md`
+
+Minimum fields:
+- stage actions taken
+- reads attempted and succeeded
+- writes attempted and succeeded
+- fallback events
+- token budget consumption
+- ignored or denied writes
+- retrieval relevance scores
+- fold trigger reason
+
+## Wave Plan
+
+### Wave 1: Freeze Stage-Aware Memory Contract
+- Write stable governance doc for stage-aware activation
+- Add trigger matrix and owner-boundary restatement
+- Add explicit non-goals against transcript dumping and authority transfer
+
+### Wave 2: Add Write Admission Contracts
+- Add lane-specific write contracts
+- Define candidate-to-approved decision flow for `Serena`
+- Define XL milestone card schema for `ruflo`
+- Define entity-relation ingest schema for `Cognee`
+
+### Wave 3: Add Retrieval Budget Policy
+- Add a canonical top-k and token-budget policy
+- Define replacement vs append behavior
+- Define per-stage allowable recall lanes
+
+### Wave 4: Wire Runtime Hooks
+- Add read hooks to `skeleton_check`, `deep_interview`, `xl_plan`
+- Add write hooks to `plan_execute` and `phase_cleanup`
+- Emit per-stage memory receipts
+
+### Wave 5: Add Context-Pressure Compaction
+- Define fold trigger conditions
+- Add a bounded call path for `deepagent-memory-fold`
+- Guarantee fold artifact replaces historical context in continuation flows
+
+### Wave 6: Add Scenario Corpus
+Create scenarios for:
+- no-backend baseline
+- Serena-only decision reuse
+- XL milestone continuity with `ruflo`
+- long-term relationship reuse with `Cognee`
+- context-pressure fold continuation
+- missing-backend fallback
+- low-relevance recall rejection
+- write-admission rejection
+
+### Wave 7: Add Gates And Benchmarks
+- runtime activation gate
+- retrieval budget gate
+- fold replacement gate
+- fallback integrity gate
+- repeated-run flake gate
+
+### Wave 8: Release Truth And Operator Docs
+- add operator runbook
+- add release-facing truth gate for memory claims
+- forbid README language that overstates automatic persistence or recall beyond tested reality
+
+## Detailed Test Program
+
+### 1. Owner Boundary Tests
+- `state_store` stays session-only
+- `Serena` does not accept raw transcripts
+- `ruflo` does not become long-term store
+- `Cognee` does not ingest arbitrary transcript blocks
+- `mem0` and `Letta` do not gain canonical owner status
+
+### 2. Stage Trigger Tests
+- each stage invokes only permitted lanes
+- out-of-scope stages do not read or write memory
+- write actions are deferred until approved persistence points
+
+### 3. Retrieval Quality Tests
+- high-relevance cards are recalled
+- low-relevance cards are rejected
+- no more than configured top-k are injected
+- token budget never exceeds policy cap
+
+### 4. Fallback Tests
+- missing Serena backend falls back to local docs and `state_store`
+- missing `ruflo` keeps XL execution viable
+- missing `Cognee` does not break startup
+- fold unavailable degrades to local handoff artifacts
+
+### 5. Compaction Tests
+- fold triggers only at allowed conditions
+- fold artifact includes working/tool/evidence/decision/resume sections
+- fold replaces large historical context rather than appending to it
+
+### 6. Continuity Tests
+- repeated clarification rate decreases when approved decisions exist
+- XL handoff retains blocker/next-step continuity
+- resumed session can continue from folded memory with bounded context
+
+### 7. Anti-Explosion Tests
+- transcript-size write attempts are rejected
+- oversized recall is truncated or denied
+- duplicate recalls are deduplicated before injection
+- cumulative memory injection stays under a global stage budget
+
+### 8. Operator Usability Tests
+- activation report is readable and actionable
+- denied-write reasons are explicit
+- fallback status is operator-visible
+- release wording aligns with actual tested capability
+
+## Proof Strategy
+
+### Stability Proof
+- repeated-run matrix for each scenario
+- flake accounting for repeated recall and fallback behavior
+- failure injection for missing backends and denied writes
+
+Target proof:
+- memory activation does not destabilize the runtime
+- stage actions remain deterministic enough to audit
+
+### Availability Proof
+- no-backend baseline still succeeds using `state_store`
+- partial-backend availability produces bounded degraded behavior
+- runtime artifacts remain sufficient for continuation without external memory services
+
+### Intelligence Proof
+- compare runs with and without bounded memory recall
+- measure:
+  - repeated clarification count
+  - handoff completeness
+  - irrelevant recall count
+  - budget overrun count
+  - route drift count
+
+Target proof:
+- recall is relevant more often than noisy
+- useful continuity improves without widening authority or prompt size
+
+## Rollback Rules
+- Any owner-boundary violation:
+  - disable the offending lane
+  - revert to `shadow`
+- Any repeated irrelevant recall or budget overrun:
+  - reduce top-k and token caps
+  - disable the stage hook if needed
+- Any runtime instability:
+  - fall back to `state_store` plus local artifacts only
+
+## Success Criteria
+This plan succeeds when the repository can prove all of the following at once:
+
+- memory activation is stage-aware rather than always-on
+- each lane preserves its intended role
+- memory recall is bounded and relevance-aware
+- context compaction reduces context size instead of increasing it
+- external backend failures do not break `vibe`
+- repository documentation and release wording match the tested runtime truth

--- a/docs/requirements/2026-03-28-vibe-memory-runtime-activation-closure.md
+++ b/docs/requirements/2026-03-28-vibe-memory-runtime-activation-closure.md
@@ -1,0 +1,118 @@
+# Vibe Memory Runtime Activation Closure
+
+## Summary
+Close the gap between the repository's memory-governance claims and the actual `vibe` runtime behavior. The current repository already defines strong owner boundaries for `state_store`, `Serena`, `ruflo`, `Cognee`, `mem0`, and `Letta`, but most of those roles still operate as post-route governance guidance rather than as stage-bound runtime behavior with bounded write, retrieval, and injection contracts.
+
+## Goal
+Design and land a memory-runtime architecture where each canonical memory role is invoked only at the right stage, with bounded payload size, audited write admission, intelligent retrieval gates, and explicit rollback rules, so memory becomes useful without becoming a second control plane or a context-amplification source.
+
+## Deliverable
+A repository change program and documentation bundle that adds:
+
+- a stage-aware activation model for `state_store`, `Serena`, `ruflo`, `Cognee`, `knowledge-steward`, and `deepagent-memory-fold`
+- machine-readable write-admission and retrieval-budget contracts for each memory lane
+- runtime integration points for memory read/write/fold actions inside the existing six-stage `vibe` lifecycle
+- scenario tests and executable gates proving stability, usability, and intelligence
+- operator documentation describing when memory is invoked, when it must stay silent, and how to disable or roll back each lane
+
+## Constraints
+- Preserve `VCO` as the single runtime and control plane owner.
+- Preserve the canonical router as route authority.
+- Do not create a second visible startup surface, second requirement surface, or second execution-plan surface.
+- Do not allow any memory lane to mutate `selected.pack_id`, `selected.skill`, or grade choice.
+- Preserve the current canonical owner matrix:
+  - `state_store` for session truth
+  - `Serena` for explicit project decisions
+  - `ruflo` for short-term semantic cache
+  - `Cognee` for long-term relationship memory
+- Keep `episodic-memory` disabled in governed routing.
+- Keep `mem0` preference-only and `Letta` contract-only.
+- Prefer additive runtime hooks and bounded artifacts over a broad router/runtime rewrite.
+
+## Acceptance Criteria
+- The repository defines a stage-aware memory trigger matrix covering:
+  - `skeleton_check`
+  - `deep_interview`
+  - `requirement_doc`
+  - `xl_plan`
+  - `plan_execute`
+  - `phase_cleanup`
+- Every memory lane has an explicit write-admission contract:
+  - what can be written
+  - what must not be written
+  - required evidence shape
+  - retention or expiry rule
+- Every retrievable memory lane has an explicit retrieval contract:
+  - allowed trigger conditions
+  - maximum item count
+  - maximum prompt-injection budget
+  - fallback behavior when the backend is unavailable
+- `state_store` remains the default always-on runtime memory lane.
+- `Serena` is only written when the runtime has an explicit project decision surface or explicit operator approval.
+- `ruflo` is only used for bounded XL milestone summaries, handoff blocks, or short-horizon semantic retrieval, never as a generic long transcript store.
+- `Cognee` is only used for bounded graph retrieval or long-term ingest at approved persistence points, never as a raw transcript sink.
+- `knowledge-steward` remains explicit-user-trigger only and is not silently promoted into a background auto-capture path.
+- `deepagent-memory-fold` becomes a governed compaction lane that can be invoked only under documented context-pressure or handoff conditions, and its folded artifact replaces large historical context instead of being appended to it.
+- The repository includes a bounded memory injection policy proving that memory recall cannot expand prompt context without limit.
+- The repository includes executable tests proving:
+  - stability across repeated runs
+  - availability and graceful fallback when memory backends are missing
+  - intelligence of retrieval choice and budgeted injection
+
+## Primary Objective
+Make memory in `vibe` useful enough to preserve continuity and decision quality, while keeping it sufficiently bounded that it cannot destabilize routing, runtime truth, or prompt size.
+
+## Proxy Signals
+- Memory recall reduces repeated clarification or lost context without increasing route drift.
+- Memory writes are sparse, typed, and evidence-backed rather than transcript-dump based.
+- Retrieval returns only the minimum relevant cards required for the current stage.
+- Missing memory backends degrade gracefully to `state_store` and local artifacts.
+
+## Scope
+In scope:
+- stage-aware memory activation design
+- write-admission rules
+- retrieval gating rules
+- prompt-injection budget design
+- context-pressure fold design
+- backend fallback semantics
+- executable verification and proof strategy
+- repository documentation and rollout plan
+
+Out of scope:
+- replacing the canonical router
+- granting memory lanes route mutation or runtime ownership
+- making every memory backend mandatory for every host
+- storing full raw conversation transcripts as long-term truth
+- turning `knowledge-steward` into implicit background ingestion
+
+## Completion
+The work is complete when the repository can prove, with executable tests and bounded runtime contracts, that each memory lane is called at the correct time, injects only bounded information, degrades safely when unavailable, and measurably improves continuity without causing context explosion or governance drift.
+
+## Evidence
+- new or updated governance docs for stage-aware memory activation
+- requirement and plan docs for rollout
+- runtime integration design for read/write/fold hooks
+- machine-readable budget and admission policies
+- scenario corpus and gates covering stability, availability, and intelligence
+
+## Non-Goals
+- Do not treat memory backend availability as proof of useful recall.
+- Do not equate more recalled text with better intelligence.
+- Do not let long-term memory become a dump of unresolved thoughts or temporary state.
+- Do not append folded memory on top of the original large context.
+- Do not allow advisory memory suggestions to silently become execution authority.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- The current six-stage `vibe` lifecycle is sufficient to host memory activation without adding a second runtime.
+- Existing `state_store` and runtime artifacts already provide a stable baseline fallback.
+- The main missing layer is stage-aware runtime activation, not owner-boundary definition.
+- The repository can add new config contracts, runtime hooks, and tests without breaking current router invariants.
+
+## Evidence Inputs
+- Source task: plan a full activation-closure program for the current memory system
+- Current finding: governance, contracts, and gates exist; automatic stage-bound runtime invocation is still partial
+- Current policy: `memory-runtime-v3` remains `shadow` and `advisory_first_post_route_only`

--- a/scripts/common/vibe-governance-helpers.ps1
+++ b/scripts/common/vibe-governance-helpers.ps1
@@ -1038,6 +1038,38 @@ function Get-VgoLegacySourceOfTruthCompatibility {
     }
 }
 
+function Test-VgoInstalledRuntimeMaterialization {
+    param(
+        [AllowEmptyString()] [string]$RepoRoot,
+        [AllowNull()] [psobject]$RuntimeConfig
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RepoRoot) -or $null -eq $RuntimeConfig) {
+        return $false
+    }
+
+    $requiredMarkers = @()
+    if ($RuntimeConfig.PSObject.Properties.Name -contains 'required_runtime_markers' -and $null -ne $RuntimeConfig.required_runtime_markers) {
+        $requiredMarkers = @($RuntimeConfig.required_runtime_markers)
+    }
+    if (@($requiredMarkers).Count -eq 0) {
+        return $false
+    }
+
+    foreach ($marker in @($requiredMarkers)) {
+        if ([string]::IsNullOrWhiteSpace([string]$marker)) {
+            continue
+        }
+
+        $markerPath = Join-Path $RepoRoot ([string]$marker)
+        if (-not (Test-Path -LiteralPath $markerPath)) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
 function Assert-VgoCanonicalExecutionContext {
     param(
         [Parameter(Mandatory)] [psobject]$Context
@@ -1056,7 +1088,9 @@ function Assert-VgoCanonicalExecutionContext {
         }
     }
 
-    if ($requireOuterGitRoot -and -not (Test-Path -LiteralPath (Join-Path $Context.repoRoot '.git'))) {
+    $hasOuterGitRoot = (Test-Path -LiteralPath (Join-Path $Context.repoRoot '.git'))
+    $hasInstalledRuntimeMaterialization = Test-VgoInstalledRuntimeMaterialization -RepoRoot ([string]$Context.repoRoot) -RuntimeConfig $Context.runtimeConfig
+    if ($requireOuterGitRoot -and -not $hasOuterGitRoot -and -not $hasInstalledRuntimeMaterialization) {
         throw "Execution-context lock failed: resolved repo root is not the outer git root -> $($Context.repoRoot)"
     }
 

--- a/scripts/runtime/VibeMemoryActivation.Common.ps1
+++ b/scripts/runtime/VibeMemoryActivation.Common.ps1
@@ -1,0 +1,469 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-VibeMemoryArtifactsRoot {
+    param(
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $path = Join-Path $SessionRoot 'memory-activation'
+    New-Item -ItemType Directory -Path $path -Force | Out-Null
+    return $path
+}
+
+function Get-VibeMemoryBudgetSpec {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [string]$Stage
+    )
+
+    $defaults = $Runtime.memory_retrieval_budget_policy.defaults
+    $topK = [int]$defaults.top_k
+    $maxTokens = [int]$defaults.max_tokens
+    $maxCharsPerItem = [int]$defaults.max_chars_per_item
+
+    if ($Runtime.memory_retrieval_budget_policy.stages.PSObject.Properties.Name -contains $Stage) {
+        $stageBudget = $Runtime.memory_retrieval_budget_policy.stages.$Stage
+        if ($null -ne $stageBudget.top_k) {
+            $topK = [int]$stageBudget.top_k
+        }
+        if ($null -ne $stageBudget.max_tokens) {
+            $maxTokens = [int]$stageBudget.max_tokens
+        }
+        if ($null -ne $stageBudget.max_chars_per_item) {
+            $maxCharsPerItem = [int]$stageBudget.max_chars_per_item
+        }
+    }
+
+    return [pscustomobject]@{
+        top_k = $topK
+        max_tokens = $maxTokens
+        max_chars_per_item = $maxCharsPerItem
+    }
+}
+
+function Get-VibeMemoryCanonicalOwners {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime
+    )
+
+    $owners = $Runtime.memory_runtime_v3_policy.canonical_owners
+    return [ordered]@{
+        session = [string]$owners.session
+        project_decision = switch ([string]$owners.project_decision) {
+            'serena' { 'Serena' }
+            default { [string]$owners.project_decision }
+        }
+        short_term_semantic = [string]$owners.short_term_semantic
+        long_term_graph = switch ([string]$owners.long_term_graph) {
+            'cognee' { 'Cognee' }
+            default { [string]$owners.long_term_graph }
+        }
+    }
+}
+
+function Get-VibeMemoryStagePolicy {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [string]$Stage
+    )
+
+    foreach ($stagePolicy in @($Runtime.memory_stage_activation_policy.stages)) {
+        if ([string]$stagePolicy.stage -eq $Stage) {
+            return $stagePolicy
+        }
+    }
+
+    throw "Missing memory stage policy for stage: $Stage"
+}
+
+function Get-VibeBoundedMemoryItems {
+    param(
+        [AllowEmptyCollection()] [string[]]$Items = @(),
+        [Parameter(Mandatory)] [object]$Budget
+    )
+
+    $bounded = [System.Collections.Generic.List[string]]::new()
+    foreach ($item in @($Items)) {
+        if ([string]::IsNullOrWhiteSpace($item)) {
+            continue
+        }
+        if ($bounded.Count -ge [int]$Budget.top_k) {
+            break
+        }
+
+        $text = [string]$item
+        if ($text.Length -gt [int]$Budget.max_chars_per_item) {
+            $text = $text.Substring(0, [int]$Budget.max_chars_per_item).TrimEnd() + '...'
+        }
+        $bounded.Add($text) | Out-Null
+    }
+    return @($bounded)
+}
+
+function Get-VibeEstimatedTokenCount {
+    param(
+        [AllowEmptyCollection()] [string[]]$Items = @()
+    )
+
+    $charCount = 0
+    foreach ($item in @($Items)) {
+        $charCount += ([string]$item).Length
+    }
+
+    if ($charCount -le 0) {
+        return 0
+    }
+
+    return [int][Math]::Ceiling($charCount / 4.0)
+}
+
+function New-VibeSkeletonMemoryDigest {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [object]$Skeleton,
+        [Parameter(Mandatory)] [string]$Task,
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $budget = Get-VibeMemoryBudgetSpec -Runtime $Runtime -Stage 'skeleton_check'
+    $receipt = $Skeleton.receipt
+    $missingPaths = @($receipt.required_paths | Where-Object { -not [bool]$_.exists } | ForEach-Object { [string]$_.path })
+    $requirementDocs = @($receipt.existing_requirement_docs | Select-Object -First 5)
+    $planDocs = @($receipt.existing_plan_docs | Select-Object -First 5)
+
+    $items = @()
+    $items += ('Task focus: {0}' -f $Task)
+    $items += ('Git branch: {0}' -f [string]$receipt.git_branch)
+    if (@($missingPaths).Count -gt 0) {
+        $items += 'Missing runtime prerequisites: ' + (@($missingPaths) -join ', ')
+    } else {
+        $items += 'All required governed runtime prerequisite paths are present.'
+    }
+    if (@($requirementDocs).Count -gt 0) {
+        $items += 'Existing requirement docs: ' + (@($requirementDocs) -join ', ')
+    } else {
+        $items += 'Existing requirement docs: none'
+    }
+    if (@($planDocs).Count -gt 0) {
+        $items += 'Existing plan docs: ' + (@($planDocs) -join ', ')
+    } else {
+        $items += 'Existing plan docs: none'
+    }
+
+    $boundedItems = Get-VibeBoundedMemoryItems -Items $items -Budget $budget
+    $artifactPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'skeleton-local-digest.json'
+    $artifact = [pscustomobject]@{
+        stage = 'skeleton_check'
+        owner = 'state_store'
+        status = 'fallback_local_digest'
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        source_receipt_path = [string]$Skeleton.receipt_path
+        items = @($boundedItems)
+        budget = $budget
+    }
+    Write-VibeJsonArtifact -Path $artifactPath -Value $artifact
+
+    return [pscustomobject]@{
+        owner = 'state_store'
+        status = 'fallback_local_digest'
+        item_count = @($boundedItems).Count
+        items = @($boundedItems)
+        artifact_path = $artifactPath
+        budget = $budget
+    }
+}
+
+function Get-VibeDeepInterviewMemoryReadAction {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime
+    )
+
+    $stagePolicy = Get-VibeMemoryStagePolicy -Runtime $Runtime -Stage 'deep_interview'
+    $readPolicy = @($stagePolicy.read_actions)[0]
+    $projectKeyEnv = @($readPolicy.project_key_env)
+    $projectKeyName = $null
+    foreach ($envName in $projectKeyEnv) {
+        $value = [Environment]::GetEnvironmentVariable([string]$envName)
+        if (-not [string]::IsNullOrWhiteSpace($value)) {
+            $projectKeyName = [string]$envName
+            break
+        }
+    }
+
+    return [pscustomobject]@{
+        owner = 'Serena'
+        status = if ($null -eq $projectKeyName) { [string]$readPolicy.status_if_missing_project_key } else { 'backend_key_available' }
+        item_count = 0
+        items = @()
+        project_key_env = if ($null -eq $projectKeyName) { $null } else { $projectKeyName }
+    }
+}
+
+function New-VibeRequirementContextPack {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [object]$SkeletonDigestAction,
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $budget = Get-VibeMemoryBudgetSpec -Runtime $Runtime -Stage 'requirement_doc'
+    $boundedItems = Get-VibeBoundedMemoryItems -Items @($SkeletonDigestAction.items) -Budget $budget
+    $estimatedTokens = Get-VibeEstimatedTokenCount -Items @($boundedItems)
+    $artifactPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'requirement-context-pack.json'
+    $artifact = [pscustomobject]@{
+        stage = 'requirement_doc'
+        source_stage = 'skeleton_check'
+        owner = 'state_store'
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        items = @($boundedItems)
+        estimated_tokens = $estimatedTokens
+        budget = $budget
+    }
+    Write-VibeJsonArtifact -Path $artifactPath -Value $artifact
+
+    return [pscustomobject]@{
+        context_path = $artifactPath
+        injected_item_count = @($boundedItems).Count
+        estimated_tokens = $estimatedTokens
+        budget = $budget
+        items = @($boundedItems)
+    }
+}
+
+function New-VibeExecutionMemoryWriteAction {
+    param(
+        [Parameter(Mandatory)] [string]$ExecutionManifestPath,
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $manifest = Get-Content -LiteralPath $ExecutionManifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $items = @(
+        ('Execution status: {0}' -f [string]$manifest.status),
+        ('Executed units: {0}; failures: {1}' -f [int]$manifest.executed_unit_count, [int]$manifest.failed_unit_count),
+        ('Specialist execution status: {0}' -f [string]$manifest.specialist_accounting.effective_execution_status)
+    )
+    $artifactPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'execution-handoff-card.json'
+    $artifact = [pscustomobject]@{
+        stage = 'plan_execute'
+        owner = 'state_store'
+        status = 'fallback_local_artifact'
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        source_execution_manifest = $ExecutionManifestPath
+        items = @($items)
+    }
+    Write-VibeJsonArtifact -Path $artifactPath -Value $artifact
+
+    return [pscustomobject]@{
+        owner = 'state_store'
+        status = 'fallback_local_artifact'
+        item_count = @($items).Count
+        items = @($items)
+        artifact_path = $artifactPath
+    }
+}
+
+function Get-VibeCleanupDecisionWriteAction {
+    param(
+        [Parameter(Mandatory)] [string]$RequirementDocPath,
+        [Parameter(Mandatory)] [string]$ExecutionPlanPath
+    )
+
+    $requirementText = if (Test-Path -LiteralPath $RequirementDocPath) {
+        Get-Content -LiteralPath $RequirementDocPath -Raw -Encoding UTF8
+    } else {
+        ''
+    }
+    $planText = if (Test-Path -LiteralPath $ExecutionPlanPath) {
+        Get-Content -LiteralPath $ExecutionPlanPath -Raw -Encoding UTF8
+    } else {
+        ''
+    }
+    $combined = "$requirementText`n$planText"
+    $hasExplicitDecision = $combined -match 'approved decision|decision record|adr-|## decision'
+
+    return [pscustomobject]@{
+        owner = 'Serena'
+        status = if ($hasExplicitDecision) { 'backend_write_candidate' } else { 'guarded_no_write' }
+        item_count = 0
+        items = @()
+        artifact_path = $null
+        reason = if ($hasExplicitDecision) { 'explicit decision markers detected' } else { 'no explicit approved decision markers detected in frozen requirement/plan surfaces' }
+    }
+}
+
+function New-VibeCleanupMemoryFold {
+    param(
+        [Parameter(Mandatory)] [string]$RequirementDocPath,
+        [Parameter(Mandatory)] [string]$ExecutionPlanPath,
+        [Parameter(Mandatory)] [string]$ExecutionManifestPath,
+        [Parameter(Mandatory)] [string]$CleanupReceiptPath,
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    $manifest = Get-Content -LiteralPath $ExecutionManifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $fold = [pscustomobject]@{
+        stage = 'phase_cleanup'
+        fold_kind = 'deepagent_memory_fold_local'
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        working_memory = @(
+            ('Requirement doc: {0}' -f $RequirementDocPath),
+            ('Execution plan: {0}' -f $ExecutionPlanPath),
+            ('Runtime status: {0}' -f [string]$manifest.status)
+        )
+        tool_memory = @(
+            ('Execution manifest: {0}' -f $ExecutionManifestPath),
+            ('Cleanup receipt: {0}' -f $CleanupReceiptPath)
+        )
+        evidence_anchors = @(
+            $RequirementDocPath,
+            $ExecutionPlanPath,
+            $ExecutionManifestPath,
+            $CleanupReceiptPath
+        )
+    }
+    $artifactPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'phase-cleanup-memory-fold.json'
+    Write-VibeJsonArtifact -Path $artifactPath -Value $fold
+
+    return [pscustomobject]@{
+        owner = 'state_store'
+        status = 'generated_local_fold'
+        item_count = @($fold.working_memory).Count + @($fold.tool_memory).Count
+        items = @($fold.working_memory + $fold.tool_memory)
+        artifact_path = $artifactPath
+    }
+}
+
+function New-VibeMemoryActivationReport {
+    param(
+        [Parameter(Mandatory)] [object]$Runtime,
+        [Parameter(Mandatory)] [string]$RunId,
+        [Parameter(Mandatory)] [string]$SessionRoot,
+        [Parameter(Mandatory)] [object]$SkeletonDigestAction,
+        [Parameter(Mandatory)] [object]$DeepInterviewReadAction,
+        [Parameter(Mandatory)] [object]$RequirementContextPack,
+        [Parameter(Mandatory)] [object]$ExecuteWriteAction,
+        [Parameter(Mandatory)] [object]$CleanupDecisionAction,
+        [Parameter(Mandatory)] [object]$CleanupFoldAction
+    )
+
+    $stages = @(
+        [pscustomobject]@{
+            stage = 'skeleton_check'
+            read_actions = @($SkeletonDigestAction)
+            context_injection = $null
+            write_actions = @()
+        },
+        [pscustomobject]@{
+            stage = 'deep_interview'
+            read_actions = @($DeepInterviewReadAction)
+            context_injection = $null
+            write_actions = @()
+        },
+        [pscustomobject]@{
+            stage = 'requirement_doc'
+            read_actions = @()
+            context_injection = [pscustomobject]@{
+                injected_item_count = [int]$RequirementContextPack.injected_item_count
+                estimated_tokens = [int]$RequirementContextPack.estimated_tokens
+                budget = $RequirementContextPack.budget
+                artifact_path = [string]$RequirementContextPack.context_path
+            }
+            write_actions = @()
+        },
+        [pscustomobject]@{
+            stage = 'xl_plan'
+            read_actions = @()
+            context_injection = $null
+            write_actions = @()
+        },
+        [pscustomobject]@{
+            stage = 'plan_execute'
+            read_actions = @()
+            context_injection = $null
+            write_actions = @($ExecuteWriteAction)
+        },
+        [pscustomobject]@{
+            stage = 'phase_cleanup'
+            read_actions = @()
+            context_injection = $null
+            write_actions = @($CleanupDecisionAction, $CleanupFoldAction)
+        }
+    )
+
+    $artifactPaths = [System.Collections.Generic.List[string]]::new()
+    $fallbackEventCount = 0
+    $budgetGuardRespected = $true
+    foreach ($stage in @($stages)) {
+        foreach ($readAction in @($stage.read_actions)) {
+            if ($readAction.PSObject.Properties.Name -contains 'artifact_path' -and -not [string]::IsNullOrWhiteSpace([string]$readAction.artifact_path)) {
+                $artifactPaths.Add([string]$readAction.artifact_path) | Out-Null
+            }
+            if ([string]$readAction.status -match 'fallback|deferred|guarded|generated') {
+                $fallbackEventCount += 1
+            }
+            if ($readAction.PSObject.Properties.Name -contains 'budget' -and $readAction.PSObject.Properties.Name -contains 'items') {
+                if (@($readAction.items).Count -gt [int]$readAction.budget.top_k) {
+                    $budgetGuardRespected = $false
+                }
+            }
+        }
+
+        if ($null -ne $stage.context_injection) {
+            if (-not [string]::IsNullOrWhiteSpace([string]$stage.context_injection.artifact_path)) {
+                $artifactPaths.Add([string]$stage.context_injection.artifact_path) | Out-Null
+            }
+            if ([int]$stage.context_injection.estimated_tokens -gt [int]$stage.context_injection.budget.max_tokens) {
+                $budgetGuardRespected = $false
+            }
+        }
+
+        foreach ($writeAction in @($stage.write_actions)) {
+            if ($writeAction.PSObject.Properties.Name -contains 'artifact_path' -and -not [string]::IsNullOrWhiteSpace([string]$writeAction.artifact_path)) {
+                $artifactPaths.Add([string]$writeAction.artifact_path) | Out-Null
+            }
+            if ([string]$writeAction.status -match 'fallback|deferred|guarded|generated') {
+                $fallbackEventCount += 1
+            }
+        }
+    }
+
+    $owners = Get-VibeMemoryCanonicalOwners -Runtime $Runtime
+    $report = [pscustomobject]@{
+        run_id = $RunId
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        policy = [pscustomobject]@{
+            mode = [string]$Runtime.memory_runtime_v3_policy.mode
+            routing_contract = [string]$Runtime.memory_runtime_v3_policy.routing_contract
+            canonical_owners = [pscustomobject]$owners
+        }
+        stages = @($stages)
+        summary = [pscustomobject]@{
+            stage_count = @($stages).Count
+            fallback_event_count = $fallbackEventCount
+            artifact_count = @($artifactPaths | Select-Object -Unique).Count
+            budget_guard_respected = [bool]$budgetGuardRespected
+        }
+    }
+
+    $reportPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'memory-activation-report.json'
+    $markdownPath = Join-Path (Get-VibeMemoryArtifactsRoot -SessionRoot $SessionRoot) 'memory-activation-report.md'
+    Write-VibeJsonArtifact -Path $reportPath -Value $report
+    Write-VibeMarkdownArtifact -Path $markdownPath -Lines @(
+        '# Memory Activation Report',
+        '',
+        ('- run_id: `{0}`' -f $RunId),
+        ('- mode: `{0}`' -f [string]$Runtime.memory_runtime_v3_policy.mode),
+        ('- routing_contract: `{0}`' -f [string]$Runtime.memory_runtime_v3_policy.routing_contract),
+        ('- fallback_event_count: `{0}`' -f [int]$report.summary.fallback_event_count),
+        ('- artifact_count: `{0}`' -f [int]$report.summary.artifact_count),
+        ('- budget_guard_respected: `{0}`' -f [bool]$report.summary.budget_guard_respected),
+        ''
+    )
+
+    return [pscustomobject]@{
+        report = $report
+        report_path = $reportPath
+        markdown_path = $markdownPath
+    }
+}

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -24,6 +24,11 @@ function Get-VibeRuntimeContext {
         benchmark_execution_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\benchmark-execution-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         cleanup_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\phase-cleanup-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         proof_class_registry = Get-Content -LiteralPath (Join-Path $repoRoot 'config\proof-class-registry.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_governance = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-governance.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_tier_router = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-tier-router.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_runtime_v3_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-runtime-v3-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_stage_activation_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-stage-activation-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
+        memory_retrieval_budget_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\memory-retrieval-budget-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json
     }
 }
 

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -4,6 +4,7 @@ param(
     [string]$RunId = '',
     [string]$IntentContractPath = '',
     [string]$RuntimeInputPacketPath = '',
+    [string]$MemoryContextPath = '',
     [string]$ArtifactRoot = '',
     [AllowEmptyString()] [string]$GovernanceScope = '',
     [AllowEmptyString()] [string]$RootRunId = '',
@@ -120,6 +121,11 @@ $runtimeInputPacket = if (-not [string]::IsNullOrWhiteSpace($RuntimeInputPacketP
 } else {
     $null
 }
+$memoryContextPack = if (-not [string]::IsNullOrWhiteSpace($MemoryContextPath) -and (Test-Path -LiteralPath $MemoryContextPath)) {
+    Get-Content -LiteralPath $MemoryContextPath -Raw -Encoding UTF8 | ConvertFrom-Json
+} else {
+    $null
+}
 $lines = @(
     "# $($intentContract.title)",
     '',
@@ -224,6 +230,15 @@ if ($runtimeInputPacket) {
     }
 }
 
+if ($memoryContextPack -and @($memoryContextPack.items).Count -gt 0) {
+    $lines += @(
+        '',
+        '## Memory Context',
+        'Bounded stage-aware memory context injected into requirement freezing:'
+    )
+    $lines += @($memoryContextPack.items | ForEach-Object { "- $_" })
+}
+
 $childHandoffPath = $null
 if ($isChildScope) {
     if (-not (Test-Path -LiteralPath $docPath)) {
@@ -258,6 +273,9 @@ $receipt = [pscustomobject]@{
     canonical_write_allowed = -not $isChildScope
     inherited_requirement_doc_path = if ($isChildScope) { $docPath } else { $null }
     runtime_input_packet_path = $RuntimeInputPacketPath
+    memory_context_path = if ($memoryContextPack) { $MemoryContextPath } else { $null }
+    memory_context_item_count = if ($memoryContextPack) { @($memoryContextPack.items).Count } else { 0 }
+    memory_context_estimated_tokens = if ($memoryContextPack) { [int]$memoryContextPack.estimated_tokens } else { 0 }
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 }
 $receiptPath = Join-Path $sessionRoot 'requirement-doc-receipt.json'

--- a/scripts/runtime/invoke-vibe-runtime.ps1
+++ b/scripts/runtime/invoke-vibe-runtime.ps1
@@ -18,6 +18,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'VibeRuntime.Common.ps1')
+. (Join-Path $PSScriptRoot 'VibeMemoryActivation.Common.ps1')
 
 function Wait-VibeArtifactSet {
     param(
@@ -105,6 +106,8 @@ if (-not [string]::IsNullOrWhiteSpace([string]$hierarchyState.inherited_executio
 }
 
 $skeleton = & (Join-Path $PSScriptRoot 'Invoke-SkeletonCheck.ps1') -Task $Task -Mode $Mode -RunId $RunId -ArtifactRoot $ArtifactRoot
+$memorySkeletonDigest = New-VibeSkeletonMemoryDigest -Runtime $runtime -Skeleton $skeleton -Task $Task -SessionRoot ([string]$skeleton.session_root)
+$requirementMemoryContext = New-VibeRequirementContextPack -Runtime $runtime -SkeletonDigestAction $memorySkeletonDigest -SessionRoot ([string]$skeleton.session_root)
 $freezeArgs = @{
     Task = $Task
     Mode = $Mode
@@ -123,6 +126,7 @@ $requirementArgs = @{
     RunId = $RunId
     IntentContractPath = $interview.receipt_path
     RuntimeInputPacketPath = $runtimeInput.packet_path
+    MemoryContextPath = $requirementMemoryContext.context_path
     ArtifactRoot = $ArtifactRoot
 }
 foreach ($key in @($hierarchyArgs.Keys)) {
@@ -158,6 +162,25 @@ foreach ($key in @('GovernanceScope', 'RootRunId', 'ParentRunId', 'ParentUnitId'
 }
 $execute = & (Join-Path $PSScriptRoot 'Invoke-PlanExecute.ps1') @executeArgs
 $cleanup = & (Join-Path $PSScriptRoot 'Invoke-PhaseCleanup.ps1') -Task $Task -Mode $Mode -RunId $RunId -ArtifactRoot $ArtifactRoot -ExecuteGovernanceCleanup:$ExecuteGovernanceCleanup -ApplyManagedNodeCleanup:$ApplyManagedNodeCleanup
+$memoryDeepInterviewRead = Get-VibeDeepInterviewMemoryReadAction -Runtime $runtime
+$memoryExecuteWrite = New-VibeExecutionMemoryWriteAction -ExecutionManifestPath ([string]$execute.execution_manifest_path) -SessionRoot ([string]$skeleton.session_root)
+$memoryCleanupDecision = Get-VibeCleanupDecisionWriteAction -RequirementDocPath ([string]$requirement.requirement_doc_path) -ExecutionPlanPath ([string]$plan.execution_plan_path)
+$memoryCleanupFold = New-VibeCleanupMemoryFold `
+    -RequirementDocPath ([string]$requirement.requirement_doc_path) `
+    -ExecutionPlanPath ([string]$plan.execution_plan_path) `
+    -ExecutionManifestPath ([string]$execute.execution_manifest_path) `
+    -CleanupReceiptPath ([string]$cleanup.receipt_path) `
+    -SessionRoot ([string]$skeleton.session_root)
+$memoryActivation = New-VibeMemoryActivationReport `
+    -Runtime $runtime `
+    -RunId $RunId `
+    -SessionRoot ([string]$skeleton.session_root) `
+    -SkeletonDigestAction $memorySkeletonDigest `
+    -DeepInterviewReadAction $memoryDeepInterviewRead `
+    -RequirementContextPack $requirementMemoryContext `
+    -ExecuteWriteAction $memoryExecuteWrite `
+    -CleanupDecisionAction $memoryCleanupDecision `
+    -CleanupFoldAction $memoryCleanupFold
 $deliveryAcceptanceReportPath = Join-Path $skeleton.session_root 'delivery-acceptance-report.json'
 $deliveryAcceptanceMarkdownPath = Join-Path $skeleton.session_root 'delivery-acceptance-report.md'
 
@@ -174,7 +197,9 @@ $artifactReadiness = Wait-VibeArtifactSet -Paths @(
     [string]$execute.execution_topology_path,
     [string]$execute.benchmark_proof_manifest_path,
     [string]$cleanup.receipt_path,
-    [string]$deliveryAcceptanceReportPath
+    [string]$deliveryAcceptanceReportPath,
+    [string]$memoryActivation.report_path,
+    [string]$memoryActivation.markdown_path
 )
 
 if (-not $artifactReadiness.ready) {
@@ -196,6 +221,8 @@ $relativeArtifacts = [ordered]@{
     cleanup_receipt = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$cleanup.receipt_path)
     delivery_acceptance_report = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$deliveryAcceptanceReportPath)
     delivery_acceptance_markdown = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$deliveryAcceptanceMarkdownPath)
+    memory_activation_report = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$memoryActivation.report_path)
+    memory_activation_markdown = Get-VibeRelativePathCompat -BasePath $artifactBaseRoot -TargetPath ([string]$memoryActivation.markdown_path)
 }
 
 $deliveryAcceptanceReport = if (Test-Path -LiteralPath $deliveryAcceptanceReportPath) {
@@ -243,6 +270,15 @@ $summary = [pscustomobject]@{
         cleanup_receipt = $cleanup.receipt_path
         delivery_acceptance_report = $deliveryAcceptanceReportPath
         delivery_acceptance_markdown = $deliveryAcceptanceMarkdownPath
+        memory_activation_report = $memoryActivation.report_path
+        memory_activation_markdown = $memoryActivation.markdown_path
+    }
+    memory_activation = [pscustomobject]@{
+        policy_mode = [string]$memoryActivation.report.policy.mode
+        routing_contract = [string]$memoryActivation.report.policy.routing_contract
+        fallback_event_count = [int]$memoryActivation.report.summary.fallback_event_count
+        artifact_count = [int]$memoryActivation.report.summary.artifact_count
+        budget_guard_respected = [bool]$memoryActivation.report.summary.budget_guard_respected
     }
     delivery_acceptance = if ($deliveryAcceptanceReport) {
         [pscustomobject]@{

--- a/scripts/verify/runtime_neutral/freshness_gate.py
+++ b/scripts/verify/runtime_neutral/freshness_gate.py
@@ -211,11 +211,22 @@ def runtime_config(governance: dict[str, Any]) -> dict[str, Any]:
     return merged
 
 
+def installed_runtime_materialized(repo_root: Path, runtime_cfg: dict[str, Any]) -> bool:
+    required_markers = list(runtime_cfg.get("required_runtime_markers") or [])
+    if not required_markers:
+        return False
+    return all((repo_root / marker).exists() for marker in required_markers)
+
+
 def enforce_execution_context(context: GovernanceContext, script_path: Path) -> None:
     policy = context.governance.get("execution_context_policy") or {}
     require_outer_git_root = bool(policy.get("require_outer_git_root", True))
     fail_if_under_mirror = bool(policy.get("fail_if_script_path_is_under_mirror_root", True))
-    if require_outer_git_root and not (context.repo_root / ".git").exists():
+    if (
+        require_outer_git_root
+        and not (context.repo_root / ".git").exists()
+        and not installed_runtime_materialized(context.repo_root, context.runtime_config)
+    ):
         raise RuntimeError(
             f"Execution-context lock failed: resolved repo root is not the outer git root -> {context.repo_root}"
         )

--- a/tests/runtime_neutral/test_freshness_gate.py
+++ b/tests/runtime_neutral/test_freshness_gate.py
@@ -183,6 +183,37 @@ class FreshnessGateTests(unittest.TestCase):
         docs_entry = next(item for item in artifact["results"]["directories"] if item["path"] == "docs")
         self.assertEqual(["unexpected.md"], docs_entry["only_in_installed"])
 
+    def test_execution_context_allows_installed_runtime_without_outer_git_root(self) -> None:
+        with tempfile.TemporaryDirectory() as isolated_dir:
+            installed_context_root = Path(isolated_dir)
+            self.seed_tree(installed_context_root, canonical=False)
+            (installed_context_root / "config").mkdir(parents=True, exist_ok=True)
+            (installed_context_root / "config" / "version-governance.json").write_text(
+                json.dumps(self.governance, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            script_path = installed_context_root / "scripts" / "runtime" / "invoke-vibe-runtime.ps1"
+            script_path.parent.mkdir(parents=True, exist_ok=True)
+            script_path.write_text("Write-Host 'runtime'\n", encoding="utf-8")
+
+            context = self.module.load_governance_context(script_path, enforce_context=True)
+            self.assertEqual(installed_context_root, context.repo_root)
+
+    def test_execution_context_rejects_missing_git_and_incomplete_installed_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as isolated_dir:
+            incomplete_root = Path(isolated_dir)
+            (incomplete_root / "config").mkdir(parents=True, exist_ok=True)
+            (incomplete_root / "config" / "version-governance.json").write_text(
+                json.dumps(self.governance, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            script_path = incomplete_root / "scripts" / "runtime" / "invoke-vibe-runtime.ps1"
+            script_path.parent.mkdir(parents=True, exist_ok=True)
+            script_path.write_text("Write-Host 'runtime'\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "resolved repo root is not the outer git root"):
+                self.module.load_governance_context(script_path, enforce_context=True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/runtime_neutral/test_memory_runtime_activation.py
+++ b/tests/runtime_neutral/test_memory_runtime_activation.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def resolve_powershell() -> str | None:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("pwsh.exe"),
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files\PowerShell\7-preview\pwsh.exe",
+        shutil.which("powershell"),
+        shutil.which("powershell.exe"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
+def run_governed_runtime(task: str, artifact_root: Path) -> dict[str, object]:
+    shell = resolve_powershell()
+    if shell is None:
+        raise unittest.SkipTest("PowerShell executable not available in PATH")
+
+    script_path = REPO_ROOT / "scripts" / "runtime" / "invoke-vibe-runtime.ps1"
+    run_id = "pytest-memory-runtime-" + uuid.uuid4().hex[:10]
+    command = [
+        shell,
+        "-NoLogo",
+        "-NoProfile",
+        "-Command",
+        (
+            "& { "
+            f"$result = & '{script_path}' "
+            f"-Task '{task}' "
+            "-Mode benchmark_autonomous "
+            f"-RunId '{run_id}' "
+            f"-ArtifactRoot '{artifact_root}'; "
+            "$result | ConvertTo-Json -Depth 20 }"
+        ),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+    stdout = completed.stdout.strip()
+    if stdout in ("", "null"):
+        raise AssertionError(
+            "invoke-vibe-runtime returned null payload. "
+            f"stderr={completed.stderr.strip()}"
+        )
+    return json.loads(stdout)
+
+
+class MemoryRuntimeActivationTests(unittest.TestCase):
+    def test_runtime_emits_stage_aware_memory_activation_report(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            payload = run_governed_runtime(
+                "Plan and debug a governed runtime enhancement with long-horizon continuity needs.",
+                artifact_root=Path(tempdir),
+            )
+            summary = payload["summary"]
+            artifacts = summary["artifacts"]
+
+            self.assertIn("memory_activation_report", artifacts)
+            self.assertIn("memory_activation_markdown", artifacts)
+
+            report_path = Path(artifacts["memory_activation_report"])
+            markdown_path = Path(artifacts["memory_activation_markdown"])
+
+            self.assertTrue(report_path.exists())
+            self.assertTrue(markdown_path.exists())
+
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["run_id"], report["run_id"])
+            self.assertEqual("shadow", report["policy"]["mode"])
+            self.assertEqual("advisory_first_post_route_only", report["policy"]["routing_contract"])
+            self.assertEqual("state_store", report["policy"]["canonical_owners"]["session"])
+            self.assertEqual("Serena", report["policy"]["canonical_owners"]["project_decision"])
+            self.assertEqual("ruflo", report["policy"]["canonical_owners"]["short_term_semantic"])
+            self.assertEqual("Cognee", report["policy"]["canonical_owners"]["long_term_graph"])
+
+            stages = report["stages"]
+            self.assertEqual(
+                [
+                    "skeleton_check",
+                    "deep_interview",
+                    "requirement_doc",
+                    "xl_plan",
+                    "plan_execute",
+                    "phase_cleanup",
+                ],
+                [stage["stage"] for stage in stages],
+            )
+
+            skeleton = stages[0]
+            self.assertEqual("fallback_local_digest", skeleton["read_actions"][0]["status"])
+            self.assertLessEqual(
+                len(skeleton["read_actions"][0]["items"]),
+                skeleton["read_actions"][0]["budget"]["top_k"],
+            )
+
+            deep_interview = stages[1]
+            self.assertEqual("deferred_no_project_key", deep_interview["read_actions"][0]["status"])
+
+            requirement_stage = stages[2]
+            self.assertGreaterEqual(requirement_stage["context_injection"]["injected_item_count"], 1)
+            self.assertLessEqual(
+                requirement_stage["context_injection"]["estimated_tokens"],
+                requirement_stage["context_injection"]["budget"]["max_tokens"],
+            )
+
+            execute_stage = stages[4]
+            self.assertGreaterEqual(execute_stage["write_actions"][0]["item_count"], 1)
+            self.assertTrue(Path(execute_stage["write_actions"][0]["artifact_path"]).exists())
+            self.assertIn(
+                execute_stage["write_actions"][0]["status"],
+                {"fallback_local_artifact", "backend_write"},
+            )
+
+            cleanup_stage = stages[5]
+            self.assertEqual("guarded_no_write", cleanup_stage["write_actions"][0]["status"])
+            self.assertTrue(Path(cleanup_stage["write_actions"][1]["artifact_path"]).exists())
+            self.assertEqual("generated_local_fold", cleanup_stage["write_actions"][1]["status"])
+
+            summary_block = report["summary"]
+            self.assertEqual(6, summary_block["stage_count"])
+            self.assertGreaterEqual(summary_block["fallback_event_count"], 1)
+            self.assertGreaterEqual(summary_block["artifact_count"], 3)
+            self.assertTrue(summary_block["budget_guard_respected"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a stage-aware memory activation runtime path with bounded retrieval budgets and auditable local fallback artifacts
- inject bounded memory context into requirement freezing and emit execution/cleanup memory artifacts in the governed runtime summary
- allow installed runtime materializations to execute without an outer git root while still blocking bundled mirror execution inside the canonical repo tree
- sync the runtime/common/freshness changes into bundled and nested bundled mirrors
- add runtime-neutral coverage for memory activation and installed-runtime execution-context behavior

## Verification
- python3 -m pytest -q tests/runtime_neutral/test_memory_runtime_activation.py tests/runtime_neutral/test_freshness_gate.py tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py
- Result: 26 passed, 38 subtests passed

## Notes
- Verified real runtime scenarios for L, XL, child-governed inheritance, Serena-key branch, and external installed-bundle execution.
