### PR TITLE
release: cut v2.3.52

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -291,7 +291,7 @@ The governed runtime should leave behind:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 2.3.51
-- Updated: 2026-03-28
+- Version: 2.3.52
+- Updated: 2026-03-29
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/bundled/skills/vibe/SKILL.md
+++ b/bundled/skills/vibe/SKILL.md
@@ -291,7 +291,7 @@ The governed runtime should leave behind:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 2.3.51
-- Updated: 2026-03-28
+- Version: 2.3.52
+- Updated: 2026-03-29
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/bundled/skills/vibe/bundled/skills/vibe/SKILL.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/SKILL.md
@@ -291,7 +291,7 @@ The governed runtime should leave behind:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 2.3.51
-- Updated: 2026-03-28
+- Version: 2.3.52
+- Updated: 2026-03-29
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/bundled/skills/vibe/bundled/skills/vibe/config/version-governance.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/version-governance.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
   "release": {
-    "version": "2.3.51",
-    "updated": "2026-03-28",
+    "version": "2.3.52",
+    "updated": "2026-03-29",
     "channel": "stable",
-    "notes": "Adds main-chain delivery acceptance under vibe, hardens stage-bound specialist dispatch and Windows specialist runtime handoff, and promotes stricter completion-language truth for governed runs."
+    "notes": "Adds stage-aware memory activation to the main vibe runtime, wires governed Serena/ruflo/Cognee backend adapters into observable session artifacts, and keeps memory-scope boundaries explicit."
   },
   "source_of_truth": {
     "canonical_root": ".",

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-28-vibe-memory-runtime-activation-closure-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-28-vibe-memory-runtime-activation-closure-plan.md
@@ -1,0 +1,358 @@
+# Vibe Memory Runtime Activation Closure Plan
+
+## Execution Summary
+The repository already has the right owner-boundary model for memory. The smallest coherent path is not to widen memory authority. It is to convert the current governance-only memory plane into a stage-aware runtime activation model with strict write admission, retrieval gating, prompt-budget controls, and fallback-safe runtime hooks. The design goal is to keep memory useful, sparse, and auditable.
+
+## Frozen Inputs
+- Requirement doc: [2026-03-28-vibe-memory-runtime-activation-closure.md](../requirements/2026-03-28-vibe-memory-runtime-activation-closure.md)
+- Current reality:
+  - `state_store` is the only reliably active default memory lane
+  - `Serena`, `ruflo`, and `Cognee` are mostly defined in governance and protocol surfaces, not yet fully wired into normal `vibe` runtime execution
+  - `knowledge-steward` and `deepagent-memory-fold` are real skills, but they are explicit or keyword-triggered rather than systematically stage-bound
+  - `memory-runtime-v3` remains `shadow` and `advisory_first_post_route_only`
+- Invariants that must stay unchanged:
+  - canonical router remains route authority
+  - `vibe` remains runtime authority
+  - memory stays post-route and subordinate to runtime governance
+  - canonical owners remain `state_store`, `Serena`, `ruflo`, and `Cognee`
+
+## Internal Grade Decision
+- Grade: XL
+- The work spans runtime integration, config contracts, test harnesses, rollout policy, prompt-budget rules, operator documentation, and failure proof.
+- The design must coordinate router metadata, runtime stages, retro surfaces, and benchmark evaluation without creating a parallel control plane.
+
+## Design Overview
+
+### Design Principle 1: Memory Must Be Stage-Bound
+Memory activation should depend on the runtime stage, not on generic availability.
+
+Required behavior:
+- `skeleton_check`: light background recall only
+- `deep_interview`: minimum decision recall only
+- `requirement_doc`: citeable acceptance-relevant recall only
+- `xl_plan`: planning-relevant recall only
+- `plan_execute`: bounded milestone and handoff memory only
+- `phase_cleanup`: persistence and fold cleanup only
+
+### Design Principle 2: Write Admission Must Be Narrower Than Recall
+The system must reject most candidate writes.
+Memory quality comes from selective persistence, not from large-volume storage.
+
+Required write shapes:
+- `state_store`: run-local progress and artifacts
+- `Serena`: explicit approved project decisions only
+- `ruflo`: short-horizon milestone cards and handoff cards only
+- `Cognee`: entities and relations only
+- `knowledge-steward`: explicit user-requested durable capture only
+- `deepagent-memory-fold`: structured compaction object only
+
+### Design Principle 3: Retrieval Must Be Budgeted
+Memory should return cards, not transcripts.
+Every recall lane requires:
+- trigger condition
+- top-k cap
+- token budget
+- replacement vs append semantics
+
+### Design Principle 4: Fallback Must Preserve Continuity
+Backend outages must not break `vibe`.
+The runtime must degrade to:
+- `state_store`
+- local session artifacts
+- requirement/plan/handoff outputs
+
+### Design Principle 5: Intelligence Must Be Proven, Not Assumed
+A memory lane is intelligent only if it:
+- reduces repeated clarification or lost context
+- improves handoff continuity
+- avoids irrelevant recall
+- stays within prompt budget
+
+## Target Architecture
+
+### A. Stage-Aware Memory Trigger Matrix
+Add one canonical trigger matrix document and config contract that maps memory actions to `vibe` stages.
+
+Expected stage actions:
+
+#### `skeleton_check`
+- Read:
+  - `Serena` decision digest: allowed
+  - `Cognee` small relationship digest: allowed
+- Write: none
+- Budget:
+  - max 3 decision cards
+  - max 1 graph digest block
+- Failure behavior:
+  - fallback to local docs and `state_store`
+
+#### `deep_interview`
+- Read:
+  - `Serena` only if the same project already has approved conventions
+- Write: none
+- Budget:
+  - max 2 decision cards
+- Goal:
+  - avoid re-asking settled project conventions
+
+#### `requirement_doc`
+- Read:
+  - only citeable constraints and approved decisions
+- Write:
+  - candidate decisions staged locally, not yet persisted to `Serena`
+- Budget:
+  - max 3 cited memory anchors
+
+#### `xl_plan`
+- Read:
+  - `Serena` decision digest
+  - bounded `Cognee` relationship digest for cross-module dependencies
+- Write:
+  - none to long-term stores
+  - optional local `state_store` planning memo
+
+#### `plan_execute`
+- `M`:
+  - use `state_store` only
+- `L`:
+  - use `state_store`; no default `ruflo`
+- `XL`:
+  - optional `ruflo` milestone cards
+  - optional `ruflo` handoff summaries
+  - no raw transcript storage
+- Specialist lanes:
+  - child lanes receive only root-approved handoff digests
+
+#### `phase_cleanup`
+- Write:
+  - `Serena`: only approved decisions
+  - `Cognee`: only approved entities/relations
+  - `deepagent-memory-fold`: only when context-pressure or handoff criteria were met
+  - `knowledge-steward`: only on explicit user request
+- Read:
+  - none unless required for retro comparison
+
+### B. Write Admission Contracts
+Add explicit config or reference contracts for:
+- `serena-write-admission.json`
+- `ruflo-card-contract.json`
+- `cognee-entity-relation-contract.json`
+- `memory-fold-trigger-policy.json`
+
+Each contract must define:
+- allowed payload classes
+- forbidden payload classes
+- required metadata
+- retention policy
+- rollback behavior
+
+### C. Retrieval Budget Contracts
+Add one canonical budget contract, for example:
+- `config/memory-retrieval-budget-policy.json`
+
+Minimum fields:
+- stage
+- lane
+- `top_k`
+- `max_tokens`
+- `replacement_mode`
+- `inject_as`
+- `fallback_mode`
+
+Required semantics:
+- recall injects compact cards or digests only
+- full raw stored content stays out of prompt context
+- folded memory replaces old context instead of appending
+
+### D. Runtime Integration Hooks
+Add bounded runtime hook points inside the existing stage implementation:
+
+- `Invoke-SkeletonCheck`:
+  - optional pre-run recall receipts
+- `Write-RequirementDoc`:
+  - citeable memory anchors only
+- `Write-XlPlan`:
+  - bounded dependency recall only
+- `Invoke-PlanExecute`:
+  - XL milestone/handoff store and search
+- `Invoke-PhaseCleanup`:
+  - durable persistence receipts
+  - optional fold receipt
+
+Every hook must emit:
+- attempted lane
+- action type
+- success/fallback
+- payload count
+- token budget used
+
+### E. Intelligence Guardrails
+Introduce runtime guardrails that block low-quality memory usage:
+- no memory read if stage is out of scope
+- no memory write if payload lacks required type metadata
+- no recall when relevance score is below threshold
+- no injection if budget would be exceeded
+- no fold append on top of full historical context
+
+### F. Proof Surface
+Add one memory activation report family under:
+- `outputs/runtime/vibe-sessions/<run-id>/memory-activation.json`
+- `outputs/runtime/vibe-sessions/<run-id>/memory-activation.md`
+
+Minimum fields:
+- stage actions taken
+- reads attempted and succeeded
+- writes attempted and succeeded
+- fallback events
+- token budget consumption
+- ignored or denied writes
+- retrieval relevance scores
+- fold trigger reason
+
+## Wave Plan
+
+### Wave 1: Freeze Stage-Aware Memory Contract
+- Write stable governance doc for stage-aware activation
+- Add trigger matrix and owner-boundary restatement
+- Add explicit non-goals against transcript dumping and authority transfer
+
+### Wave 2: Add Write Admission Contracts
+- Add lane-specific write contracts
+- Define candidate-to-approved decision flow for `Serena`
+- Define XL milestone card schema for `ruflo`
+- Define entity-relation ingest schema for `Cognee`
+
+### Wave 3: Add Retrieval Budget Policy
+- Add a canonical top-k and token-budget policy
+- Define replacement vs append behavior
+- Define per-stage allowable recall lanes
+
+### Wave 4: Wire Runtime Hooks
+- Add read hooks to `skeleton_check`, `deep_interview`, `xl_plan`
+- Add write hooks to `plan_execute` and `phase_cleanup`
+- Emit per-stage memory receipts
+
+### Wave 5: Add Context-Pressure Compaction
+- Define fold trigger conditions
+- Add a bounded call path for `deepagent-memory-fold`
+- Guarantee fold artifact replaces historical context in continuation flows
+
+### Wave 6: Add Scenario Corpus
+Create scenarios for:
+- no-backend baseline
+- Serena-only decision reuse
+- XL milestone continuity with `ruflo`
+- long-term relationship reuse with `Cognee`
+- context-pressure fold continuation
+- missing-backend fallback
+- low-relevance recall rejection
+- write-admission rejection
+
+### Wave 7: Add Gates And Benchmarks
+- runtime activation gate
+- retrieval budget gate
+- fold replacement gate
+- fallback integrity gate
+- repeated-run flake gate
+
+### Wave 8: Release Truth And Operator Docs
+- add operator runbook
+- add release-facing truth gate for memory claims
+- forbid README language that overstates automatic persistence or recall beyond tested reality
+
+## Detailed Test Program
+
+### 1. Owner Boundary Tests
+- `state_store` stays session-only
+- `Serena` does not accept raw transcripts
+- `ruflo` does not become long-term store
+- `Cognee` does not ingest arbitrary transcript blocks
+- `mem0` and `Letta` do not gain canonical owner status
+
+### 2. Stage Trigger Tests
+- each stage invokes only permitted lanes
+- out-of-scope stages do not read or write memory
+- write actions are deferred until approved persistence points
+
+### 3. Retrieval Quality Tests
+- high-relevance cards are recalled
+- low-relevance cards are rejected
+- no more than configured top-k are injected
+- token budget never exceeds policy cap
+
+### 4. Fallback Tests
+- missing Serena backend falls back to local docs and `state_store`
+- missing `ruflo` keeps XL execution viable
+- missing `Cognee` does not break startup
+- fold unavailable degrades to local handoff artifacts
+
+### 5. Compaction Tests
+- fold triggers only at allowed conditions
+- fold artifact includes working/tool/evidence/decision/resume sections
+- fold replaces large historical context rather than appending to it
+
+### 6. Continuity Tests
+- repeated clarification rate decreases when approved decisions exist
+- XL handoff retains blocker/next-step continuity
+- resumed session can continue from folded memory with bounded context
+
+### 7. Anti-Explosion Tests
+- transcript-size write attempts are rejected
+- oversized recall is truncated or denied
+- duplicate recalls are deduplicated before injection
+- cumulative memory injection stays under a global stage budget
+
+### 8. Operator Usability Tests
+- activation report is readable and actionable
+- denied-write reasons are explicit
+- fallback status is operator-visible
+- release wording aligns with actual tested capability
+
+## Proof Strategy
+
+### Stability Proof
+- repeated-run matrix for each scenario
+- flake accounting for repeated recall and fallback behavior
+- failure injection for missing backends and denied writes
+
+Target proof:
+- memory activation does not destabilize the runtime
+- stage actions remain deterministic enough to audit
+
+### Availability Proof
+- no-backend baseline still succeeds using `state_store`
+- partial-backend availability produces bounded degraded behavior
+- runtime artifacts remain sufficient for continuation without external memory services
+
+### Intelligence Proof
+- compare runs with and without bounded memory recall
+- measure:
+  - repeated clarification count
+  - handoff completeness
+  - irrelevant recall count
+  - budget overrun count
+  - route drift count
+
+Target proof:
+- recall is relevant more often than noisy
+- useful continuity improves without widening authority or prompt size
+
+## Rollback Rules
+- Any owner-boundary violation:
+  - disable the offending lane
+  - revert to `shadow`
+- Any repeated irrelevant recall or budget overrun:
+  - reduce top-k and token caps
+  - disable the stage hook if needed
+- Any runtime instability:
+  - fall back to `state_store` plus local artifacts only
+
+## Success Criteria
+This plan succeeds when the repository can prove all of the following at once:
+
+- memory activation is stage-aware rather than always-on
+- each lane preserves its intended role
+- memory recall is bounded and relevance-aware
+- context compaction reduces context size instead of increasing it
+- external backend failures do not break `vibe`
+- repository documentation and release wording match the tested runtime truth

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/releases/v2.3.52.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/releases/v2.3.52.md
@@ -1,0 +1,40 @@
+# VCO Release v2.3.52
+
+- Date: 2026-03-29
+- Commit(base): 870fd20
+- Previous release: `v2.3.51`
+
+## Highlights
+
+- Landed stage-aware memory activation inside the normal six-stage `vibe` governed runtime. Governed runs now emit `memory-activation-report.json` and `memory-activation-report.md`, carry bounded memory-context injection into requirement/plan artifacts, and keep the activation path visible in per-stage receipts.
+- Added real governed backend adapter calls for `Serena`, `ruflo`, and `Cognee`. When enabled, the runtime now writes request/response artifacts under the session's `memory-backend/` directory instead of only recording advisory ownership policy.
+- Kept the memory contract narrow and explicit instead of widening it into an uncontrolled background memory layer:
+  - `Serena` remains for explicit project decisions
+  - `Cognee` remains for bounded relation recall / ingest
+  - `ruflo` remains XL-scoped for milestone and handoff continuity in `plan_execute`
+  - `knowledge-steward` is still an explicit skill, not automatic runtime capture
+  - the cleanup fold is a local governed fold artifact, not silent auto-invocation of the `deepagent-memory-fold` skill
+
+## What Changed Compared With v2.3.51
+
+- `v2.3.51` moved delivery acceptance into the main governed runtime chain and tightened specialist-governance closure.
+- `v2.3.52` moves the memory plane forward from mainly policy / route advice into observable stage-bound runtime behavior with real backend read/write paths and runtime artifacts.
+- The important difference is not "more memory everywhere". The difference is that governed runs now show where memory was read, where it was written, and where the runtime deliberately refused to widen memory scope.
+
+## Validation Notes
+
+- Memory activation/runtime backend coverage:
+  - `pytest -q tests/runtime_neutral/test_memory_runtime_activation.py`
+- Governed runtime / topology / hierarchy regression coverage:
+  - `pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py`
+- Release-surface hygiene:
+  - `git diff --check`
+  - `pwsh -NoProfile -File scripts/verify/vibe-version-consistency-gate.ps1`
+  - `pwsh -NoProfile -File scripts/verify/vibe-dist-manifest-gate.ps1`
+  - `pwsh -NoProfile -File scripts/verify/vibe-nested-bundled-parity-gate.ps1`
+
+## Migration Notes
+
+- Operators should expect new runtime artifacts under `outputs/runtime/vibe-sessions/<run-id>/`, especially the memory activation report family and, when backend lanes are enabled, request/response receipts under `memory-backend/`.
+- This release proves governed memory activation and bounded backend integration. It does not claim that every memory-related skill is now silently auto-running in the background.
+- `knowledge-steward` still requires explicit user intent, and the runtime cleanup fold should be read as local governed context compaction rather than as a full skill-level memory handoff backend.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-28-vibe-memory-runtime-activation-closure.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-28-vibe-memory-runtime-activation-closure.md
@@ -1,0 +1,118 @@
+# Vibe Memory Runtime Activation Closure
+
+## Summary
+Close the gap between the repository's memory-governance claims and the actual `vibe` runtime behavior. The current repository already defines strong owner boundaries for `state_store`, `Serena`, `ruflo`, `Cognee`, `mem0`, and `Letta`, but most of those roles still operate as post-route governance guidance rather than as stage-bound runtime behavior with bounded write, retrieval, and injection contracts.
+
+## Goal
+Design and land a memory-runtime architecture where each canonical memory role is invoked only at the right stage, with bounded payload size, audited write admission, intelligent retrieval gates, and explicit rollback rules, so memory becomes useful without becoming a second control plane or a context-amplification source.
+
+## Deliverable
+A repository change program and documentation bundle that adds:
+
+- a stage-aware activation model for `state_store`, `Serena`, `ruflo`, `Cognee`, `knowledge-steward`, and `deepagent-memory-fold`
+- machine-readable write-admission and retrieval-budget contracts for each memory lane
+- runtime integration points for memory read/write/fold actions inside the existing six-stage `vibe` lifecycle
+- scenario tests and executable gates proving stability, usability, and intelligence
+- operator documentation describing when memory is invoked, when it must stay silent, and how to disable or roll back each lane
+
+## Constraints
+- Preserve `VCO` as the single runtime and control plane owner.
+- Preserve the canonical router as route authority.
+- Do not create a second visible startup surface, second requirement surface, or second execution-plan surface.
+- Do not allow any memory lane to mutate `selected.pack_id`, `selected.skill`, or grade choice.
+- Preserve the current canonical owner matrix:
+  - `state_store` for session truth
+  - `Serena` for explicit project decisions
+  - `ruflo` for short-term semantic cache
+  - `Cognee` for long-term relationship memory
+- Keep `episodic-memory` disabled in governed routing.
+- Keep `mem0` preference-only and `Letta` contract-only.
+- Prefer additive runtime hooks and bounded artifacts over a broad router/runtime rewrite.
+
+## Acceptance Criteria
+- The repository defines a stage-aware memory trigger matrix covering:
+  - `skeleton_check`
+  - `deep_interview`
+  - `requirement_doc`
+  - `xl_plan`
+  - `plan_execute`
+  - `phase_cleanup`
+- Every memory lane has an explicit write-admission contract:
+  - what can be written
+  - what must not be written
+  - required evidence shape
+  - retention or expiry rule
+- Every retrievable memory lane has an explicit retrieval contract:
+  - allowed trigger conditions
+  - maximum item count
+  - maximum prompt-injection budget
+  - fallback behavior when the backend is unavailable
+- `state_store` remains the default always-on runtime memory lane.
+- `Serena` is only written when the runtime has an explicit project decision surface or explicit operator approval.
+- `ruflo` is only used for bounded XL milestone summaries, handoff blocks, or short-horizon semantic retrieval, never as a generic long transcript store.
+- `Cognee` is only used for bounded graph retrieval or long-term ingest at approved persistence points, never as a raw transcript sink.
+- `knowledge-steward` remains explicit-user-trigger only and is not silently promoted into a background auto-capture path.
+- `deepagent-memory-fold` becomes a governed compaction lane that can be invoked only under documented context-pressure or handoff conditions, and its folded artifact replaces large historical context instead of being appended to it.
+- The repository includes a bounded memory injection policy proving that memory recall cannot expand prompt context without limit.
+- The repository includes executable tests proving:
+  - stability across repeated runs
+  - availability and graceful fallback when memory backends are missing
+  - intelligence of retrieval choice and budgeted injection
+
+## Primary Objective
+Make memory in `vibe` useful enough to preserve continuity and decision quality, while keeping it sufficiently bounded that it cannot destabilize routing, runtime truth, or prompt size.
+
+## Proxy Signals
+- Memory recall reduces repeated clarification or lost context without increasing route drift.
+- Memory writes are sparse, typed, and evidence-backed rather than transcript-dump based.
+- Retrieval returns only the minimum relevant cards required for the current stage.
+- Missing memory backends degrade gracefully to `state_store` and local artifacts.
+
+## Scope
+In scope:
+- stage-aware memory activation design
+- write-admission rules
+- retrieval gating rules
+- prompt-injection budget design
+- context-pressure fold design
+- backend fallback semantics
+- executable verification and proof strategy
+- repository documentation and rollout plan
+
+Out of scope:
+- replacing the canonical router
+- granting memory lanes route mutation or runtime ownership
+- making every memory backend mandatory for every host
+- storing full raw conversation transcripts as long-term truth
+- turning `knowledge-steward` into implicit background ingestion
+
+## Completion
+The work is complete when the repository can prove, with executable tests and bounded runtime contracts, that each memory lane is called at the correct time, injects only bounded information, degrades safely when unavailable, and measurably improves continuity without causing context explosion or governance drift.
+
+## Evidence
+- new or updated governance docs for stage-aware memory activation
+- requirement and plan docs for rollout
+- runtime integration design for read/write/fold hooks
+- machine-readable budget and admission policies
+- scenario corpus and gates covering stability, availability, and intelligence
+
+## Non-Goals
+- Do not treat memory backend availability as proof of useful recall.
+- Do not equate more recalled text with better intelligence.
+- Do not let long-term memory become a dump of unresolved thoughts or temporary state.
+- Do not append folded memory on top of the original large context.
+- Do not allow advisory memory suggestions to silently become execution authority.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- The current six-stage `vibe` lifecycle is sufficient to host memory activation without adding a second runtime.
+- Existing `state_store` and runtime artifacts already provide a stable baseline fallback.
+- The main missing layer is stage-aware runtime activation, not owner-boundary definition.
+- The repository can add new config contracts, runtime hooks, and tests without breaking current router invariants.
+
+## Evidence Inputs
+- Source task: plan a full activation-closure program for the current memory system
+- Current finding: governance, contracts, and gates exist; automatic stage-bound runtime invocation is still partial
+- Current policy: `memory-runtime-v3` remains `shadow` and `advisory_first_post_route_only`

--- a/bundled/skills/vibe/bundled/skills/vibe/references/changelog.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/references/changelog.md
@@ -1,5 +1,13 @@
 # VCO Changelog
 
+## v2.3.52 (2026-03-29)
+
+- Landed stage-aware memory activation inside the standard six-stage `vibe` runtime, including per-run memory activation reports and bounded context injection into governed artifacts.
+- Added real governed backend adapter read/write paths for `Serena`, `ruflo`, and `Cognee`, with session-local request/response receipts instead of policy-only ownership claims.
+- Kept memory-scope boundaries explicit: `ruflo` remains XL-scoped, `knowledge-steward` remains explicit-only, and the runtime cleanup fold is local governed compaction rather than silent skill auto-invocation.
+- Detailed release notes: `docs/releases/v2.3.52.md`.
+
+
 ## v2.3.51 (2026-03-28)
 
 - Integrated downstream delivery acceptance into the normal `vibe` main chain so governed runs now freeze product acceptance semantics, plan delivery checks, and emit a per-run delivery-acceptance report during cleanup.

--- a/bundled/skills/vibe/bundled/skills/vibe/references/release-ledger.jsonl
+++ b/bundled/skills/vibe/bundled/skills/vibe/references/release-ledger.jsonl
@@ -29,3 +29,4 @@
 {"recorded_at":"2026-03-23T01:38:21","version":"2.3.49","updated":"2026-03-23","git_head":"dc0430d","actor":null}
 {"recorded_at":"2026-03-26T20:39:51","version":"2.3.50","updated":"2026-03-26","git_head":"d5da111","actor":null}
 {"recorded_at":"2026-03-28T00:00:00","version":"2.3.51","updated":"2026-03-28","git_head":"18e6b9c","actor":null}
+{"recorded_at":"2026-03-29T10:14:24","version":"2.3.52","updated":"2026-03-29","git_head":"870fd20","actor":null}

--- a/bundled/skills/vibe/config/version-governance.json
+++ b/bundled/skills/vibe/config/version-governance.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
   "release": {
-    "version": "2.3.51",
-    "updated": "2026-03-28",
+    "version": "2.3.52",
+    "updated": "2026-03-29",
     "channel": "stable",
-    "notes": "Adds main-chain delivery acceptance under vibe, hardens stage-bound specialist dispatch and Windows specialist runtime handoff, and promotes stricter completion-language truth for governed runs."
+    "notes": "Adds stage-aware memory activation to the main vibe runtime, wires governed Serena/ruflo/Cognee backend adapters into observable session artifacts, and keeps memory-scope boundaries explicit."
   },
   "source_of_truth": {
     "canonical_root": ".",

--- a/bundled/skills/vibe/docs/plans/2026-03-28-vibe-memory-runtime-activation-closure-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-28-vibe-memory-runtime-activation-closure-plan.md
@@ -1,0 +1,358 @@
+# Vibe Memory Runtime Activation Closure Plan
+
+## Execution Summary
+The repository already has the right owner-boundary model for memory. The smallest coherent path is not to widen memory authority. It is to convert the current governance-only memory plane into a stage-aware runtime activation model with strict write admission, retrieval gating, prompt-budget controls, and fallback-safe runtime hooks. The design goal is to keep memory useful, sparse, and auditable.
+
+## Frozen Inputs
+- Requirement doc: [2026-03-28-vibe-memory-runtime-activation-closure.md](../requirements/2026-03-28-vibe-memory-runtime-activation-closure.md)
+- Current reality:
+  - `state_store` is the only reliably active default memory lane
+  - `Serena`, `ruflo`, and `Cognee` are mostly defined in governance and protocol surfaces, not yet fully wired into normal `vibe` runtime execution
+  - `knowledge-steward` and `deepagent-memory-fold` are real skills, but they are explicit or keyword-triggered rather than systematically stage-bound
+  - `memory-runtime-v3` remains `shadow` and `advisory_first_post_route_only`
+- Invariants that must stay unchanged:
+  - canonical router remains route authority
+  - `vibe` remains runtime authority
+  - memory stays post-route and subordinate to runtime governance
+  - canonical owners remain `state_store`, `Serena`, `ruflo`, and `Cognee`
+
+## Internal Grade Decision
+- Grade: XL
+- The work spans runtime integration, config contracts, test harnesses, rollout policy, prompt-budget rules, operator documentation, and failure proof.
+- The design must coordinate router metadata, runtime stages, retro surfaces, and benchmark evaluation without creating a parallel control plane.
+
+## Design Overview
+
+### Design Principle 1: Memory Must Be Stage-Bound
+Memory activation should depend on the runtime stage, not on generic availability.
+
+Required behavior:
+- `skeleton_check`: light background recall only
+- `deep_interview`: minimum decision recall only
+- `requirement_doc`: citeable acceptance-relevant recall only
+- `xl_plan`: planning-relevant recall only
+- `plan_execute`: bounded milestone and handoff memory only
+- `phase_cleanup`: persistence and fold cleanup only
+
+### Design Principle 2: Write Admission Must Be Narrower Than Recall
+The system must reject most candidate writes.
+Memory quality comes from selective persistence, not from large-volume storage.
+
+Required write shapes:
+- `state_store`: run-local progress and artifacts
+- `Serena`: explicit approved project decisions only
+- `ruflo`: short-horizon milestone cards and handoff cards only
+- `Cognee`: entities and relations only
+- `knowledge-steward`: explicit user-requested durable capture only
+- `deepagent-memory-fold`: structured compaction object only
+
+### Design Principle 3: Retrieval Must Be Budgeted
+Memory should return cards, not transcripts.
+Every recall lane requires:
+- trigger condition
+- top-k cap
+- token budget
+- replacement vs append semantics
+
+### Design Principle 4: Fallback Must Preserve Continuity
+Backend outages must not break `vibe`.
+The runtime must degrade to:
+- `state_store`
+- local session artifacts
+- requirement/plan/handoff outputs
+
+### Design Principle 5: Intelligence Must Be Proven, Not Assumed
+A memory lane is intelligent only if it:
+- reduces repeated clarification or lost context
+- improves handoff continuity
+- avoids irrelevant recall
+- stays within prompt budget
+
+## Target Architecture
+
+### A. Stage-Aware Memory Trigger Matrix
+Add one canonical trigger matrix document and config contract that maps memory actions to `vibe` stages.
+
+Expected stage actions:
+
+#### `skeleton_check`
+- Read:
+  - `Serena` decision digest: allowed
+  - `Cognee` small relationship digest: allowed
+- Write: none
+- Budget:
+  - max 3 decision cards
+  - max 1 graph digest block
+- Failure behavior:
+  - fallback to local docs and `state_store`
+
+#### `deep_interview`
+- Read:
+  - `Serena` only if the same project already has approved conventions
+- Write: none
+- Budget:
+  - max 2 decision cards
+- Goal:
+  - avoid re-asking settled project conventions
+
+#### `requirement_doc`
+- Read:
+  - only citeable constraints and approved decisions
+- Write:
+  - candidate decisions staged locally, not yet persisted to `Serena`
+- Budget:
+  - max 3 cited memory anchors
+
+#### `xl_plan`
+- Read:
+  - `Serena` decision digest
+  - bounded `Cognee` relationship digest for cross-module dependencies
+- Write:
+  - none to long-term stores
+  - optional local `state_store` planning memo
+
+#### `plan_execute`
+- `M`:
+  - use `state_store` only
+- `L`:
+  - use `state_store`; no default `ruflo`
+- `XL`:
+  - optional `ruflo` milestone cards
+  - optional `ruflo` handoff summaries
+  - no raw transcript storage
+- Specialist lanes:
+  - child lanes receive only root-approved handoff digests
+
+#### `phase_cleanup`
+- Write:
+  - `Serena`: only approved decisions
+  - `Cognee`: only approved entities/relations
+  - `deepagent-memory-fold`: only when context-pressure or handoff criteria were met
+  - `knowledge-steward`: only on explicit user request
+- Read:
+  - none unless required for retro comparison
+
+### B. Write Admission Contracts
+Add explicit config or reference contracts for:
+- `serena-write-admission.json`
+- `ruflo-card-contract.json`
+- `cognee-entity-relation-contract.json`
+- `memory-fold-trigger-policy.json`
+
+Each contract must define:
+- allowed payload classes
+- forbidden payload classes
+- required metadata
+- retention policy
+- rollback behavior
+
+### C. Retrieval Budget Contracts
+Add one canonical budget contract, for example:
+- `config/memory-retrieval-budget-policy.json`
+
+Minimum fields:
+- stage
+- lane
+- `top_k`
+- `max_tokens`
+- `replacement_mode`
+- `inject_as`
+- `fallback_mode`
+
+Required semantics:
+- recall injects compact cards or digests only
+- full raw stored content stays out of prompt context
+- folded memory replaces old context instead of appending
+
+### D. Runtime Integration Hooks
+Add bounded runtime hook points inside the existing stage implementation:
+
+- `Invoke-SkeletonCheck`:
+  - optional pre-run recall receipts
+- `Write-RequirementDoc`:
+  - citeable memory anchors only
+- `Write-XlPlan`:
+  - bounded dependency recall only
+- `Invoke-PlanExecute`:
+  - XL milestone/handoff store and search
+- `Invoke-PhaseCleanup`:
+  - durable persistence receipts
+  - optional fold receipt
+
+Every hook must emit:
+- attempted lane
+- action type
+- success/fallback
+- payload count
+- token budget used
+
+### E. Intelligence Guardrails
+Introduce runtime guardrails that block low-quality memory usage:
+- no memory read if stage is out of scope
+- no memory write if payload lacks required type metadata
+- no recall when relevance score is below threshold
+- no injection if budget would be exceeded
+- no fold append on top of full historical context
+
+### F. Proof Surface
+Add one memory activation report family under:
+- `outputs/runtime/vibe-sessions/<run-id>/memory-activation.json`
+- `outputs/runtime/vibe-sessions/<run-id>/memory-activation.md`
+
+Minimum fields:
+- stage actions taken
+- reads attempted and succeeded
+- writes attempted and succeeded
+- fallback events
+- token budget consumption
+- ignored or denied writes
+- retrieval relevance scores
+- fold trigger reason
+
+## Wave Plan
+
+### Wave 1: Freeze Stage-Aware Memory Contract
+- Write stable governance doc for stage-aware activation
+- Add trigger matrix and owner-boundary restatement
+- Add explicit non-goals against transcript dumping and authority transfer
+
+### Wave 2: Add Write Admission Contracts
+- Add lane-specific write contracts
+- Define candidate-to-approved decision flow for `Serena`
+- Define XL milestone card schema for `ruflo`
+- Define entity-relation ingest schema for `Cognee`
+
+### Wave 3: Add Retrieval Budget Policy
+- Add a canonical top-k and token-budget policy
+- Define replacement vs append behavior
+- Define per-stage allowable recall lanes
+
+### Wave 4: Wire Runtime Hooks
+- Add read hooks to `skeleton_check`, `deep_interview`, `xl_plan`
+- Add write hooks to `plan_execute` and `phase_cleanup`
+- Emit per-stage memory receipts
+
+### Wave 5: Add Context-Pressure Compaction
+- Define fold trigger conditions
+- Add a bounded call path for `deepagent-memory-fold`
+- Guarantee fold artifact replaces historical context in continuation flows
+
+### Wave 6: Add Scenario Corpus
+Create scenarios for:
+- no-backend baseline
+- Serena-only decision reuse
+- XL milestone continuity with `ruflo`
+- long-term relationship reuse with `Cognee`
+- context-pressure fold continuation
+- missing-backend fallback
+- low-relevance recall rejection
+- write-admission rejection
+
+### Wave 7: Add Gates And Benchmarks
+- runtime activation gate
+- retrieval budget gate
+- fold replacement gate
+- fallback integrity gate
+- repeated-run flake gate
+
+### Wave 8: Release Truth And Operator Docs
+- add operator runbook
+- add release-facing truth gate for memory claims
+- forbid README language that overstates automatic persistence or recall beyond tested reality
+
+## Detailed Test Program
+
+### 1. Owner Boundary Tests
+- `state_store` stays session-only
+- `Serena` does not accept raw transcripts
+- `ruflo` does not become long-term store
+- `Cognee` does not ingest arbitrary transcript blocks
+- `mem0` and `Letta` do not gain canonical owner status
+
+### 2. Stage Trigger Tests
+- each stage invokes only permitted lanes
+- out-of-scope stages do not read or write memory
+- write actions are deferred until approved persistence points
+
+### 3. Retrieval Quality Tests
+- high-relevance cards are recalled
+- low-relevance cards are rejected
+- no more than configured top-k are injected
+- token budget never exceeds policy cap
+
+### 4. Fallback Tests
+- missing Serena backend falls back to local docs and `state_store`
+- missing `ruflo` keeps XL execution viable
+- missing `Cognee` does not break startup
+- fold unavailable degrades to local handoff artifacts
+
+### 5. Compaction Tests
+- fold triggers only at allowed conditions
+- fold artifact includes working/tool/evidence/decision/resume sections
+- fold replaces large historical context rather than appending to it
+
+### 6. Continuity Tests
+- repeated clarification rate decreases when approved decisions exist
+- XL handoff retains blocker/next-step continuity
+- resumed session can continue from folded memory with bounded context
+
+### 7. Anti-Explosion Tests
+- transcript-size write attempts are rejected
+- oversized recall is truncated or denied
+- duplicate recalls are deduplicated before injection
+- cumulative memory injection stays under a global stage budget
+
+### 8. Operator Usability Tests
+- activation report is readable and actionable
+- denied-write reasons are explicit
+- fallback status is operator-visible
+- release wording aligns with actual tested capability
+
+## Proof Strategy
+
+### Stability Proof
+- repeated-run matrix for each scenario
+- flake accounting for repeated recall and fallback behavior
+- failure injection for missing backends and denied writes
+
+Target proof:
+- memory activation does not destabilize the runtime
+- stage actions remain deterministic enough to audit
+
+### Availability Proof
+- no-backend baseline still succeeds using `state_store`
+- partial-backend availability produces bounded degraded behavior
+- runtime artifacts remain sufficient for continuation without external memory services
+
+### Intelligence Proof
+- compare runs with and without bounded memory recall
+- measure:
+  - repeated clarification count
+  - handoff completeness
+  - irrelevant recall count
+  - budget overrun count
+  - route drift count
+
+Target proof:
+- recall is relevant more often than noisy
+- useful continuity improves without widening authority or prompt size
+
+## Rollback Rules
+- Any owner-boundary violation:
+  - disable the offending lane
+  - revert to `shadow`
+- Any repeated irrelevant recall or budget overrun:
+  - reduce top-k and token caps
+  - disable the stage hook if needed
+- Any runtime instability:
+  - fall back to `state_store` plus local artifacts only
+
+## Success Criteria
+This plan succeeds when the repository can prove all of the following at once:
+
+- memory activation is stage-aware rather than always-on
+- each lane preserves its intended role
+- memory recall is bounded and relevance-aware
+- context compaction reduces context size instead of increasing it
+- external backend failures do not break `vibe`
+- repository documentation and release wording match the tested runtime truth

--- a/bundled/skills/vibe/docs/releases/v2.3.52.md
+++ b/bundled/skills/vibe/docs/releases/v2.3.52.md
@@ -1,0 +1,40 @@
+# VCO Release v2.3.52
+
+- Date: 2026-03-29
+- Commit(base): 870fd20
+- Previous release: `v2.3.51`
+
+## Highlights
+
+- Landed stage-aware memory activation inside the normal six-stage `vibe` governed runtime. Governed runs now emit `memory-activation-report.json` and `memory-activation-report.md`, carry bounded memory-context injection into requirement/plan artifacts, and keep the activation path visible in per-stage receipts.
+- Added real governed backend adapter calls for `Serena`, `ruflo`, and `Cognee`. When enabled, the runtime now writes request/response artifacts under the session's `memory-backend/` directory instead of only recording advisory ownership policy.
+- Kept the memory contract narrow and explicit instead of widening it into an uncontrolled background memory layer:
+  - `Serena` remains for explicit project decisions
+  - `Cognee` remains for bounded relation recall / ingest
+  - `ruflo` remains XL-scoped for milestone and handoff continuity in `plan_execute`
+  - `knowledge-steward` is still an explicit skill, not automatic runtime capture
+  - the cleanup fold is a local governed fold artifact, not silent auto-invocation of the `deepagent-memory-fold` skill
+
+## What Changed Compared With v2.3.51
+
+- `v2.3.51` moved delivery acceptance into the main governed runtime chain and tightened specialist-governance closure.
+- `v2.3.52` moves the memory plane forward from mainly policy / route advice into observable stage-bound runtime behavior with real backend read/write paths and runtime artifacts.
+- The important difference is not "more memory everywhere". The difference is that governed runs now show where memory was read, where it was written, and where the runtime deliberately refused to widen memory scope.
+
+## Validation Notes
+
+- Memory activation/runtime backend coverage:
+  - `pytest -q tests/runtime_neutral/test_memory_runtime_activation.py`
+- Governed runtime / topology / hierarchy regression coverage:
+  - `pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py`
+- Release-surface hygiene:
+  - `git diff --check`
+  - `pwsh -NoProfile -File scripts/verify/vibe-version-consistency-gate.ps1`
+  - `pwsh -NoProfile -File scripts/verify/vibe-dist-manifest-gate.ps1`
+  - `pwsh -NoProfile -File scripts/verify/vibe-nested-bundled-parity-gate.ps1`
+
+## Migration Notes
+
+- Operators should expect new runtime artifacts under `outputs/runtime/vibe-sessions/<run-id>/`, especially the memory activation report family and, when backend lanes are enabled, request/response receipts under `memory-backend/`.
+- This release proves governed memory activation and bounded backend integration. It does not claim that every memory-related skill is now silently auto-running in the background.
+- `knowledge-steward` still requires explicit user intent, and the runtime cleanup fold should be read as local governed context compaction rather than as a full skill-level memory handoff backend.

--- a/bundled/skills/vibe/docs/requirements/2026-03-28-vibe-memory-runtime-activation-closure.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-28-vibe-memory-runtime-activation-closure.md
@@ -1,0 +1,118 @@
+# Vibe Memory Runtime Activation Closure
+
+## Summary
+Close the gap between the repository's memory-governance claims and the actual `vibe` runtime behavior. The current repository already defines strong owner boundaries for `state_store`, `Serena`, `ruflo`, `Cognee`, `mem0`, and `Letta`, but most of those roles still operate as post-route governance guidance rather than as stage-bound runtime behavior with bounded write, retrieval, and injection contracts.
+
+## Goal
+Design and land a memory-runtime architecture where each canonical memory role is invoked only at the right stage, with bounded payload size, audited write admission, intelligent retrieval gates, and explicit rollback rules, so memory becomes useful without becoming a second control plane or a context-amplification source.
+
+## Deliverable
+A repository change program and documentation bundle that adds:
+
+- a stage-aware activation model for `state_store`, `Serena`, `ruflo`, `Cognee`, `knowledge-steward`, and `deepagent-memory-fold`
+- machine-readable write-admission and retrieval-budget contracts for each memory lane
+- runtime integration points for memory read/write/fold actions inside the existing six-stage `vibe` lifecycle
+- scenario tests and executable gates proving stability, usability, and intelligence
+- operator documentation describing when memory is invoked, when it must stay silent, and how to disable or roll back each lane
+
+## Constraints
+- Preserve `VCO` as the single runtime and control plane owner.
+- Preserve the canonical router as route authority.
+- Do not create a second visible startup surface, second requirement surface, or second execution-plan surface.
+- Do not allow any memory lane to mutate `selected.pack_id`, `selected.skill`, or grade choice.
+- Preserve the current canonical owner matrix:
+  - `state_store` for session truth
+  - `Serena` for explicit project decisions
+  - `ruflo` for short-term semantic cache
+  - `Cognee` for long-term relationship memory
+- Keep `episodic-memory` disabled in governed routing.
+- Keep `mem0` preference-only and `Letta` contract-only.
+- Prefer additive runtime hooks and bounded artifacts over a broad router/runtime rewrite.
+
+## Acceptance Criteria
+- The repository defines a stage-aware memory trigger matrix covering:
+  - `skeleton_check`
+  - `deep_interview`
+  - `requirement_doc`
+  - `xl_plan`
+  - `plan_execute`
+  - `phase_cleanup`
+- Every memory lane has an explicit write-admission contract:
+  - what can be written
+  - what must not be written
+  - required evidence shape
+  - retention or expiry rule
+- Every retrievable memory lane has an explicit retrieval contract:
+  - allowed trigger conditions
+  - maximum item count
+  - maximum prompt-injection budget
+  - fallback behavior when the backend is unavailable
+- `state_store` remains the default always-on runtime memory lane.
+- `Serena` is only written when the runtime has an explicit project decision surface or explicit operator approval.
+- `ruflo` is only used for bounded XL milestone summaries, handoff blocks, or short-horizon semantic retrieval, never as a generic long transcript store.
+- `Cognee` is only used for bounded graph retrieval or long-term ingest at approved persistence points, never as a raw transcript sink.
+- `knowledge-steward` remains explicit-user-trigger only and is not silently promoted into a background auto-capture path.
+- `deepagent-memory-fold` becomes a governed compaction lane that can be invoked only under documented context-pressure or handoff conditions, and its folded artifact replaces large historical context instead of being appended to it.
+- The repository includes a bounded memory injection policy proving that memory recall cannot expand prompt context without limit.
+- The repository includes executable tests proving:
+  - stability across repeated runs
+  - availability and graceful fallback when memory backends are missing
+  - intelligence of retrieval choice and budgeted injection
+
+## Primary Objective
+Make memory in `vibe` useful enough to preserve continuity and decision quality, while keeping it sufficiently bounded that it cannot destabilize routing, runtime truth, or prompt size.
+
+## Proxy Signals
+- Memory recall reduces repeated clarification or lost context without increasing route drift.
+- Memory writes are sparse, typed, and evidence-backed rather than transcript-dump based.
+- Retrieval returns only the minimum relevant cards required for the current stage.
+- Missing memory backends degrade gracefully to `state_store` and local artifacts.
+
+## Scope
+In scope:
+- stage-aware memory activation design
+- write-admission rules
+- retrieval gating rules
+- prompt-injection budget design
+- context-pressure fold design
+- backend fallback semantics
+- executable verification and proof strategy
+- repository documentation and rollout plan
+
+Out of scope:
+- replacing the canonical router
+- granting memory lanes route mutation or runtime ownership
+- making every memory backend mandatory for every host
+- storing full raw conversation transcripts as long-term truth
+- turning `knowledge-steward` into implicit background ingestion
+
+## Completion
+The work is complete when the repository can prove, with executable tests and bounded runtime contracts, that each memory lane is called at the correct time, injects only bounded information, degrades safely when unavailable, and measurably improves continuity without causing context explosion or governance drift.
+
+## Evidence
+- new or updated governance docs for stage-aware memory activation
+- requirement and plan docs for rollout
+- runtime integration design for read/write/fold hooks
+- machine-readable budget and admission policies
+- scenario corpus and gates covering stability, availability, and intelligence
+
+## Non-Goals
+- Do not treat memory backend availability as proof of useful recall.
+- Do not equate more recalled text with better intelligence.
+- Do not let long-term memory become a dump of unresolved thoughts or temporary state.
+- Do not append folded memory on top of the original large context.
+- Do not allow advisory memory suggestions to silently become execution authority.
+
+## Autonomy Mode
+interactive_governed
+
+## Assumptions
+- The current six-stage `vibe` lifecycle is sufficient to host memory activation without adding a second runtime.
+- Existing `state_store` and runtime artifacts already provide a stable baseline fallback.
+- The main missing layer is stage-aware runtime activation, not owner-boundary definition.
+- The repository can add new config contracts, runtime hooks, and tests without breaking current router invariants.
+
+## Evidence Inputs
+- Source task: plan a full activation-closure program for the current memory system
+- Current finding: governance, contracts, and gates exist; automatic stage-bound runtime invocation is still partial
+- Current policy: `memory-runtime-v3` remains `shadow` and `advisory_first_post_route_only`

--- a/bundled/skills/vibe/references/changelog.md
+++ b/bundled/skills/vibe/references/changelog.md
@@ -1,5 +1,13 @@
 # VCO Changelog
 
+## v2.3.52 (2026-03-29)
+
+- Landed stage-aware memory activation inside the standard six-stage `vibe` runtime, including per-run memory activation reports and bounded context injection into governed artifacts.
+- Added real governed backend adapter read/write paths for `Serena`, `ruflo`, and `Cognee`, with session-local request/response receipts instead of policy-only ownership claims.
+- Kept memory-scope boundaries explicit: `ruflo` remains XL-scoped, `knowledge-steward` remains explicit-only, and the runtime cleanup fold is local governed compaction rather than silent skill auto-invocation.
+- Detailed release notes: `docs/releases/v2.3.52.md`.
+
+
 ## v2.3.51 (2026-03-28)
 
 - Integrated downstream delivery acceptance into the normal `vibe` main chain so governed runs now freeze product acceptance semantics, plan delivery checks, and emit a per-run delivery-acceptance report during cleanup.

--- a/bundled/skills/vibe/references/release-ledger.jsonl
+++ b/bundled/skills/vibe/references/release-ledger.jsonl
@@ -29,3 +29,4 @@
 {"recorded_at":"2026-03-23T01:38:21","version":"2.3.49","updated":"2026-03-23","git_head":"dc0430d","actor":null}
 {"recorded_at":"2026-03-26T20:39:51","version":"2.3.50","updated":"2026-03-26","git_head":"d5da111","actor":null}
 {"recorded_at":"2026-03-28T00:00:00","version":"2.3.51","updated":"2026-03-28","git_head":"18e6b9c","actor":null}
+{"recorded_at":"2026-03-29T10:14:24","version":"2.3.52","updated":"2026-03-29","git_head":"870fd20","actor":null}

--- a/config/version-governance.json
+++ b/config/version-governance.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
   "release": {
-    "version": "2.3.51",
-    "updated": "2026-03-28",
+    "version": "2.3.52",
+    "updated": "2026-03-29",
     "channel": "stable",
-    "notes": "Adds main-chain delivery acceptance under vibe, hardens stage-bound specialist dispatch and Windows specialist runtime handoff, and promotes stricter completion-language truth for governed runs."
+    "notes": "Adds stage-aware memory activation to the main vibe runtime, wires governed Serena/ruflo/Cognee backend adapters into observable session artifacts, and keeps memory-scope boundaries explicit."
   },
   "source_of_truth": {
     "canonical_root": ".",

--- a/dist/core/manifest.json
+++ b/dist/core/manifest.json
@@ -4,8 +4,8 @@
   "lane_kind": "universal-core",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.51",
-    "updated": "2026-03-26"
+    "version": "2.3.52",
+    "updated": "2026-03-29"
   },
   "summary": "Universal contracts only. No install/check runtime closure is promised by this lane.",
   "runtime_ownership": {

--- a/dist/host-claude-code/manifest.json
+++ b/dist/host-claude-code/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "claude-code",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.51",
-    "updated": "2026-03-26"
+    "version": "2.3.52",
+    "updated": "2026-03-29"
   },
   "summary": "Claude Code host adapter preview. The repo can now scaffold preview artifacts and run preview health checks, but still does not claim full governed closure.",
   "runtime_ownership": {

--- a/dist/host-codex/manifest.json
+++ b/dist/host-codex/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "codex",
   "stability": "supported-with-constraints",
   "source_release": {
-    "version": "2.3.51",
-    "updated": "2026-03-26"
+    "version": "2.3.52",
+    "updated": "2026-03-29"
   },
   "summary": "Codex host adapter lane. Uses the official runtime entrypoints, but remains honest about host-managed plugin and credential surfaces.",
   "runtime_ownership": {

--- a/dist/host-cursor/manifest.json
+++ b/dist/host-cursor/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "cursor",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.51",
-    "updated": "2026-03-26"
+    "version": "2.3.52",
+    "updated": "2026-03-29"
   },
   "summary": "Cursor host adapter preview. The repository can expose runtime-core payload and preview health checks, but does not claim full governed closure yet.",
   "runtime_ownership": {

--- a/dist/host-openclaw/manifest.json
+++ b/dist/host-openclaw/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "openclaw",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.51",
-    "updated": "2026-03-26"
+    "version": "2.3.52",
+    "updated": "2026-03-29"
   },
   "summary": "OpenClaw host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/host-opencode/manifest.json
+++ b/dist/host-opencode/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "opencode",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.51",
-    "updated": "2026-03-26"
+    "version": "2.3.52",
+    "updated": "2026-03-29"
   },
   "summary": "OpenCode host adapter preview. The repo can install runtime-core plus OpenCode-native command and agent wrapper payload into OpenCode roots, but final host config and platform closure remain incomplete.",
   "runtime_ownership": {

--- a/dist/host-windsurf/manifest.json
+++ b/dist/host-windsurf/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "windsurf",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.51",
-    "updated": "2026-03-26"
+    "version": "2.3.52",
+    "updated": "2026-03-29"
   },
   "summary": "Windsurf host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/official-runtime/manifest.json
+++ b/dist/official-runtime/manifest.json
@@ -4,8 +4,8 @@
   "lane_kind": "tier-1-official-runtime",
   "stability": "tier-1",
   "source_release": {
-    "version": "2.3.51",
-    "updated": "2026-03-26"
+    "version": "2.3.52",
+    "updated": "2026-03-29"
   },
   "summary": "Reference lane for the current governed official runtime. This dist pack points to it and must not rewrite it.",
   "runtime_ownership": {

--- a/docs/releases/v2.3.52.md
+++ b/docs/releases/v2.3.52.md
@@ -1,0 +1,40 @@
+# VCO Release v2.3.52
+
+- Date: 2026-03-29
+- Commit(base): 870fd20
+- Previous release: `v2.3.51`
+
+## Highlights
+
+- Landed stage-aware memory activation inside the normal six-stage `vibe` governed runtime. Governed runs now emit `memory-activation-report.json` and `memory-activation-report.md`, carry bounded memory-context injection into requirement/plan artifacts, and keep the activation path visible in per-stage receipts.
+- Added real governed backend adapter calls for `Serena`, `ruflo`, and `Cognee`. When enabled, the runtime now writes request/response artifacts under the session's `memory-backend/` directory instead of only recording advisory ownership policy.
+- Kept the memory contract narrow and explicit instead of widening it into an uncontrolled background memory layer:
+  - `Serena` remains for explicit project decisions
+  - `Cognee` remains for bounded relation recall / ingest
+  - `ruflo` remains XL-scoped for milestone and handoff continuity in `plan_execute`
+  - `knowledge-steward` is still an explicit skill, not automatic runtime capture
+  - the cleanup fold is a local governed fold artifact, not silent auto-invocation of the `deepagent-memory-fold` skill
+
+## What Changed Compared With v2.3.51
+
+- `v2.3.51` moved delivery acceptance into the main governed runtime chain and tightened specialist-governance closure.
+- `v2.3.52` moves the memory plane forward from mainly policy / route advice into observable stage-bound runtime behavior with real backend read/write paths and runtime artifacts.
+- The important difference is not "more memory everywhere". The difference is that governed runs now show where memory was read, where it was written, and where the runtime deliberately refused to widen memory scope.
+
+## Validation Notes
+
+- Memory activation/runtime backend coverage:
+  - `pytest -q tests/runtime_neutral/test_memory_runtime_activation.py`
+- Governed runtime / topology / hierarchy regression coverage:
+  - `pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py`
+- Release-surface hygiene:
+  - `git diff --check`
+  - `pwsh -NoProfile -File scripts/verify/vibe-version-consistency-gate.ps1`
+  - `pwsh -NoProfile -File scripts/verify/vibe-dist-manifest-gate.ps1`
+  - `pwsh -NoProfile -File scripts/verify/vibe-nested-bundled-parity-gate.ps1`
+
+## Migration Notes
+
+- Operators should expect new runtime artifacts under `outputs/runtime/vibe-sessions/<run-id>/`, especially the memory activation report family and, when backend lanes are enabled, request/response receipts under `memory-backend/`.
+- This release proves governed memory activation and bounded backend integration. It does not claim that every memory-related skill is now silently auto-running in the background.
+- `knowledge-steward` still requires explicit user intent, and the runtime cleanup fold should be read as local governed context compaction rather than as a full skill-level memory handoff backend.

--- a/references/changelog.md
+++ b/references/changelog.md
@@ -1,5 +1,13 @@
 # VCO Changelog
 
+## v2.3.52 (2026-03-29)
+
+- Landed stage-aware memory activation inside the standard six-stage `vibe` runtime, including per-run memory activation reports and bounded context injection into governed artifacts.
+- Added real governed backend adapter read/write paths for `Serena`, `ruflo`, and `Cognee`, with session-local request/response receipts instead of policy-only ownership claims.
+- Kept memory-scope boundaries explicit: `ruflo` remains XL-scoped, `knowledge-steward` remains explicit-only, and the runtime cleanup fold is local governed compaction rather than silent skill auto-invocation.
+- Detailed release notes: `docs/releases/v2.3.52.md`.
+
+
 ## v2.3.51 (2026-03-28)
 
 - Integrated downstream delivery acceptance into the normal `vibe` main chain so governed runs now freeze product acceptance semantics, plan delivery checks, and emit a per-run delivery-acceptance report during cleanup.

--- a/references/release-ledger.jsonl
+++ b/references/release-ledger.jsonl
@@ -29,3 +29,4 @@
 {"recorded_at":"2026-03-23T01:38:21","version":"2.3.49","updated":"2026-03-23","git_head":"dc0430d","actor":null}
 {"recorded_at":"2026-03-26T20:39:51","version":"2.3.50","updated":"2026-03-26","git_head":"d5da111","actor":null}
 {"recorded_at":"2026-03-28T00:00:00","version":"2.3.51","updated":"2026-03-28","git_head":"18e6b9c","actor":null}
+{"recorded_at":"2026-03-29T10:14:24","version":"2.3.52","updated":"2026-03-29","git_head":"870fd20","actor":null}


### PR DESCRIPTION
# VCO Release v2.3.52

- Date: 2026-03-29
- Commit(base): 870fd20
- Previous release: `v2.3.51`

## Highlights

- Landed stage-aware memory activation inside the normal six-stage `vibe` governed runtime. Governed runs now emit `memory-activation-report.json` and `memory-activation-report.md`, carry bounded memory-context injection into requirement/plan artifacts, and keep the activation path visible in per-stage receipts.
- Added real governed backend adapter calls for `Serena`, `ruflo`, and `Cognee`. When enabled, the runtime now writes request/response artifacts under the session's `memory-backend/` directory instead of only recording advisory ownership policy.
- Kept the memory contract narrow and explicit instead of widening it into an uncontrolled background memory layer:
  - `Serena` remains for explicit project decisions
  - `Cognee` remains for bounded relation recall / ingest
  - `ruflo` remains XL-scoped for milestone and handoff continuity in `plan_execute`
  - `knowledge-steward` is still an explicit skill, not automatic runtime capture
  - the cleanup fold is a local governed fold artifact, not silent auto-invocation of the `deepagent-memory-fold` skill

## What Changed Compared With v2.3.51

- `v2.3.51` moved delivery acceptance into the main governed runtime chain and tightened specialist-governance closure.
- `v2.3.52` moves the memory plane forward from mainly policy / route advice into observable stage-bound runtime behavior with real backend read/write paths and runtime artifacts.
- The important difference is not "more memory everywhere". The difference is that governed runs now show where memory was read, where it was written, and where the runtime deliberately refused to widen memory scope.

## Validation Notes

- Memory activation/runtime backend coverage:
  - `pytest -q tests/runtime_neutral/test_memory_runtime_activation.py`
- Governed runtime / topology / hierarchy regression coverage:
  - `pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py`
- Release-surface hygiene:
  - `git diff --check`
  - `pwsh -NoProfile -File scripts/verify/vibe-version-consistency-gate.ps1`
  - `pwsh -NoProfile -File scripts/verify/vibe-dist-manifest-gate.ps1`
  - `pwsh -NoProfile -File scripts/verify/vibe-nested-bundled-parity-gate.ps1`

## Migration Notes

- Operators should expect new runtime artifacts under `outputs/runtime/vibe-sessions/<run-id>/`, especially the memory activation report family and, when backend lanes are enabled, request/response receipts under `memory-backend/`.
- This release proves governed memory activation and bounded backend integration. It does not claim that every memory-related skill is now silently auto-running in the background.
- `knowledge-steward` still requires explicit user intent, and the runtime cleanup fold should be read as local governed context compaction rather than as a full skill-level memory handoff backend.
