### PR TITLE
Fix Windows PowerShell host resolution for install and runtime checks

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -37,6 +37,53 @@ pick_python_for_adapter() {
   return 1
 }
 
+pick_powershell() {
+  local candidate resolved=""
+  for candidate in pwsh pwsh.exe powershell powershell.exe; do
+    if resolved="$(command -v "${candidate}" 2>/dev/null)"; then
+      if [[ -n "${resolved}" ]]; then
+        printf '%s' "${resolved}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+run_powershell_command() {
+  local command_text="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-Command" "${command_text}")
+  "${cmd[@]}" "$@"
+}
+
+run_powershell_file() {
+  local script_path="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-File" "${script_path}")
+  "${cmd[@]}" "$@"
+}
+
 adapter_query_for_host() {
   local host_id="$1"
   local property="$2"
@@ -404,8 +451,8 @@ else:
     print(value)
 PY
     return $?
-  elif command -v pwsh >/dev/null 2>&1; then
-    pwsh -NoProfile -Command '
+  elif pick_powershell >/dev/null 2>&1; then
+    run_powershell_command '
 param([string]$Path,[string]$Expr)
 $raw = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
 $value = $raw | ConvertFrom-Json
@@ -541,8 +588,8 @@ validate_runtime_receipt() {
       warn_note "vibe runtime freshness receipt unavailable because check.sh is not running from the canonical repo root."
       return
     fi
-    if ! command -v pwsh >/dev/null 2>&1; then
-      warn_note "vibe runtime freshness receipt unavailable because pwsh is not installed in this shell environment."
+    if ! pick_powershell >/dev/null 2>&1; then
+      warn_note "vibe runtime freshness receipt unavailable because pwsh is not installed and no compatible PowerShell host is available in this shell environment."
       return
     fi
     echo "[FAIL] vibe runtime freshness receipt -> $receipt_path"
@@ -653,11 +700,11 @@ run_runtime_freshness_gate() {
     echo "[OK] vibe installed runtime freshness gate"
     PASS=$((PASS+1))
   elif [[ $? -eq 127 ]]; then
-    if ! command -v pwsh >/dev/null 2>&1; then
-      warn_note 'runtime freshness gate skipped: neither Python runtime-neutral gate nor pwsh fallback is available.'
+    if ! pick_powershell >/dev/null 2>&1; then
+      warn_note 'runtime freshness gate skipped: neither Python runtime-neutral gate nor a PowerShell fallback is available.'
       return
     fi
-    if pwsh -NoProfile -File "$gate_path" -TargetRoot "$TARGET_ROOT"; then
+    if run_powershell_file "$gate_path" -TargetRoot "$TARGET_ROOT"; then
       echo "[OK] vibe installed runtime freshness gate"
       PASS=$((PASS+1))
     else
@@ -697,11 +744,11 @@ run_runtime_coherence_gate() {
     echo "[OK] vibe release/install/runtime coherence gate"
     PASS=$((PASS+1))
   elif [[ $? -eq 127 ]]; then
-    if ! command -v pwsh >/dev/null 2>&1; then
-      warn_note 'runtime coherence gate skipped: neither Python runtime-neutral gate nor pwsh fallback is available.'
+    if ! pick_powershell >/dev/null 2>&1; then
+      warn_note 'runtime coherence gate skipped: neither Python runtime-neutral gate nor a PowerShell fallback is available.'
       return
     fi
-    if pwsh -NoProfile -File "$gate_path" -TargetRoot "$TARGET_ROOT"; then
+    if run_powershell_file "$gate_path" -TargetRoot "$TARGET_ROOT"; then
       echo "[OK] vibe release/install/runtime coherence gate"
       PASS=$((PASS+1))
     else
@@ -851,10 +898,10 @@ if [[ "${DEEP}" == "true" ]]; then
       echo "[OK] vibe bootstrap doctor gate"
       PASS=$((PASS+1))
     elif [[ $? -eq 127 ]]; then
-      if ! command -v pwsh >/dev/null 2>&1; then
-        echo "[WARN] vibe bootstrap doctor gate skipped because neither the Python runtime-neutral doctor nor pwsh is available in this shell environment."
+      if ! pick_powershell >/dev/null 2>&1; then
+        echo "[WARN] vibe bootstrap doctor gate skipped because neither the Python runtime-neutral doctor nor a PowerShell host is available in this shell environment."
         WARN=$((WARN+1))
-      elif pwsh -NoProfile -File "${doctor_path}" -TargetRoot "${TARGET_ROOT}" -WriteArtifacts; then
+      elif run_powershell_file "${doctor_path}" -TargetRoot "${TARGET_ROOT}" -WriteArtifacts; then
         echo "[OK] vibe bootstrap doctor gate"
         PASS=$((PASS+1))
       else

--- a/install.ps1
+++ b/install.ps1
@@ -485,4 +485,19 @@ Invoke-CodexDuplicateSkillQuarantine -TargetRoot $TargetRoot -HostId $HostId
 Invoke-InstalledRuntimeFreshnessGate -RepoRoot $RepoRoot -TargetRoot $TargetRoot -SkipGate:$SkipRuntimeFreshnessGate
 Write-Host ""
 Write-Host "Installation complete." -ForegroundColor Green
-Write-Host "Run: powershell -ExecutionPolicy Bypass -File .\check.ps1 -Profile $Profile -TargetRoot `"$TargetRoot`""
+$checkShellPath = Get-VgoPowerShellCommand
+$checkShellLeaf = [System.IO.Path]::GetFileName($checkShellPath).ToLowerInvariant()
+$checkCommandParts = @($checkShellLeaf, '-NoProfile')
+if ($checkShellLeaf -like 'powershell*') {
+  $checkCommandParts += @('-ExecutionPolicy', 'Bypass')
+}
+$checkCommandParts += @('-File', '.\check.ps1', '-Profile', $Profile, '-TargetRoot', $TargetRoot)
+$checkCommand = ($checkCommandParts | ForEach-Object {
+  $text = [string]$_
+  if ($text -match '\s') {
+    '"' + ($text -replace '"', '\"') + '"'
+  } else {
+    $text
+  }
+}) -join ' '
+Write-Host ("Run: {0}" -f $checkCommand)

--- a/install.sh
+++ b/install.sh
@@ -348,8 +348,8 @@ else:
     print(value)
 PY
     return $?
-  elif command -v pwsh >/dev/null 2>&1; then
-    pwsh -NoProfile -Command '
+  elif pick_powershell >/dev/null 2>&1; then
+    run_powershell_command '
 param([string]$Path,[string]$Expr)
 $raw = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
 $value = $raw | ConvertFrom-Json
@@ -391,6 +391,53 @@ pick_python() {
     return 0
   fi
   return 1
+}
+
+pick_powershell() {
+  local candidate resolved=""
+  for candidate in pwsh pwsh.exe powershell powershell.exe; do
+    if resolved="$(command -v "${candidate}" 2>/dev/null)"; then
+      if [[ -n "${resolved}" ]]; then
+        printf '%s' "${resolved}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+run_powershell_command() {
+  local command_text="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-Command" "${command_text}")
+  "${cmd[@]}" "$@"
+}
+
+run_powershell_file() {
+  local script_path="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-File" "${script_path}")
+  "${cmd[@]}" "$@"
 }
 
 adapter_query() {
@@ -442,11 +489,11 @@ run_runtime_freshness_gate() {
   if run_runtime_neutral_freshness_gate; then
     :
   elif [[ $? -eq 127 ]]; then
-    if ! command -v pwsh >/dev/null 2>&1; then
-      echo "[WARN] runtime freshness gate skipped: neither Python runtime-neutral gate nor pwsh fallback is available."
+    if ! pick_powershell >/dev/null 2>&1; then
+      echo "[WARN] runtime freshness gate skipped: neither Python runtime-neutral gate nor a PowerShell fallback is available."
       return 0
     fi
-    pwsh -NoProfile -File "${gate_path}" -TargetRoot "${TARGET_ROOT}" -WriteReceipt
+    run_powershell_file "${gate_path}" -TargetRoot "${TARGET_ROOT}" -WriteReceipt
   else
     return 1
   fi
@@ -716,12 +763,12 @@ if [[ "${STRICT_OFFLINE}" == "true" ]]; then
     echo "[FAIL] StrictOffline requested, but offline gate script is missing: ${OFFLINE_GATE}"
     exit 1
   fi
-  if ! command -v pwsh >/dev/null 2>&1; then
-    echo "[FAIL] StrictOffline requires pwsh to run offline gate"
+  if ! pick_powershell >/dev/null 2>&1; then
+    echo "[FAIL] StrictOffline requires an available PowerShell host to run the offline gate"
     exit 1
   fi
 
-  pwsh -NoProfile -File "${OFFLINE_GATE}" \
+  run_powershell_file "${OFFLINE_GATE}" \
     -SkillsRoot "${TARGET_ROOT}/skills" \
     -PackManifestPath "${SCRIPT_DIR}/config/pack-manifest.json" \
     -SkillsLockPath "${SCRIPT_DIR}/config/skills-lock.json"

--- a/scripts/bootstrap/one-shot-setup.ps1
+++ b/scripts/bootstrap/one-shot-setup.ps1
@@ -193,7 +193,22 @@ switch ([string]$Adapter.bootstrap_mode) {
 
 Write-Host ''
 Write-Host 'One-shot setup completed.' -ForegroundColor Green
-Write-Host ('- Re-run deep doctor anytime with: pwsh -File "{0}" -Profile {1} -HostId {2} -TargetRoot "{3}" -Deep' -f $checkPath, $Profile, $HostId, $TargetRoot)
+$checkShellPath = Get-VgoPowerShellCommand
+$checkShellLeaf = [System.IO.Path]::GetFileName($checkShellPath).ToLowerInvariant()
+$checkCommandParts = @($checkShellLeaf, '-NoProfile')
+if ($checkShellLeaf -like 'powershell*') {
+    $checkCommandParts += @('-ExecutionPolicy', 'Bypass')
+}
+$checkCommandParts += @('-File', $checkPath, '-Profile', $Profile, '-HostId', $HostId, '-TargetRoot', $TargetRoot, '-Deep')
+$checkCommand = ($checkCommandParts | ForEach-Object {
+    $text = [string]$_
+    if ($text -match '\s') {
+        '"' + ($text -replace '"', '\"') + '"'
+    } else {
+        $text
+    }
+}) -join ' '
+Write-Host ('- Re-run deep doctor anytime with: {0}' -f $checkCommand)
 if ($Adapter.bootstrap_mode -eq 'governed') {
     Write-Host ('- MCP active file: {0}' -f (Join-Path $TargetRoot 'mcp\servers.active.json'))
 }

--- a/scripts/bootstrap/one-shot-setup.sh
+++ b/scripts/bootstrap/one-shot-setup.sh
@@ -222,6 +222,36 @@ pick_python() {
   return 1
 }
 
+pick_powershell() {
+  local candidate resolved=""
+  for candidate in pwsh pwsh.exe powershell powershell.exe; do
+    if resolved="$(command -v "${candidate}" 2>/dev/null)"; then
+      if [[ -n "${resolved}" ]]; then
+        printf '%s' "${resolved}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+run_powershell_file() {
+  local script_path="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-File" "${script_path}")
+  "${cmd[@]}" "$@"
+}
+
 adapter_query() {
   local property="$1"
   local python_bin=""
@@ -319,7 +349,7 @@ materialize_mcp_profile_with_python() {
   local python_bin
 
   if ! python_bin="$(pick_python)"; then
-    echo "[FAIL] Python is required to materialize the MCP active profile when pwsh is unavailable." >&2
+    echo "[FAIL] Python is required to materialize the MCP active profile when no PowerShell host is available." >&2
     exit 1
   fi
 
@@ -425,8 +455,8 @@ if [[ "${ADAPTER_BOOTSTRAP_MODE}" == "governed" ]]; then
   fi
   if [[ -n "${resolved_openai_api_key}" ]]; then
     echo "[2/5] Seeding OPENAI settings into target settings.json..."
-    if command -v pwsh >/dev/null 2>&1; then
-      pwsh -NoProfile -File "${PERSIST_OPENAI_PS1}" -CodexRoot "${TARGET_ROOT}" -BaseUrl "${OPENAI_BASE_URL}" -ApiKey "${resolved_openai_api_key}"
+    if pick_powershell >/dev/null 2>&1; then
+      run_powershell_file "${PERSIST_OPENAI_PS1}" -CodexRoot "${TARGET_ROOT}" -BaseUrl "${OPENAI_BASE_URL}" -ApiKey "${resolved_openai_api_key}"
     else
       seed_settings_env_with_python "${TARGET_ROOT}" "openai" "${OPENAI_BASE_URL}" "${resolved_openai_api_key}"
     fi
@@ -439,8 +469,8 @@ if [[ "${ADAPTER_BOOTSTRAP_MODE}" == "governed" ]]; then
   echo "[3/5] Built-in AI governance now supports only OpenAI-compatible provider wiring; no secondary provider seeding is performed."
 
   echo "[4/5] Materializing MCP profile..."
-  if command -v pwsh >/dev/null 2>&1; then
-    pwsh -NoProfile -File "${MATERIALIZE_PS1}" -TargetRoot "${TARGET_ROOT}" -Force >/dev/null
+  if pick_powershell >/dev/null 2>&1; then
+    run_powershell_file "${MATERIALIZE_PS1}" -TargetRoot "${TARGET_ROOT}" -Force >/dev/null
   else
     materialize_mcp_profile_with_python "${REPO_ROOT}" "${TARGET_ROOT}" "${PROFILE}"
   fi
@@ -473,10 +503,10 @@ if [[ "${ADAPTER_BOOTSTRAP_MODE}" == "governed" ]]; then
   echo "- MCP active file: ${TARGET_ROOT}/mcp/servers.active.json"
 fi
 echo "- Doctor artifacts: ${REPO_ROOT}/outputs/verify"
-if ! command -v pwsh >/dev/null 2>&1; then
+if ! pick_powershell >/dev/null 2>&1; then
   if ! command -v python3 >/dev/null 2>&1 && ! command -v python >/dev/null 2>&1; then
-    echo "[WARN] Neither pwsh nor Python is available. Deep authoritative doctor coverage remains unavailable in this shell environment."
+    echo "[WARN] Neither a PowerShell host nor Python is available. Deep authoritative doctor coverage remains unavailable in this shell environment."
   else
-    echo "[INFO] pwsh is not installed, but the shell runtime-neutral verification path was used where supported."
+    echo "[INFO] No PowerShell host was found, but the shell runtime-neutral verification path was used where supported."
   fi
 fi

--- a/tests/runtime_neutral/test_claude_preview_scaffold.py
+++ b/tests/runtime_neutral/test_claude_preview_scaffold.py
@@ -12,6 +12,21 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PREVIEW_FILE = 'settings.vibe.preview.json'
 
 
+def resolve_powershell() -> str | None:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("pwsh.exe"),
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files\PowerShell\7-preview\pwsh.exe",
+        shutil.which("powershell"),
+        shutil.which("powershell.exe"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
 class ClaudePreviewScaffoldTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
@@ -55,10 +70,11 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
         self.assertIn('temporarily frozen', payload['message'])
 
     def test_powershell_scaffold_preserves_existing_settings_and_writes_preview_file(self) -> None:
-        if shutil.which('pwsh') is None:
-            self.skipTest('pwsh not available')
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest('PowerShell executable not available in PATH')
         cmd = [
-            'pwsh',
+            powershell,
             '-NoProfile',
             '-File',
             str(REPO_ROOT / 'scripts' / 'bootstrap' / 'scaffold-claude-preview.ps1'),

--- a/tests/runtime_neutral/test_installed_runtime_scripts.py
+++ b/tests/runtime_neutral/test_installed_runtime_scripts.py
@@ -11,6 +11,21 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def resolve_powershell() -> str | None:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("pwsh.exe"),
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files\PowerShell\7-preview\pwsh.exe",
+        shutil.which("powershell"),
+        shutil.which("powershell.exe"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
 class InstalledRuntimeScriptsTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
@@ -215,11 +230,12 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         self.assertNotIn("rm -rf", install_script)
 
     def test_installed_powershell_scripts_work_without_repo_level_adapter_registry(self) -> None:
-        if shutil.which("pwsh") is None:
-            self.skipTest("pwsh not available")
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
 
         install_cmd = [
-            "pwsh",
+            powershell,
             "-NoProfile",
             "-ExecutionPolicy",
             "Bypass",
@@ -237,7 +253,7 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
 
         installed_root = self.target_root / "skills" / "vibe"
         check_cmd = [
-            "pwsh",
+            powershell,
             "-NoProfile",
             "-ExecutionPolicy",
             "Bypass",
@@ -256,8 +272,9 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         self.assertNotIn("VGO adapter registry not found", check_result.stderr)
 
     def test_powershell_install_quarantines_legacy_agents_duplicate_for_default_codex_root(self) -> None:
-        if shutil.which("pwsh") is None:
-            self.skipTest("pwsh not available")
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
 
         home_root = self.root / "home"
         target_root = home_root / ".codex"
@@ -273,7 +290,7 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         env["HOME"] = str(home_root)
 
         install_cmd = [
-            "pwsh",
+            powershell,
             "-NoProfile",
             "-ExecutionPolicy",
             "Bypass",
@@ -296,8 +313,9 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         self.assertTrue((quarantined[0] / "SKILL.md").exists())
 
     def test_powershell_check_fails_when_legacy_agents_duplicate_is_reintroduced(self) -> None:
-        if shutil.which("pwsh") is None:
-            self.skipTest("pwsh not available")
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
 
         home_root = self.root / "home"
         target_root = home_root / ".codex"
@@ -307,7 +325,7 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         env["HOME"] = str(home_root)
 
         install_cmd = [
-            "pwsh",
+            powershell,
             "-NoProfile",
             "-ExecutionPolicy",
             "Bypass",
@@ -331,7 +349,7 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
 
         installed_root = target_root / "skills" / "vibe"
         check_cmd = [
-            "pwsh",
+            powershell,
             "-NoProfile",
             "-ExecutionPolicy",
             "Bypass",


### PR DESCRIPTION
## Summary
- allow shell install/check/bootstrap flows to use any available PowerShell host on Windows, not just `pwsh`
- keep `powershell.exe` on the authoritative lane by adding `-ExecutionPolicy Bypass` automatically when needed
- update Windows-facing tests to accept `powershell.exe` as a valid PowerShell runtime

## Why
Windows users could have a real PowerShell host available while still being incorrectly degraded because shell entrypoints only checked for `pwsh`. This patch fixes that execution-path mismatch instead of only changing docs.

## Validation
- `pytest -q tests/runtime_neutral/test_installed_runtime_scripts.py`
- `pytest -q tests/runtime_neutral/test_claude_preview_scaffold.py`
- `pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py`
- `pytest -q tests/runtime_neutral/test_memory_runtime_activation.py tests/runtime_neutral/test_native_specialist_failure_injection.py tests/runtime_neutral/test_router_bridge.py`
