### PR TITLE
Tighten host closure install guarantees

### DIFF
--- a/adapters/claude-code/closure.json
+++ b/adapters/claude-code/closure.json
@@ -1,24 +1,32 @@
 {
   "adapter_id": "claude-code",
-  "closure_level": "preview-guidance",
+  "closure_level": "preview-managed",
   "install_mode": "preview-guidance",
   "check_mode": "preview-guidance",
   "bootstrap_mode": "preview-guidance",
   "repo_managed_payload": [
     "runtime core payload",
-    "canonical vibe mirror under skills/vibe/**"
+    "canonical vibe mirror under skills/vibe/**",
+    ".vibeskills/host-closure.json",
+    ".vibeskills/bin/**",
+    "settings.json managed vibeskills stanza"
   ],
-  "host_state_written": [],
+  "host_state_written": [
+    ".vibeskills/host-closure.json",
+    ".vibeskills/bin/**",
+    "settings.json managed vibeskills stanza"
+  ],
   "host_managed_boundaries": [
     "plugin provisioning",
     "hook installation",
     "MCP registration",
     "provider credentials",
-    "final Claude host configuration"
+    "broader Claude host behavior outside the managed vibeskills surface"
   ],
   "verification_contract": [
     "runtime freshness gate",
     "runtime BOM/frontmatter gate",
-    "runtime coherence gate"
+    "runtime coherence gate",
+    "host closure presence check"
   ]
 }

--- a/adapters/claude-code/host-profile.json
+++ b/adapters/claude-code/host-profile.json
@@ -11,21 +11,22 @@
   ],
   "settings_surface": {
     "path": "~/.claude/settings.json",
-    "managed_by_repo": false,
-    "notes": "The repository currently provides preview guidance only. Hook installation and preview-settings scaffold are frozen because of compatibility issues, and the real Claude settings.json stays host-managed."
+    "managed_by_repo": true,
+    "notes": "The repository now preserves existing Claude settings while adding a minimal vibeskills-managed surface and host-closure metadata. Hook installation remains preview-scoped."
   },
   "host_managed_surfaces": [
     "plugin enablement",
     "hook installation",
     "MCP registration",
-    "provider credentials"
+    "provider credentials",
+    "broader Claude host behavior outside the managed vibeskills surface"
   ],
   "capabilities": {
     "fs.read": "expected",
     "fs.write": "expected",
     "shell.exec": "expected",
     "mcp.client": "supported-with-constraints",
-    "settings.materialize": "preview-guidance",
+    "settings.materialize": "preview-managed",
     "plugin.provision": "manual-host-managed",
     "agent.spawn": "expected",
     "route.provider_call": "supported-with-constraints",
@@ -34,7 +35,7 @@
   },
   "degrade_contract": {
     "missing_plugins": "degraded-but-supported",
-    "missing_provider_credentials": "degraded-but-supported",
+    "missing_provider_credentials": "configured_offline_unready",
     "unverified_platform_lane": "not-yet-proven"
   },
   "supported_platform_contracts": [

--- a/adapters/claude-code/settings-map.json
+++ b/adapters/claude-code/settings-map.json
@@ -3,13 +3,17 @@
   "template": "config/settings.template.claude.json",
   "target": "~/.claude/settings.json",
   "semantics": {
+    "vco.host_root": "~/.claude",
+    "vco.command_root": "~/.claude/commands",
+    "vco.settings_surface": "~/.claude/settings.json",
+    "vco.host_closure": "~/.claude/.vibeskills/host-closure.json",
     "env.ANTHROPIC_AUTH_TOKEN": "primary provider credential",
     "env.ANTHROPIC_BASE_URL": "provider endpoint binding",
     "env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "host runtime behavior toggle",
     "env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "host runtime team capability flag"
   },
   "notes": [
-    "This mapping is template-derived and currently guidance-only.",
-    "Hook installation and preview-settings scaffold are temporarily frozen because of compatibility issues. Configure the real host settings.json manually."
+    "This mapping is template-derived and now writes a minimal managed vibeskills surface into the host settings file while preserving existing values.",
+    "Hook installation remains preview-scoped until broader compatibility proof is available."
   ]
 }

--- a/adapters/cursor/closure.json
+++ b/adapters/cursor/closure.json
@@ -1,24 +1,33 @@
 {
   "adapter_id": "cursor",
-  "closure_level": "preview-guidance",
+  "closure_level": "preview-managed",
   "install_mode": "preview-guidance",
   "check_mode": "preview-guidance",
   "bootstrap_mode": "preview-guidance",
   "repo_managed_payload": [
     "runtime core payload",
-    "canonical vibe mirror under skills/vibe/**"
+    "commands/**",
+    "canonical vibe mirror under skills/vibe/**",
+    ".vibeskills/host-closure.json",
+    ".vibeskills/bin/**",
+    "settings.json managed vibeskills stanza"
   ],
-  "host_state_written": [],
+  "host_state_written": [
+    "commands/**",
+    ".vibeskills/host-closure.json",
+    ".vibeskills/bin/**",
+    "settings.json managed vibeskills stanza"
+  ],
   "host_managed_boundaries": [
     "plugin provisioning",
-    "hook installation",
     "MCP registration",
     "provider credentials",
-    "final Cursor host configuration"
+    "broader host-native workflow behavior outside the managed Vibe closure surface"
   ],
   "verification_contract": [
     "runtime freshness gate",
     "runtime BOM/frontmatter gate",
-    "runtime coherence gate"
+    "runtime coherence gate",
+    "host closure presence check"
   ]
 }

--- a/adapters/cursor/host-profile.json
+++ b/adapters/cursor/host-profile.json
@@ -10,21 +10,21 @@
   ],
   "settings_surface": {
     "path": "~/.cursor/settings.json",
-    "managed_by_repo": false,
-    "notes": "The repository currently provides preview guidance only. Real Cursor host settings remain host-managed."
+    "managed_by_repo": true,
+    "notes": "The repository now materializes commands, a host-closure manifest, and a minimal Cursor settings surface under the documented host root. Broader host-native workflow behavior remains preview-scoped."
   },
   "host_managed_surfaces": [
     "plugin enablement",
-    "hook installation",
     "MCP registration",
-    "provider credentials"
+    "provider credentials",
+    "broader host-native workflow behavior outside the managed Vibe closure surface"
   ],
   "capabilities": {
     "fs.read": "expected",
     "fs.write": "expected",
     "shell.exec": "expected",
     "mcp.client": "supported-with-constraints",
-    "settings.materialize": "preview-guidance",
+    "settings.materialize": "preview-managed",
     "plugin.provision": "manual-host-managed",
     "agent.spawn": "supported-with-constraints",
     "route.provider_call": "supported-with-constraints",
@@ -33,7 +33,7 @@
   },
   "degrade_contract": {
     "missing_plugins": "degraded-but-supported",
-    "missing_provider_credentials": "degraded-but-supported",
+    "missing_provider_credentials": "configured_offline_unready",
     "unverified_platform_lane": "not-yet-proven"
   },
   "supported_platform_contracts": [

--- a/adapters/cursor/settings-map.json
+++ b/adapters/cursor/settings-map.json
@@ -2,9 +2,15 @@
   "adapter_id": "cursor",
   "template": null,
   "target": "~/.cursor/settings.json",
-  "semantics": {},
+  "semantics": {
+    "vco.host_root": "~/.cursor",
+    "vco.skill_root": "~/.cursor/skills",
+    "vco.command_root": "~/.cursor/commands",
+    "vco.settings_surface": "~/.cursor/settings.json",
+    "vco.host_closure": "~/.cursor/.vibeskills/host-closure.json"
+  },
   "notes": [
-    "Cursor mapping is currently guidance-only and host-managed.",
-    "No repository-managed hook installation is promised in this preview lane."
+    "Cursor mapping now materializes commands, a managed host-closure manifest, and a minimal settings surface.",
+    "Deeper host-native workflow projection remains preview-scoped until broader replay-backed proof is available."
   ]
 }

--- a/adapters/openclaw/closure.json
+++ b/adapters/openclaw/closure.json
@@ -11,13 +11,17 @@
     "config/skills-lock.json",
     "canonical vibe mirror under skills/vibe/**",
     "host-root global_workflows/** when commands exist",
-    "host-root mcp_config.json from mcp/servers.template.json when absent"
+    "host-root mcp_config.json from mcp/servers.template.json when absent",
+    "host-root .vibeskills/host-closure.json",
+    "host-root .vibeskills/bin/**"
   ],
   "host_state_written": [
     "skills/**",
     "skills/vibe/**",
     "global_workflows/** when commands exist",
-    "mcp_config.json when absent"
+    "mcp_config.json when absent",
+    ".vibeskills/host-closure.json",
+    ".vibeskills/bin/**"
   ],
   "host_managed_boundaries": [
     "login and account state",
@@ -30,6 +34,7 @@
     "runtime freshness gate",
     "runtime BOM/frontmatter gate",
     "runtime coherence gate",
-    "runtime-core presence check"
+    "runtime-core presence check",
+    "host closure presence check"
   ]
 }

--- a/adapters/opencode/closure.json
+++ b/adapters/opencode/closure.json
@@ -1,6 +1,6 @@
 {
   "adapter_id": "opencode",
-  "closure_level": "preview-guidance",
+  "closure_level": "preview-managed",
   "install_mode": "preview-guidance",
   "check_mode": "preview-guidance",
   "bootstrap_mode": "preview-guidance",
@@ -8,7 +8,10 @@
     "runtime core payload",
     "OpenCode command wrappers under commands/** and command/**",
     "OpenCode agent wrappers under agents/** and agent/**",
-    "OpenCode preview config example under opencode.json.example"
+    "OpenCode preview config example under opencode.json.example",
+    ".vibeskills/host-closure.json",
+    ".vibeskills/bin/**",
+    "opencode.json managed vibeskills stanza"
   ],
   "host_state_written": [
     "skills/**",
@@ -16,7 +19,10 @@
     "command/**",
     "agents/**",
     "agent/**",
-    "opencode.json.example"
+    "opencode.json.example",
+    ".vibeskills/host-closure.json",
+    ".vibeskills/bin/**",
+    "opencode.json managed vibeskills stanza"
   ],
   "host_managed_boundaries": [
     "final opencode.json ownership",
@@ -29,6 +35,7 @@
     "runtime freshness gate",
     "runtime BOM/frontmatter gate",
     "runtime coherence gate",
-    "OpenCode preview smoke gate"
+    "OpenCode preview smoke gate",
+    "host closure presence check"
   ]
 }

--- a/adapters/opencode/host-profile.json
+++ b/adapters/opencode/host-profile.json
@@ -14,8 +14,8 @@
   ],
   "settings_surface": {
     "path": "~/.config/opencode/opencode.json",
-    "managed_by_repo": false,
-    "notes": "The repository installs skills, commands, and agents into OpenCode roots, but the real opencode.json remains host-managed. The repo only ships an example config scaffold for preview guidance."
+    "managed_by_repo": true,
+    "notes": "The repository now installs skills, commands, agents, host-closure metadata, and a minimal vibeskills-managed opencode.json surface while preserving existing values."
   },
   "host_managed_surfaces": [
     "final permission policy",
@@ -29,7 +29,7 @@
     "fs.write": "expected",
     "shell.exec": "expected",
     "mcp.client": "supported-with-constraints",
-    "settings.materialize": "preview-guidance",
+    "settings.materialize": "preview-managed",
     "plugin.provision": "manual-host-managed",
     "agent.spawn": "expected",
     "route.provider_call": "supported-with-constraints",
@@ -37,8 +37,8 @@
     "release.verify": "preview-guidance"
   },
   "degrade_contract": {
-    "missing_provider_credentials": "degraded-but-supported",
-    "missing_user_permission_policy": "degraded-but-supported",
+    "missing_provider_credentials": "configured_offline_unready",
+    "missing_user_permission_policy": "configured_offline_unready",
     "unverified_platform_lane": "not-yet-proven",
     "skill_debug_surface_diverges_from_docs": "preview-guidance-only"
   },

--- a/adapters/opencode/settings-map.json
+++ b/adapters/opencode/settings-map.json
@@ -3,6 +3,7 @@
   "template": "config/opencode/opencode.json.example",
   "target": "~/.config/opencode/opencode.json",
   "semantics": {
+    "vco.host_root.global": "~/.config/opencode",
     "vco.skill_root.global": "~/.config/opencode/skills",
     "vco.skill_root.project": ".opencode/skills",
     "vco.command_root.global": "~/.config/opencode/commands",
@@ -11,13 +12,14 @@
     "vco.agent_root.global": "~/.config/opencode/agents",
     "vco.agent_root.project": ".opencode/agents",
     "vco.agent_root.compat": "~/.config/opencode/agent",
+    "vco.host_closure": "~/.config/opencode/.vibeskills/host-closure.json",
     "permission.skill": "skill allow/ask rules for Vibe-Skills entrypoints",
     "permission.external_directory": "needed only when the operator intentionally points OpenCode at compatibility roots outside the project or OpenCode config home",
     "provider.*": "host-managed provider credentials and endpoint bindings"
   },
   "notes": [
-    "The repository does not overwrite the real opencode.json during preview installation.",
-    "Preview install writes markdown wrapper files into OpenCode command/agent roots and ships an example opencode.json scaffold only.",
+    "The repository now writes a minimal vibeskills-managed opencode.json surface while preserving any existing values.",
+    "Preview install writes markdown wrapper files into OpenCode command/agent roots and keeps the example opencode.json scaffold for reference.",
     "Both plural and singular command/agent subdirectories are mirrored during preview installation for compatibility with current doc/runtime drift."
   ]
 }

--- a/adapters/windsurf/closure.json
+++ b/adapters/windsurf/closure.json
@@ -11,13 +11,17 @@
     "config/skills-lock.json",
     "canonical vibe mirror under skills/vibe/**",
     "host-root global_workflows/** when commands exist",
-    "host-root mcp_config.json from mcp/servers.template.json when absent"
+    "host-root mcp_config.json from mcp/servers.template.json when absent",
+    "host-root .vibeskills/host-closure.json",
+    "host-root .vibeskills/bin/**"
   ],
   "host_state_written": [
     "skills/**",
     "skills/vibe/**",
     "global_workflows/** when commands exist",
-    "mcp_config.json when absent"
+    "mcp_config.json when absent",
+    ".vibeskills/host-closure.json",
+    ".vibeskills/bin/**"
   ],
   "host_managed_boundaries": [
     "login and account state",
@@ -31,6 +35,7 @@
     "runtime freshness gate",
     "runtime BOM/frontmatter gate",
     "runtime coherence gate",
-    "runtime-core presence check"
+    "runtime-core presence check",
+    "host closure presence check"
   ]
 }

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Freeze-RuntimeInputPacket.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Freeze-RuntimeInputPacket.ps1
@@ -434,6 +434,14 @@ $packet = [pscustomobject]@{
     stage = 'runtime_input_freeze'
     run_id = $RunId
     governance_scope = [string]$hierarchyState.governance_scope
+    host_adapter = [pscustomobject]@{
+        requested_host_id = if ($runtime.host_adapter -and $runtime.host_adapter.requested_id) { [string]$runtime.host_adapter.requested_id } else { [string]$runtime.host_adapter.id }
+        effective_host_id = if ($runtime.host_adapter) { [string]$runtime.host_adapter.id } else { 'codex' }
+        status = if ($runtime.host_adapter -and $runtime.host_adapter.status) { [string]$runtime.host_adapter.status } else { $null }
+        install_mode = if ($runtime.host_adapter -and $runtime.host_adapter.install_mode) { [string]$runtime.host_adapter.install_mode } else { $null }
+        check_mode = if ($runtime.host_adapter -and $runtime.host_adapter.check_mode) { [string]$runtime.host_adapter.check_mode } else { $null }
+        bootstrap_mode = if ($runtime.host_adapter -and $runtime.host_adapter.bootstrap_mode) { [string]$runtime.host_adapter.bootstrap_mode } else { $null }
+    }
     task = $Task
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     runtime_mode = $Mode

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
@@ -1104,6 +1104,8 @@ $executionManifest = [pscustomobject]@{
     route_runtime_alignment = [pscustomobject]@{
         router_selected_skill = if ($runtimeInputPacket) { [string]$runtimeInputPacket.route_snapshot.selected_skill } else { $null }
         runtime_selected_skill = if ($runtimeInputPacket) { [string]$runtimeInputPacket.authority_flags.explicit_runtime_skill } else { 'vibe' }
+        requested_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.requested_host_id } else { [string]$runtime.host_adapter.id }
+        effective_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.effective_host_id } else { [string]$runtime.host_adapter.id }
         skill_mismatch = if ($runtimeInputPacket) { [bool]$runtimeInputPacket.divergence_shadow.skill_mismatch } else { $false }
         confirm_required = if ($runtimeInputPacket) { [bool]$runtimeInputPacket.route_snapshot.confirm_required } else { $false }
     }
@@ -1145,6 +1147,8 @@ $executionManifest = [pscustomobject]@{
         ambiguous_unit_count = [int]$planShadow.payload.ambiguous_unit_count
     }
     specialist_accounting = [pscustomobject]@{
+        requested_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.requested_host_id } else { [string]$runtime.host_adapter.id }
+        effective_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.effective_host_id } else { [string]$runtime.host_adapter.id }
         recommendation_count = @($specialistRecommendations).Count
         specialist_skill_count = @($specialistSkills).Count
         specialist_skills = @($specialistSkills)

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/VibeExecution.Common.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/VibeExecution.Common.ps1
@@ -263,6 +263,66 @@ function Resolve-VibeProcessInvocationSpec {
     }
 }
 
+function Resolve-VibeBridgeExecutable {
+    param(
+        [Parameter(Mandatory)] [object]$Adapter,
+        [object]$Runtime = $null
+    )
+
+    $resolvedCommandPath = $null
+    $envName = if ($Adapter.PSObject.Properties.Name -contains 'bridge_executable_env') { [string]$Adapter.bridge_executable_env } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($envName)) {
+        $envValue = [Environment]::GetEnvironmentVariable($envName)
+        if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+            $candidate = Get-Command $envValue -ErrorAction SilentlyContinue
+            if ($candidate) {
+                $resolvedCommandPath = [string]$candidate.Source
+            } elseif (Test-Path -LiteralPath $envValue) {
+                $resolvedCommandPath = [System.IO.Path]::GetFullPath($envValue)
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($resolvedCommandPath) -and $null -ne $Runtime -and $Runtime.PSObject.Properties.Name -contains 'host_closure' -and $null -ne $Runtime.host_closure) {
+        $hostClosure = $Runtime.host_closure
+        if ($hostClosure.PSObject.Properties.Name -contains 'data' -and $null -ne $hostClosure.data) {
+            $specialistWrapper = if ($hostClosure.data.PSObject.Properties.Name -contains 'specialist_wrapper') { $hostClosure.data.specialist_wrapper } else { $null }
+            if ($null -ne $specialistWrapper) {
+                $ready = if ($specialistWrapper.PSObject.Properties.Name -contains 'ready') { [bool]$specialistWrapper.ready } else { $false }
+                $launcherPath = if ($specialistWrapper.PSObject.Properties.Name -contains 'launcher_path') { [string]$specialistWrapper.launcher_path } else { '' }
+                if ($ready -and -not [string]::IsNullOrWhiteSpace($launcherPath) -and (Test-Path -LiteralPath $launcherPath -PathType Leaf)) {
+                    $resolvedCommandPath = [System.IO.Path]::GetFullPath($launcherPath)
+                }
+            }
+        }
+    }
+
+    $defaultCommand = if ($Adapter.PSObject.Properties.Name -contains 'bridge_command') { [string]$Adapter.bridge_command } else { '' }
+    if ([string]::IsNullOrWhiteSpace($resolvedCommandPath) -and -not [string]::IsNullOrWhiteSpace($defaultCommand)) {
+        $candidate = Get-Command $defaultCommand -ErrorAction SilentlyContinue
+        if ($candidate) {
+            $resolvedCommandPath = [string]$candidate.Source
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($resolvedCommandPath)) {
+        $reason = if (-not [string]::IsNullOrWhiteSpace($envName)) {
+            ("native_specialist_bridge_command_unavailable:{0}" -f [string]$Adapter.id)
+        } else {
+            ("native_specialist_adapter_command_unavailable:{0}" -f [string]$Adapter.id)
+        }
+        return [pscustomobject]@{
+            command_path = $null
+            reason = $reason
+        }
+    }
+
+    return [pscustomobject]@{
+        command_path = [string]$resolvedCommandPath
+        reason = 'native_specialist_bridge_ready'
+    }
+}
+
 function Resolve-VibeNativeSpecialistAdapter {
     param(
         [Parameter(Mandatory)] [string]$ScriptPath
@@ -323,7 +383,9 @@ function Resolve-VibeNativeSpecialistAdapter {
         }
     }
 
-    $adapterId = if ($policy.PSObject.Properties.Name -contains 'default_adapter_id' -and -not [string]::IsNullOrWhiteSpace([string]$policy.default_adapter_id)) {
+    $adapterId = if ($runtime.host_adapter -and -not [string]::IsNullOrWhiteSpace([string]$runtime.host_adapter.id)) {
+        [string]$runtime.host_adapter.id
+    } elseif ($policy.PSObject.Properties.Name -contains 'default_adapter_id' -and -not [string]::IsNullOrWhiteSpace([string]$policy.default_adapter_id)) {
         [string]$policy.default_adapter_id
     } else {
         'codex'
@@ -351,29 +413,62 @@ function Resolve-VibeNativeSpecialistAdapter {
     $commandPath = $null
     $invocationArgumentsPrefix = @()
     $resolvedReason = $null
-    if ($adapter.PSObject.Properties.Name -contains 'executable_env' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.executable_env)) {
-        $envCommand = [Environment]::GetEnvironmentVariable([string]$adapter.executable_env)
-        if (-not [string]::IsNullOrWhiteSpace($envCommand)) {
-            $candidate = Get-Command $envCommand -ErrorAction SilentlyContinue
-            if ($candidate) {
-                $commandPath = [string]$candidate.Source
-            } elseif (Test-Path -LiteralPath $envCommand) {
-                $commandPath = [System.IO.Path]::GetFullPath($envCommand)
+    $invocationKind = if ($adapter.PSObject.Properties.Name -contains 'invocation_kind') { [string]$adapter.invocation_kind } else { 'direct' }
+
+    if ($invocationKind -eq 'python_runner') {
+        $bridgeResolution = Resolve-VibeBridgeExecutable -Adapter $adapter -Runtime $runtime
+        if ([string]::IsNullOrWhiteSpace([string]$bridgeResolution.command_path)) {
+            $resolvedReason = [string]$bridgeResolution.reason
+        } else {
+            $pythonInvocation = Resolve-VgoPythonCommandSpec -Command '${VGO_PYTHON}'
+            $runnerScriptPath = if ($adapter.PSObject.Properties.Name -contains 'runner_script_path' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.runner_script_path)) {
+                [System.IO.Path]::GetFullPath((Join-Path $runtime.repo_root ([string]$adapter.runner_script_path)))
+            } else {
+                $null
+            }
+            if ([string]::IsNullOrWhiteSpace($runnerScriptPath) -or -not (Test-Path -LiteralPath $runnerScriptPath)) {
+                $resolvedReason = ("native_specialist_runner_missing:{0}" -f [string]$adapter.id)
+            } else {
+                $commandPath = [string]$pythonInvocation.host_path
+                $invocationArgumentsPrefix = @($pythonInvocation.prefix_arguments)
+                $invocationArgumentsPrefix += @(
+                    $runnerScriptPath,
+                    '--host-adapter', ([string]$adapter.id),
+                    '--bridge-executable', ([string]$bridgeResolution.command_path)
+                )
+                if ($adapter.PSObject.Properties.Name -contains 'bridge_contract' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.bridge_contract)) {
+                    $invocationArgumentsPrefix += @('--bridge-contract', ([string]$adapter.bridge_contract))
+                }
+                foreach ($item in @($adapter.runner_arguments_prefix)) {
+                    $invocationArgumentsPrefix += [string]$item
+                }
             }
         }
-    }
-    if ([string]::IsNullOrWhiteSpace($commandPath)) {
-        $candidate = Get-Command ([string]$adapter.command) -ErrorAction SilentlyContinue
-        if ($candidate) {
-            $commandPath = [string]$candidate.Source
-        }
-    }
-    if ([string]::IsNullOrWhiteSpace($commandPath)) {
-        $resolvedReason = ("native_specialist_adapter_command_unavailable:{0}" -f [string]$adapter.command)
     } else {
-        $invocationSpec = Resolve-VibeProcessInvocationSpec -CommandPath $commandPath -ArgumentList @()
-        $commandPath = [string]$invocationSpec.command_path
-        $invocationArgumentsPrefix = @($invocationSpec.arguments)
+        if ($adapter.PSObject.Properties.Name -contains 'executable_env' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.executable_env)) {
+            $envCommand = [Environment]::GetEnvironmentVariable([string]$adapter.executable_env)
+            if (-not [string]::IsNullOrWhiteSpace($envCommand)) {
+                $candidate = Get-Command $envCommand -ErrorAction SilentlyContinue
+                if ($candidate) {
+                    $commandPath = [string]$candidate.Source
+                } elseif (Test-Path -LiteralPath $envCommand) {
+                    $commandPath = [System.IO.Path]::GetFullPath($envCommand)
+                }
+            }
+        }
+        if ([string]::IsNullOrWhiteSpace($commandPath)) {
+            $candidate = Get-Command ([string]$adapter.command) -ErrorAction SilentlyContinue
+            if ($candidate) {
+                $commandPath = [string]$candidate.Source
+            }
+        }
+        if ([string]::IsNullOrWhiteSpace($commandPath)) {
+            $resolvedReason = ("native_specialist_adapter_command_unavailable:{0}" -f [string]$adapter.command)
+        } else {
+            $invocationSpec = Resolve-VibeProcessInvocationSpec -CommandPath $commandPath -ArgumentList @()
+            $commandPath = [string]$invocationSpec.command_path
+            $invocationArgumentsPrefix = @($invocationSpec.arguments)
+        }
     }
 
     return [pscustomobject]@{
@@ -383,6 +478,8 @@ function Resolve-VibeNativeSpecialistAdapter {
         runtime = $runtime
         policy = $policy
         adapter = $adapter
+        requested_host_adapter_id = if ($runtime.host_adapter -and $runtime.host_adapter.requested_id) { [string]$runtime.host_adapter.requested_id } else { [string]$adapterId }
+        effective_host_adapter_id = [string]$adapter.id
         command_path = $commandPath
         invocation_arguments_prefix = @($invocationArgumentsPrefix)
     }
@@ -644,6 +741,7 @@ function New-VibeDegradedSpecialistDispatchResult {
         [Parameter(Mandatory)] [string]$SessionRoot,
         [Parameter(Mandatory)] [object]$Policy,
         [Parameter(Mandatory)] [string]$Reason,
+        [AllowNull()] [object]$AdapterResolution = $null,
         [AllowEmptyString()] [string]$WriteScope = '',
         [AllowEmptyString()] [string]$ReviewMode = 'native_contract'
     )
@@ -695,6 +793,8 @@ function New-VibeDegradedSpecialistDispatchResult {
         write_scope = $WriteScope
         review_mode = $ReviewMode
         execution_driver = [string]$Policy.degrade_contract.execution_driver
+        requested_host_adapter_id = if ($AdapterResolution -and $AdapterResolution.PSObject.Properties.Name -contains 'requested_host_adapter_id') { [string]$AdapterResolution.requested_host_adapter_id } else { $null }
+        host_adapter_id = if ($AdapterResolution -and $AdapterResolution.PSObject.Properties.Name -contains 'effective_host_adapter_id') { [string]$AdapterResolution.effective_host_adapter_id } else { $null }
         live_native_execution = $false
         degraded = $true
         degradation_reason = $Reason
@@ -739,6 +839,7 @@ function Invoke-VibeSpecialistDispatchUnit {
             -SessionRoot $SessionRoot `
             -Policy $policy `
             -Reason ([string]$adapterResolution.reason) `
+            -AdapterResolution $adapterResolution `
             -WriteScope $WriteScope `
             -ReviewMode $ReviewMode
     }
@@ -893,6 +994,7 @@ function Invoke-VibeSpecialistDispatchUnit {
         write_scope = $WriteScope
         review_mode = $ReviewMode
         execution_driver = [string]$adapter.execution_driver
+        requested_host_adapter_id = [string]$adapterResolution.requested_host_adapter_id
         host_adapter_id = [string]$adapter.id
         live_native_execution = $true
         degraded = $false

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/VibeRuntime.Common.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/VibeRuntime.Common.ps1
@@ -3,6 +3,108 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
 
+function Get-VibeHostAdapterEntry {
+    param(
+        [Parameter(Mandatory)] [string]$RepoRoot,
+        [AllowEmptyString()] [string]$HostId = ''
+    )
+
+    $requestedHostId = if ([string]::IsNullOrWhiteSpace($HostId)) { $env:VCO_HOST_ID } else { $HostId }
+    $resolvedHostId = Resolve-VgoHostId -HostId $requestedHostId
+    $registryPath = Join-Path $RepoRoot 'adapters\index.json'
+    if (-not (Test-Path -LiteralPath $registryPath)) {
+        return [pscustomobject]@{
+            requested_id = if ([string]::IsNullOrWhiteSpace($requestedHostId)) { $null } else { [string]$requestedHostId }
+            id = $resolvedHostId
+            status = $null
+            install_mode = $null
+            check_mode = $null
+            bootstrap_mode = $null
+            default_target_root = $null
+        }
+    }
+
+    $registry = Get-Content -LiteralPath $registryPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $adapter = @($registry.adapters | Where-Object { [string]$_.id -eq $resolvedHostId } | Select-Object -First 1)[0]
+    if ($null -eq $adapter) {
+        return [pscustomobject]@{
+            requested_id = if ([string]::IsNullOrWhiteSpace($requestedHostId)) { $null } else { [string]$requestedHostId }
+            id = $resolvedHostId
+            status = $null
+            install_mode = $null
+            check_mode = $null
+            bootstrap_mode = $null
+            default_target_root = $null
+        }
+    }
+
+    return [pscustomobject]@{
+        requested_id = if ([string]::IsNullOrWhiteSpace($requestedHostId)) { $null } else { [string]$requestedHostId }
+        id = [string]$adapter.id
+        status = if ($adapter.PSObject.Properties.Name -contains 'status') { [string]$adapter.status } else { $null }
+        install_mode = if ($adapter.PSObject.Properties.Name -contains 'install_mode') { [string]$adapter.install_mode } else { $null }
+        check_mode = if ($adapter.PSObject.Properties.Name -contains 'check_mode') { [string]$adapter.check_mode } else { $null }
+        bootstrap_mode = if ($adapter.PSObject.Properties.Name -contains 'bootstrap_mode') { [string]$adapter.bootstrap_mode } else { $null }
+        default_target_root = if ($adapter.PSObject.Properties.Name -contains 'default_target_root') { $adapter.default_target_root } else { $null }
+    }
+}
+
+function Resolve-VibeHostTargetRoot {
+    param(
+        [Parameter(Mandatory)] [object]$HostAdapter
+    )
+
+    if ($null -eq $HostAdapter -or $null -eq $HostAdapter.default_target_root) {
+        return $null
+    }
+
+    $targetSpec = $HostAdapter.default_target_root
+    $envName = if ($targetSpec.PSObject.Properties.Name -contains 'env') { [string]$targetSpec.env } else { '' }
+    $rel = if ($targetSpec.PSObject.Properties.Name -contains 'rel') { [string]$targetSpec.rel } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($envName)) {
+        $envValue = [Environment]::GetEnvironmentVariable($envName)
+        if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+            return [System.IO.Path]::GetFullPath($envValue)
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($rel)) {
+        return $null
+    }
+    if ([System.IO.Path]::IsPathRooted($rel)) {
+        return [System.IO.Path]::GetFullPath($rel)
+    }
+    $homeDir = Resolve-VgoHomeDirectory
+    return [System.IO.Path]::GetFullPath((Join-Path $homeDir $rel))
+}
+
+function Get-VibeHostClosureRecord {
+    param(
+        [Parameter(Mandatory)] [object]$HostAdapter
+    )
+
+    $targetRoot = Resolve-VibeHostTargetRoot -HostAdapter $HostAdapter
+    if ([string]::IsNullOrWhiteSpace($targetRoot)) {
+        return $null
+    }
+
+    $closurePath = Join-Path $targetRoot '.vibeskills\host-closure.json'
+    if (-not (Test-Path -LiteralPath $closurePath -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        $closure = Get-Content -LiteralPath $closurePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+
+    return [pscustomobject]@{
+        target_root = $targetRoot
+        path = $closurePath
+        data = $closure
+    }
+}
+
 function Get-VibeRuntimeContext {
     param(
         [Parameter(Mandatory)] [string]$ScriptPath
@@ -10,10 +112,13 @@ function Get-VibeRuntimeContext {
 
     $governanceContext = Get-VgoGovernanceContext -ScriptPath $ScriptPath -EnforceExecutionContext
     $repoRoot = $governanceContext.repoRoot
+    $hostAdapter = Get-VibeHostAdapterEntry -RepoRoot $repoRoot
 
     return [pscustomobject]@{
         repo_root = $repoRoot
         governance_context = $governanceContext
+        host_adapter = $hostAdapter
+        host_closure = Get-VibeHostClosureRecord -HostAdapter $hostAdapter
         runtime_contract = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-contract.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         runtime_modes = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-modes.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         runtime_input_packet_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-input-packet-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/native_specialist_runner.py
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/native_specialist_runner.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def resolve_wrapper_invocation(bridge_executable: str, bridge_args: list[str]) -> list[str]:
+    bridge_path = Path(bridge_executable)
+    suffix = bridge_path.suffix.lower()
+
+    if os.name == "nt" and suffix in {".cmd", ".bat"}:
+        comspec = os.environ.get("COMSPEC") or shutil.which("cmd.exe") or "cmd.exe"
+        return [comspec, "/d", "/s", "/c", str(bridge_path), *bridge_args]
+
+    if suffix == ".ps1":
+        powershell = (
+            shutil.which("pwsh")
+            or shutil.which("pwsh.exe")
+            or shutil.which("powershell")
+            or shutil.which("powershell.exe")
+        )
+        if powershell:
+            return [powershell, "-NoLogo", "-NoProfile", "-File", str(bridge_path), *bridge_args]
+
+    return [str(bridge_path), *bridge_args]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host-adapter", required=True)
+    parser.add_argument("--bridge-executable", required=True)
+    parser.add_argument("--bridge-contract", default="vco_specialist_wrapper_v1")
+    parser.add_argument("-C", "--repo-root", required=True)
+    parser.add_argument("--output-schema", required=True)
+    parser.add_argument("-o", "--output", required=True)
+    parser.add_argument("prompt")
+    args = parser.parse_args()
+
+    bridge_args = [
+        "--repo-root",
+        args.repo_root,
+        "--output-schema",
+        args.output_schema,
+        "--output",
+        args.output,
+        "--host-adapter",
+        args.host_adapter,
+        "--bridge-contract",
+        args.bridge_contract,
+        "--prompt",
+        args.prompt,
+    ]
+    invocation = resolve_wrapper_invocation(args.bridge_executable, bridge_args)
+
+    completed = subprocess.run(
+        invocation,
+        cwd=args.repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if completed.stdout:
+        sys.stdout.write(completed.stdout)
+    if completed.stderr:
+        sys.stderr.write(completed.stderr)
+    return int(completed.returncode)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bundled/skills/vibe/scripts/runtime/Freeze-RuntimeInputPacket.ps1
+++ b/bundled/skills/vibe/scripts/runtime/Freeze-RuntimeInputPacket.ps1
@@ -434,6 +434,14 @@ $packet = [pscustomobject]@{
     stage = 'runtime_input_freeze'
     run_id = $RunId
     governance_scope = [string]$hierarchyState.governance_scope
+    host_adapter = [pscustomobject]@{
+        requested_host_id = if ($runtime.host_adapter -and $runtime.host_adapter.requested_id) { [string]$runtime.host_adapter.requested_id } else { [string]$runtime.host_adapter.id }
+        effective_host_id = if ($runtime.host_adapter) { [string]$runtime.host_adapter.id } else { 'codex' }
+        status = if ($runtime.host_adapter -and $runtime.host_adapter.status) { [string]$runtime.host_adapter.status } else { $null }
+        install_mode = if ($runtime.host_adapter -and $runtime.host_adapter.install_mode) { [string]$runtime.host_adapter.install_mode } else { $null }
+        check_mode = if ($runtime.host_adapter -and $runtime.host_adapter.check_mode) { [string]$runtime.host_adapter.check_mode } else { $null }
+        bootstrap_mode = if ($runtime.host_adapter -and $runtime.host_adapter.bootstrap_mode) { [string]$runtime.host_adapter.bootstrap_mode } else { $null }
+    }
     task = $Task
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     runtime_mode = $Mode

--- a/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
@@ -1104,6 +1104,8 @@ $executionManifest = [pscustomobject]@{
     route_runtime_alignment = [pscustomobject]@{
         router_selected_skill = if ($runtimeInputPacket) { [string]$runtimeInputPacket.route_snapshot.selected_skill } else { $null }
         runtime_selected_skill = if ($runtimeInputPacket) { [string]$runtimeInputPacket.authority_flags.explicit_runtime_skill } else { 'vibe' }
+        requested_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.requested_host_id } else { [string]$runtime.host_adapter.id }
+        effective_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.effective_host_id } else { [string]$runtime.host_adapter.id }
         skill_mismatch = if ($runtimeInputPacket) { [bool]$runtimeInputPacket.divergence_shadow.skill_mismatch } else { $false }
         confirm_required = if ($runtimeInputPacket) { [bool]$runtimeInputPacket.route_snapshot.confirm_required } else { $false }
     }
@@ -1145,6 +1147,8 @@ $executionManifest = [pscustomobject]@{
         ambiguous_unit_count = [int]$planShadow.payload.ambiguous_unit_count
     }
     specialist_accounting = [pscustomobject]@{
+        requested_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.requested_host_id } else { [string]$runtime.host_adapter.id }
+        effective_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.effective_host_id } else { [string]$runtime.host_adapter.id }
         recommendation_count = @($specialistRecommendations).Count
         specialist_skill_count = @($specialistSkills).Count
         specialist_skills = @($specialistSkills)

--- a/bundled/skills/vibe/scripts/runtime/VibeExecution.Common.ps1
+++ b/bundled/skills/vibe/scripts/runtime/VibeExecution.Common.ps1
@@ -263,6 +263,66 @@ function Resolve-VibeProcessInvocationSpec {
     }
 }
 
+function Resolve-VibeBridgeExecutable {
+    param(
+        [Parameter(Mandatory)] [object]$Adapter,
+        [object]$Runtime = $null
+    )
+
+    $resolvedCommandPath = $null
+    $envName = if ($Adapter.PSObject.Properties.Name -contains 'bridge_executable_env') { [string]$Adapter.bridge_executable_env } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($envName)) {
+        $envValue = [Environment]::GetEnvironmentVariable($envName)
+        if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+            $candidate = Get-Command $envValue -ErrorAction SilentlyContinue
+            if ($candidate) {
+                $resolvedCommandPath = [string]$candidate.Source
+            } elseif (Test-Path -LiteralPath $envValue) {
+                $resolvedCommandPath = [System.IO.Path]::GetFullPath($envValue)
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($resolvedCommandPath) -and $null -ne $Runtime -and $Runtime.PSObject.Properties.Name -contains 'host_closure' -and $null -ne $Runtime.host_closure) {
+        $hostClosure = $Runtime.host_closure
+        if ($hostClosure.PSObject.Properties.Name -contains 'data' -and $null -ne $hostClosure.data) {
+            $specialistWrapper = if ($hostClosure.data.PSObject.Properties.Name -contains 'specialist_wrapper') { $hostClosure.data.specialist_wrapper } else { $null }
+            if ($null -ne $specialistWrapper) {
+                $ready = if ($specialistWrapper.PSObject.Properties.Name -contains 'ready') { [bool]$specialistWrapper.ready } else { $false }
+                $launcherPath = if ($specialistWrapper.PSObject.Properties.Name -contains 'launcher_path') { [string]$specialistWrapper.launcher_path } else { '' }
+                if ($ready -and -not [string]::IsNullOrWhiteSpace($launcherPath) -and (Test-Path -LiteralPath $launcherPath -PathType Leaf)) {
+                    $resolvedCommandPath = [System.IO.Path]::GetFullPath($launcherPath)
+                }
+            }
+        }
+    }
+
+    $defaultCommand = if ($Adapter.PSObject.Properties.Name -contains 'bridge_command') { [string]$Adapter.bridge_command } else { '' }
+    if ([string]::IsNullOrWhiteSpace($resolvedCommandPath) -and -not [string]::IsNullOrWhiteSpace($defaultCommand)) {
+        $candidate = Get-Command $defaultCommand -ErrorAction SilentlyContinue
+        if ($candidate) {
+            $resolvedCommandPath = [string]$candidate.Source
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($resolvedCommandPath)) {
+        $reason = if (-not [string]::IsNullOrWhiteSpace($envName)) {
+            ("native_specialist_bridge_command_unavailable:{0}" -f [string]$Adapter.id)
+        } else {
+            ("native_specialist_adapter_command_unavailable:{0}" -f [string]$Adapter.id)
+        }
+        return [pscustomobject]@{
+            command_path = $null
+            reason = $reason
+        }
+    }
+
+    return [pscustomobject]@{
+        command_path = [string]$resolvedCommandPath
+        reason = 'native_specialist_bridge_ready'
+    }
+}
+
 function Resolve-VibeNativeSpecialistAdapter {
     param(
         [Parameter(Mandatory)] [string]$ScriptPath
@@ -323,7 +383,9 @@ function Resolve-VibeNativeSpecialistAdapter {
         }
     }
 
-    $adapterId = if ($policy.PSObject.Properties.Name -contains 'default_adapter_id' -and -not [string]::IsNullOrWhiteSpace([string]$policy.default_adapter_id)) {
+    $adapterId = if ($runtime.host_adapter -and -not [string]::IsNullOrWhiteSpace([string]$runtime.host_adapter.id)) {
+        [string]$runtime.host_adapter.id
+    } elseif ($policy.PSObject.Properties.Name -contains 'default_adapter_id' -and -not [string]::IsNullOrWhiteSpace([string]$policy.default_adapter_id)) {
         [string]$policy.default_adapter_id
     } else {
         'codex'
@@ -351,29 +413,62 @@ function Resolve-VibeNativeSpecialistAdapter {
     $commandPath = $null
     $invocationArgumentsPrefix = @()
     $resolvedReason = $null
-    if ($adapter.PSObject.Properties.Name -contains 'executable_env' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.executable_env)) {
-        $envCommand = [Environment]::GetEnvironmentVariable([string]$adapter.executable_env)
-        if (-not [string]::IsNullOrWhiteSpace($envCommand)) {
-            $candidate = Get-Command $envCommand -ErrorAction SilentlyContinue
-            if ($candidate) {
-                $commandPath = [string]$candidate.Source
-            } elseif (Test-Path -LiteralPath $envCommand) {
-                $commandPath = [System.IO.Path]::GetFullPath($envCommand)
+    $invocationKind = if ($adapter.PSObject.Properties.Name -contains 'invocation_kind') { [string]$adapter.invocation_kind } else { 'direct' }
+
+    if ($invocationKind -eq 'python_runner') {
+        $bridgeResolution = Resolve-VibeBridgeExecutable -Adapter $adapter -Runtime $runtime
+        if ([string]::IsNullOrWhiteSpace([string]$bridgeResolution.command_path)) {
+            $resolvedReason = [string]$bridgeResolution.reason
+        } else {
+            $pythonInvocation = Resolve-VgoPythonCommandSpec -Command '${VGO_PYTHON}'
+            $runnerScriptPath = if ($adapter.PSObject.Properties.Name -contains 'runner_script_path' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.runner_script_path)) {
+                [System.IO.Path]::GetFullPath((Join-Path $runtime.repo_root ([string]$adapter.runner_script_path)))
+            } else {
+                $null
+            }
+            if ([string]::IsNullOrWhiteSpace($runnerScriptPath) -or -not (Test-Path -LiteralPath $runnerScriptPath)) {
+                $resolvedReason = ("native_specialist_runner_missing:{0}" -f [string]$adapter.id)
+            } else {
+                $commandPath = [string]$pythonInvocation.host_path
+                $invocationArgumentsPrefix = @($pythonInvocation.prefix_arguments)
+                $invocationArgumentsPrefix += @(
+                    $runnerScriptPath,
+                    '--host-adapter', ([string]$adapter.id),
+                    '--bridge-executable', ([string]$bridgeResolution.command_path)
+                )
+                if ($adapter.PSObject.Properties.Name -contains 'bridge_contract' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.bridge_contract)) {
+                    $invocationArgumentsPrefix += @('--bridge-contract', ([string]$adapter.bridge_contract))
+                }
+                foreach ($item in @($adapter.runner_arguments_prefix)) {
+                    $invocationArgumentsPrefix += [string]$item
+                }
             }
         }
-    }
-    if ([string]::IsNullOrWhiteSpace($commandPath)) {
-        $candidate = Get-Command ([string]$adapter.command) -ErrorAction SilentlyContinue
-        if ($candidate) {
-            $commandPath = [string]$candidate.Source
-        }
-    }
-    if ([string]::IsNullOrWhiteSpace($commandPath)) {
-        $resolvedReason = ("native_specialist_adapter_command_unavailable:{0}" -f [string]$adapter.command)
     } else {
-        $invocationSpec = Resolve-VibeProcessInvocationSpec -CommandPath $commandPath -ArgumentList @()
-        $commandPath = [string]$invocationSpec.command_path
-        $invocationArgumentsPrefix = @($invocationSpec.arguments)
+        if ($adapter.PSObject.Properties.Name -contains 'executable_env' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.executable_env)) {
+            $envCommand = [Environment]::GetEnvironmentVariable([string]$adapter.executable_env)
+            if (-not [string]::IsNullOrWhiteSpace($envCommand)) {
+                $candidate = Get-Command $envCommand -ErrorAction SilentlyContinue
+                if ($candidate) {
+                    $commandPath = [string]$candidate.Source
+                } elseif (Test-Path -LiteralPath $envCommand) {
+                    $commandPath = [System.IO.Path]::GetFullPath($envCommand)
+                }
+            }
+        }
+        if ([string]::IsNullOrWhiteSpace($commandPath)) {
+            $candidate = Get-Command ([string]$adapter.command) -ErrorAction SilentlyContinue
+            if ($candidate) {
+                $commandPath = [string]$candidate.Source
+            }
+        }
+        if ([string]::IsNullOrWhiteSpace($commandPath)) {
+            $resolvedReason = ("native_specialist_adapter_command_unavailable:{0}" -f [string]$adapter.command)
+        } else {
+            $invocationSpec = Resolve-VibeProcessInvocationSpec -CommandPath $commandPath -ArgumentList @()
+            $commandPath = [string]$invocationSpec.command_path
+            $invocationArgumentsPrefix = @($invocationSpec.arguments)
+        }
     }
 
     return [pscustomobject]@{
@@ -383,6 +478,8 @@ function Resolve-VibeNativeSpecialistAdapter {
         runtime = $runtime
         policy = $policy
         adapter = $adapter
+        requested_host_adapter_id = if ($runtime.host_adapter -and $runtime.host_adapter.requested_id) { [string]$runtime.host_adapter.requested_id } else { [string]$adapterId }
+        effective_host_adapter_id = [string]$adapter.id
         command_path = $commandPath
         invocation_arguments_prefix = @($invocationArgumentsPrefix)
     }
@@ -644,6 +741,7 @@ function New-VibeDegradedSpecialistDispatchResult {
         [Parameter(Mandatory)] [string]$SessionRoot,
         [Parameter(Mandatory)] [object]$Policy,
         [Parameter(Mandatory)] [string]$Reason,
+        [AllowNull()] [object]$AdapterResolution = $null,
         [AllowEmptyString()] [string]$WriteScope = '',
         [AllowEmptyString()] [string]$ReviewMode = 'native_contract'
     )
@@ -695,6 +793,8 @@ function New-VibeDegradedSpecialistDispatchResult {
         write_scope = $WriteScope
         review_mode = $ReviewMode
         execution_driver = [string]$Policy.degrade_contract.execution_driver
+        requested_host_adapter_id = if ($AdapterResolution -and $AdapterResolution.PSObject.Properties.Name -contains 'requested_host_adapter_id') { [string]$AdapterResolution.requested_host_adapter_id } else { $null }
+        host_adapter_id = if ($AdapterResolution -and $AdapterResolution.PSObject.Properties.Name -contains 'effective_host_adapter_id') { [string]$AdapterResolution.effective_host_adapter_id } else { $null }
         live_native_execution = $false
         degraded = $true
         degradation_reason = $Reason
@@ -739,6 +839,7 @@ function Invoke-VibeSpecialistDispatchUnit {
             -SessionRoot $SessionRoot `
             -Policy $policy `
             -Reason ([string]$adapterResolution.reason) `
+            -AdapterResolution $adapterResolution `
             -WriteScope $WriteScope `
             -ReviewMode $ReviewMode
     }
@@ -893,6 +994,7 @@ function Invoke-VibeSpecialistDispatchUnit {
         write_scope = $WriteScope
         review_mode = $ReviewMode
         execution_driver = [string]$adapter.execution_driver
+        requested_host_adapter_id = [string]$adapterResolution.requested_host_adapter_id
         host_adapter_id = [string]$adapter.id
         live_native_execution = $true
         degraded = $false

--- a/bundled/skills/vibe/scripts/runtime/VibeRuntime.Common.ps1
+++ b/bundled/skills/vibe/scripts/runtime/VibeRuntime.Common.ps1
@@ -3,6 +3,108 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
 
+function Get-VibeHostAdapterEntry {
+    param(
+        [Parameter(Mandatory)] [string]$RepoRoot,
+        [AllowEmptyString()] [string]$HostId = ''
+    )
+
+    $requestedHostId = if ([string]::IsNullOrWhiteSpace($HostId)) { $env:VCO_HOST_ID } else { $HostId }
+    $resolvedHostId = Resolve-VgoHostId -HostId $requestedHostId
+    $registryPath = Join-Path $RepoRoot 'adapters\index.json'
+    if (-not (Test-Path -LiteralPath $registryPath)) {
+        return [pscustomobject]@{
+            requested_id = if ([string]::IsNullOrWhiteSpace($requestedHostId)) { $null } else { [string]$requestedHostId }
+            id = $resolvedHostId
+            status = $null
+            install_mode = $null
+            check_mode = $null
+            bootstrap_mode = $null
+            default_target_root = $null
+        }
+    }
+
+    $registry = Get-Content -LiteralPath $registryPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $adapter = @($registry.adapters | Where-Object { [string]$_.id -eq $resolvedHostId } | Select-Object -First 1)[0]
+    if ($null -eq $adapter) {
+        return [pscustomobject]@{
+            requested_id = if ([string]::IsNullOrWhiteSpace($requestedHostId)) { $null } else { [string]$requestedHostId }
+            id = $resolvedHostId
+            status = $null
+            install_mode = $null
+            check_mode = $null
+            bootstrap_mode = $null
+            default_target_root = $null
+        }
+    }
+
+    return [pscustomobject]@{
+        requested_id = if ([string]::IsNullOrWhiteSpace($requestedHostId)) { $null } else { [string]$requestedHostId }
+        id = [string]$adapter.id
+        status = if ($adapter.PSObject.Properties.Name -contains 'status') { [string]$adapter.status } else { $null }
+        install_mode = if ($adapter.PSObject.Properties.Name -contains 'install_mode') { [string]$adapter.install_mode } else { $null }
+        check_mode = if ($adapter.PSObject.Properties.Name -contains 'check_mode') { [string]$adapter.check_mode } else { $null }
+        bootstrap_mode = if ($adapter.PSObject.Properties.Name -contains 'bootstrap_mode') { [string]$adapter.bootstrap_mode } else { $null }
+        default_target_root = if ($adapter.PSObject.Properties.Name -contains 'default_target_root') { $adapter.default_target_root } else { $null }
+    }
+}
+
+function Resolve-VibeHostTargetRoot {
+    param(
+        [Parameter(Mandatory)] [object]$HostAdapter
+    )
+
+    if ($null -eq $HostAdapter -or $null -eq $HostAdapter.default_target_root) {
+        return $null
+    }
+
+    $targetSpec = $HostAdapter.default_target_root
+    $envName = if ($targetSpec.PSObject.Properties.Name -contains 'env') { [string]$targetSpec.env } else { '' }
+    $rel = if ($targetSpec.PSObject.Properties.Name -contains 'rel') { [string]$targetSpec.rel } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($envName)) {
+        $envValue = [Environment]::GetEnvironmentVariable($envName)
+        if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+            return [System.IO.Path]::GetFullPath($envValue)
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($rel)) {
+        return $null
+    }
+    if ([System.IO.Path]::IsPathRooted($rel)) {
+        return [System.IO.Path]::GetFullPath($rel)
+    }
+    $homeDir = Resolve-VgoHomeDirectory
+    return [System.IO.Path]::GetFullPath((Join-Path $homeDir $rel))
+}
+
+function Get-VibeHostClosureRecord {
+    param(
+        [Parameter(Mandatory)] [object]$HostAdapter
+    )
+
+    $targetRoot = Resolve-VibeHostTargetRoot -HostAdapter $HostAdapter
+    if ([string]::IsNullOrWhiteSpace($targetRoot)) {
+        return $null
+    }
+
+    $closurePath = Join-Path $targetRoot '.vibeskills\host-closure.json'
+    if (-not (Test-Path -LiteralPath $closurePath -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        $closure = Get-Content -LiteralPath $closurePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+
+    return [pscustomobject]@{
+        target_root = $targetRoot
+        path = $closurePath
+        data = $closure
+    }
+}
+
 function Get-VibeRuntimeContext {
     param(
         [Parameter(Mandatory)] [string]$ScriptPath
@@ -10,10 +112,13 @@ function Get-VibeRuntimeContext {
 
     $governanceContext = Get-VgoGovernanceContext -ScriptPath $ScriptPath -EnforceExecutionContext
     $repoRoot = $governanceContext.repoRoot
+    $hostAdapter = Get-VibeHostAdapterEntry -RepoRoot $repoRoot
 
     return [pscustomobject]@{
         repo_root = $repoRoot
         governance_context = $governanceContext
+        host_adapter = $hostAdapter
+        host_closure = Get-VibeHostClosureRecord -HostAdapter $hostAdapter
         runtime_contract = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-contract.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         runtime_modes = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-modes.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         runtime_input_packet_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-input-packet-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json

--- a/bundled/skills/vibe/scripts/runtime/native_specialist_runner.py
+++ b/bundled/skills/vibe/scripts/runtime/native_specialist_runner.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def resolve_wrapper_invocation(bridge_executable: str, bridge_args: list[str]) -> list[str]:
+    bridge_path = Path(bridge_executable)
+    suffix = bridge_path.suffix.lower()
+
+    if os.name == "nt" and suffix in {".cmd", ".bat"}:
+        comspec = os.environ.get("COMSPEC") or shutil.which("cmd.exe") or "cmd.exe"
+        return [comspec, "/d", "/s", "/c", str(bridge_path), *bridge_args]
+
+    if suffix == ".ps1":
+        powershell = (
+            shutil.which("pwsh")
+            or shutil.which("pwsh.exe")
+            or shutil.which("powershell")
+            or shutil.which("powershell.exe")
+        )
+        if powershell:
+            return [powershell, "-NoLogo", "-NoProfile", "-File", str(bridge_path), *bridge_args]
+
+    return [str(bridge_path), *bridge_args]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host-adapter", required=True)
+    parser.add_argument("--bridge-executable", required=True)
+    parser.add_argument("--bridge-contract", default="vco_specialist_wrapper_v1")
+    parser.add_argument("-C", "--repo-root", required=True)
+    parser.add_argument("--output-schema", required=True)
+    parser.add_argument("-o", "--output", required=True)
+    parser.add_argument("prompt")
+    args = parser.parse_args()
+
+    bridge_args = [
+        "--repo-root",
+        args.repo_root,
+        "--output-schema",
+        args.output_schema,
+        "--output",
+        args.output,
+        "--host-adapter",
+        args.host_adapter,
+        "--bridge-contract",
+        args.bridge_contract,
+        "--prompt",
+        args.prompt,
+    ]
+    invocation = resolve_wrapper_invocation(args.bridge_executable, bridge_args)
+
+    completed = subprocess.run(
+        invocation,
+        cwd=args.repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if completed.stdout:
+        sys.stdout.write(completed.stdout)
+    if completed.stderr:
+        sys.stderr.write(completed.stderr)
+    return int(completed.returncode)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/check.ps1
+++ b/check.ps1
@@ -501,6 +501,8 @@ function Invoke-AdapterSpecificChecks {
   if ([string]$Adapter.check_mode -eq 'preview-guidance') {
     if ([string]$Adapter.id -eq 'opencode') {
       Warn-Note -Message 'opencode preview keeps the real opencode.json host-managed; only skills, commands, agents, and an example config scaffold are verified'
+    } elseif ([string]$Adapter.id -eq 'cursor') {
+      Write-Host '[INFO] cursor preview now materializes managed commands, host-closure state, and a minimal settings surface; deeper host-native workflow remains preview-scoped' -ForegroundColor Cyan
     } else {
       Write-Host ("[INFO] {0} preview hook/settings scaffold remains intentionally unavailable while the author works through compatibility issues; this is a current product boundary, not an install failure" -f $Adapter.id) -ForegroundColor Cyan
     }
@@ -520,6 +522,28 @@ function Invoke-AdapterSpecificChecks {
     Check-Path -Label "plugins manifest" -Path (Join-Path $TargetRoot 'config\plugins-manifest.codex.json')
     Check-Path -Label "rules/common" -Path (Join-Path $TargetRoot 'rules\common\agents.md')
     Check-Path -Label "mcp template" -Path (Join-Path $TargetRoot 'mcp\servers.template.json')
+  }
+
+  $hostClosurePath = Join-Path $TargetRoot '.vibeskills\host-closure.json'
+  Check-Path -Label "host closure manifest" -Path $hostClosurePath
+  if (Test-Path -LiteralPath $hostClosurePath) {
+    $hostClosure = Get-JsonObject -Path $hostClosurePath -Label 'host closure manifest'
+    if ($null -ne $hostClosure) {
+      $closureState = if ($hostClosure.PSObject.Properties.Name -contains 'host_closure_state') { [string]$hostClosure.host_closure_state } else { '' }
+      if (-not [string]::IsNullOrWhiteSpace($closureState)) {
+        if ($closureState -eq 'closed_ready') {
+          Check-Condition -Label 'host closure state' -Condition $true
+        } else {
+          Warn-Note -Message ("host closure state -> {0}" -f $closureState)
+        }
+      }
+    }
+    if ($null -ne $hostClosure -and $hostClosure.PSObject.Properties.Name -contains 'specialist_wrapper' -and $null -ne $hostClosure.specialist_wrapper) {
+      $launcherPath = if ($hostClosure.specialist_wrapper.PSObject.Properties.Name -contains 'launcher_path') { [string]$hostClosure.specialist_wrapper.launcher_path } else { '' }
+      if (-not [string]::IsNullOrWhiteSpace($launcherPath)) {
+        Check-Path -Label "specialist wrapper launcher" -Path $launcherPath
+      }
+    }
   }
 
   Check-Path -Label "upstream lock" -Path (Join-Path $TargetRoot 'config\upstream-lock.json')

--- a/check.sh
+++ b/check.sh
@@ -788,6 +788,8 @@ fi
 if [[ "${ADAPTER_CHECK_MODE}" == "preview-guidance" ]]; then
   if [[ "${HOST_ID}" == "opencode" ]]; then
     warn_note "opencode preview keeps the real opencode.json host-managed; only skills, commands, agents, and an example config scaffold are verified"
+  elif [[ "${HOST_ID}" == "cursor" ]]; then
+    info_note "cursor preview now materializes managed commands, host-closure state, and a minimal settings surface; deeper host-native workflow remains preview-scoped"
   else
     info_note "${HOST_ID} preview hook/settings scaffold remains intentionally unavailable while the author works through compatibility issues; this is a current product boundary, not an install failure"
   fi
@@ -798,6 +800,22 @@ if [[ "${ADAPTER_CHECK_MODE}" == "runtime-core" ]]; then
   fi
   if [[ -f "${SCRIPT_DIR}/mcp/servers.template.json" ]]; then
     check_path "mcp_config.json" "${TARGET_ROOT}/mcp_config.json"
+  fi
+fi
+check_path "host closure manifest" "${TARGET_ROOT}/.vibeskills/host-closure.json"
+if [[ -f "${TARGET_ROOT}/.vibeskills/host-closure.json" ]]; then
+  closure_state="$(json_query_scalar_from_file "${TARGET_ROOT}/.vibeskills/host-closure.json" 'host_closure_state' 2>/dev/null || true)"
+  if [[ -n "${closure_state}" ]]; then
+    if [[ "${closure_state}" == "closed_ready" ]]; then
+      echo "[OK] host closure state -> ${closure_state}"
+      PASS=$((PASS+1))
+    else
+      warn_note "host closure state -> ${closure_state}"
+    fi
+  fi
+  wrapper_launcher="$(json_query_scalar_from_file "${TARGET_ROOT}/.vibeskills/host-closure.json" 'specialist_wrapper.launcher_path' 2>/dev/null || true)"
+  if [[ -n "${wrapper_launcher}" ]]; then
+    check_path "specialist wrapper launcher" "${wrapper_launcher}"
   fi
 fi
 if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then

--- a/commands/vibe-implement.md
+++ b/commands/vibe-implement.md
@@ -1,0 +1,8 @@
+---
+description: Run the governed Vibe-Skills runtime for implementation after planning approval.
+---
+
+Use the `vibe` skill and execute the approved plan without opening a second requirement or plan surface.
+
+Request:
+$ARGUMENTS

--- a/commands/vibe-review.md
+++ b/commands/vibe-review.md
@@ -1,0 +1,8 @@
+---
+description: Run the governed Vibe-Skills runtime for review-first work.
+---
+
+Use the `vibe` skill and apply bug-first, evidence-backed review under the governed runtime.
+
+Request:
+$ARGUMENTS

--- a/commands/vibe.md
+++ b/commands/vibe.md
@@ -1,0 +1,8 @@
+---
+description: Run the governed Vibe-Skills runtime for planning-first work.
+---
+
+Use the `vibe` skill and follow its governed runtime contract for this request.
+
+Request:
+$ARGUMENTS

--- a/config/native-specialist-execution-policy.json
+++ b/config/native-specialist-execution-policy.json
@@ -1,6 +1,6 @@
 {
-  "version": 1,
-  "updated_at": "2026-03-28",
+  "version": 2,
+  "updated_at": "2026-03-29",
   "enabled": true,
   "default_adapter_id": "codex",
   "enable_env": "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION",
@@ -31,6 +31,7 @@
     {
       "id": "codex",
       "enabled": true,
+      "invocation_kind": "direct",
       "executable_env": "VGO_CODEX_EXECUTABLE",
       "command": "codex",
       "arguments_prefix": [
@@ -40,6 +41,61 @@
         "--full-auto"
       ],
       "execution_driver": "codex_exec_native_specialist"
+    },
+    {
+      "id": "claude-code",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_CLAUDE_CODE_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
+    },
+    {
+      "id": "cursor",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_CURSOR_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
+    },
+    {
+      "id": "windsurf",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_WINDSURF_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
+    },
+    {
+      "id": "openclaw",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_OPENCLAW_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
+    },
+    {
+      "id": "opencode",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_OPENCODE_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
     }
   ]
 }

--- a/config/runtime-input-packet-policy.json
+++ b/config/runtime-input-packet-policy.json
@@ -10,6 +10,7 @@
   "required_fields": [
     "run_id",
     "governance_scope",
+    "host_adapter",
     "hierarchy",
     "task",
     "runtime_mode",

--- a/config/version-governance.json
+++ b/config/version-governance.json
@@ -106,6 +106,7 @@
         "scripts/runtime/Freeze-RuntimeInputPacket.ps1",
         "scripts/runtime/invoke-vibe-runtime.ps1",
         "scripts/runtime/Invoke-PlanExecute.ps1",
+        "scripts/runtime/native_specialist_runner.py",
         "scripts/runtime/memory_backend_driver.py",
         "scripts/verify/vibe-installed-runtime-freshness-gate.ps1",
         "scripts/verify/vibe-release-install-runtime-coherence-gate.ps1",

--- a/install.ps1
+++ b/install.ps1
@@ -6,6 +6,7 @@ param(
   [string]$TargetRoot = '',
   [switch]$InstallExternal,
   [switch]$StrictOffline,
+  [switch]$RequireClosedReady,
   [switch]$AllowExternalSkillFallback,
   [switch]$SkipRuntimeFreshnessGate
 )
@@ -332,6 +333,7 @@ Write-Host "Mode   : $($Adapter.install_mode)"
 Write-Host "Profile: $Profile"
 Write-Host "Target : $TargetRoot"
 Write-Host "StrictOffline: $StrictOffline"
+Write-Host "RequireClosedReady: $RequireClosedReady"
 Write-Host "AllowExternalSkillFallback: $AllowExternalSkillFallback"
 Write-Host "SkipRuntimeFreshnessGate: $SkipRuntimeFreshnessGate"
 $installGovernance = Get-InstallGovernance -RepoRoot $RepoRoot
@@ -345,13 +347,20 @@ $adapterInstallerPath = Join-Path $RepoRoot 'scripts\install\Install-VgoAdapter.
 if (-not (Test-Path -LiteralPath $adapterInstallerPath)) {
   throw "Adapter installer script missing: $adapterInstallerPath"
 }
-$adapterInstallResult = & $adapterInstallerPath -RepoRoot $RepoRoot -TargetRoot $TargetRoot -HostId $HostId -Profile $Profile -AllowExternalSkillFallback:$AllowExternalSkillFallback
+$adapterInstallResult = & $adapterInstallerPath -RepoRoot $RepoRoot -TargetRoot $TargetRoot -HostId $HostId -Profile $Profile -RequireClosedReady:$RequireClosedReady -AllowExternalSkillFallback:$AllowExternalSkillFallback
 $adapterInstallReceipt = $null
 if ($adapterInstallResult) {
   try {
     $adapterInstallReceipt = ($adapterInstallResult | Out-String) | ConvertFrom-Json
   } catch {
     $adapterInstallReceipt = $null
+  }
+}
+if ($RequireClosedReady -and $null -ne $adapterInstallReceipt) {
+  $effective = if ($adapterInstallReceipt.PSObject.Properties.Name -contains 'require_closed_ready_effective') { [bool]$adapterInstallReceipt.require_closed_ready_effective } else { $false }
+  $state = if ($adapterInstallReceipt.PSObject.Properties.Name -contains 'host_closure_state') { [string]$adapterInstallReceipt.host_closure_state } else { '' }
+  if ($effective -and $state -ne 'closed_ready') {
+    throw ("Install receipt is not closed_ready under RequireClosedReady (got '{0}')." -f $state)
   }
 }
 $externalFallbackUsed = New-Object System.Collections.Generic.List[string]

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ PROFILE="full"
 HOST_ID="codex"
 INSTALL_EXTERNAL="false"
 STRICT_OFFLINE="false"
+REQUIRE_CLOSED_READY="false"
 ALLOW_EXTERNAL_SKILL_FALLBACK="false"
 SKIP_RUNTIME_FRESHNESS_GATE="false"
 TARGET_ROOT=""
@@ -28,6 +29,7 @@ while [[ $# -gt 0 ]]; do
     --target-root) TARGET_ROOT="$2"; shift 2 ;;
     --install-external) INSTALL_EXTERNAL="true"; shift ;;
     --strict-offline) STRICT_OFFLINE="true"; shift ;;
+    --require-closed-ready) REQUIRE_CLOSED_READY="true"; shift ;;
     --allow-external-skill-fallback) ALLOW_EXTERNAL_SKILL_FALLBACK="true"; shift ;;
     --skip-runtime-freshness-gate) SKIP_RUNTIME_FRESHNESS_GATE="true"; shift ;;
     *) echo "Unknown arg: $1"; exit 1 ;;
@@ -676,6 +678,7 @@ echo "Mode   : ${ADAPTER_INSTALL_MODE}"
 echo "Profile: ${PROFILE}"
 echo "Target : ${TARGET_ROOT}"
 echo "StrictOffline: ${STRICT_OFFLINE}"
+echo "RequireClosedReady: ${REQUIRE_CLOSED_READY}"
 echo "AllowExternalSkillFallback: ${ALLOW_EXTERNAL_SKILL_FALLBACK}"
 echo "SkipRuntimeFreshnessGate: ${SKIP_RUNTIME_FRESHNESS_GATE}"
 
@@ -692,6 +695,7 @@ ADAPTER_INSTALL_JSON="$("${PYTHON_BIN_FOR_ADAPTER}" "${ADAPTER_INSTALLER}" \
   --target-root "${TARGET_ROOT}" \
   --host "${HOST_ID}" \
   --profile "${PROFILE}" \
+  $([[ "${REQUIRE_CLOSED_READY}" == "true" ]] && printf '%s' '--require-closed-ready') \
   $([[ "${ALLOW_EXTERNAL_SKILL_FALLBACK}" == "true" ]] && printf '%s' '--allow-external-skill-fallback'))"
 if [[ -n "${ADAPTER_INSTALL_JSON}" ]]; then
   mapfile -t EXTERNAL_FALLBACK_USED < <(printf '%s\n' "${ADAPTER_INSTALL_JSON}" | "${PYTHON_BIN_FOR_ADAPTER}" -c 'import json,sys; data=json.load(sys.stdin); [print(x) for x in data.get("external_fallback_used", [])]')

--- a/scripts/install/Install-VgoAdapter.ps1
+++ b/scripts/install/Install-VgoAdapter.ps1
@@ -3,6 +3,7 @@ param(
     [Parameter(Mandatory)] [string]$TargetRoot,
     [Parameter(Mandatory)] [string]$HostId,
     [ValidateSet('minimal', 'full')] [string]$Profile = 'full',
+    [switch]$RequireClosedReady,
     [switch]$AllowExternalSkillFallback
 )
 
@@ -11,6 +12,43 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $RepoRoot 'scripts\common\vibe-governance-helpers.ps1')
 . (Join-Path $RepoRoot 'scripts\common\Resolve-VgoAdapter.ps1')
+
+function Get-VgoPreferredPythonCommand {
+    foreach ($candidate in @('python', 'python3', 'py')) {
+        $command = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($null -ne $command) {
+            return [string]$command.Source
+        }
+    }
+    return $null
+}
+
+$pythonInstaller = Join-Path $RepoRoot 'scripts\install\install_vgo_adapter.py'
+$pythonCommand = Get-VgoPreferredPythonCommand
+if ((Test-Path -LiteralPath $pythonInstaller) -and -not [string]::IsNullOrWhiteSpace($pythonCommand)) {
+    $cmd = @($pythonCommand)
+    if ([System.IO.Path]::GetFileName($pythonCommand).ToLowerInvariant() -eq 'py') {
+        $cmd += '-3'
+    }
+    $cmd += @(
+        $pythonInstaller,
+        '--repo-root', $RepoRoot,
+        '--target-root', $TargetRoot,
+        '--host', $HostId,
+        '--profile', $Profile
+    )
+    if ($RequireClosedReady) {
+        $cmd += '--require-closed-ready'
+    }
+    if ($AllowExternalSkillFallback) {
+        $cmd += '--allow-external-skill-fallback'
+    }
+    & $cmd[0] @($cmd[1..($cmd.Count - 1)])
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Python adapter installer failed with exit code {0}." -f $LASTEXITCODE)
+    }
+    return
+}
 
 function Copy-DirContent {
     param(
@@ -38,6 +76,303 @@ function Restore-SkillEntryPointIfNeeded {
     }
 
     Move-Item -LiteralPath $mirrorPath -Destination $skillMd -Force
+}
+
+function Get-VgoPlatformTag {
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+        return 'windows'
+    }
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::OSX)) {
+        return 'macos'
+    }
+    return 'linux'
+}
+
+function Merge-JsonObject {
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [Parameter(Mandatory)] [hashtable]$Patch
+    )
+
+    $existing = @{}
+    if (Test-Path -LiteralPath $Path) {
+        try {
+            $parsed = Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json -AsHashtable
+            if ($null -ne $parsed) {
+                $existing = $parsed
+            }
+        } catch {
+            $existing = @{}
+        }
+    }
+
+    $merged = @{}
+    foreach ($key in $existing.Keys) {
+        $merged[$key] = $existing[$key]
+    }
+    foreach ($key in $Patch.Keys) {
+        $value = $Patch[$key]
+        if ($merged.ContainsKey($key) -and $merged[$key] -is [hashtable] -and $value -is [hashtable]) {
+            $next = @{}
+            foreach ($nestedKey in $merged[$key].Keys) {
+                $next[$nestedKey] = $merged[$key][$nestedKey]
+            }
+            foreach ($nestedKey in $value.Keys) {
+                $next[$nestedKey] = $value[$nestedKey]
+            }
+            $merged[$key] = $next
+        } else {
+            $merged[$key] = $value
+        }
+    }
+
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Path) | Out-Null
+    $merged | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Path -Encoding UTF8
+}
+
+function Get-VgoHostBridgeCommandEnvName {
+    param([string]$HostId)
+
+    switch ([string]$HostId) {
+        'claude-code' { return 'VGO_CLAUDE_CODE_SPECIALIST_BRIDGE_COMMAND' }
+        'cursor' { return 'VGO_CURSOR_SPECIALIST_BRIDGE_COMMAND' }
+        'windsurf' { return 'VGO_WINDSURF_SPECIALIST_BRIDGE_COMMAND' }
+        'openclaw' { return 'VGO_OPENCLAW_SPECIALIST_BRIDGE_COMMAND' }
+        'opencode' { return 'VGO_OPENCODE_SPECIALIST_BRIDGE_COMMAND' }
+        default { return $null }
+    }
+}
+
+function Resolve-VgoHostBridgeCommand {
+    param([string]$HostId)
+
+    $envName = Get-VgoHostBridgeCommandEnvName -HostId $HostId
+    if (-not [string]::IsNullOrWhiteSpace($envName)) {
+        $envValue = [Environment]::GetEnvironmentVariable($envName)
+        if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+            $command = Get-Command $envValue -ErrorAction SilentlyContinue
+            if ($null -ne $command) {
+                return [pscustomobject]@{
+                    command = [string]$command.Source
+                    source = "env:$envName"
+                    env_name = $envName
+                }
+            }
+            if (Test-Path -LiteralPath $envValue) {
+                return [pscustomobject]@{
+                    command = [System.IO.Path]::GetFullPath($envValue)
+                    source = "env:$envName"
+                    env_name = $envName
+                }
+            }
+        }
+    }
+
+    $candidates = switch ([string]$HostId) {
+        'claude-code' { @('claude', 'claude-code') }
+        'cursor' { @('cursor-agent', 'cursor') }
+        'windsurf' { @('windsurf', 'codeium') }
+        'openclaw' { @('openclaw') }
+        'opencode' { @('opencode') }
+        default { @() }
+    }
+    foreach ($candidate in $candidates) {
+        $command = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($null -ne $command) {
+            return [pscustomobject]@{
+                command = [string]$command.Source
+                source = "path:$candidate"
+                env_name = $envName
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        command = $null
+        source = $null
+        env_name = $envName
+    }
+}
+
+function New-VgoHostSpecialistWrapper {
+    param(
+        [Parameter(Mandatory)] [string]$TargetRoot,
+        [Parameter(Mandatory)] [string]$HostId,
+        [string]$BridgeCommand,
+        [string]$BridgeEnvName
+    )
+
+    $toolsRoot = Join-Path $TargetRoot '.vibeskills\bin'
+    New-Item -ItemType Directory -Force -Path $toolsRoot | Out-Null
+
+    $wrapperPy = Join-Path $toolsRoot ("{0}-specialist-wrapper.py" -f $HostId)
+    $embeddedCommand = if ([string]::IsNullOrWhiteSpace($BridgeCommand)) { '' } else { $BridgeCommand }
+    $pythonScript = @"
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+
+HOST_ID = $(ConvertTo-Json $HostId -Compress)
+TARGET_COMMAND = $(ConvertTo-Json $embeddedCommand -Compress)
+BRIDGE_ENV_NAME = $(ConvertTo-Json $BridgeEnvName -Compress)
+
+def main() -> int:
+    command = TARGET_COMMAND or os.environ.get(BRIDGE_ENV_NAME or "", "").strip()
+    if not command:
+        sys.stderr.write(f"host specialist bridge command unavailable for {HOST_ID}\n")
+        return 3
+    return subprocess.run([command, *sys.argv[1:]], check=False).returncode
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+"@
+    Set-Content -LiteralPath $wrapperPy -Value $pythonScript -Encoding UTF8
+
+    $platformTag = Get-VgoPlatformTag
+    if ($platformTag -eq 'windows') {
+        $launcherPath = Join-Path $toolsRoot ("{0}-specialist-wrapper.cmd" -f $HostId)
+        $cmdScript = @"
+@echo off
+setlocal
+set SCRIPT_DIR=%~dp0
+if exist "%LocalAppData%\Programs\Python\Python311\python.exe" (
+  set PY_CMD=%LocalAppData%\Programs\Python\Python311\python.exe
+) else if exist "%ProgramFiles%\Python311\python.exe" (
+  set PY_CMD=%ProgramFiles%\Python311\python.exe
+) else (
+  set PY_CMD=py -3
+)
+%PY_CMD% "%SCRIPT_DIR%$(Split-Path -Leaf $wrapperPy)" %*
+"@
+        Set-Content -LiteralPath $launcherPath -Value $cmdScript -Encoding ASCII
+    } else {
+        $launcherPath = Join-Path $toolsRoot ("{0}-specialist-wrapper.sh" -f $HostId)
+        $shScript = @"
+#!/usr/bin/env sh
+set -eu
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN=python3
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN=python
+else
+  echo 'python runtime unavailable for host specialist wrapper' >&2
+  exit 127
+fi
+exec "$PYTHON_BIN" "$SCRIPT_DIR/$(Split-Path -Leaf $wrapperPy)" "$@"
+"@
+        Set-Content -LiteralPath $launcherPath -Value $shScript -Encoding UTF8
+        try {
+            chmod +x $launcherPath
+            chmod +x $wrapperPy
+        } catch {
+        }
+    }
+
+    return [pscustomobject]@{
+        platform = $platformTag
+        launcher_path = [System.IO.Path]::GetFullPath($launcherPath)
+        script_path = [System.IO.Path]::GetFullPath($wrapperPy)
+        ready = -not [string]::IsNullOrWhiteSpace($BridgeCommand)
+        bridge_command = $BridgeCommand
+    }
+}
+
+function Set-VgoManagedHostSettings {
+    param(
+        [Parameter(Mandatory)] [string]$TargetRoot,
+        [Parameter(Mandatory)] [string]$HostId,
+        [Parameter(Mandatory)] [pscustomobject]$WrapperInfo
+    )
+
+    $materialized = New-Object System.Collections.Generic.List[string]
+    if ($HostId -in @('cursor', 'claude-code')) {
+        $settingsPath = Join-Path $TargetRoot 'settings.json'
+        Merge-JsonObject -Path $settingsPath -Patch @{
+            vibeskills = @{
+                host_id = $HostId
+                managed = $true
+                commands_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'commands'))
+                specialist_wrapper = [string]$WrapperInfo.launcher_path
+            }
+        }
+        $materialized.Add([System.IO.Path]::GetFullPath($settingsPath)) | Out-Null
+    } elseif ($HostId -eq 'opencode') {
+        $settingsPath = Join-Path $TargetRoot 'opencode.json'
+        Merge-JsonObject -Path $settingsPath -Patch @{
+            vibeskills = @{
+                host_id = $HostId
+                managed = $true
+                commands_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'commands'))
+                command_root_compat = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'command'))
+                agents_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'agents'))
+                agent_root_compat = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'agent'))
+                specialist_wrapper = [string]$WrapperInfo.launcher_path
+            }
+        }
+        $materialized.Add([System.IO.Path]::GetFullPath($settingsPath)) | Out-Null
+    } elseif ($HostId -in @('openclaw', 'windsurf')) {
+        $settingsPath = Join-Path $TargetRoot '.vibeskills\host-settings.json'
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $settingsPath) | Out-Null
+        @{
+            host_id = $HostId
+            managed = $true
+            commands_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'commands'))
+            workflow_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'global_workflows'))
+            mcp_config = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'mcp_config.json'))
+            specialist_wrapper = [string]$WrapperInfo.launcher_path
+        } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $settingsPath -Encoding UTF8
+        $materialized.Add([System.IO.Path]::GetFullPath($settingsPath)) | Out-Null
+    }
+
+    return @($materialized)
+}
+
+function Test-VgoClosedReadyRequiredForAdapter {
+    param([psobject]$Adapter)
+
+    return ([string]$Adapter.install_mode).ToLowerInvariant() -ne 'governed'
+}
+
+function Write-VgoHostClosure {
+    param(
+        [Parameter(Mandatory)] [string]$TargetRoot,
+        [Parameter(Mandatory)] [psobject]$Adapter
+    )
+
+    $bridgeResolution = Resolve-VgoHostBridgeCommand -HostId ([string]$Adapter.id)
+    $wrapperInfo = New-VgoHostSpecialistWrapper -TargetRoot $TargetRoot -HostId ([string]$Adapter.id) -BridgeCommand ([string]$bridgeResolution.command) -BridgeEnvName ([string]$bridgeResolution.env_name)
+    $settingsMaterialized = Set-VgoManagedHostSettings -TargetRoot $TargetRoot -HostId ([string]$Adapter.id) -WrapperInfo $wrapperInfo
+    $commandsRoot = Join-Path $TargetRoot 'commands'
+    $closureState = if ($wrapperInfo.ready) { 'closed_ready' } else { 'configured_offline_unready' }
+    $closure = [ordered]@{
+        schema_version = 1
+        host_id = [string]$Adapter.id
+        platform = Get-VgoPlatformTag
+        target_root = [System.IO.Path]::GetFullPath($TargetRoot)
+        install_mode = [string]$Adapter.install_mode
+        commands_root = [System.IO.Path]::GetFullPath($commandsRoot)
+        global_workflows_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'global_workflows'))
+        mcp_config_path = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'mcp_config.json'))
+        host_closure_state = $closureState
+        commands_materialized = (Test-Path -LiteralPath $commandsRoot -PathType Container)
+        settings_materialized = @($settingsMaterialized)
+        specialist_wrapper = [ordered]@{
+            launcher_path = [string]$wrapperInfo.launcher_path
+            script_path = [string]$wrapperInfo.script_path
+            ready = [bool]$wrapperInfo.ready
+            bridge_command = [string]$bridgeResolution.command
+            bridge_source = [string]$bridgeResolution.source
+        }
+    }
+    $closurePath = Join-Path $TargetRoot '.vibeskills\host-closure.json'
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $closurePath) | Out-Null
+    $closure | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $closurePath -Encoding UTF8
+    return [pscustomobject]@{
+        path = [System.IO.Path]::GetFullPath($closurePath)
+        data = [pscustomobject]$closure
+    }
 }
 
 function Ensure-SkillPresent {
@@ -273,9 +608,21 @@ switch ([string]$adapter.install_mode) {
     default { throw "Unsupported adapter install mode: $($adapter.install_mode)" }
 }
 
+$closureReceipt = Write-VgoHostClosure -TargetRoot $TargetRoot -Adapter $adapter
+$requireClosedReadyEffective = [bool]($RequireClosedReady -and (Test-VgoClosedReadyRequiredForAdapter -Adapter $adapter))
+if ($requireClosedReadyEffective -and [string]$closureReceipt.data.host_closure_state -ne 'closed_ready') {
+    throw ("Host closure for '{0}' is not closed_ready (got '{1}'). Configure the host specialist bridge command first, then retry install." -f [string]$adapter.id, [string]$closureReceipt.data.host_closure_state)
+}
+
 [pscustomobject]@{
     host_id = [string]$adapter.id
     install_mode = [string]$adapter.install_mode
     target_root = [System.IO.Path]::GetFullPath($TargetRoot)
     external_fallback_used = @($result.external_fallback_used)
+    host_closure_path = [string]$closureReceipt.path
+    host_closure_state = [string]$closureReceipt.data.host_closure_state
+    settings_materialized = @($closureReceipt.data.settings_materialized)
+    specialist_wrapper_ready = [bool]$closureReceipt.data.specialist_wrapper.ready
+    require_closed_ready_requested = [bool]$RequireClosedReady
+    require_closed_ready_effective = $requireClosedReadyEffective
 } | ConvertTo-Json -Depth 10

--- a/scripts/install/install_vgo_adapter.py
+++ b/scripts/install/install_vgo_adapter.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
+import stat
 import shutil
 import tempfile
 from pathlib import Path
@@ -26,6 +28,32 @@ OPTIONAL_WORKFLOW = [
     "receiving-code-review",
     "verification-before-completion",
 ]
+HOST_BRIDGE_COMMAND_CANDIDATES = {
+    "claude-code": ["claude", "claude-code"],
+    "cursor": ["cursor-agent", "cursor"],
+    "windsurf": ["windsurf", "codeium"],
+    "openclaw": ["openclaw"],
+    "opencode": ["opencode"],
+}
+HOST_BRIDGE_COMMAND_ENV = {
+    "claude-code": "VGO_CLAUDE_CODE_SPECIALIST_BRIDGE_COMMAND",
+    "cursor": "VGO_CURSOR_SPECIALIST_BRIDGE_COMMAND",
+    "windsurf": "VGO_WINDSURF_SPECIALIST_BRIDGE_COMMAND",
+    "openclaw": "VGO_OPENCLAW_SPECIALIST_BRIDGE_COMMAND",
+    "opencode": "VGO_OPENCODE_SPECIALIST_BRIDGE_COMMAND",
+}
+
+
+def detect_platform_tag() -> str:
+    if os.name == "nt":
+        return "windows"
+    if sys_platform().startswith("darwin"):
+        return "macos"
+    return "linux"
+
+
+def sys_platform() -> str:
+    return os.sys.platform.lower()
 
 
 def load_json(path: Path):
@@ -35,6 +63,11 @@ def load_json(path: Path):
 
 def write_json(data):
     print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def write_json_file(path: Path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def is_relative_to(path: Path, base: Path) -> bool:
@@ -96,6 +129,11 @@ def copy_file(src: Path, dst: Path):
         return
     dst.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dst)
+
+
+def ensure_executable(path: Path):
+    current = path.stat().st_mode
+    path.chmod(current | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def restore_skill_entrypoint_if_needed(skill_root: Path):
@@ -228,6 +266,238 @@ def resolve_adapter(repo_root: Path, host_id: str):
         if entry.get("id") == normalized:
             return entry
     raise SystemExit(f"Unsupported VGO host id: {host_id}")
+
+
+def resolve_target_root_for_adapter(adapter: dict, explicit_target_root: Path | None = None) -> Path:
+    if explicit_target_root is not None:
+        return explicit_target_root.resolve()
+
+    target_spec = adapter.get("default_target_root") or {}
+    env_name = target_spec.get("env") or ""
+    rel = target_spec.get("rel") or ""
+    env_value = os.environ.get(env_name, "").strip() if env_name else ""
+    if env_value:
+        return Path(env_value).expanduser().resolve()
+    if not rel:
+        raise SystemExit(f"Adapter '{adapter.get('id')}' does not define default_target_root.rel")
+    rel_path = Path(rel)
+    if rel_path.is_absolute():
+        return rel_path.resolve()
+    return (Path.home() / rel_path).expanduser().resolve()
+
+
+def load_specialist_policy(repo_root: Path):
+    return load_json(repo_root / "config" / "native-specialist-execution-policy.json")
+
+
+def resolve_specialist_policy_entry(repo_root: Path, host_id: str):
+    policy = load_specialist_policy(repo_root)
+    for entry in policy.get("adapters", []):
+        if entry.get("id") == host_id:
+            return entry
+    return None
+
+
+def resolve_bridge_command(host_id: str) -> tuple[str | None, str | None]:
+    env_name = HOST_BRIDGE_COMMAND_ENV.get(host_id)
+    if env_name:
+        env_value = os.environ.get(env_name, "").strip()
+        if env_value:
+            candidate = shutil.which(env_value)
+            if candidate:
+                return candidate, f"env:{env_name}"
+            path_candidate = Path(env_value).expanduser()
+            if path_candidate.exists():
+                return str(path_candidate.resolve()), f"env:{env_name}"
+
+    for candidate_name in HOST_BRIDGE_COMMAND_CANDIDATES.get(host_id, []):
+        resolved = shutil.which(candidate_name)
+        if resolved:
+            return resolved, f"path:{candidate_name}"
+
+    return None, None
+
+
+def materialize_host_specialist_wrapper(target_root: Path, host_id: str, bridge_command: str | None):
+    tools_root = target_root / ".vibeskills" / "bin"
+    tools_root.mkdir(parents=True, exist_ok=True)
+
+    wrapper_py = tools_root / f"{host_id}-specialist-wrapper.py"
+    embedded_command = json.dumps(bridge_command or "")
+    bridge_env_name = f"VGO_{host_id.upper().replace('-', '_')}_SPECIALIST_BRIDGE_COMMAND"
+    wrapper_py.write_text(
+        (
+            "#!/usr/bin/env python3\n"
+            "import os\n"
+            "import subprocess\n"
+            "import sys\n\n"
+            f"HOST_ID = {json.dumps(host_id)}\n"
+            f"TARGET_COMMAND = {embedded_command}\n\n"
+            "def main() -> int:\n"
+            f"    command = TARGET_COMMAND or os.environ.get({json.dumps(bridge_env_name)}, '').strip()\n"
+            "    if not command:\n"
+            "        sys.stderr.write(f'host specialist bridge command unavailable for {HOST_ID}\\n')\n"
+            "        return 3\n"
+            "    return subprocess.run([command, *sys.argv[1:]], check=False).returncode\n\n"
+            "if __name__ == '__main__':\n"
+            "    raise SystemExit(main())\n"
+        ),
+        encoding="utf-8",
+    )
+    ensure_executable(wrapper_py)
+
+    platform_tag = detect_platform_tag()
+    if platform_tag == "windows":
+        launcher = tools_root / f"{host_id}-specialist-wrapper.cmd"
+        launcher.write_text(
+            (
+                "@echo off\r\n"
+                "setlocal\r\n"
+                "set SCRIPT_DIR=%~dp0\r\n"
+                "if exist \"%LocalAppData%\\Programs\\Python\\Python311\\python.exe\" (\r\n"
+                "  set PY_CMD=%LocalAppData%\\Programs\\Python\\Python311\\python.exe\r\n"
+                ") else if exist \"%ProgramFiles%\\Python311\\python.exe\" (\r\n"
+                "  set PY_CMD=%ProgramFiles%\\Python311\\python.exe\r\n"
+                ") else (\r\n"
+                "  set PY_CMD=py -3\r\n"
+                ")\r\n"
+                "%PY_CMD% \"%SCRIPT_DIR%\\" + wrapper_py.name + "\" %*\r\n"
+            ),
+            encoding="utf-8",
+        )
+    else:
+        launcher = tools_root / f"{host_id}-specialist-wrapper.sh"
+        launcher.write_text(
+            (
+                "#!/usr/bin/env sh\n"
+                "set -eu\n"
+                "SCRIPT_DIR=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\n"
+                "if command -v python3 >/dev/null 2>&1; then\n"
+                "  PYTHON_BIN=python3\n"
+                "elif command -v python >/dev/null 2>&1; then\n"
+                "  PYTHON_BIN=python\n"
+                "else\n"
+                "  echo 'python runtime unavailable for host specialist wrapper' >&2\n"
+                "  exit 127\n"
+                "fi\n"
+                f"exec \"$PYTHON_BIN\" \"$SCRIPT_DIR/{wrapper_py.name}\" \"$@\"\n"
+            ),
+            encoding="utf-8",
+        )
+        ensure_executable(launcher)
+
+    return {
+        "platform": platform_tag,
+        "launcher_path": str(launcher.resolve()),
+        "script_path": str(wrapper_py.resolve()),
+        "ready": bool(bridge_command),
+        "bridge_command": bridge_command,
+    }
+
+
+def merge_json_object(path: Path, patch: dict):
+    existing = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            existing = {}
+    merged = dict(existing)
+    for key, value in patch.items():
+        if isinstance(value, dict) and isinstance(existing.get(key), dict):
+            next_value = dict(existing[key])
+            next_value.update(value)
+            merged[key] = next_value
+        else:
+            merged[key] = value
+    write_json_file(path, merged)
+
+
+def materialize_host_settings(target_root: Path, adapter: dict, wrapper_info: dict):
+    host_id = adapter["id"]
+    materialized = []
+    if host_id in {"cursor", "claude-code"}:
+        settings_path = target_root / "settings.json"
+        merge_json_object(
+            settings_path,
+            {
+                "vibeskills": {
+                    "host_id": host_id,
+                    "managed": True,
+                    "commands_root": str((target_root / "commands").resolve()),
+                    "specialist_wrapper": wrapper_info["launcher_path"],
+                }
+            },
+        )
+        materialized.append(str(settings_path.resolve()))
+    elif host_id == "opencode":
+        settings_path = target_root / "opencode.json"
+        merge_json_object(
+            settings_path,
+            {
+                "vibeskills": {
+                    "host_id": host_id,
+                    "managed": True,
+                    "commands_root": str((target_root / "commands").resolve()),
+                    "command_root_compat": str((target_root / "command").resolve()),
+                    "agents_root": str((target_root / "agents").resolve()),
+                    "agent_root_compat": str((target_root / "agent").resolve()),
+                    "specialist_wrapper": wrapper_info["launcher_path"],
+                }
+            },
+        )
+        materialized.append(str(settings_path.resolve()))
+    elif host_id in {"openclaw", "windsurf"}:
+        settings_path = target_root / ".vibeskills" / "host-settings.json"
+        write_json_file(
+            settings_path,
+            {
+                "host_id": host_id,
+                "managed": True,
+                "commands_root": str((target_root / "commands").resolve()),
+                "workflow_root": str((target_root / "global_workflows").resolve()),
+                "mcp_config": str((target_root / "mcp_config.json").resolve()),
+                "specialist_wrapper": wrapper_info["launcher_path"],
+            },
+        )
+        materialized.append(str(settings_path.resolve()))
+    return materialized
+
+
+def materialize_host_closure(repo_root: Path, target_root: Path, adapter: dict):
+    host_id = adapter["id"]
+    bridge_command, bridge_source = resolve_bridge_command(host_id)
+    wrapper_info = materialize_host_specialist_wrapper(target_root, host_id, bridge_command)
+    settings_materialized = materialize_host_settings(target_root, adapter, wrapper_info)
+    commands_root = target_root / "commands"
+    closure_state = "closed_ready" if wrapper_info["ready"] else "configured_offline_unready"
+    closure = {
+        "schema_version": 1,
+        "host_id": host_id,
+        "platform": detect_platform_tag(),
+        "target_root": str(target_root.resolve()),
+        "install_mode": adapter["install_mode"],
+        "commands_root": str(commands_root.resolve()),
+        "global_workflows_root": str((target_root / "global_workflows").resolve()),
+        "mcp_config_path": str((target_root / "mcp_config.json").resolve()),
+        "host_closure_state": closure_state,
+        "commands_materialized": commands_root.exists(),
+        "settings_materialized": settings_materialized,
+        "specialist_wrapper": {
+            "launcher_path": wrapper_info["launcher_path"],
+            "script_path": wrapper_info["script_path"],
+            "ready": wrapper_info["ready"],
+            "bridge_command": bridge_command,
+            "bridge_source": bridge_source,
+        },
+    }
+    closure_path = target_root / ".vibeskills" / "host-closure.json"
+    write_json_file(closure_path, closure)
+    return closure_path, closure
+
+
+def is_closed_ready_required(adapter: dict) -> bool:
+    return (adapter.get("install_mode") or "").strip().lower() != "governed"
 
 
 def sync_vibe_canonical(repo_root: Path, target_root: Path, target_rel: str):
@@ -379,6 +649,7 @@ def main():
     parser.add_argument("--host", required=True)
     parser.add_argument("--profile", choices=("minimal", "full"), default="full")
     parser.add_argument("--allow-external-skill-fallback", action="store_true")
+    parser.add_argument("--require-closed-ready", action="store_true")
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root).resolve()
@@ -401,12 +672,28 @@ def main():
     else:
         raise SystemExit(f"Unsupported adapter install mode: {mode}")
 
+    closure_path, closure = materialize_host_closure(repo_root, target_root, adapter)
+    require_closed_ready_effective = bool(args.require_closed_ready and is_closed_ready_required(adapter))
+    if require_closed_ready_effective and closure["host_closure_state"] != "closed_ready":
+        raise SystemExit(
+            "Host closure for "
+            f"'{adapter['id']}' is not closed_ready "
+            f"(got '{closure['host_closure_state']}'). "
+            "Configure the host specialist bridge command first, then retry install."
+        )
+
     write_json(
         {
             "host_id": adapter["id"],
             "install_mode": mode,
             "target_root": str(target_root),
             "external_fallback_used": external_used,
+            "host_closure_path": str(closure_path),
+            "host_closure_state": closure["host_closure_state"],
+            "settings_materialized": closure["settings_materialized"],
+            "specialist_wrapper_ready": bool(closure["specialist_wrapper"]["ready"]),
+            "require_closed_ready_requested": bool(args.require_closed_ready),
+            "require_closed_ready_effective": require_closed_ready_effective,
         }
     )
 

--- a/scripts/runtime/Freeze-RuntimeInputPacket.ps1
+++ b/scripts/runtime/Freeze-RuntimeInputPacket.ps1
@@ -434,6 +434,14 @@ $packet = [pscustomobject]@{
     stage = 'runtime_input_freeze'
     run_id = $RunId
     governance_scope = [string]$hierarchyState.governance_scope
+    host_adapter = [pscustomobject]@{
+        requested_host_id = if ($runtime.host_adapter -and $runtime.host_adapter.requested_id) { [string]$runtime.host_adapter.requested_id } else { [string]$runtime.host_adapter.id }
+        effective_host_id = if ($runtime.host_adapter) { [string]$runtime.host_adapter.id } else { 'codex' }
+        status = if ($runtime.host_adapter -and $runtime.host_adapter.status) { [string]$runtime.host_adapter.status } else { $null }
+        install_mode = if ($runtime.host_adapter -and $runtime.host_adapter.install_mode) { [string]$runtime.host_adapter.install_mode } else { $null }
+        check_mode = if ($runtime.host_adapter -and $runtime.host_adapter.check_mode) { [string]$runtime.host_adapter.check_mode } else { $null }
+        bootstrap_mode = if ($runtime.host_adapter -and $runtime.host_adapter.bootstrap_mode) { [string]$runtime.host_adapter.bootstrap_mode } else { $null }
+    }
     task = $Task
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     runtime_mode = $Mode

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -1104,6 +1104,8 @@ $executionManifest = [pscustomobject]@{
     route_runtime_alignment = [pscustomobject]@{
         router_selected_skill = if ($runtimeInputPacket) { [string]$runtimeInputPacket.route_snapshot.selected_skill } else { $null }
         runtime_selected_skill = if ($runtimeInputPacket) { [string]$runtimeInputPacket.authority_flags.explicit_runtime_skill } else { 'vibe' }
+        requested_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.requested_host_id } else { [string]$runtime.host_adapter.id }
+        effective_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.effective_host_id } else { [string]$runtime.host_adapter.id }
         skill_mismatch = if ($runtimeInputPacket) { [bool]$runtimeInputPacket.divergence_shadow.skill_mismatch } else { $false }
         confirm_required = if ($runtimeInputPacket) { [bool]$runtimeInputPacket.route_snapshot.confirm_required } else { $false }
     }
@@ -1145,6 +1147,8 @@ $executionManifest = [pscustomobject]@{
         ambiguous_unit_count = [int]$planShadow.payload.ambiguous_unit_count
     }
     specialist_accounting = [pscustomobject]@{
+        requested_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.requested_host_id } else { [string]$runtime.host_adapter.id }
+        effective_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.effective_host_id } else { [string]$runtime.host_adapter.id }
         recommendation_count = @($specialistRecommendations).Count
         specialist_skill_count = @($specialistSkills).Count
         specialist_skills = @($specialistSkills)

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -263,6 +263,66 @@ function Resolve-VibeProcessInvocationSpec {
     }
 }
 
+function Resolve-VibeBridgeExecutable {
+    param(
+        [Parameter(Mandatory)] [object]$Adapter,
+        [object]$Runtime = $null
+    )
+
+    $resolvedCommandPath = $null
+    $envName = if ($Adapter.PSObject.Properties.Name -contains 'bridge_executable_env') { [string]$Adapter.bridge_executable_env } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($envName)) {
+        $envValue = [Environment]::GetEnvironmentVariable($envName)
+        if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+            $candidate = Get-Command $envValue -ErrorAction SilentlyContinue
+            if ($candidate) {
+                $resolvedCommandPath = [string]$candidate.Source
+            } elseif (Test-Path -LiteralPath $envValue) {
+                $resolvedCommandPath = [System.IO.Path]::GetFullPath($envValue)
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($resolvedCommandPath) -and $null -ne $Runtime -and $Runtime.PSObject.Properties.Name -contains 'host_closure' -and $null -ne $Runtime.host_closure) {
+        $hostClosure = $Runtime.host_closure
+        if ($hostClosure.PSObject.Properties.Name -contains 'data' -and $null -ne $hostClosure.data) {
+            $specialistWrapper = if ($hostClosure.data.PSObject.Properties.Name -contains 'specialist_wrapper') { $hostClosure.data.specialist_wrapper } else { $null }
+            if ($null -ne $specialistWrapper) {
+                $ready = if ($specialistWrapper.PSObject.Properties.Name -contains 'ready') { [bool]$specialistWrapper.ready } else { $false }
+                $launcherPath = if ($specialistWrapper.PSObject.Properties.Name -contains 'launcher_path') { [string]$specialistWrapper.launcher_path } else { '' }
+                if ($ready -and -not [string]::IsNullOrWhiteSpace($launcherPath) -and (Test-Path -LiteralPath $launcherPath -PathType Leaf)) {
+                    $resolvedCommandPath = [System.IO.Path]::GetFullPath($launcherPath)
+                }
+            }
+        }
+    }
+
+    $defaultCommand = if ($Adapter.PSObject.Properties.Name -contains 'bridge_command') { [string]$Adapter.bridge_command } else { '' }
+    if ([string]::IsNullOrWhiteSpace($resolvedCommandPath) -and -not [string]::IsNullOrWhiteSpace($defaultCommand)) {
+        $candidate = Get-Command $defaultCommand -ErrorAction SilentlyContinue
+        if ($candidate) {
+            $resolvedCommandPath = [string]$candidate.Source
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($resolvedCommandPath)) {
+        $reason = if (-not [string]::IsNullOrWhiteSpace($envName)) {
+            ("native_specialist_bridge_command_unavailable:{0}" -f [string]$Adapter.id)
+        } else {
+            ("native_specialist_adapter_command_unavailable:{0}" -f [string]$Adapter.id)
+        }
+        return [pscustomobject]@{
+            command_path = $null
+            reason = $reason
+        }
+    }
+
+    return [pscustomobject]@{
+        command_path = [string]$resolvedCommandPath
+        reason = 'native_specialist_bridge_ready'
+    }
+}
+
 function Resolve-VibeNativeSpecialistAdapter {
     param(
         [Parameter(Mandatory)] [string]$ScriptPath
@@ -323,7 +383,9 @@ function Resolve-VibeNativeSpecialistAdapter {
         }
     }
 
-    $adapterId = if ($policy.PSObject.Properties.Name -contains 'default_adapter_id' -and -not [string]::IsNullOrWhiteSpace([string]$policy.default_adapter_id)) {
+    $adapterId = if ($runtime.host_adapter -and -not [string]::IsNullOrWhiteSpace([string]$runtime.host_adapter.id)) {
+        [string]$runtime.host_adapter.id
+    } elseif ($policy.PSObject.Properties.Name -contains 'default_adapter_id' -and -not [string]::IsNullOrWhiteSpace([string]$policy.default_adapter_id)) {
         [string]$policy.default_adapter_id
     } else {
         'codex'
@@ -351,29 +413,62 @@ function Resolve-VibeNativeSpecialistAdapter {
     $commandPath = $null
     $invocationArgumentsPrefix = @()
     $resolvedReason = $null
-    if ($adapter.PSObject.Properties.Name -contains 'executable_env' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.executable_env)) {
-        $envCommand = [Environment]::GetEnvironmentVariable([string]$adapter.executable_env)
-        if (-not [string]::IsNullOrWhiteSpace($envCommand)) {
-            $candidate = Get-Command $envCommand -ErrorAction SilentlyContinue
-            if ($candidate) {
-                $commandPath = [string]$candidate.Source
-            } elseif (Test-Path -LiteralPath $envCommand) {
-                $commandPath = [System.IO.Path]::GetFullPath($envCommand)
+    $invocationKind = if ($adapter.PSObject.Properties.Name -contains 'invocation_kind') { [string]$adapter.invocation_kind } else { 'direct' }
+
+    if ($invocationKind -eq 'python_runner') {
+        $bridgeResolution = Resolve-VibeBridgeExecutable -Adapter $adapter -Runtime $runtime
+        if ([string]::IsNullOrWhiteSpace([string]$bridgeResolution.command_path)) {
+            $resolvedReason = [string]$bridgeResolution.reason
+        } else {
+            $pythonInvocation = Resolve-VgoPythonCommandSpec -Command '${VGO_PYTHON}'
+            $runnerScriptPath = if ($adapter.PSObject.Properties.Name -contains 'runner_script_path' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.runner_script_path)) {
+                [System.IO.Path]::GetFullPath((Join-Path $runtime.repo_root ([string]$adapter.runner_script_path)))
+            } else {
+                $null
+            }
+            if ([string]::IsNullOrWhiteSpace($runnerScriptPath) -or -not (Test-Path -LiteralPath $runnerScriptPath)) {
+                $resolvedReason = ("native_specialist_runner_missing:{0}" -f [string]$adapter.id)
+            } else {
+                $commandPath = [string]$pythonInvocation.host_path
+                $invocationArgumentsPrefix = @($pythonInvocation.prefix_arguments)
+                $invocationArgumentsPrefix += @(
+                    $runnerScriptPath,
+                    '--host-adapter', ([string]$adapter.id),
+                    '--bridge-executable', ([string]$bridgeResolution.command_path)
+                )
+                if ($adapter.PSObject.Properties.Name -contains 'bridge_contract' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.bridge_contract)) {
+                    $invocationArgumentsPrefix += @('--bridge-contract', ([string]$adapter.bridge_contract))
+                }
+                foreach ($item in @($adapter.runner_arguments_prefix)) {
+                    $invocationArgumentsPrefix += [string]$item
+                }
             }
         }
-    }
-    if ([string]::IsNullOrWhiteSpace($commandPath)) {
-        $candidate = Get-Command ([string]$adapter.command) -ErrorAction SilentlyContinue
-        if ($candidate) {
-            $commandPath = [string]$candidate.Source
-        }
-    }
-    if ([string]::IsNullOrWhiteSpace($commandPath)) {
-        $resolvedReason = ("native_specialist_adapter_command_unavailable:{0}" -f [string]$adapter.command)
     } else {
-        $invocationSpec = Resolve-VibeProcessInvocationSpec -CommandPath $commandPath -ArgumentList @()
-        $commandPath = [string]$invocationSpec.command_path
-        $invocationArgumentsPrefix = @($invocationSpec.arguments)
+        if ($adapter.PSObject.Properties.Name -contains 'executable_env' -and -not [string]::IsNullOrWhiteSpace([string]$adapter.executable_env)) {
+            $envCommand = [Environment]::GetEnvironmentVariable([string]$adapter.executable_env)
+            if (-not [string]::IsNullOrWhiteSpace($envCommand)) {
+                $candidate = Get-Command $envCommand -ErrorAction SilentlyContinue
+                if ($candidate) {
+                    $commandPath = [string]$candidate.Source
+                } elseif (Test-Path -LiteralPath $envCommand) {
+                    $commandPath = [System.IO.Path]::GetFullPath($envCommand)
+                }
+            }
+        }
+        if ([string]::IsNullOrWhiteSpace($commandPath)) {
+            $candidate = Get-Command ([string]$adapter.command) -ErrorAction SilentlyContinue
+            if ($candidate) {
+                $commandPath = [string]$candidate.Source
+            }
+        }
+        if ([string]::IsNullOrWhiteSpace($commandPath)) {
+            $resolvedReason = ("native_specialist_adapter_command_unavailable:{0}" -f [string]$adapter.command)
+        } else {
+            $invocationSpec = Resolve-VibeProcessInvocationSpec -CommandPath $commandPath -ArgumentList @()
+            $commandPath = [string]$invocationSpec.command_path
+            $invocationArgumentsPrefix = @($invocationSpec.arguments)
+        }
     }
 
     return [pscustomobject]@{
@@ -383,6 +478,8 @@ function Resolve-VibeNativeSpecialistAdapter {
         runtime = $runtime
         policy = $policy
         adapter = $adapter
+        requested_host_adapter_id = if ($runtime.host_adapter -and $runtime.host_adapter.requested_id) { [string]$runtime.host_adapter.requested_id } else { [string]$adapterId }
+        effective_host_adapter_id = [string]$adapter.id
         command_path = $commandPath
         invocation_arguments_prefix = @($invocationArgumentsPrefix)
     }
@@ -644,6 +741,7 @@ function New-VibeDegradedSpecialistDispatchResult {
         [Parameter(Mandatory)] [string]$SessionRoot,
         [Parameter(Mandatory)] [object]$Policy,
         [Parameter(Mandatory)] [string]$Reason,
+        [AllowNull()] [object]$AdapterResolution = $null,
         [AllowEmptyString()] [string]$WriteScope = '',
         [AllowEmptyString()] [string]$ReviewMode = 'native_contract'
     )
@@ -695,6 +793,8 @@ function New-VibeDegradedSpecialistDispatchResult {
         write_scope = $WriteScope
         review_mode = $ReviewMode
         execution_driver = [string]$Policy.degrade_contract.execution_driver
+        requested_host_adapter_id = if ($AdapterResolution -and $AdapterResolution.PSObject.Properties.Name -contains 'requested_host_adapter_id') { [string]$AdapterResolution.requested_host_adapter_id } else { $null }
+        host_adapter_id = if ($AdapterResolution -and $AdapterResolution.PSObject.Properties.Name -contains 'effective_host_adapter_id') { [string]$AdapterResolution.effective_host_adapter_id } else { $null }
         live_native_execution = $false
         degraded = $true
         degradation_reason = $Reason
@@ -739,6 +839,7 @@ function Invoke-VibeSpecialistDispatchUnit {
             -SessionRoot $SessionRoot `
             -Policy $policy `
             -Reason ([string]$adapterResolution.reason) `
+            -AdapterResolution $adapterResolution `
             -WriteScope $WriteScope `
             -ReviewMode $ReviewMode
     }
@@ -893,6 +994,7 @@ function Invoke-VibeSpecialistDispatchUnit {
         write_scope = $WriteScope
         review_mode = $ReviewMode
         execution_driver = [string]$adapter.execution_driver
+        requested_host_adapter_id = [string]$adapterResolution.requested_host_adapter_id
         host_adapter_id = [string]$adapter.id
         live_native_execution = $true
         degraded = $false

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -3,6 +3,108 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
 
+function Get-VibeHostAdapterEntry {
+    param(
+        [Parameter(Mandatory)] [string]$RepoRoot,
+        [AllowEmptyString()] [string]$HostId = ''
+    )
+
+    $requestedHostId = if ([string]::IsNullOrWhiteSpace($HostId)) { $env:VCO_HOST_ID } else { $HostId }
+    $resolvedHostId = Resolve-VgoHostId -HostId $requestedHostId
+    $registryPath = Join-Path $RepoRoot 'adapters\index.json'
+    if (-not (Test-Path -LiteralPath $registryPath)) {
+        return [pscustomobject]@{
+            requested_id = if ([string]::IsNullOrWhiteSpace($requestedHostId)) { $null } else { [string]$requestedHostId }
+            id = $resolvedHostId
+            status = $null
+            install_mode = $null
+            check_mode = $null
+            bootstrap_mode = $null
+            default_target_root = $null
+        }
+    }
+
+    $registry = Get-Content -LiteralPath $registryPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $adapter = @($registry.adapters | Where-Object { [string]$_.id -eq $resolvedHostId } | Select-Object -First 1)[0]
+    if ($null -eq $adapter) {
+        return [pscustomobject]@{
+            requested_id = if ([string]::IsNullOrWhiteSpace($requestedHostId)) { $null } else { [string]$requestedHostId }
+            id = $resolvedHostId
+            status = $null
+            install_mode = $null
+            check_mode = $null
+            bootstrap_mode = $null
+            default_target_root = $null
+        }
+    }
+
+    return [pscustomobject]@{
+        requested_id = if ([string]::IsNullOrWhiteSpace($requestedHostId)) { $null } else { [string]$requestedHostId }
+        id = [string]$adapter.id
+        status = if ($adapter.PSObject.Properties.Name -contains 'status') { [string]$adapter.status } else { $null }
+        install_mode = if ($adapter.PSObject.Properties.Name -contains 'install_mode') { [string]$adapter.install_mode } else { $null }
+        check_mode = if ($adapter.PSObject.Properties.Name -contains 'check_mode') { [string]$adapter.check_mode } else { $null }
+        bootstrap_mode = if ($adapter.PSObject.Properties.Name -contains 'bootstrap_mode') { [string]$adapter.bootstrap_mode } else { $null }
+        default_target_root = if ($adapter.PSObject.Properties.Name -contains 'default_target_root') { $adapter.default_target_root } else { $null }
+    }
+}
+
+function Resolve-VibeHostTargetRoot {
+    param(
+        [Parameter(Mandatory)] [object]$HostAdapter
+    )
+
+    if ($null -eq $HostAdapter -or $null -eq $HostAdapter.default_target_root) {
+        return $null
+    }
+
+    $targetSpec = $HostAdapter.default_target_root
+    $envName = if ($targetSpec.PSObject.Properties.Name -contains 'env') { [string]$targetSpec.env } else { '' }
+    $rel = if ($targetSpec.PSObject.Properties.Name -contains 'rel') { [string]$targetSpec.rel } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($envName)) {
+        $envValue = [Environment]::GetEnvironmentVariable($envName)
+        if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+            return [System.IO.Path]::GetFullPath($envValue)
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($rel)) {
+        return $null
+    }
+    if ([System.IO.Path]::IsPathRooted($rel)) {
+        return [System.IO.Path]::GetFullPath($rel)
+    }
+    $homeDir = Resolve-VgoHomeDirectory
+    return [System.IO.Path]::GetFullPath((Join-Path $homeDir $rel))
+}
+
+function Get-VibeHostClosureRecord {
+    param(
+        [Parameter(Mandatory)] [object]$HostAdapter
+    )
+
+    $targetRoot = Resolve-VibeHostTargetRoot -HostAdapter $HostAdapter
+    if ([string]::IsNullOrWhiteSpace($targetRoot)) {
+        return $null
+    }
+
+    $closurePath = Join-Path $targetRoot '.vibeskills\host-closure.json'
+    if (-not (Test-Path -LiteralPath $closurePath -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        $closure = Get-Content -LiteralPath $closurePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+
+    return [pscustomobject]@{
+        target_root = $targetRoot
+        path = $closurePath
+        data = $closure
+    }
+}
+
 function Get-VibeRuntimeContext {
     param(
         [Parameter(Mandatory)] [string]$ScriptPath
@@ -10,10 +112,13 @@ function Get-VibeRuntimeContext {
 
     $governanceContext = Get-VgoGovernanceContext -ScriptPath $ScriptPath -EnforceExecutionContext
     $repoRoot = $governanceContext.repoRoot
+    $hostAdapter = Get-VibeHostAdapterEntry -RepoRoot $repoRoot
 
     return [pscustomobject]@{
         repo_root = $repoRoot
         governance_context = $governanceContext
+        host_adapter = $hostAdapter
+        host_closure = Get-VibeHostClosureRecord -HostAdapter $hostAdapter
         runtime_contract = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-contract.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         runtime_modes = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-modes.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         runtime_input_packet_policy = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-input-packet-policy.json') -Raw -Encoding UTF8 | ConvertFrom-Json

--- a/scripts/runtime/native_specialist_runner.py
+++ b/scripts/runtime/native_specialist_runner.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def resolve_wrapper_invocation(bridge_executable: str, bridge_args: list[str]) -> list[str]:
+    bridge_path = Path(bridge_executable)
+    suffix = bridge_path.suffix.lower()
+
+    if os.name == "nt" and suffix in {".cmd", ".bat"}:
+        comspec = os.environ.get("COMSPEC") or shutil.which("cmd.exe") or "cmd.exe"
+        return [comspec, "/d", "/s", "/c", str(bridge_path), *bridge_args]
+
+    if suffix == ".ps1":
+        powershell = (
+            shutil.which("pwsh")
+            or shutil.which("pwsh.exe")
+            or shutil.which("powershell")
+            or shutil.which("powershell.exe")
+        )
+        if powershell:
+            return [powershell, "-NoLogo", "-NoProfile", "-File", str(bridge_path), *bridge_args]
+
+    return [str(bridge_path), *bridge_args]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host-adapter", required=True)
+    parser.add_argument("--bridge-executable", required=True)
+    parser.add_argument("--bridge-contract", default="vco_specialist_wrapper_v1")
+    parser.add_argument("-C", "--repo-root", required=True)
+    parser.add_argument("--output-schema", required=True)
+    parser.add_argument("-o", "--output", required=True)
+    parser.add_argument("prompt")
+    args = parser.parse_args()
+
+    bridge_args = [
+        "--repo-root",
+        args.repo_root,
+        "--output-schema",
+        args.output_schema,
+        "--output",
+        args.output,
+        "--host-adapter",
+        args.host_adapter,
+        "--bridge-contract",
+        args.bridge_contract,
+        "--prompt",
+        args.prompt,
+    ]
+    invocation = resolve_wrapper_invocation(args.bridge_executable, bridge_args)
+
+    completed = subprocess.run(
+        invocation,
+        cwd=args.repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if completed.stdout:
+        sys.stdout.write(completed.stdout)
+    if completed.stderr:
+        sys.stderr.write(completed.stderr)
+    return int(completed.returncode)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime_neutral/test_claude_preview_scaffold.py
+++ b/tests/runtime_neutral/test_claude_preview_scaffold.py
@@ -112,10 +112,14 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
         payload = json.loads(result.stdout)
 
         settings_path = self.target_root / 'settings.json'
-        preview_path = self.target_root / PREVIEW_FILE
-        self.assertEqual(self.existing_settings, json.loads(settings_path.read_text(encoding='utf-8')))
-        self.assertFalse(preview_path.exists())
+        closure_path = self.target_root / '.vibeskills' / 'host-closure.json'
+        settings = json.loads(settings_path.read_text(encoding='utf-8'))
+        self.assertEqual(self.existing_settings['env'], settings['env'])
+        self.assertEqual(self.existing_settings['model'], settings['model'])
+        self.assertEqual('claude-code', settings['vibeskills']['host_id'])
+        self.assertTrue(closure_path.exists())
         self.assertEqual('preview-guidance', payload['install_mode'])
+        self.assertEqual(str(closure_path), payload['host_closure_path'])
 
     def test_preview_check_accepts_preview_settings_file_without_touching_real_settings(self) -> None:
         install_cmd = [
@@ -142,9 +146,11 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
         ]
         result = subprocess.run(check_cmd, capture_output=True, text=True, check=True)
 
-        self.assertIn('preview hook/settings scaffold remains intentionally unavailable', result.stdout)
-        self.assertNotIn('[FAIL] settings.json', result.stdout)
-        self.assertEqual(self.existing_settings, json.loads((self.target_root / 'settings.json').read_text(encoding='utf-8')))
+        self.assertIn('[OK] host closure manifest', result.stdout)
+        settings = json.loads((self.target_root / 'settings.json').read_text(encoding='utf-8'))
+        self.assertEqual(self.existing_settings['env'], settings['env'])
+        self.assertEqual(self.existing_settings['model'], settings['model'])
+        self.assertEqual('claude-code', settings['vibeskills']['host_id'])
 
 
 if __name__ == '__main__':

--- a/tests/runtime_neutral/test_cursor_managed_preview.py
+++ b/tests/runtime_neutral/test_cursor_managed_preview.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "scripts" / "install" / "install_vgo_adapter.py"
+
+
+class CursorManagedPreviewTests(unittest.TestCase):
+    def test_python_installer_materializes_cursor_host_closure_and_settings_surface(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(INSTALLER),
+                    "--repo-root",
+                    str(REPO_ROOT),
+                    "--target-root",
+                    str(target_root),
+                    "--host",
+                    "cursor",
+                    "--profile",
+                    "full",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            payload = json.loads(result.stdout)
+            closure_path = target_root / ".vibeskills" / "host-closure.json"
+            settings_path = target_root / "settings.json"
+
+            self.assertEqual("cursor", payload["host_id"])
+            self.assertEqual("preview-guidance", payload["install_mode"])
+            self.assertTrue(closure_path.exists())
+            self.assertTrue(settings_path.exists())
+            self.assertTrue((target_root / "commands" / "vibe.md").exists())
+
+            closure = json.loads(closure_path.read_text(encoding="utf-8"))
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+
+            self.assertEqual("cursor", closure["host_id"])
+            self.assertEqual(str(target_root.resolve()), closure["target_root"])
+            self.assertIn("vibeskills", settings)
+            self.assertEqual("cursor", settings["vibeskills"]["host_id"])
+            self.assertIn("specialist_wrapper_ready", payload)
+            self.assertIsInstance(payload["specialist_wrapper_ready"], bool)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -100,6 +100,7 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
         self.assertIn("scripts/runtime/Freeze-RuntimeInputPacket.ps1", required_markers)
         self.assertIn("scripts/runtime/invoke-vibe-runtime.ps1", required_markers)
         self.assertIn("scripts/runtime/memory_backend_driver.py", required_markers)
+        self.assertIn("scripts/runtime/native_specialist_runner.py", required_markers)
         self.assertIn("scripts/verify/vibe-governed-runtime-contract-gate.ps1", required_markers)
         self.assertIn("config/runtime-contract.json", required_markers)
         self.assertIn("config/runtime-modes.json", required_markers)

--- a/tests/runtime_neutral/test_installed_runtime_scripts.py
+++ b/tests/runtime_neutral/test_installed_runtime_scripts.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
+import stat
 import subprocess
 import tempfile
 import unittest
@@ -9,6 +11,13 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+STRICT_READY_HOSTS = [
+    ("claude-code", "VGO_CLAUDE_CODE_SPECIALIST_BRIDGE_COMMAND"),
+    ("cursor", "VGO_CURSOR_SPECIALIST_BRIDGE_COMMAND"),
+    ("windsurf", "VGO_WINDSURF_SPECIALIST_BRIDGE_COMMAND"),
+    ("openclaw", "VGO_OPENCLAW_SPECIALIST_BRIDGE_COMMAND"),
+    ("opencode", "VGO_OPENCODE_SPECIALIST_BRIDGE_COMMAND"),
+]
 
 
 def resolve_powershell() -> str | None:
@@ -48,6 +57,92 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
             str(self.target_root),
         ]
         subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+    def create_fake_bridge(self, name: str, host_id: str) -> Path:
+        suffix = ".cmd" if os.name == "nt" else ""
+        bridge_path = self.root / f"{name}{suffix}"
+        if os.name == "nt":
+            bridge_path.write_text(
+                "@echo off\r\n"
+                "setlocal EnableDelayedExpansion\r\n"
+                "set OUT=\r\n"
+                ":loop\r\n"
+                "if \"%~1\"==\"\" goto done\r\n"
+                "if /I \"%~1\"==\"--output\" (\r\n"
+                "  set OUT=%~2\r\n"
+                "  shift\r\n"
+                "  shift\r\n"
+                "  goto loop\r\n"
+                ")\r\n"
+                "shift\r\n"
+                "goto loop\r\n"
+                ":done\r\n"
+                "if \"%OUT%\"==\"\" exit /b 2\r\n"
+                f"> \"%OUT%\" echo {{\"status\":\"completed\",\"summary\":\"{host_id} bridge executed\"}}\r\n"
+                f"echo {host_id} bridge ok\r\n"
+                "exit /b 0\r\n",
+                encoding="utf-8",
+            )
+        else:
+            bridge_path.write_text(
+                "#!/usr/bin/env sh\n"
+                "OUT=''\n"
+                "while [ \"$#\" -gt 0 ]; do\n"
+                "  case \"$1\" in\n"
+                "    --output)\n"
+                "      OUT=\"$2\"\n"
+                "      shift 2\n"
+                "      ;;\n"
+                "    *)\n"
+                "      shift\n"
+                "      ;;\n"
+                "  esac\n"
+                "done\n"
+                "if [ -z \"$OUT\" ]; then\n"
+                "  exit 2\n"
+                "fi\n"
+                f"printf '%s' '{{\"status\":\"completed\",\"summary\":\"{host_id} bridge executed\"}}' > \"$OUT\"\n"
+                f"printf '{host_id} bridge ok\\n'\n",
+                encoding="utf-8",
+            )
+            bridge_path.chmod(bridge_path.stat().st_mode | stat.S_IXUSR)
+        return bridge_path
+
+    def invoke_installed_specialist_wrapper(self, launcher_path: Path, host_id: str) -> None:
+        output_path = self.root / f"{host_id}-wrapper-result.json"
+        completed = subprocess.run(
+            [str(launcher_path), "--output", str(output_path)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertIn(f"{host_id} bridge ok", completed.stdout)
+        self.assertTrue(output_path.exists())
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+        self.assertEqual("completed", payload["status"])
+
+    def strict_install_env(self, *, powershell: str | None = None, include_fake_bridge: tuple[str, str] | None = None) -> dict[str, str]:
+        env = os.environ.copy()
+        sanitized_bin = self.root / "strict-bin"
+        sanitized_bin.mkdir(parents=True, exist_ok=True)
+        blocked = {"claude", "claude-code", "cursor", "cursor-agent", "windsurf", "codeium", "openclaw", "opencode"}
+        for candidate in Path("/bin").iterdir():
+            if candidate.name in blocked:
+                continue
+            target = sanitized_bin / candidate.name
+            if target.exists():
+                continue
+            try:
+                target.symlink_to(candidate)
+            except FileExistsError:
+                continue
+        env["PATH"] = str(sanitized_bin)
+        for _host_id, env_name in STRICT_READY_HOSTS:
+            env.pop(env_name, None)
+        if include_fake_bridge is not None:
+            env_name, bridge_path = include_fake_bridge
+            env[env_name] = bridge_path
+        return env
 
     def assert_nested_runtime_skill_entrypoints_sanitized(self, target_root: Path) -> None:
         nested_skills_root = target_root / "skills" / "vibe" / "bundled" / "skills"
@@ -229,6 +324,70 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         install_script = (self.target_root / "skills" / "vibe" / "install.sh").read_text(encoding="utf-8")
         self.assertNotIn("rm -rf", install_script)
 
+    def test_shell_install_require_closed_ready_fails_without_bridge_command(self) -> None:
+        for host_id, _env_name in STRICT_READY_HOSTS:
+            with self.subTest(host_id=host_id):
+                target_root = self.root / f"{host_id}-strict-fail"
+                target_root.mkdir(parents=True, exist_ok=True)
+                result = subprocess.run(
+                    [
+                        "bash",
+                        str(REPO_ROOT / "install.sh"),
+                        "--host",
+                        host_id,
+                        "--profile",
+                        "full",
+                        "--target-root",
+                        str(target_root),
+                        "--require-closed-ready",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    env=self.strict_install_env(),
+                )
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn("not closed_ready", result.stderr or result.stdout)
+                closure_path = target_root / ".vibeskills" / "host-closure.json"
+                self.assertTrue(closure_path.exists())
+                closure = json.loads(closure_path.read_text(encoding="utf-8"))
+                self.assertEqual("configured_offline_unready", closure["host_closure_state"])
+
+    def test_shell_install_require_closed_ready_succeeds_with_real_bridge_command(self) -> None:
+        for host_id, env_name in STRICT_READY_HOSTS:
+            with self.subTest(host_id=host_id):
+                target_root = self.root / f"{host_id}-strict-pass"
+                target_root.mkdir(parents=True, exist_ok=True)
+                bridge = self.create_fake_bridge(f"{host_id}-strict-bridge", host_id)
+                env = os.environ.copy()
+                env = self.strict_install_env(include_fake_bridge=(env_name, str(bridge)))
+                result = subprocess.run(
+                    [
+                        "bash",
+                        str(REPO_ROOT / "install.sh"),
+                        "--host",
+                        host_id,
+                        "--profile",
+                        "full",
+                        "--target-root",
+                        str(target_root),
+                        "--require-closed-ready",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    env=env,
+                )
+                self.assertIn("Install done.", result.stdout)
+                closure_path = target_root / ".vibeskills" / "host-closure.json"
+                self.assertTrue(closure_path.exists())
+                closure = json.loads(closure_path.read_text(encoding="utf-8"))
+                self.assertEqual("closed_ready", closure["host_closure_state"])
+                self.assertTrue(bool(closure["specialist_wrapper"]["ready"]))
+                self.assertEqual(f"env:{env_name}", closure["specialist_wrapper"]["bridge_source"])
+                launcher_path = Path(closure["specialist_wrapper"]["launcher_path"])
+                self.assertTrue(launcher_path.exists())
+                self.invoke_installed_specialist_wrapper(launcher_path, host_id)
+
     def test_installed_powershell_scripts_work_without_repo_level_adapter_registry(self) -> None:
         powershell = resolve_powershell()
         if powershell is None:
@@ -365,6 +524,74 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         check_result = subprocess.run(check_cmd, capture_output=True, text=True, env=env)
         self.assertNotEqual(0, check_result.returncode)
         self.assertIn("duplicate Codex-discovered vibe skill surface", check_result.stdout)
+
+    def test_powershell_install_require_closed_ready_enforces_real_host_closure(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        host_id = "openclaw"
+        env_name = "VGO_OPENCLAW_SPECIALIST_BRIDGE_COMMAND"
+
+        failure_target = self.root / "pwsh-openclaw-strict-fail"
+        failure_target.mkdir(parents=True, exist_ok=True)
+        fail_result = subprocess.run(
+            [
+                powershell,
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(REPO_ROOT / "install.ps1"),
+                "-HostId",
+                host_id,
+                "-Profile",
+                "full",
+                "-TargetRoot",
+                str(failure_target),
+                "-RequireClosedReady",
+            ],
+            capture_output=True,
+            text=True,
+            env=self.strict_install_env(powershell=powershell),
+        )
+        self.assertNotEqual(0, fail_result.returncode)
+        self.assertIn("not closed_ready", fail_result.stderr or fail_result.stdout)
+
+        success_target = self.root / "pwsh-openclaw-strict-pass"
+        success_target.mkdir(parents=True, exist_ok=True)
+        bridge = self.create_fake_bridge("pwsh-openclaw-bridge", host_id)
+        env = self.strict_install_env(powershell=powershell, include_fake_bridge=(env_name, str(bridge)))
+        success_result = subprocess.run(
+            [
+                powershell,
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(REPO_ROOT / "install.ps1"),
+                "-HostId",
+                host_id,
+                "-Profile",
+                "full",
+                "-TargetRoot",
+                str(success_target),
+                "-RequireClosedReady",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+        self.assertIn("Installation complete.", success_result.stdout)
+        closure_path = success_target / ".vibeskills" / "host-closure.json"
+        self.assertTrue(closure_path.exists())
+        closure = json.loads(closure_path.read_text(encoding="utf-8"))
+        self.assertEqual("closed_ready", closure["host_closure_state"])
+        self.assertEqual(f"env:{env_name}", closure["specialist_wrapper"]["bridge_source"])
+        launcher_path = Path(closure["specialist_wrapper"]["launcher_path"])
+        self.assertTrue(launcher_path.exists())
+        self.invoke_installed_specialist_wrapper(launcher_path, host_id)
 
 
 if __name__ == "__main__":

--- a/tests/runtime_neutral/test_multi_host_specialist_execution.py
+++ b/tests/runtime_neutral/test_multi_host_specialist_execution.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "scripts" / "install" / "install_vgo_adapter.py"
+TASK = "I have a failing test and a stack trace. Help me debug systematically before proposing fixes."
+HOST_CASES = [
+    ("claude-code", "VGO_CLAUDE_CODE_SPECIALIST_WRAPPER", "claude-code-wrapper"),
+    ("cursor", "VGO_CURSOR_SPECIALIST_WRAPPER", "cursor-wrapper"),
+    ("windsurf", "VGO_WINDSURF_SPECIALIST_WRAPPER", "windsurf-wrapper"),
+    ("openclaw", "VGO_OPENCLAW_SPECIALIST_WRAPPER", "openclaw-wrapper"),
+]
+
+
+def resolve_powershell() -> str | None:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("pwsh.exe"),
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files\PowerShell\7-preview\pwsh.exe",
+        shutil.which("powershell"),
+        shutil.which("powershell.exe"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
+def run_runtime(task: str, artifact_root: Path, *, extra_env: dict[str, str] | None = None) -> dict[str, object]:
+    shell = resolve_powershell()
+    if shell is None:
+        raise unittest.SkipTest("PowerShell executable not available in PATH")
+
+    script_path = REPO_ROOT / "scripts/runtime/invoke-vibe-runtime.ps1"
+    run_id = "pytest-host-exec-" + uuid.uuid4().hex[:10]
+    command = [
+        shell,
+        "-NoLogo",
+        "-NoProfile",
+        "-Command",
+        (
+            "& { "
+            f"$result = & '{script_path}' "
+            f"-Task '{task}' "
+            "-Mode benchmark_autonomous "
+            f"-RunId '{run_id}' "
+            f"-ArtifactRoot '{artifact_root}'; "
+            "$result | ConvertTo-Json -Depth 20 }"
+        ),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        env={**os.environ, **(extra_env or {})},
+    )
+    stdout = completed.stdout.strip()
+    if stdout in ("", "null"):
+        raise AssertionError(
+            "invoke-vibe-runtime returned null payload. "
+            f"stderr={completed.stderr.strip()}"
+        )
+    return json.loads(stdout)
+
+
+def load_json(path: str | Path) -> dict[str, object]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def create_fake_wrapper(directory: Path, name: str, host_id: str) -> Path:
+    suffix = ".cmd" if os.name == "nt" else ""
+    wrapper_path = directory / f"{name}{suffix}"
+    if os.name == "nt":
+        wrapper_path.write_text(
+            "@echo off\r\n"
+            "setlocal EnableDelayedExpansion\r\n"
+            "set OUT=\r\n"
+            ":loop\r\n"
+            "if \"%~1\"==\"\" goto done\r\n"
+            "if /I \"%~1\"==\"--output\" (\r\n"
+            "  set OUT=%~2\r\n"
+            "  shift\r\n"
+            "  shift\r\n"
+            "  goto loop\r\n"
+            ")\r\n"
+            "shift\r\n"
+            "goto loop\r\n"
+            ":done\r\n"
+            "if \"%OUT%\"==\"\" exit /b 2\r\n"
+            f"> \"%OUT%\" echo {{\"status\":\"completed\",\"summary\":\"{host_id} wrapper executed specialist\",\"verification_notes\":[\"{host_id} live wrapper ok\"],\"changed_files\":[],\"bounded_output_notes\":[\"{host_id} host-neutral bridge\"]}}\r\n"
+            f"echo {host_id} wrapper ok\r\n"
+            "exit /b 0\r\n",
+            encoding="utf-8",
+        )
+    else:
+        wrapper_path.write_text(
+            "#!/usr/bin/env sh\n"
+            "OUT=''\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    --output)\n"
+            "      OUT=\"$2\"\n"
+            "      shift 2\n"
+            "      ;;\n"
+            "    *)\n"
+            "      shift\n"
+            "      ;;\n"
+            "  esac\n"
+            "done\n"
+            "if [ -z \"$OUT\" ]; then\n"
+            "  exit 2\n"
+            "fi\n"
+            f"printf '%s' '{{\"status\":\"completed\",\"summary\":\"{host_id} wrapper executed specialist\",\"verification_notes\":[\"{host_id} live wrapper ok\"],\"changed_files\":[],\"bounded_output_notes\":[\"{host_id} host-neutral bridge\"]}}' > \"$OUT\"\n"
+            f"printf '{host_id} wrapper ok\\n'\n",
+            encoding="utf-8",
+        )
+        wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IXUSR)
+    return wrapper_path
+
+
+class MultiHostSpecialistExecutionTests(unittest.TestCase):
+    def test_runtime_packet_records_requested_and_effective_host_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            payload = run_runtime(
+                TASK,
+                artifact_root=Path(tempdir),
+                extra_env={"VCO_HOST_ID": "openclaw"},
+            )
+            summary = payload["summary"]
+            runtime_input = load_json(summary["artifacts"]["runtime_input_packet"])
+            execution_manifest = load_json(summary["artifacts"]["execution_manifest"])
+
+            self.assertEqual("openclaw", runtime_input["host_adapter"]["requested_host_id"])
+            self.assertEqual("openclaw", runtime_input["host_adapter"]["effective_host_id"])
+            self.assertEqual(
+                "openclaw",
+                execution_manifest["route_runtime_alignment"]["requested_host_adapter_id"],
+            )
+            self.assertEqual(
+                "openclaw",
+                execution_manifest["route_runtime_alignment"]["effective_host_adapter_id"],
+            )
+
+    def test_non_codex_hosts_can_execute_live_specialist_lane_when_wrapper_is_configured(self) -> None:
+        for host_id, env_name, command_name in HOST_CASES:
+            with self.subTest(host_id=host_id):
+                with tempfile.TemporaryDirectory() as tempdir:
+                    temp_path = Path(tempdir)
+                    wrapper = create_fake_wrapper(temp_path, command_name, host_id)
+                    payload = run_runtime(
+                        TASK,
+                        artifact_root=temp_path,
+                        extra_env={
+                            "VCO_HOST_ID": host_id,
+                            "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                            "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                            env_name: str(wrapper),
+                        },
+                    )
+                    summary = payload["summary"]
+                    execution_manifest = load_json(summary["artifacts"]["execution_manifest"])
+                    specialist_accounting = execution_manifest["specialist_accounting"]
+
+                    self.assertEqual("live_native_executed", specialist_accounting["effective_execution_status"])
+                    self.assertGreaterEqual(int(specialist_accounting["executed_specialist_unit_count"]), 1)
+                    self.assertEqual(host_id, specialist_accounting["effective_host_adapter_id"])
+
+                    executed_units = list(specialist_accounting["executed_specialist_units"])
+                    self.assertGreaterEqual(len(executed_units), 1)
+                    for unit in executed_units:
+                        result = load_json(unit["result_path"])
+                        self.assertEqual("host_neutral_exec_native_specialist", result["execution_driver"])
+                        self.assertEqual(host_id, result["host_adapter_id"])
+                        self.assertEqual(host_id, result["requested_host_adapter_id"])
+                        self.assertTrue(bool(result["live_native_execution"]))
+                        self.assertFalse(bool(result["degraded"]))
+
+    def test_non_codex_hosts_degrade_honestly_when_wrapper_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            payload = run_runtime(
+                TASK,
+                artifact_root=Path(tempdir),
+                extra_env={
+                    "VCO_HOST_ID": "windsurf",
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                },
+            )
+            summary = payload["summary"]
+            execution_manifest = load_json(summary["artifacts"]["execution_manifest"])
+            specialist_accounting = execution_manifest["specialist_accounting"]
+
+            self.assertEqual("explicitly_degraded", specialist_accounting["effective_execution_status"])
+            self.assertEqual("windsurf", specialist_accounting["effective_host_adapter_id"])
+            degraded_units = list(specialist_accounting["degraded_specialist_units"])
+            self.assertGreaterEqual(len(degraded_units), 1)
+            for unit in degraded_units:
+                result = load_json(unit["result_path"])
+                self.assertEqual("degraded_specialist_contract_receipt", result["execution_driver"])
+                self.assertEqual("windsurf", result["host_adapter_id"])
+                self.assertEqual(
+                    "native_specialist_bridge_command_unavailable:windsurf",
+                    result["degradation_reason"],
+                )
+
+    def test_runtime_can_use_installed_host_closure_manifest_without_wrapper_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_path = Path(tempdir)
+            target_root = temp_path / "openclaw-home"
+            target_root.mkdir(parents=True, exist_ok=True)
+            bridge = create_fake_wrapper(temp_path, "openclaw-bridge", "openclaw")
+
+            install_env = dict(os.environ)
+            install_env["OPENCLAW_HOME"] = str(target_root)
+            install_env["VGO_OPENCLAW_SPECIALIST_BRIDGE_COMMAND"] = str(bridge)
+            install_result = subprocess.run(
+                [
+                    sys.executable,
+                    str(INSTALLER),
+                    "--repo-root",
+                    str(REPO_ROOT),
+                    "--target-root",
+                    str(target_root),
+                    "--host",
+                    "openclaw",
+                    "--profile",
+                    "full",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+                env=install_env,
+            )
+            install_payload = json.loads(install_result.stdout)
+            self.assertTrue(install_payload["specialist_wrapper_ready"])
+
+            payload = run_runtime(
+                TASK,
+                artifact_root=temp_path,
+                extra_env={
+                    "VCO_HOST_ID": "openclaw",
+                    "OPENCLAW_HOME": str(target_root),
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                },
+            )
+            summary = payload["summary"]
+            execution_manifest = load_json(summary["artifacts"]["execution_manifest"])
+            specialist_accounting = execution_manifest["specialist_accounting"]
+
+            self.assertEqual("live_native_executed", specialist_accounting["effective_execution_status"])
+            self.assertEqual("openclaw", specialist_accounting["effective_host_adapter_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime_neutral/test_openclaw_runtime_core.py
+++ b/tests/runtime_neutral/test_openclaw_runtime_core.py
@@ -71,10 +71,13 @@ class OpenClawRuntimeCoreTests(unittest.TestCase):
 
             self.assertEqual("openclaw", payload["host_id"])
             self.assertEqual("runtime-core", payload["install_mode"])
+            self.assertIn("host_closure_path", payload)
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
             self.assertTrue((target_root / "skills" / "brainstorming" / "SKILL.md").exists())
             self.assertTrue((target_root / "commands").exists())
+            self.assertTrue((target_root / "commands" / "vibe.md").exists())
             self.assertTrue((target_root / "mcp_config.json").exists())
+            self.assertTrue((target_root / ".vibeskills" / "host-closure.json").exists())
             self.assertFalse((target_root / "settings.json").exists())
             self.assertFalse((target_root / "config" / "plugins-manifest.codex.json").exists())
 
@@ -100,7 +103,10 @@ class OpenClawRuntimeCoreTests(unittest.TestCase):
             self.assertIn("Mode   : runtime-core", install_result.stdout)
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
             self.assertTrue((target_root / "commands").exists())
+            self.assertTrue((target_root / "commands" / "vibe.md").exists())
+            self.assertTrue((target_root / "global_workflows" / "vibe.md").exists())
             self.assertTrue((target_root / "mcp_config.json").exists())
+            self.assertTrue((target_root / ".vibeskills" / "host-closure.json").exists())
             self.assertFalse((target_root / "settings.json").exists())
 
             check_result = subprocess.run(
@@ -120,6 +126,7 @@ class OpenClawRuntimeCoreTests(unittest.TestCase):
             )
             self.assertIn("Host: openclaw", check_result.stdout)
             self.assertIn("Mode: runtime-core", check_result.stdout)
+            self.assertIn("[OK] host closure manifest", check_result.stdout)
             self.assertIn("[OK] npm check skipped for non-governed adapter mode", check_result.stdout)
             self.assertNotIn("[FAIL] settings.json", check_result.stdout)
             self.assertNotIn("[FAIL] config/plugins-manifest.codex.json", check_result.stdout)

--- a/tests/runtime_neutral/test_opencode_managed_preview.py
+++ b/tests/runtime_neutral/test_opencode_managed_preview.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "scripts" / "install" / "install_vgo_adapter.py"
+
+
+class OpenCodeManagedPreviewTests(unittest.TestCase):
+    def test_python_installer_materializes_opencode_host_closure_and_settings_surface(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(INSTALLER),
+                    "--repo-root",
+                    str(REPO_ROOT),
+                    "--target-root",
+                    str(target_root),
+                    "--host",
+                    "opencode",
+                    "--profile",
+                    "full",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            payload = json.loads(result.stdout)
+            closure_path = target_root / ".vibeskills" / "host-closure.json"
+            settings_path = target_root / "opencode.json"
+
+            self.assertEqual("opencode", payload["host_id"])
+            self.assertEqual("preview-guidance", payload["install_mode"])
+            self.assertTrue(closure_path.exists())
+            self.assertTrue(settings_path.exists())
+            self.assertTrue((target_root / "commands" / "vibe.md").exists())
+            self.assertTrue((target_root / "command" / "vibe.md").exists())
+            self.assertTrue((target_root / "agents").exists())
+            self.assertTrue((target_root / "agent").exists())
+
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+            self.assertIn("vibeskills", settings)
+            self.assertEqual("opencode", settings["vibeskills"]["host_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime_neutral/test_windsurf_runtime_core.py
+++ b/tests/runtime_neutral/test_windsurf_runtime_core.py
@@ -59,9 +59,13 @@ class WindsurfRuntimeCoreTests(unittest.TestCase):
 
             self.assertEqual("windsurf", payload["host_id"])
             self.assertEqual("runtime-core", payload["install_mode"])
+            self.assertIn("host_closure_path", payload)
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
             self.assertTrue((target_root / "skills" / "brainstorming" / "SKILL.md").exists())
+            self.assertTrue((target_root / "commands" / "vibe.md").exists())
+            self.assertTrue((target_root / "global_workflows" / "vibe.md").exists())
             self.assertTrue((target_root / "mcp_config.json").exists())
+            self.assertTrue((target_root / ".vibeskills" / "host-closure.json").exists())
             self.assertFalse((target_root / "settings.json").exists())
             self.assertFalse((target_root / "config" / "plugins-manifest.codex.json").exists())
 
@@ -86,7 +90,10 @@ class WindsurfRuntimeCoreTests(unittest.TestCase):
             self.assertIn("Host   : windsurf", install_result.stdout)
             self.assertIn("Mode   : runtime-core", install_result.stdout)
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
+            self.assertTrue((target_root / "commands" / "vibe.md").exists())
+            self.assertTrue((target_root / "global_workflows" / "vibe.md").exists())
             self.assertTrue((target_root / "mcp_config.json").exists())
+            self.assertTrue((target_root / ".vibeskills" / "host-closure.json").exists())
             self.assertFalse((target_root / "settings.json").exists())
 
             check_result = subprocess.run(
@@ -105,6 +112,7 @@ class WindsurfRuntimeCoreTests(unittest.TestCase):
                 check=True,
             )
             self.assertIn("Host: windsurf", check_result.stdout)
+            self.assertIn("[OK] host closure manifest", check_result.stdout)
             self.assertNotIn("[FAIL] settings.json", check_result.stdout)
 
 


### PR DESCRIPTION
## Summary
- tighten multi-host installation so preview/runtime-core hosts can be forced to fail unless host closure reaches `closed_ready`
- wire host-closure strictness through bash, PowerShell, and Python installer entrypoints
- add real install proof coverage that runs the installers and invokes the installed wrapper launchers instead of only checking static artifacts

## What changed
- add `--require-closed-ready` / `-RequireClosedReady` to the public install entrypoints
- make the Python installer emit strictness metadata in the install receipt and fail when a required host closure stays `configured_offline_unready`
- harden the PowerShell installer path so Python installer failures are surfaced instead of silently passing through
- materialize and validate host closure artifacts consistently in the PowerShell fallback path too
- extend health/install/runtime tests for cursor, opencode, windsurf, openclaw, and claude-code closure states

## Proof
- `pytest -q tests/runtime_neutral/test_installed_runtime_scripts.py -k 'require_closed_ready'`
- `pytest -q tests/runtime_neutral/test_claude_preview_scaffold.py tests/runtime_neutral/test_cursor_managed_preview.py tests/runtime_neutral/test_opencode_managed_preview.py tests/runtime_neutral/test_openclaw_runtime_core.py tests/runtime_neutral/test_windsurf_runtime_core.py tests/runtime_neutral/test_multi_host_specialist_execution.py tests/runtime_neutral/test_installed_runtime_scripts.py tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py`

## Scope note
This improves installation truthfulness and host-closure/runtime usability. It does not claim every non-codex host is already fully equivalent to the codex governed lane.