### PR TITLE
release: cut v2.3.53

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -291,7 +291,7 @@ The governed runtime should leave behind:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 2.3.52
-- Updated: 2026-03-29
+- Version: 2.3.53
+- Updated: 2026-03-30
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/bundled/skills/vibe/SKILL.md
+++ b/bundled/skills/vibe/SKILL.md
@@ -291,7 +291,7 @@ The governed runtime should leave behind:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 2.3.52
-- Updated: 2026-03-29
+- Version: 2.3.53
+- Updated: 2026-03-30
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/bundled/skills/vibe/bundled/skills/vibe/SKILL.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/SKILL.md
@@ -291,7 +291,7 @@ The governed runtime should leave behind:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 2.3.52
-- Updated: 2026-03-29
+- Version: 2.3.53
+- Updated: 2026-03-30
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/bundled/skills/vibe/bundled/skills/vibe/check.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/check.ps1
@@ -501,6 +501,8 @@ function Invoke-AdapterSpecificChecks {
   if ([string]$Adapter.check_mode -eq 'preview-guidance') {
     if ([string]$Adapter.id -eq 'opencode') {
       Warn-Note -Message 'opencode preview keeps the real opencode.json host-managed; only skills, commands, agents, and an example config scaffold are verified'
+    } elseif ([string]$Adapter.id -eq 'cursor') {
+      Write-Host '[INFO] cursor preview now materializes managed commands, host-closure state, and a minimal settings surface; deeper host-native workflow remains preview-scoped' -ForegroundColor Cyan
     } else {
       Write-Host ("[INFO] {0} preview hook/settings scaffold remains intentionally unavailable while the author works through compatibility issues; this is a current product boundary, not an install failure" -f $Adapter.id) -ForegroundColor Cyan
     }
@@ -520,6 +522,28 @@ function Invoke-AdapterSpecificChecks {
     Check-Path -Label "plugins manifest" -Path (Join-Path $TargetRoot 'config\plugins-manifest.codex.json')
     Check-Path -Label "rules/common" -Path (Join-Path $TargetRoot 'rules\common\agents.md')
     Check-Path -Label "mcp template" -Path (Join-Path $TargetRoot 'mcp\servers.template.json')
+  }
+
+  $hostClosurePath = Join-Path $TargetRoot '.vibeskills\host-closure.json'
+  Check-Path -Label "host closure manifest" -Path $hostClosurePath
+  if (Test-Path -LiteralPath $hostClosurePath) {
+    $hostClosure = Get-JsonObject -Path $hostClosurePath -Label 'host closure manifest'
+    if ($null -ne $hostClosure) {
+      $closureState = if ($hostClosure.PSObject.Properties.Name -contains 'host_closure_state') { [string]$hostClosure.host_closure_state } else { '' }
+      if (-not [string]::IsNullOrWhiteSpace($closureState)) {
+        if ($closureState -eq 'closed_ready') {
+          Check-Condition -Label 'host closure state' -Condition $true
+        } else {
+          Warn-Note -Message ("host closure state -> {0}" -f $closureState)
+        }
+      }
+    }
+    if ($null -ne $hostClosure -and $hostClosure.PSObject.Properties.Name -contains 'specialist_wrapper' -and $null -ne $hostClosure.specialist_wrapper) {
+      $launcherPath = if ($hostClosure.specialist_wrapper.PSObject.Properties.Name -contains 'launcher_path') { [string]$hostClosure.specialist_wrapper.launcher_path } else { '' }
+      if (-not [string]::IsNullOrWhiteSpace($launcherPath)) {
+        Check-Path -Label "specialist wrapper launcher" -Path $launcherPath
+      }
+    }
   }
 
   Check-Path -Label "upstream lock" -Path (Join-Path $TargetRoot 'config\upstream-lock.json')

--- a/bundled/skills/vibe/bundled/skills/vibe/check.sh
+++ b/bundled/skills/vibe/bundled/skills/vibe/check.sh
@@ -37,6 +37,53 @@ pick_python_for_adapter() {
   return 1
 }
 
+pick_powershell() {
+  local candidate resolved=""
+  for candidate in pwsh pwsh.exe powershell powershell.exe; do
+    if resolved="$(command -v "${candidate}" 2>/dev/null)"; then
+      if [[ -n "${resolved}" ]]; then
+        printf '%s' "${resolved}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+run_powershell_command() {
+  local command_text="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-Command" "${command_text}")
+  "${cmd[@]}" "$@"
+}
+
+run_powershell_file() {
+  local script_path="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-File" "${script_path}")
+  "${cmd[@]}" "$@"
+}
+
 adapter_query_for_host() {
   local host_id="$1"
   local property="$2"
@@ -404,8 +451,8 @@ else:
     print(value)
 PY
     return $?
-  elif command -v pwsh >/dev/null 2>&1; then
-    pwsh -NoProfile -Command '
+  elif pick_powershell >/dev/null 2>&1; then
+    run_powershell_command '
 param([string]$Path,[string]$Expr)
 $raw = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
 $value = $raw | ConvertFrom-Json
@@ -541,8 +588,8 @@ validate_runtime_receipt() {
       warn_note "vibe runtime freshness receipt unavailable because check.sh is not running from the canonical repo root."
       return
     fi
-    if ! command -v pwsh >/dev/null 2>&1; then
-      warn_note "vibe runtime freshness receipt unavailable because pwsh is not installed in this shell environment."
+    if ! pick_powershell >/dev/null 2>&1; then
+      warn_note "vibe runtime freshness receipt unavailable because pwsh is not installed and no compatible PowerShell host is available in this shell environment."
       return
     fi
     echo "[FAIL] vibe runtime freshness receipt -> $receipt_path"
@@ -653,11 +700,11 @@ run_runtime_freshness_gate() {
     echo "[OK] vibe installed runtime freshness gate"
     PASS=$((PASS+1))
   elif [[ $? -eq 127 ]]; then
-    if ! command -v pwsh >/dev/null 2>&1; then
-      warn_note 'runtime freshness gate skipped: neither Python runtime-neutral gate nor pwsh fallback is available.'
+    if ! pick_powershell >/dev/null 2>&1; then
+      warn_note 'runtime freshness gate skipped: neither Python runtime-neutral gate nor a PowerShell fallback is available.'
       return
     fi
-    if pwsh -NoProfile -File "$gate_path" -TargetRoot "$TARGET_ROOT"; then
+    if run_powershell_file "$gate_path" -TargetRoot "$TARGET_ROOT"; then
       echo "[OK] vibe installed runtime freshness gate"
       PASS=$((PASS+1))
     else
@@ -697,11 +744,11 @@ run_runtime_coherence_gate() {
     echo "[OK] vibe release/install/runtime coherence gate"
     PASS=$((PASS+1))
   elif [[ $? -eq 127 ]]; then
-    if ! command -v pwsh >/dev/null 2>&1; then
-      warn_note 'runtime coherence gate skipped: neither Python runtime-neutral gate nor pwsh fallback is available.'
+    if ! pick_powershell >/dev/null 2>&1; then
+      warn_note 'runtime coherence gate skipped: neither Python runtime-neutral gate nor a PowerShell fallback is available.'
       return
     fi
-    if pwsh -NoProfile -File "$gate_path" -TargetRoot "$TARGET_ROOT"; then
+    if run_powershell_file "$gate_path" -TargetRoot "$TARGET_ROOT"; then
       echo "[OK] vibe release/install/runtime coherence gate"
       PASS=$((PASS+1))
     else
@@ -741,6 +788,8 @@ fi
 if [[ "${ADAPTER_CHECK_MODE}" == "preview-guidance" ]]; then
   if [[ "${HOST_ID}" == "opencode" ]]; then
     warn_note "opencode preview keeps the real opencode.json host-managed; only skills, commands, agents, and an example config scaffold are verified"
+  elif [[ "${HOST_ID}" == "cursor" ]]; then
+    info_note "cursor preview now materializes managed commands, host-closure state, and a minimal settings surface; deeper host-native workflow remains preview-scoped"
   else
     info_note "${HOST_ID} preview hook/settings scaffold remains intentionally unavailable while the author works through compatibility issues; this is a current product boundary, not an install failure"
   fi
@@ -751,6 +800,22 @@ if [[ "${ADAPTER_CHECK_MODE}" == "runtime-core" ]]; then
   fi
   if [[ -f "${SCRIPT_DIR}/mcp/servers.template.json" ]]; then
     check_path "mcp_config.json" "${TARGET_ROOT}/mcp_config.json"
+  fi
+fi
+check_path "host closure manifest" "${TARGET_ROOT}/.vibeskills/host-closure.json"
+if [[ -f "${TARGET_ROOT}/.vibeskills/host-closure.json" ]]; then
+  closure_state="$(json_query_scalar_from_file "${TARGET_ROOT}/.vibeskills/host-closure.json" 'host_closure_state' 2>/dev/null || true)"
+  if [[ -n "${closure_state}" ]]; then
+    if [[ "${closure_state}" == "closed_ready" ]]; then
+      echo "[OK] host closure state -> ${closure_state}"
+      PASS=$((PASS+1))
+    else
+      warn_note "host closure state -> ${closure_state}"
+    fi
+  fi
+  wrapper_launcher="$(json_query_scalar_from_file "${TARGET_ROOT}/.vibeskills/host-closure.json" 'specialist_wrapper.launcher_path' 2>/dev/null || true)"
+  if [[ -n "${wrapper_launcher}" ]]; then
+    check_path "specialist wrapper launcher" "${wrapper_launcher}"
   fi
 fi
 if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
@@ -851,10 +916,10 @@ if [[ "${DEEP}" == "true" ]]; then
       echo "[OK] vibe bootstrap doctor gate"
       PASS=$((PASS+1))
     elif [[ $? -eq 127 ]]; then
-      if ! command -v pwsh >/dev/null 2>&1; then
-        echo "[WARN] vibe bootstrap doctor gate skipped because neither the Python runtime-neutral doctor nor pwsh is available in this shell environment."
+      if ! pick_powershell >/dev/null 2>&1; then
+        echo "[WARN] vibe bootstrap doctor gate skipped because neither the Python runtime-neutral doctor nor a PowerShell host is available in this shell environment."
         WARN=$((WARN+1))
-      elif pwsh -NoProfile -File "${doctor_path}" -TargetRoot "${TARGET_ROOT}" -WriteArtifacts; then
+      elif run_powershell_file "${doctor_path}" -TargetRoot "${TARGET_ROOT}" -WriteArtifacts; then
         echo "[OK] vibe bootstrap doctor gate"
         PASS=$((PASS+1))
       else

--- a/bundled/skills/vibe/bundled/skills/vibe/config/native-specialist-execution-policy.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/native-specialist-execution-policy.json
@@ -1,6 +1,6 @@
 {
-  "version": 1,
-  "updated_at": "2026-03-28",
+  "version": 2,
+  "updated_at": "2026-03-29",
   "enabled": true,
   "default_adapter_id": "codex",
   "enable_env": "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION",
@@ -31,6 +31,7 @@
     {
       "id": "codex",
       "enabled": true,
+      "invocation_kind": "direct",
       "executable_env": "VGO_CODEX_EXECUTABLE",
       "command": "codex",
       "arguments_prefix": [
@@ -40,6 +41,61 @@
         "--full-auto"
       ],
       "execution_driver": "codex_exec_native_specialist"
+    },
+    {
+      "id": "claude-code",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_CLAUDE_CODE_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
+    },
+    {
+      "id": "cursor",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_CURSOR_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
+    },
+    {
+      "id": "windsurf",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_WINDSURF_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
+    },
+    {
+      "id": "openclaw",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_OPENCLAW_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
+    },
+    {
+      "id": "opencode",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_OPENCODE_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
     }
   ]
 }

--- a/bundled/skills/vibe/bundled/skills/vibe/config/phase-cleanup-policy.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/phase-cleanup-policy.json
@@ -22,6 +22,22 @@
     "attempt_node_zombie_cleanup_if_needed",
     "record_remaining_manual_actions"
   ],
+  "destructive_cleanup_guardrails": {
+    "forbid_blind_recursive_wipe": true,
+    "forbid_batch_delete_in_managed_roots": true,
+    "require_explicit_hazard_alert": true,
+    "require_receipt_backed_path_list": true,
+    "managed_roots": [
+      "config",
+      "docs",
+      "references",
+      "scripts",
+      "bundled",
+      "protocols",
+      "mcp",
+      "third_party"
+    ]
+  },
   "protected_document_policy": {
     "enabled": true,
     "extensions": [

--- a/bundled/skills/vibe/bundled/skills/vibe/config/runtime-input-packet-policy.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/runtime-input-packet-policy.json
@@ -10,6 +10,7 @@
   "required_fields": [
     "run_id",
     "governance_scope",
+    "host_adapter",
     "hierarchy",
     "task",
     "runtime_mode",

--- a/bundled/skills/vibe/bundled/skills/vibe/config/version-governance.json
+++ b/bundled/skills/vibe/bundled/skills/vibe/config/version-governance.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
   "release": {
-    "version": "2.3.52",
-    "updated": "2026-03-29",
+    "version": "2.3.53",
+    "updated": "2026-03-30",
     "channel": "stable",
-    "notes": "Adds stage-aware memory activation to the main vibe runtime, wires governed Serena/ruflo/Cognee backend adapters into observable session artifacts, and keeps memory-scope boundaries explicit."
+    "notes": "Closes governed specialist dispatch and custom admission, hardens Windows PowerShell host resolution plus managed-host install guarantees, and tightens cleanup-truth safety wording."
   },
   "source_of_truth": {
     "canonical_root": ".",
@@ -106,6 +106,7 @@
         "scripts/runtime/Freeze-RuntimeInputPacket.ps1",
         "scripts/runtime/invoke-vibe-runtime.ps1",
         "scripts/runtime/Invoke-PlanExecute.ps1",
+        "scripts/runtime/native_specialist_runner.py",
         "scripts/runtime/memory_backend_driver.py",
         "scripts/verify/vibe-installed-runtime-freshness-gate.ps1",
         "scripts/verify/vibe-release-install-runtime-coherence-gate.ps1",

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-30-release-v2.3.53-plan.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/plans/2026-03-30-release-v2.3.53-plan.md
@@ -1,0 +1,62 @@
+# 发布 v2.3.53 执行计划
+
+**日期**: 2026-03-30
+**需求文档**: [2026-03-30-release-v2.3.53.md](../requirements/2026-03-30-release-v2.3.53.md)
+**Internal Grade**: `L`
+
+## Wave Structure
+
+### Wave 1: Freeze Release Surface
+
+- 基于 `v2.3.52..main` 汇总本次版本主题与边界。
+- 新增 `docs/releases/v2.3.53.md`。
+- 更新 `docs/releases/README.md` 当前 release surface。
+- 更新 `config/version-governance.json` 的 release summary。
+- 预先对齐 `dist/*/manifest.json` 的 `source_release`。
+
+### Wave 2: Governed Version Cut
+
+- 运行 `scripts/governance/release-cut.ps1 -Version 2.3.53 -Updated 2026-03-30`。
+- 让脚本完成版本治理字段、maintenance section、changelog header、release ledger 写入。
+- 让脚本触发 `sync-bundled-vibe.ps1`，把 root 发布面同步到 bundled / nested bundled mirror。
+
+### Wave 3: Verification And Publish
+
+- 运行版本一致性、dist manifest、specialist dispatch closure 相关 gate。
+- 运行针对 custom admission、multi-host specialist execution、installed runtime scripts 的测试。
+- 审核 `git diff` 后提交、推送分支、合并到 `main`。
+- 在合并后的 `main` 上创建 `v2.3.53` tag 和 GitHub release。
+
+## Ownership Boundaries
+
+- Root governed lane: 版本号、release notes、验证、GitHub 发布。
+- Bundled / nested bundled mirrors: 仅通过 `sync-bundled-vibe.ps1` 同步，不做手工漂移编辑。
+
+## Verification Commands
+
+- `git diff --check`
+- `pytest -q tests/runtime_neutral/test_custom_admission_bridge.py tests/runtime_neutral/test_multi_host_specialist_execution.py tests/runtime_neutral/test_installed_runtime_scripts.py`
+- `pwsh -NoProfile -File scripts/verify/vibe-version-consistency-gate.ps1`
+- `pwsh -NoProfile -File scripts/verify/vibe-dist-manifest-gate.ps1`
+- `pwsh -NoProfile -File scripts/verify/vibe-specialist-dispatch-closure-gate.ps1`
+
+## Delivery Acceptance Plan
+
+- 版本说明必须能从 `v2.3.52..main` 的 commit 与 diff 中直接追溯。
+- 发布完成标准为：远端 `main` 含 release commit，`v2.3.53` tag 已存在，GitHub release 已创建。
+
+## Completion Language Rules
+
+- 验证未过或远端对象未创建前，只能说“已准备发布”。
+- 只有 tag 和 GitHub release 都落地后，才能说“已发布 v2.3.53”。
+
+## Rollback Rules
+
+- 若 gate 或测试失败，停止发布，不打 tag。
+- 若分支已推送但未合并，修复后复用同一发布分支，不重写历史 release note 版本号。
+- 若 tag 创建失败，不创建 GitHub release。
+
+## Cleanup Expectations
+
+- 不在版本提交中带入 `outputs/` 运行产物。
+- phase 结束后只保留受治理文档与版本面改动。

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/releases/README.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/releases/README.md
@@ -10,7 +10,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ### Current Release Surface
 
-- [`v2.3.51.md`](v2.3.51.md): main-chain delivery acceptance / specialist dispatch governance closure / Windows specialist runtime handoff fix
+- [`v2.3.53.md`](v2.3.53.md): governed specialist dispatch and custom admission closure / Windows PowerShell host resolution / managed host install guarantees / cleanup-truth tightening
 
 ### Release Runtime / Proof Handoff
 
@@ -22,6 +22,8 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ## Recent Governed Releases
 
+- [`v2.3.53.md`](v2.3.53.md) - 2026-03-30 - governed specialist dispatch and custom admission closure / Windows PowerShell host resolution / managed host install guarantees / cleanup-truth tightening
+- [`v2.3.52.md`](v2.3.52.md) - 2026-03-29 - stage-aware memory activation / governed memory backend adapters / explicit memory-scope boundaries
 - [`v2.3.51.md`](v2.3.51.md) - 2026-03-28 - main-chain delivery acceptance / specialist dispatch governance closure / Windows specialist runtime handoff fix
 - [`v2.3.50.md`](v2.3.50.md) - 2026-03-26 - router AI connectivity probe / host-adapter expansion / single-entry install surface / Windows PowerShell default verification guidance
 - [`v2.3.49.md`](v2.3.49.md) - 2026-03-23 - shallow-worktree install/check hardening / installed-runtime adapter fallback / parent-path guard convergence

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/releases/v2.3.53.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/releases/v2.3.53.md
@@ -1,0 +1,35 @@
+# VCO Release v2.3.53
+
+- Date: 2026-03-30
+- Commit(base): 4f5676f
+- Previous release: `v2.3.52`
+
+## Highlights
+
+- Closed the governed specialist-dispatch gap with explicit custom-admission handling and restored the missing delegated-lane / host-adapter metadata handoff. Router admission, confirm UI, runtime input packets, delegated lane payloads, and specialist execution now carry the same bounded-dispatch truth instead of relying on weaker implied behavior.
+- Hardened Windows PowerShell host resolution across install, check, and bootstrap surfaces, and tightened managed-host install guarantees across Claude Code, Cursor, Windsurf, OpenClaw, and OpenCode adapter lanes.
+- Tightened cleanup-truth wording and policy so public docs and runtime policy stop overstating what phase cleanup can guarantee, especially around no-false-cleanliness claims.
+
+## What Changed Compared With v2.3.52
+
+- `v2.3.52` pushed governed memory activation into the standard six-stage runtime and made backend memory activity observable.
+- `v2.3.53` shifts the focus back to release-facing reliability and truth alignment: specialist admission, specialist dispatch closure, host install guarantees, and cleanup-safety claims now line up more tightly across router, runtime, install, and adapter surfaces.
+- The important difference is not a new product lane. The difference is that governed execution and host-facing entrypoints now make fewer promises they cannot prove, while carrying stronger explicit proof for the promises they do make.
+
+## Validation Notes
+
+- Runtime / specialist dispatch coverage:
+  - `pytest -q tests/runtime_neutral/test_custom_admission_bridge.py tests/runtime_neutral/test_multi_host_specialist_execution.py`
+- Install / host-resolution coverage:
+  - `pytest -q tests/runtime_neutral/test_installed_runtime_scripts.py`
+- Release-surface and version consistency:
+  - `git diff --check`
+  - `pwsh -NoProfile -File scripts/verify/vibe-version-consistency-gate.ps1`
+  - `pwsh -NoProfile -File scripts/verify/vibe-dist-manifest-gate.ps1`
+  - `pwsh -NoProfile -File scripts/verify/vibe-specialist-dispatch-closure-gate.ps1`
+
+## Migration Notes
+
+- Operators on stock Windows PowerShell hosts should see more reliable install and runtime detection without needing ad-hoc shell overrides in normal supported setups.
+- Specialist-capable governed runs now expose stricter admission and dispatch behavior. Treat those receipts and gates as the source of truth rather than assuming older implicit dispatch behavior still applies.
+- This release improves closure and truth alignment. It does not claim any new broad host-native support tier beyond what the current adapter / distribution documents already state.

--- a/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-30-release-v2.3.53.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/docs/requirements/2026-03-30-release-v2.3.53.md
@@ -1,0 +1,38 @@
+# 发布 v2.3.53 需求
+
+**日期**: 2026-03-30
+**目标**: 基于 GitHub 当前最新 `main`（`4f5676f`）切出新的稳定版本，完成受治理版本面更新、版本说明、tag / GitHub release 发布。
+
+## Intent Contract
+
+- Goal: 发布一个能准确反映 `v2.3.52..main` 真实变更范围的新稳定版本。
+- Deliverable: `v2.3.53` 的仓库版本更新、release notes、changelog / ledger 记录，以及 GitHub tag / release。
+- Constraints:
+  - 必须基于远端最新 `main`，不能基于本地脏工作树。
+  - 不能跳过仓库既有 release governance。
+  - 版本说明必须只陈述已经落在 `main` 上的事实。
+- Acceptance Criteria:
+  - `config/version-governance.json`、`SKILL.md`、`bundled/skills/vibe/SKILL.md` 与 `dist/*/manifest.json` 对齐到 `2.3.53 / 2026-03-30`。
+  - `docs/releases/v2.3.53.md` 完整描述本次变更与验证面。
+  - `references/changelog.md` 与 `references/release-ledger.jsonl` 新增 `v2.3.53` 记录。
+  - GitHub 上出现 `v2.3.53` tag 与 release。
+- Product Acceptance Criteria:
+  - 发布说明清楚覆盖 governed specialist dispatch / custom admission closure、Windows PowerShell host resolution 修复、managed host install guarantees 收紧、cleanup truth wording 收口。
+  - 不把 memory runtime 或未进 `main` 的事项错误归入本次版本。
+- Manual Spot Checks:
+  - 对照 `git log v2.3.52..main` 检查 release highlights。
+  - 对照 `git diff --stat v2.3.52..main` 检查说明未遗漏主要变更面。
+  - 在 GitHub release 页面确认标题、tag 和 notes 对齐。
+- Completion Language Policy:
+  - 只有在本地验证通过且远端 tag / release 已创建后，才允许使用“已发布”表述。
+- Delivery Truth Contract:
+  - 版本说明以仓库 `main` 上的合并结果为准，不把本地临时产物当成发布内容。
+  - 任何未验证或未推送的变更都不能写入完成声明。
+- Non-goals:
+  - 不在本轮引入新的功能开发。
+  - 不重写历史 release notes。
+  - 不改动与本次版本无关的发布流程设计。
+- Autonomy Mode: `interactive_governed`
+- Inferred Assumptions:
+  - 下一稳定版本按 patch 递增为 `v2.3.53`。
+  - 当前 GitHub 认证足以创建分支、PR、tag 和 release。

--- a/bundled/skills/vibe/bundled/skills/vibe/install.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/install.ps1
@@ -6,6 +6,7 @@ param(
   [string]$TargetRoot = '',
   [switch]$InstallExternal,
   [switch]$StrictOffline,
+  [switch]$RequireClosedReady,
   [switch]$AllowExternalSkillFallback,
   [switch]$SkipRuntimeFreshnessGate
 )
@@ -332,6 +333,7 @@ Write-Host "Mode   : $($Adapter.install_mode)"
 Write-Host "Profile: $Profile"
 Write-Host "Target : $TargetRoot"
 Write-Host "StrictOffline: $StrictOffline"
+Write-Host "RequireClosedReady: $RequireClosedReady"
 Write-Host "AllowExternalSkillFallback: $AllowExternalSkillFallback"
 Write-Host "SkipRuntimeFreshnessGate: $SkipRuntimeFreshnessGate"
 $installGovernance = Get-InstallGovernance -RepoRoot $RepoRoot
@@ -345,13 +347,20 @@ $adapterInstallerPath = Join-Path $RepoRoot 'scripts\install\Install-VgoAdapter.
 if (-not (Test-Path -LiteralPath $adapterInstallerPath)) {
   throw "Adapter installer script missing: $adapterInstallerPath"
 }
-$adapterInstallResult = & $adapterInstallerPath -RepoRoot $RepoRoot -TargetRoot $TargetRoot -HostId $HostId -Profile $Profile -AllowExternalSkillFallback:$AllowExternalSkillFallback
+$adapterInstallResult = & $adapterInstallerPath -RepoRoot $RepoRoot -TargetRoot $TargetRoot -HostId $HostId -Profile $Profile -RequireClosedReady:$RequireClosedReady -AllowExternalSkillFallback:$AllowExternalSkillFallback
 $adapterInstallReceipt = $null
 if ($adapterInstallResult) {
   try {
     $adapterInstallReceipt = ($adapterInstallResult | Out-String) | ConvertFrom-Json
   } catch {
     $adapterInstallReceipt = $null
+  }
+}
+if ($RequireClosedReady -and $null -ne $adapterInstallReceipt) {
+  $effective = if ($adapterInstallReceipt.PSObject.Properties.Name -contains 'require_closed_ready_effective') { [bool]$adapterInstallReceipt.require_closed_ready_effective } else { $false }
+  $state = if ($adapterInstallReceipt.PSObject.Properties.Name -contains 'host_closure_state') { [string]$adapterInstallReceipt.host_closure_state } else { '' }
+  if ($effective -and $state -ne 'closed_ready') {
+    throw ("Install receipt is not closed_ready under RequireClosedReady (got '{0}')." -f $state)
   }
 }
 $externalFallbackUsed = New-Object System.Collections.Generic.List[string]
@@ -485,4 +494,19 @@ Invoke-CodexDuplicateSkillQuarantine -TargetRoot $TargetRoot -HostId $HostId
 Invoke-InstalledRuntimeFreshnessGate -RepoRoot $RepoRoot -TargetRoot $TargetRoot -SkipGate:$SkipRuntimeFreshnessGate
 Write-Host ""
 Write-Host "Installation complete." -ForegroundColor Green
-Write-Host "Run: powershell -ExecutionPolicy Bypass -File .\check.ps1 -Profile $Profile -TargetRoot `"$TargetRoot`""
+$checkShellPath = Get-VgoPowerShellCommand
+$checkShellLeaf = [System.IO.Path]::GetFileName($checkShellPath).ToLowerInvariant()
+$checkCommandParts = @($checkShellLeaf, '-NoProfile')
+if ($checkShellLeaf -like 'powershell*') {
+  $checkCommandParts += @('-ExecutionPolicy', 'Bypass')
+}
+$checkCommandParts += @('-File', '.\check.ps1', '-Profile', $Profile, '-TargetRoot', $TargetRoot)
+$checkCommand = ($checkCommandParts | ForEach-Object {
+  $text = [string]$_
+  if ($text -match '\s') {
+    '"' + ($text -replace '"', '\"') + '"'
+  } else {
+    $text
+  }
+}) -join ' '
+Write-Host ("Run: {0}" -f $checkCommand)

--- a/bundled/skills/vibe/bundled/skills/vibe/install.sh
+++ b/bundled/skills/vibe/bundled/skills/vibe/install.sh
@@ -5,6 +5,7 @@ PROFILE="full"
 HOST_ID="codex"
 INSTALL_EXTERNAL="false"
 STRICT_OFFLINE="false"
+REQUIRE_CLOSED_READY="false"
 ALLOW_EXTERNAL_SKILL_FALLBACK="false"
 SKIP_RUNTIME_FRESHNESS_GATE="false"
 TARGET_ROOT=""
@@ -28,6 +29,7 @@ while [[ $# -gt 0 ]]; do
     --target-root) TARGET_ROOT="$2"; shift 2 ;;
     --install-external) INSTALL_EXTERNAL="true"; shift ;;
     --strict-offline) STRICT_OFFLINE="true"; shift ;;
+    --require-closed-ready) REQUIRE_CLOSED_READY="true"; shift ;;
     --allow-external-skill-fallback) ALLOW_EXTERNAL_SKILL_FALLBACK="true"; shift ;;
     --skip-runtime-freshness-gate) SKIP_RUNTIME_FRESHNESS_GATE="true"; shift ;;
     *) echo "Unknown arg: $1"; exit 1 ;;
@@ -348,8 +350,8 @@ else:
     print(value)
 PY
     return $?
-  elif command -v pwsh >/dev/null 2>&1; then
-    pwsh -NoProfile -Command '
+  elif pick_powershell >/dev/null 2>&1; then
+    run_powershell_command '
 param([string]$Path,[string]$Expr)
 $raw = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
 $value = $raw | ConvertFrom-Json
@@ -391,6 +393,53 @@ pick_python() {
     return 0
   fi
   return 1
+}
+
+pick_powershell() {
+  local candidate resolved=""
+  for candidate in pwsh pwsh.exe powershell powershell.exe; do
+    if resolved="$(command -v "${candidate}" 2>/dev/null)"; then
+      if [[ -n "${resolved}" ]]; then
+        printf '%s' "${resolved}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+run_powershell_command() {
+  local command_text="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-Command" "${command_text}")
+  "${cmd[@]}" "$@"
+}
+
+run_powershell_file() {
+  local script_path="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-File" "${script_path}")
+  "${cmd[@]}" "$@"
 }
 
 adapter_query() {
@@ -442,11 +491,11 @@ run_runtime_freshness_gate() {
   if run_runtime_neutral_freshness_gate; then
     :
   elif [[ $? -eq 127 ]]; then
-    if ! command -v pwsh >/dev/null 2>&1; then
-      echo "[WARN] runtime freshness gate skipped: neither Python runtime-neutral gate nor pwsh fallback is available."
+    if ! pick_powershell >/dev/null 2>&1; then
+      echo "[WARN] runtime freshness gate skipped: neither Python runtime-neutral gate nor a PowerShell fallback is available."
       return 0
     fi
-    pwsh -NoProfile -File "${gate_path}" -TargetRoot "${TARGET_ROOT}" -WriteReceipt
+    run_powershell_file "${gate_path}" -TargetRoot "${TARGET_ROOT}" -WriteReceipt
   else
     return 1
   fi
@@ -467,6 +516,40 @@ copy_dir_content() {
   [[ -d "${src}" ]] || return 0
   mkdir -p "${dst}"
   cp -R "${src}/." "${dst}/"
+}
+
+remove_path_entry() {
+  local path="$1"
+  if [[ -L "${path}" || -f "${path}" ]]; then
+    rm -f "${path}"
+    return 0
+  fi
+  if [[ -d "${path}" ]]; then
+    rmdir "${path}"
+  fi
+}
+
+prune_dir_content_individually() {
+  local src="$1"
+  local dst="$2"
+  [[ -d "${src}" && -d "${dst}" ]] || return 0
+
+  local path="" rel="" src_equivalent=""
+  while IFS= read -r -d '' path; do
+    rel="${path#${dst}/}"
+    src_equivalent="${src}/${rel}"
+    if [[ ! -e "${src_equivalent}" ]]; then
+      remove_path_entry "${path}"
+    fi
+  done < <(find "${dst}" -mindepth 1 -depth -print0)
+}
+
+sync_dir_content_individually() {
+  local src="$1"
+  local dst="$2"
+  [[ -d "${src}" ]] || return 0
+  copy_dir_content "${src}" "${dst}"
+  prune_dir_content_individually "${src}" "${dst}"
 }
 
 sync_vibe_canonical_to_target() {
@@ -521,8 +604,7 @@ sync_vibe_canonical_to_target() {
   for rel in "${dirs[@]}"; do
     src="${canonical_root}/${rel}"
     dst="${target_vibe_root}/${rel}"
-    [[ -d "${dst}" ]] && rm -rf "${dst}"
-    copy_dir_content "${src}" "${dst}"
+    sync_dir_content_individually "${src}" "${dst}"
   done
 }
 
@@ -596,6 +678,7 @@ echo "Mode   : ${ADAPTER_INSTALL_MODE}"
 echo "Profile: ${PROFILE}"
 echo "Target : ${TARGET_ROOT}"
 echo "StrictOffline: ${STRICT_OFFLINE}"
+echo "RequireClosedReady: ${REQUIRE_CLOSED_READY}"
 echo "AllowExternalSkillFallback: ${ALLOW_EXTERNAL_SKILL_FALLBACK}"
 echo "SkipRuntimeFreshnessGate: ${SKIP_RUNTIME_FRESHNESS_GATE}"
 
@@ -612,6 +695,7 @@ ADAPTER_INSTALL_JSON="$("${PYTHON_BIN_FOR_ADAPTER}" "${ADAPTER_INSTALLER}" \
   --target-root "${TARGET_ROOT}" \
   --host "${HOST_ID}" \
   --profile "${PROFILE}" \
+  $([[ "${REQUIRE_CLOSED_READY}" == "true" ]] && printf '%s' '--require-closed-ready') \
   $([[ "${ALLOW_EXTERNAL_SKILL_FALLBACK}" == "true" ]] && printf '%s' '--allow-external-skill-fallback'))"
 if [[ -n "${ADAPTER_INSTALL_JSON}" ]]; then
   mapfile -t EXTERNAL_FALLBACK_USED < <(printf '%s\n' "${ADAPTER_INSTALL_JSON}" | "${PYTHON_BIN_FOR_ADAPTER}" -c 'import json,sys; data=json.load(sys.stdin); [print(x) for x in data.get("external_fallback_used", [])]')
@@ -683,12 +767,12 @@ if [[ "${STRICT_OFFLINE}" == "true" ]]; then
     echo "[FAIL] StrictOffline requested, but offline gate script is missing: ${OFFLINE_GATE}"
     exit 1
   fi
-  if ! command -v pwsh >/dev/null 2>&1; then
-    echo "[FAIL] StrictOffline requires pwsh to run offline gate"
+  if ! pick_powershell >/dev/null 2>&1; then
+    echo "[FAIL] StrictOffline requires an available PowerShell host to run the offline gate"
     exit 1
   fi
 
-  pwsh -NoProfile -File "${OFFLINE_GATE}" \
+  run_powershell_file "${OFFLINE_GATE}" \
     -SkillsRoot "${TARGET_ROOT}/skills" \
     -PackManifestPath "${SCRIPT_DIR}/config/pack-manifest.json" \
     -SkillsLockPath "${SCRIPT_DIR}/config/skills-lock.json"

--- a/bundled/skills/vibe/bundled/skills/vibe/references/changelog.md
+++ b/bundled/skills/vibe/bundled/skills/vibe/references/changelog.md
@@ -1,5 +1,13 @@
 # VCO Changelog
 
+## v2.3.53 (2026-03-30)
+
+- Closed governed specialist dispatch with explicit custom-admission handling, and restored delegated-lane payload plus host-adapter metadata continuity across router admission, runtime packets, and specialist execution closure gates.
+- Hardened Windows PowerShell host resolution for install, check, and bootstrap surfaces, and tightened managed-host install guarantees across the current preview / runtime-core adapter lanes.
+- Tightened cleanup-truth wording and policy so public release claims and runtime cleanup semantics stay aligned with what the governed runtime can actually prove.
+- Detailed release notes: `docs/releases/v2.3.53.md`.
+
+
 ## v2.3.52 (2026-03-29)
 
 - Landed stage-aware memory activation inside the standard six-stage `vibe` runtime, including per-run memory activation reports and bounded context injection into governed artifacts.

--- a/bundled/skills/vibe/bundled/skills/vibe/references/release-ledger.jsonl
+++ b/bundled/skills/vibe/bundled/skills/vibe/references/release-ledger.jsonl
@@ -30,3 +30,4 @@
 {"recorded_at":"2026-03-26T20:39:51","version":"2.3.50","updated":"2026-03-26","git_head":"d5da111","actor":null}
 {"recorded_at":"2026-03-28T00:00:00","version":"2.3.51","updated":"2026-03-28","git_head":"18e6b9c","actor":null}
 {"recorded_at":"2026-03-29T10:14:24","version":"2.3.52","updated":"2026-03-29","git_head":"870fd20","actor":null}
+{"recorded_at":"2026-03-30T00:28:44","version":"2.3.53","updated":"2026-03-30","git_head":"4f5676f","actor":null}

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/bootstrap/one-shot-setup.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/bootstrap/one-shot-setup.ps1
@@ -193,7 +193,22 @@ switch ([string]$Adapter.bootstrap_mode) {
 
 Write-Host ''
 Write-Host 'One-shot setup completed.' -ForegroundColor Green
-Write-Host ('- Re-run deep doctor anytime with: pwsh -File "{0}" -Profile {1} -HostId {2} -TargetRoot "{3}" -Deep' -f $checkPath, $Profile, $HostId, $TargetRoot)
+$checkShellPath = Get-VgoPowerShellCommand
+$checkShellLeaf = [System.IO.Path]::GetFileName($checkShellPath).ToLowerInvariant()
+$checkCommandParts = @($checkShellLeaf, '-NoProfile')
+if ($checkShellLeaf -like 'powershell*') {
+    $checkCommandParts += @('-ExecutionPolicy', 'Bypass')
+}
+$checkCommandParts += @('-File', $checkPath, '-Profile', $Profile, '-HostId', $HostId, '-TargetRoot', $TargetRoot, '-Deep')
+$checkCommand = ($checkCommandParts | ForEach-Object {
+    $text = [string]$_
+    if ($text -match '\s') {
+        '"' + ($text -replace '"', '\"') + '"'
+    } else {
+        $text
+    }
+}) -join ' '
+Write-Host ('- Re-run deep doctor anytime with: {0}' -f $checkCommand)
 if ($Adapter.bootstrap_mode -eq 'governed') {
     Write-Host ('- MCP active file: {0}' -f (Join-Path $TargetRoot 'mcp\servers.active.json'))
 }

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/bootstrap/one-shot-setup.sh
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/bootstrap/one-shot-setup.sh
@@ -222,6 +222,36 @@ pick_python() {
   return 1
 }
 
+pick_powershell() {
+  local candidate resolved=""
+  for candidate in pwsh pwsh.exe powershell powershell.exe; do
+    if resolved="$(command -v "${candidate}" 2>/dev/null)"; then
+      if [[ -n "${resolved}" ]]; then
+        printf '%s' "${resolved}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+run_powershell_file() {
+  local script_path="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-File" "${script_path}")
+  "${cmd[@]}" "$@"
+}
+
 adapter_query() {
   local property="$1"
   local python_bin=""
@@ -319,7 +349,7 @@ materialize_mcp_profile_with_python() {
   local python_bin
 
   if ! python_bin="$(pick_python)"; then
-    echo "[FAIL] Python is required to materialize the MCP active profile when pwsh is unavailable." >&2
+    echo "[FAIL] Python is required to materialize the MCP active profile when no PowerShell host is available." >&2
     exit 1
   fi
 
@@ -425,8 +455,8 @@ if [[ "${ADAPTER_BOOTSTRAP_MODE}" == "governed" ]]; then
   fi
   if [[ -n "${resolved_openai_api_key}" ]]; then
     echo "[2/5] Seeding OPENAI settings into target settings.json..."
-    if command -v pwsh >/dev/null 2>&1; then
-      pwsh -NoProfile -File "${PERSIST_OPENAI_PS1}" -CodexRoot "${TARGET_ROOT}" -BaseUrl "${OPENAI_BASE_URL}" -ApiKey "${resolved_openai_api_key}"
+    if pick_powershell >/dev/null 2>&1; then
+      run_powershell_file "${PERSIST_OPENAI_PS1}" -CodexRoot "${TARGET_ROOT}" -BaseUrl "${OPENAI_BASE_URL}" -ApiKey "${resolved_openai_api_key}"
     else
       seed_settings_env_with_python "${TARGET_ROOT}" "openai" "${OPENAI_BASE_URL}" "${resolved_openai_api_key}"
     fi
@@ -439,8 +469,8 @@ if [[ "${ADAPTER_BOOTSTRAP_MODE}" == "governed" ]]; then
   echo "[3/5] Built-in AI governance now supports only OpenAI-compatible provider wiring; no secondary provider seeding is performed."
 
   echo "[4/5] Materializing MCP profile..."
-  if command -v pwsh >/dev/null 2>&1; then
-    pwsh -NoProfile -File "${MATERIALIZE_PS1}" -TargetRoot "${TARGET_ROOT}" -Force >/dev/null
+  if pick_powershell >/dev/null 2>&1; then
+    run_powershell_file "${MATERIALIZE_PS1}" -TargetRoot "${TARGET_ROOT}" -Force >/dev/null
   else
     materialize_mcp_profile_with_python "${REPO_ROOT}" "${TARGET_ROOT}" "${PROFILE}"
   fi
@@ -473,10 +503,10 @@ if [[ "${ADAPTER_BOOTSTRAP_MODE}" == "governed" ]]; then
   echo "- MCP active file: ${TARGET_ROOT}/mcp/servers.active.json"
 fi
 echo "- Doctor artifacts: ${REPO_ROOT}/outputs/verify"
-if ! command -v pwsh >/dev/null 2>&1; then
+if ! pick_powershell >/dev/null 2>&1; then
   if ! command -v python3 >/dev/null 2>&1 && ! command -v python >/dev/null 2>&1; then
-    echo "[WARN] Neither pwsh nor Python is available. Deep authoritative doctor coverage remains unavailable in this shell environment."
+    echo "[WARN] Neither a PowerShell host nor Python is available. Deep authoritative doctor coverage remains unavailable in this shell environment."
   else
-    echo "[INFO] pwsh is not installed, but the shell runtime-neutral verification path was used where supported."
+    echo "[INFO] No PowerShell host was found, but the shell runtime-neutral verification path was used where supported."
   fi
 fi

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/install/Install-VgoAdapter.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/install/Install-VgoAdapter.ps1
@@ -3,6 +3,7 @@ param(
     [Parameter(Mandatory)] [string]$TargetRoot,
     [Parameter(Mandatory)] [string]$HostId,
     [ValidateSet('minimal', 'full')] [string]$Profile = 'full',
+    [switch]$RequireClosedReady,
     [switch]$AllowExternalSkillFallback
 )
 
@@ -11,6 +12,43 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $RepoRoot 'scripts\common\vibe-governance-helpers.ps1')
 . (Join-Path $RepoRoot 'scripts\common\Resolve-VgoAdapter.ps1')
+
+function Get-VgoPreferredPythonCommand {
+    foreach ($candidate in @('python', 'python3', 'py')) {
+        $command = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($null -ne $command) {
+            return [string]$command.Source
+        }
+    }
+    return $null
+}
+
+$pythonInstaller = Join-Path $RepoRoot 'scripts\install\install_vgo_adapter.py'
+$pythonCommand = Get-VgoPreferredPythonCommand
+if ((Test-Path -LiteralPath $pythonInstaller) -and -not [string]::IsNullOrWhiteSpace($pythonCommand)) {
+    $cmd = @($pythonCommand)
+    if ([System.IO.Path]::GetFileName($pythonCommand).ToLowerInvariant() -eq 'py') {
+        $cmd += '-3'
+    }
+    $cmd += @(
+        $pythonInstaller,
+        '--repo-root', $RepoRoot,
+        '--target-root', $TargetRoot,
+        '--host', $HostId,
+        '--profile', $Profile
+    )
+    if ($RequireClosedReady) {
+        $cmd += '--require-closed-ready'
+    }
+    if ($AllowExternalSkillFallback) {
+        $cmd += '--allow-external-skill-fallback'
+    }
+    & $cmd[0] @($cmd[1..($cmd.Count - 1)])
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Python adapter installer failed with exit code {0}." -f $LASTEXITCODE)
+    }
+    return
+}
 
 function Copy-DirContent {
     param(
@@ -38,6 +76,303 @@ function Restore-SkillEntryPointIfNeeded {
     }
 
     Move-Item -LiteralPath $mirrorPath -Destination $skillMd -Force
+}
+
+function Get-VgoPlatformTag {
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+        return 'windows'
+    }
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::OSX)) {
+        return 'macos'
+    }
+    return 'linux'
+}
+
+function Merge-JsonObject {
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [Parameter(Mandatory)] [hashtable]$Patch
+    )
+
+    $existing = @{}
+    if (Test-Path -LiteralPath $Path) {
+        try {
+            $parsed = Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json -AsHashtable
+            if ($null -ne $parsed) {
+                $existing = $parsed
+            }
+        } catch {
+            $existing = @{}
+        }
+    }
+
+    $merged = @{}
+    foreach ($key in $existing.Keys) {
+        $merged[$key] = $existing[$key]
+    }
+    foreach ($key in $Patch.Keys) {
+        $value = $Patch[$key]
+        if ($merged.ContainsKey($key) -and $merged[$key] -is [hashtable] -and $value -is [hashtable]) {
+            $next = @{}
+            foreach ($nestedKey in $merged[$key].Keys) {
+                $next[$nestedKey] = $merged[$key][$nestedKey]
+            }
+            foreach ($nestedKey in $value.Keys) {
+                $next[$nestedKey] = $value[$nestedKey]
+            }
+            $merged[$key] = $next
+        } else {
+            $merged[$key] = $value
+        }
+    }
+
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Path) | Out-Null
+    $merged | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Path -Encoding UTF8
+}
+
+function Get-VgoHostBridgeCommandEnvName {
+    param([string]$HostId)
+
+    switch ([string]$HostId) {
+        'claude-code' { return 'VGO_CLAUDE_CODE_SPECIALIST_BRIDGE_COMMAND' }
+        'cursor' { return 'VGO_CURSOR_SPECIALIST_BRIDGE_COMMAND' }
+        'windsurf' { return 'VGO_WINDSURF_SPECIALIST_BRIDGE_COMMAND' }
+        'openclaw' { return 'VGO_OPENCLAW_SPECIALIST_BRIDGE_COMMAND' }
+        'opencode' { return 'VGO_OPENCODE_SPECIALIST_BRIDGE_COMMAND' }
+        default { return $null }
+    }
+}
+
+function Resolve-VgoHostBridgeCommand {
+    param([string]$HostId)
+
+    $envName = Get-VgoHostBridgeCommandEnvName -HostId $HostId
+    if (-not [string]::IsNullOrWhiteSpace($envName)) {
+        $envValue = [Environment]::GetEnvironmentVariable($envName)
+        if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+            $command = Get-Command $envValue -ErrorAction SilentlyContinue
+            if ($null -ne $command) {
+                return [pscustomobject]@{
+                    command = [string]$command.Source
+                    source = "env:$envName"
+                    env_name = $envName
+                }
+            }
+            if (Test-Path -LiteralPath $envValue) {
+                return [pscustomobject]@{
+                    command = [System.IO.Path]::GetFullPath($envValue)
+                    source = "env:$envName"
+                    env_name = $envName
+                }
+            }
+        }
+    }
+
+    $candidates = switch ([string]$HostId) {
+        'claude-code' { @('claude', 'claude-code') }
+        'cursor' { @('cursor-agent', 'cursor') }
+        'windsurf' { @('windsurf', 'codeium') }
+        'openclaw' { @('openclaw') }
+        'opencode' { @('opencode') }
+        default { @() }
+    }
+    foreach ($candidate in $candidates) {
+        $command = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($null -ne $command) {
+            return [pscustomobject]@{
+                command = [string]$command.Source
+                source = "path:$candidate"
+                env_name = $envName
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        command = $null
+        source = $null
+        env_name = $envName
+    }
+}
+
+function New-VgoHostSpecialistWrapper {
+    param(
+        [Parameter(Mandatory)] [string]$TargetRoot,
+        [Parameter(Mandatory)] [string]$HostId,
+        [string]$BridgeCommand,
+        [string]$BridgeEnvName
+    )
+
+    $toolsRoot = Join-Path $TargetRoot '.vibeskills\bin'
+    New-Item -ItemType Directory -Force -Path $toolsRoot | Out-Null
+
+    $wrapperPy = Join-Path $toolsRoot ("{0}-specialist-wrapper.py" -f $HostId)
+    $embeddedCommand = if ([string]::IsNullOrWhiteSpace($BridgeCommand)) { '' } else { $BridgeCommand }
+    $pythonScript = @"
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+
+HOST_ID = $(ConvertTo-Json $HostId -Compress)
+TARGET_COMMAND = $(ConvertTo-Json $embeddedCommand -Compress)
+BRIDGE_ENV_NAME = $(ConvertTo-Json $BridgeEnvName -Compress)
+
+def main() -> int:
+    command = TARGET_COMMAND or os.environ.get(BRIDGE_ENV_NAME or "", "").strip()
+    if not command:
+        sys.stderr.write(f"host specialist bridge command unavailable for {HOST_ID}\n")
+        return 3
+    return subprocess.run([command, *sys.argv[1:]], check=False).returncode
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+"@
+    Set-Content -LiteralPath $wrapperPy -Value $pythonScript -Encoding UTF8
+
+    $platformTag = Get-VgoPlatformTag
+    if ($platformTag -eq 'windows') {
+        $launcherPath = Join-Path $toolsRoot ("{0}-specialist-wrapper.cmd" -f $HostId)
+        $cmdScript = @"
+@echo off
+setlocal
+set SCRIPT_DIR=%~dp0
+if exist "%LocalAppData%\Programs\Python\Python311\python.exe" (
+  set PY_CMD=%LocalAppData%\Programs\Python\Python311\python.exe
+) else if exist "%ProgramFiles%\Python311\python.exe" (
+  set PY_CMD=%ProgramFiles%\Python311\python.exe
+) else (
+  set PY_CMD=py -3
+)
+%PY_CMD% "%SCRIPT_DIR%$(Split-Path -Leaf $wrapperPy)" %*
+"@
+        Set-Content -LiteralPath $launcherPath -Value $cmdScript -Encoding ASCII
+    } else {
+        $launcherPath = Join-Path $toolsRoot ("{0}-specialist-wrapper.sh" -f $HostId)
+        $shScript = @"
+#!/usr/bin/env sh
+set -eu
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN=python3
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN=python
+else
+  echo 'python runtime unavailable for host specialist wrapper' >&2
+  exit 127
+fi
+exec "$PYTHON_BIN" "$SCRIPT_DIR/$(Split-Path -Leaf $wrapperPy)" "$@"
+"@
+        Set-Content -LiteralPath $launcherPath -Value $shScript -Encoding UTF8
+        try {
+            chmod +x $launcherPath
+            chmod +x $wrapperPy
+        } catch {
+        }
+    }
+
+    return [pscustomobject]@{
+        platform = $platformTag
+        launcher_path = [System.IO.Path]::GetFullPath($launcherPath)
+        script_path = [System.IO.Path]::GetFullPath($wrapperPy)
+        ready = -not [string]::IsNullOrWhiteSpace($BridgeCommand)
+        bridge_command = $BridgeCommand
+    }
+}
+
+function Set-VgoManagedHostSettings {
+    param(
+        [Parameter(Mandatory)] [string]$TargetRoot,
+        [Parameter(Mandatory)] [string]$HostId,
+        [Parameter(Mandatory)] [pscustomobject]$WrapperInfo
+    )
+
+    $materialized = New-Object System.Collections.Generic.List[string]
+    if ($HostId -in @('cursor', 'claude-code')) {
+        $settingsPath = Join-Path $TargetRoot 'settings.json'
+        Merge-JsonObject -Path $settingsPath -Patch @{
+            vibeskills = @{
+                host_id = $HostId
+                managed = $true
+                commands_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'commands'))
+                specialist_wrapper = [string]$WrapperInfo.launcher_path
+            }
+        }
+        $materialized.Add([System.IO.Path]::GetFullPath($settingsPath)) | Out-Null
+    } elseif ($HostId -eq 'opencode') {
+        $settingsPath = Join-Path $TargetRoot 'opencode.json'
+        Merge-JsonObject -Path $settingsPath -Patch @{
+            vibeskills = @{
+                host_id = $HostId
+                managed = $true
+                commands_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'commands'))
+                command_root_compat = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'command'))
+                agents_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'agents'))
+                agent_root_compat = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'agent'))
+                specialist_wrapper = [string]$WrapperInfo.launcher_path
+            }
+        }
+        $materialized.Add([System.IO.Path]::GetFullPath($settingsPath)) | Out-Null
+    } elseif ($HostId -in @('openclaw', 'windsurf')) {
+        $settingsPath = Join-Path $TargetRoot '.vibeskills\host-settings.json'
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $settingsPath) | Out-Null
+        @{
+            host_id = $HostId
+            managed = $true
+            commands_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'commands'))
+            workflow_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'global_workflows'))
+            mcp_config = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'mcp_config.json'))
+            specialist_wrapper = [string]$WrapperInfo.launcher_path
+        } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $settingsPath -Encoding UTF8
+        $materialized.Add([System.IO.Path]::GetFullPath($settingsPath)) | Out-Null
+    }
+
+    return @($materialized)
+}
+
+function Test-VgoClosedReadyRequiredForAdapter {
+    param([psobject]$Adapter)
+
+    return ([string]$Adapter.install_mode).ToLowerInvariant() -ne 'governed'
+}
+
+function Write-VgoHostClosure {
+    param(
+        [Parameter(Mandatory)] [string]$TargetRoot,
+        [Parameter(Mandatory)] [psobject]$Adapter
+    )
+
+    $bridgeResolution = Resolve-VgoHostBridgeCommand -HostId ([string]$Adapter.id)
+    $wrapperInfo = New-VgoHostSpecialistWrapper -TargetRoot $TargetRoot -HostId ([string]$Adapter.id) -BridgeCommand ([string]$bridgeResolution.command) -BridgeEnvName ([string]$bridgeResolution.env_name)
+    $settingsMaterialized = Set-VgoManagedHostSettings -TargetRoot $TargetRoot -HostId ([string]$Adapter.id) -WrapperInfo $wrapperInfo
+    $commandsRoot = Join-Path $TargetRoot 'commands'
+    $closureState = if ($wrapperInfo.ready) { 'closed_ready' } else { 'configured_offline_unready' }
+    $closure = [ordered]@{
+        schema_version = 1
+        host_id = [string]$Adapter.id
+        platform = Get-VgoPlatformTag
+        target_root = [System.IO.Path]::GetFullPath($TargetRoot)
+        install_mode = [string]$Adapter.install_mode
+        commands_root = [System.IO.Path]::GetFullPath($commandsRoot)
+        global_workflows_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'global_workflows'))
+        mcp_config_path = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'mcp_config.json'))
+        host_closure_state = $closureState
+        commands_materialized = (Test-Path -LiteralPath $commandsRoot -PathType Container)
+        settings_materialized = @($settingsMaterialized)
+        specialist_wrapper = [ordered]@{
+            launcher_path = [string]$wrapperInfo.launcher_path
+            script_path = [string]$wrapperInfo.script_path
+            ready = [bool]$wrapperInfo.ready
+            bridge_command = [string]$bridgeResolution.command
+            bridge_source = [string]$bridgeResolution.source
+        }
+    }
+    $closurePath = Join-Path $TargetRoot '.vibeskills\host-closure.json'
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $closurePath) | Out-Null
+    $closure | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $closurePath -Encoding UTF8
+    return [pscustomobject]@{
+        path = [System.IO.Path]::GetFullPath($closurePath)
+        data = [pscustomobject]$closure
+    }
 }
 
 function Ensure-SkillPresent {
@@ -273,9 +608,21 @@ switch ([string]$adapter.install_mode) {
     default { throw "Unsupported adapter install mode: $($adapter.install_mode)" }
 }
 
+$closureReceipt = Write-VgoHostClosure -TargetRoot $TargetRoot -Adapter $adapter
+$requireClosedReadyEffective = [bool]($RequireClosedReady -and (Test-VgoClosedReadyRequiredForAdapter -Adapter $adapter))
+if ($requireClosedReadyEffective -and [string]$closureReceipt.data.host_closure_state -ne 'closed_ready') {
+    throw ("Host closure for '{0}' is not closed_ready (got '{1}'). Configure the host specialist bridge command first, then retry install." -f [string]$adapter.id, [string]$closureReceipt.data.host_closure_state)
+}
+
 [pscustomobject]@{
     host_id = [string]$adapter.id
     install_mode = [string]$adapter.install_mode
     target_root = [System.IO.Path]::GetFullPath($TargetRoot)
     external_fallback_used = @($result.external_fallback_used)
+    host_closure_path = [string]$closureReceipt.path
+    host_closure_state = [string]$closureReceipt.data.host_closure_state
+    settings_materialized = @($closureReceipt.data.settings_materialized)
+    specialist_wrapper_ready = [bool]$closureReceipt.data.specialist_wrapper.ready
+    require_closed_ready_requested = [bool]$RequireClosedReady
+    require_closed_ready_effective = $requireClosedReadyEffective
 } | ConvertTo-Json -Depth 10

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/install/install_vgo_adapter.py
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/install/install_vgo_adapter.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
+import stat
 import shutil
 import tempfile
 from pathlib import Path
@@ -26,6 +28,32 @@ OPTIONAL_WORKFLOW = [
     "receiving-code-review",
     "verification-before-completion",
 ]
+HOST_BRIDGE_COMMAND_CANDIDATES = {
+    "claude-code": ["claude", "claude-code"],
+    "cursor": ["cursor-agent", "cursor"],
+    "windsurf": ["windsurf", "codeium"],
+    "openclaw": ["openclaw"],
+    "opencode": ["opencode"],
+}
+HOST_BRIDGE_COMMAND_ENV = {
+    "claude-code": "VGO_CLAUDE_CODE_SPECIALIST_BRIDGE_COMMAND",
+    "cursor": "VGO_CURSOR_SPECIALIST_BRIDGE_COMMAND",
+    "windsurf": "VGO_WINDSURF_SPECIALIST_BRIDGE_COMMAND",
+    "openclaw": "VGO_OPENCLAW_SPECIALIST_BRIDGE_COMMAND",
+    "opencode": "VGO_OPENCODE_SPECIALIST_BRIDGE_COMMAND",
+}
+
+
+def detect_platform_tag() -> str:
+    if os.name == "nt":
+        return "windows"
+    if sys_platform().startswith("darwin"):
+        return "macos"
+    return "linux"
+
+
+def sys_platform() -> str:
+    return os.sys.platform.lower()
 
 
 def load_json(path: Path):
@@ -35,6 +63,11 @@ def load_json(path: Path):
 
 def write_json(data):
     print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def write_json_file(path: Path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def is_relative_to(path: Path, base: Path) -> bool:
@@ -96,6 +129,11 @@ def copy_file(src: Path, dst: Path):
         return
     dst.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dst)
+
+
+def ensure_executable(path: Path):
+    current = path.stat().st_mode
+    path.chmod(current | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def restore_skill_entrypoint_if_needed(skill_root: Path):
@@ -228,6 +266,238 @@ def resolve_adapter(repo_root: Path, host_id: str):
         if entry.get("id") == normalized:
             return entry
     raise SystemExit(f"Unsupported VGO host id: {host_id}")
+
+
+def resolve_target_root_for_adapter(adapter: dict, explicit_target_root: Path | None = None) -> Path:
+    if explicit_target_root is not None:
+        return explicit_target_root.resolve()
+
+    target_spec = adapter.get("default_target_root") or {}
+    env_name = target_spec.get("env") or ""
+    rel = target_spec.get("rel") or ""
+    env_value = os.environ.get(env_name, "").strip() if env_name else ""
+    if env_value:
+        return Path(env_value).expanduser().resolve()
+    if not rel:
+        raise SystemExit(f"Adapter '{adapter.get('id')}' does not define default_target_root.rel")
+    rel_path = Path(rel)
+    if rel_path.is_absolute():
+        return rel_path.resolve()
+    return (Path.home() / rel_path).expanduser().resolve()
+
+
+def load_specialist_policy(repo_root: Path):
+    return load_json(repo_root / "config" / "native-specialist-execution-policy.json")
+
+
+def resolve_specialist_policy_entry(repo_root: Path, host_id: str):
+    policy = load_specialist_policy(repo_root)
+    for entry in policy.get("adapters", []):
+        if entry.get("id") == host_id:
+            return entry
+    return None
+
+
+def resolve_bridge_command(host_id: str) -> tuple[str | None, str | None]:
+    env_name = HOST_BRIDGE_COMMAND_ENV.get(host_id)
+    if env_name:
+        env_value = os.environ.get(env_name, "").strip()
+        if env_value:
+            candidate = shutil.which(env_value)
+            if candidate:
+                return candidate, f"env:{env_name}"
+            path_candidate = Path(env_value).expanduser()
+            if path_candidate.exists():
+                return str(path_candidate.resolve()), f"env:{env_name}"
+
+    for candidate_name in HOST_BRIDGE_COMMAND_CANDIDATES.get(host_id, []):
+        resolved = shutil.which(candidate_name)
+        if resolved:
+            return resolved, f"path:{candidate_name}"
+
+    return None, None
+
+
+def materialize_host_specialist_wrapper(target_root: Path, host_id: str, bridge_command: str | None):
+    tools_root = target_root / ".vibeskills" / "bin"
+    tools_root.mkdir(parents=True, exist_ok=True)
+
+    wrapper_py = tools_root / f"{host_id}-specialist-wrapper.py"
+    embedded_command = json.dumps(bridge_command or "")
+    bridge_env_name = f"VGO_{host_id.upper().replace('-', '_')}_SPECIALIST_BRIDGE_COMMAND"
+    wrapper_py.write_text(
+        (
+            "#!/usr/bin/env python3\n"
+            "import os\n"
+            "import subprocess\n"
+            "import sys\n\n"
+            f"HOST_ID = {json.dumps(host_id)}\n"
+            f"TARGET_COMMAND = {embedded_command}\n\n"
+            "def main() -> int:\n"
+            f"    command = TARGET_COMMAND or os.environ.get({json.dumps(bridge_env_name)}, '').strip()\n"
+            "    if not command:\n"
+            "        sys.stderr.write(f'host specialist bridge command unavailable for {HOST_ID}\\n')\n"
+            "        return 3\n"
+            "    return subprocess.run([command, *sys.argv[1:]], check=False).returncode\n\n"
+            "if __name__ == '__main__':\n"
+            "    raise SystemExit(main())\n"
+        ),
+        encoding="utf-8",
+    )
+    ensure_executable(wrapper_py)
+
+    platform_tag = detect_platform_tag()
+    if platform_tag == "windows":
+        launcher = tools_root / f"{host_id}-specialist-wrapper.cmd"
+        launcher.write_text(
+            (
+                "@echo off\r\n"
+                "setlocal\r\n"
+                "set SCRIPT_DIR=%~dp0\r\n"
+                "if exist \"%LocalAppData%\\Programs\\Python\\Python311\\python.exe\" (\r\n"
+                "  set PY_CMD=%LocalAppData%\\Programs\\Python\\Python311\\python.exe\r\n"
+                ") else if exist \"%ProgramFiles%\\Python311\\python.exe\" (\r\n"
+                "  set PY_CMD=%ProgramFiles%\\Python311\\python.exe\r\n"
+                ") else (\r\n"
+                "  set PY_CMD=py -3\r\n"
+                ")\r\n"
+                "%PY_CMD% \"%SCRIPT_DIR%\\" + wrapper_py.name + "\" %*\r\n"
+            ),
+            encoding="utf-8",
+        )
+    else:
+        launcher = tools_root / f"{host_id}-specialist-wrapper.sh"
+        launcher.write_text(
+            (
+                "#!/usr/bin/env sh\n"
+                "set -eu\n"
+                "SCRIPT_DIR=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\n"
+                "if command -v python3 >/dev/null 2>&1; then\n"
+                "  PYTHON_BIN=python3\n"
+                "elif command -v python >/dev/null 2>&1; then\n"
+                "  PYTHON_BIN=python\n"
+                "else\n"
+                "  echo 'python runtime unavailable for host specialist wrapper' >&2\n"
+                "  exit 127\n"
+                "fi\n"
+                f"exec \"$PYTHON_BIN\" \"$SCRIPT_DIR/{wrapper_py.name}\" \"$@\"\n"
+            ),
+            encoding="utf-8",
+        )
+        ensure_executable(launcher)
+
+    return {
+        "platform": platform_tag,
+        "launcher_path": str(launcher.resolve()),
+        "script_path": str(wrapper_py.resolve()),
+        "ready": bool(bridge_command),
+        "bridge_command": bridge_command,
+    }
+
+
+def merge_json_object(path: Path, patch: dict):
+    existing = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            existing = {}
+    merged = dict(existing)
+    for key, value in patch.items():
+        if isinstance(value, dict) and isinstance(existing.get(key), dict):
+            next_value = dict(existing[key])
+            next_value.update(value)
+            merged[key] = next_value
+        else:
+            merged[key] = value
+    write_json_file(path, merged)
+
+
+def materialize_host_settings(target_root: Path, adapter: dict, wrapper_info: dict):
+    host_id = adapter["id"]
+    materialized = []
+    if host_id in {"cursor", "claude-code"}:
+        settings_path = target_root / "settings.json"
+        merge_json_object(
+            settings_path,
+            {
+                "vibeskills": {
+                    "host_id": host_id,
+                    "managed": True,
+                    "commands_root": str((target_root / "commands").resolve()),
+                    "specialist_wrapper": wrapper_info["launcher_path"],
+                }
+            },
+        )
+        materialized.append(str(settings_path.resolve()))
+    elif host_id == "opencode":
+        settings_path = target_root / "opencode.json"
+        merge_json_object(
+            settings_path,
+            {
+                "vibeskills": {
+                    "host_id": host_id,
+                    "managed": True,
+                    "commands_root": str((target_root / "commands").resolve()),
+                    "command_root_compat": str((target_root / "command").resolve()),
+                    "agents_root": str((target_root / "agents").resolve()),
+                    "agent_root_compat": str((target_root / "agent").resolve()),
+                    "specialist_wrapper": wrapper_info["launcher_path"],
+                }
+            },
+        )
+        materialized.append(str(settings_path.resolve()))
+    elif host_id in {"openclaw", "windsurf"}:
+        settings_path = target_root / ".vibeskills" / "host-settings.json"
+        write_json_file(
+            settings_path,
+            {
+                "host_id": host_id,
+                "managed": True,
+                "commands_root": str((target_root / "commands").resolve()),
+                "workflow_root": str((target_root / "global_workflows").resolve()),
+                "mcp_config": str((target_root / "mcp_config.json").resolve()),
+                "specialist_wrapper": wrapper_info["launcher_path"],
+            },
+        )
+        materialized.append(str(settings_path.resolve()))
+    return materialized
+
+
+def materialize_host_closure(repo_root: Path, target_root: Path, adapter: dict):
+    host_id = adapter["id"]
+    bridge_command, bridge_source = resolve_bridge_command(host_id)
+    wrapper_info = materialize_host_specialist_wrapper(target_root, host_id, bridge_command)
+    settings_materialized = materialize_host_settings(target_root, adapter, wrapper_info)
+    commands_root = target_root / "commands"
+    closure_state = "closed_ready" if wrapper_info["ready"] else "configured_offline_unready"
+    closure = {
+        "schema_version": 1,
+        "host_id": host_id,
+        "platform": detect_platform_tag(),
+        "target_root": str(target_root.resolve()),
+        "install_mode": adapter["install_mode"],
+        "commands_root": str(commands_root.resolve()),
+        "global_workflows_root": str((target_root / "global_workflows").resolve()),
+        "mcp_config_path": str((target_root / "mcp_config.json").resolve()),
+        "host_closure_state": closure_state,
+        "commands_materialized": commands_root.exists(),
+        "settings_materialized": settings_materialized,
+        "specialist_wrapper": {
+            "launcher_path": wrapper_info["launcher_path"],
+            "script_path": wrapper_info["script_path"],
+            "ready": wrapper_info["ready"],
+            "bridge_command": bridge_command,
+            "bridge_source": bridge_source,
+        },
+    }
+    closure_path = target_root / ".vibeskills" / "host-closure.json"
+    write_json_file(closure_path, closure)
+    return closure_path, closure
+
+
+def is_closed_ready_required(adapter: dict) -> bool:
+    return (adapter.get("install_mode") or "").strip().lower() != "governed"
 
 
 def sync_vibe_canonical(repo_root: Path, target_root: Path, target_rel: str):
@@ -379,6 +649,7 @@ def main():
     parser.add_argument("--host", required=True)
     parser.add_argument("--profile", choices=("minimal", "full"), default="full")
     parser.add_argument("--allow-external-skill-fallback", action="store_true")
+    parser.add_argument("--require-closed-ready", action="store_true")
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root).resolve()
@@ -401,12 +672,28 @@ def main():
     else:
         raise SystemExit(f"Unsupported adapter install mode: {mode}")
 
+    closure_path, closure = materialize_host_closure(repo_root, target_root, adapter)
+    require_closed_ready_effective = bool(args.require_closed_ready and is_closed_ready_required(adapter))
+    if require_closed_ready_effective and closure["host_closure_state"] != "closed_ready":
+        raise SystemExit(
+            "Host closure for "
+            f"'{adapter['id']}' is not closed_ready "
+            f"(got '{closure['host_closure_state']}'). "
+            "Configure the host specialist bridge command first, then retry install."
+        )
+
     write_json(
         {
             "host_id": adapter["id"],
             "install_mode": mode,
             "target_root": str(target_root),
             "external_fallback_used": external_used,
+            "host_closure_path": str(closure_path),
+            "host_closure_state": closure["host_closure_state"],
+            "settings_materialized": closure["settings_materialized"],
+            "specialist_wrapper_ready": bool(closure["specialist_wrapper"]["ready"]),
+            "require_closed_ready_requested": bool(args.require_closed_ready),
+            "require_closed_ready_effective": require_closed_ready_effective,
         }
     )
 

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Freeze-RuntimeInputPacket.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Freeze-RuntimeInputPacket.ps1
@@ -547,6 +547,16 @@ $packet = [pscustomobject]@{
         unattended = [bool]$unattended
         route_script_path = $routerScriptPath
     }
+    host_adapter = [pscustomobject]@{
+        requested_host_id = if ($runtime.host_adapter -and -not [string]::IsNullOrWhiteSpace([string]$runtime.host_adapter.requested_id)) { [string]$runtime.host_adapter.requested_id } else { $routerHostId }
+        effective_host_id = if ($runtime.host_adapter -and -not [string]::IsNullOrWhiteSpace([string]$runtime.host_adapter.id)) { [string]$runtime.host_adapter.id } else { $routerHostId }
+        status = if ($runtime.host_adapter -and $runtime.host_adapter.PSObject.Properties.Name -contains 'status') { [string]$runtime.host_adapter.status } else { $null }
+        install_mode = if ($runtime.host_adapter -and $runtime.host_adapter.PSObject.Properties.Name -contains 'install_mode') { [string]$runtime.host_adapter.install_mode } else { $null }
+        check_mode = if ($runtime.host_adapter -and $runtime.host_adapter.PSObject.Properties.Name -contains 'check_mode') { [string]$runtime.host_adapter.check_mode } else { $null }
+        bootstrap_mode = if ($runtime.host_adapter -and $runtime.host_adapter.PSObject.Properties.Name -contains 'bootstrap_mode') { [string]$runtime.host_adapter.bootstrap_mode } else { $null }
+        target_root = $routerTargetRoot
+        closure_path = if ($runtime.host_closure) { [string]$runtime.host_closure.path } else { $null }
+    }
     route_snapshot = [pscustomobject]@{
         selected_pack = if ($routeResult.selected) { [string]$routeResult.selected.pack_id } else { $null }
         selected_skill = $routerSelectedSkill

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Invoke-DelegatedLaneUnit.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Invoke-DelegatedLaneUnit.ps1
@@ -147,6 +147,10 @@ switch ($laneKind) {
 
 Write-VibeJsonArtifact -Path $receiptPath -Value $receipt
 $payload = [pscustomobject]@{
+    lane_id = [string]$laneSpec.lane_id
+    lane_kind = $laneKind
+    status = if ($receipt) { [string]$receipt.status } else { '' }
+    payload_written = $true
     lane_receipt_path = $receiptPath
     lane_notes_path = $notesPath
     lane_result_path = $resultPath
@@ -154,9 +158,4 @@ $payload = [pscustomobject]@{
 }
 Write-VibeJsonArtifact -Path $payloadPath -Value $payload
 
-[pscustomobject]@{
-    lane_id = [string]$laneSpec.lane_id
-    lane_kind = $laneKind
-    status = if ($receipt) { [string]$receipt.status } else { '' }
-    payload_written = $true
-} | ConvertTo-Json -Depth 20 -Compress
+$payload | ConvertTo-Json -Depth 20 -Compress

--- a/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/bundled/skills/vibe/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
@@ -5,6 +5,7 @@ param(
     [string]$RequirementDocPath = '',
     [string]$ExecutionPlanPath = '',
     [string]$RuntimeInputPacketPath = '',
+    [string]$ExecutionMemoryContextPath = '',
     [string]$ArtifactRoot = '',
     [AllowEmptyString()] [string]$GovernanceScope = '',
     [AllowEmptyString()] [string]$RootRunId = '',
@@ -137,6 +138,13 @@ function Wait-VibeDelegatedLaneProcess {
     }
 
     $payload = $payloadText | ConvertFrom-Json
+    if (-not ($payload.PSObject.Properties.Name -contains 'lane_receipt_path')) {
+        $payloadPath = Join-Path ([string]($Handle.lane_root)) 'lane-payload.json'
+        if (-not (Test-Path -LiteralPath $payloadPath)) {
+            throw ("Delegated lane payload missing lane_receipt_path and no lane-payload.json exists for {0}" -f ([string]($Handle.lane_id)))
+        }
+        $payload = Get-Content -LiteralPath $payloadPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    }
     $laneReceipt = Get-Content -LiteralPath ([string]($payload.lane_receipt_path)) -Raw -Encoding UTF8 | ConvertFrom-Json
     $laneResult = if ($payload.lane_result_path -and (Test-Path -LiteralPath ([string]($payload.lane_result_path)))) {
         Get-Content -LiteralPath ([string]($payload.lane_result_path)) -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -1096,6 +1104,7 @@ $executionManifest = [pscustomobject]@{
     execution_plan_path = $planPath
     execution_topology_path = $executionTopologyPath
     runtime_input_packet_path = $runtimeInputPath
+    execution_memory_context_path = if ([string]::IsNullOrWhiteSpace($ExecutionMemoryContextPath)) { $null } else { $ExecutionMemoryContextPath }
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     planned_wave_count = @($profile.waves).Count
     planned_unit_count = $plannedUnitCount
@@ -1124,6 +1133,8 @@ $executionManifest = [pscustomobject]@{
         runtime_selected_skill = if ($runtimeInputPacket) { [string]$runtimeInputPacket.authority_flags.explicit_runtime_skill } else { 'vibe' }
         skill_mismatch = if ($runtimeInputPacket) { [bool]$runtimeInputPacket.divergence_shadow.skill_mismatch } else { $false }
         confirm_required = if ($runtimeInputPacket) { [bool]$runtimeInputPacket.route_snapshot.confirm_required } else { $false }
+        requested_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'host_adapter' -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.requested_host_id } else { $null }
+        effective_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'host_adapter' -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.effective_host_id } else { $null }
     }
     execution_topology = [pscustomobject]@{
         path = $executionTopologyPath
@@ -1177,6 +1188,8 @@ $executionManifest = [pscustomobject]@{
         approved_dispatch = @($approvedDispatch)
         auto_approved_dispatch_count = @($autoApprovedDispatch).Count
         auto_approved_dispatch = @($autoApprovedDispatch)
+        requested_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'host_adapter' -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.requested_host_id } else { $null }
+        effective_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'host_adapter' -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.effective_host_id } else { $null }
         phase_binding_counts = [pscustomobject]@{
             pre_execution = @($approvedDispatch | Where-Object { [string]$_.dispatch_phase -eq 'pre_execution' }).Count
             in_execution = @($approvedDispatch | Where-Object { [string]$_.dispatch_phase -eq 'in_execution' }).Count
@@ -1297,6 +1310,7 @@ $receipt = [pscustomobject]@{
     requirement_doc_path = $requirementPath
     execution_plan_path = $planPath
     runtime_input_packet_path = $runtimeInputPath
+    execution_memory_context_path = if ([string]::IsNullOrWhiteSpace($ExecutionMemoryContextPath)) { $null } else { $ExecutionMemoryContextPath }
     plan_shadow_path = $planShadow.path
     execution_manifest_path = $executionManifestPath
     benchmark_proof_manifest_path = $proofManifestPath

--- a/bundled/skills/vibe/check.ps1
+++ b/bundled/skills/vibe/check.ps1
@@ -501,6 +501,8 @@ function Invoke-AdapterSpecificChecks {
   if ([string]$Adapter.check_mode -eq 'preview-guidance') {
     if ([string]$Adapter.id -eq 'opencode') {
       Warn-Note -Message 'opencode preview keeps the real opencode.json host-managed; only skills, commands, agents, and an example config scaffold are verified'
+    } elseif ([string]$Adapter.id -eq 'cursor') {
+      Write-Host '[INFO] cursor preview now materializes managed commands, host-closure state, and a minimal settings surface; deeper host-native workflow remains preview-scoped' -ForegroundColor Cyan
     } else {
       Write-Host ("[INFO] {0} preview hook/settings scaffold remains intentionally unavailable while the author works through compatibility issues; this is a current product boundary, not an install failure" -f $Adapter.id) -ForegroundColor Cyan
     }
@@ -520,6 +522,28 @@ function Invoke-AdapterSpecificChecks {
     Check-Path -Label "plugins manifest" -Path (Join-Path $TargetRoot 'config\plugins-manifest.codex.json')
     Check-Path -Label "rules/common" -Path (Join-Path $TargetRoot 'rules\common\agents.md')
     Check-Path -Label "mcp template" -Path (Join-Path $TargetRoot 'mcp\servers.template.json')
+  }
+
+  $hostClosurePath = Join-Path $TargetRoot '.vibeskills\host-closure.json'
+  Check-Path -Label "host closure manifest" -Path $hostClosurePath
+  if (Test-Path -LiteralPath $hostClosurePath) {
+    $hostClosure = Get-JsonObject -Path $hostClosurePath -Label 'host closure manifest'
+    if ($null -ne $hostClosure) {
+      $closureState = if ($hostClosure.PSObject.Properties.Name -contains 'host_closure_state') { [string]$hostClosure.host_closure_state } else { '' }
+      if (-not [string]::IsNullOrWhiteSpace($closureState)) {
+        if ($closureState -eq 'closed_ready') {
+          Check-Condition -Label 'host closure state' -Condition $true
+        } else {
+          Warn-Note -Message ("host closure state -> {0}" -f $closureState)
+        }
+      }
+    }
+    if ($null -ne $hostClosure -and $hostClosure.PSObject.Properties.Name -contains 'specialist_wrapper' -and $null -ne $hostClosure.specialist_wrapper) {
+      $launcherPath = if ($hostClosure.specialist_wrapper.PSObject.Properties.Name -contains 'launcher_path') { [string]$hostClosure.specialist_wrapper.launcher_path } else { '' }
+      if (-not [string]::IsNullOrWhiteSpace($launcherPath)) {
+        Check-Path -Label "specialist wrapper launcher" -Path $launcherPath
+      }
+    }
   }
 
   Check-Path -Label "upstream lock" -Path (Join-Path $TargetRoot 'config\upstream-lock.json')

--- a/bundled/skills/vibe/check.sh
+++ b/bundled/skills/vibe/check.sh
@@ -37,6 +37,53 @@ pick_python_for_adapter() {
   return 1
 }
 
+pick_powershell() {
+  local candidate resolved=""
+  for candidate in pwsh pwsh.exe powershell powershell.exe; do
+    if resolved="$(command -v "${candidate}" 2>/dev/null)"; then
+      if [[ -n "${resolved}" ]]; then
+        printf '%s' "${resolved}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+run_powershell_command() {
+  local command_text="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-Command" "${command_text}")
+  "${cmd[@]}" "$@"
+}
+
+run_powershell_file() {
+  local script_path="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-File" "${script_path}")
+  "${cmd[@]}" "$@"
+}
+
 adapter_query_for_host() {
   local host_id="$1"
   local property="$2"
@@ -404,8 +451,8 @@ else:
     print(value)
 PY
     return $?
-  elif command -v pwsh >/dev/null 2>&1; then
-    pwsh -NoProfile -Command '
+  elif pick_powershell >/dev/null 2>&1; then
+    run_powershell_command '
 param([string]$Path,[string]$Expr)
 $raw = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
 $value = $raw | ConvertFrom-Json
@@ -541,8 +588,8 @@ validate_runtime_receipt() {
       warn_note "vibe runtime freshness receipt unavailable because check.sh is not running from the canonical repo root."
       return
     fi
-    if ! command -v pwsh >/dev/null 2>&1; then
-      warn_note "vibe runtime freshness receipt unavailable because pwsh is not installed in this shell environment."
+    if ! pick_powershell >/dev/null 2>&1; then
+      warn_note "vibe runtime freshness receipt unavailable because pwsh is not installed and no compatible PowerShell host is available in this shell environment."
       return
     fi
     echo "[FAIL] vibe runtime freshness receipt -> $receipt_path"
@@ -653,11 +700,11 @@ run_runtime_freshness_gate() {
     echo "[OK] vibe installed runtime freshness gate"
     PASS=$((PASS+1))
   elif [[ $? -eq 127 ]]; then
-    if ! command -v pwsh >/dev/null 2>&1; then
-      warn_note 'runtime freshness gate skipped: neither Python runtime-neutral gate nor pwsh fallback is available.'
+    if ! pick_powershell >/dev/null 2>&1; then
+      warn_note 'runtime freshness gate skipped: neither Python runtime-neutral gate nor a PowerShell fallback is available.'
       return
     fi
-    if pwsh -NoProfile -File "$gate_path" -TargetRoot "$TARGET_ROOT"; then
+    if run_powershell_file "$gate_path" -TargetRoot "$TARGET_ROOT"; then
       echo "[OK] vibe installed runtime freshness gate"
       PASS=$((PASS+1))
     else
@@ -697,11 +744,11 @@ run_runtime_coherence_gate() {
     echo "[OK] vibe release/install/runtime coherence gate"
     PASS=$((PASS+1))
   elif [[ $? -eq 127 ]]; then
-    if ! command -v pwsh >/dev/null 2>&1; then
-      warn_note 'runtime coherence gate skipped: neither Python runtime-neutral gate nor pwsh fallback is available.'
+    if ! pick_powershell >/dev/null 2>&1; then
+      warn_note 'runtime coherence gate skipped: neither Python runtime-neutral gate nor a PowerShell fallback is available.'
       return
     fi
-    if pwsh -NoProfile -File "$gate_path" -TargetRoot "$TARGET_ROOT"; then
+    if run_powershell_file "$gate_path" -TargetRoot "$TARGET_ROOT"; then
       echo "[OK] vibe release/install/runtime coherence gate"
       PASS=$((PASS+1))
     else
@@ -741,6 +788,8 @@ fi
 if [[ "${ADAPTER_CHECK_MODE}" == "preview-guidance" ]]; then
   if [[ "${HOST_ID}" == "opencode" ]]; then
     warn_note "opencode preview keeps the real opencode.json host-managed; only skills, commands, agents, and an example config scaffold are verified"
+  elif [[ "${HOST_ID}" == "cursor" ]]; then
+    info_note "cursor preview now materializes managed commands, host-closure state, and a minimal settings surface; deeper host-native workflow remains preview-scoped"
   else
     info_note "${HOST_ID} preview hook/settings scaffold remains intentionally unavailable while the author works through compatibility issues; this is a current product boundary, not an install failure"
   fi
@@ -751,6 +800,22 @@ if [[ "${ADAPTER_CHECK_MODE}" == "runtime-core" ]]; then
   fi
   if [[ -f "${SCRIPT_DIR}/mcp/servers.template.json" ]]; then
     check_path "mcp_config.json" "${TARGET_ROOT}/mcp_config.json"
+  fi
+fi
+check_path "host closure manifest" "${TARGET_ROOT}/.vibeskills/host-closure.json"
+if [[ -f "${TARGET_ROOT}/.vibeskills/host-closure.json" ]]; then
+  closure_state="$(json_query_scalar_from_file "${TARGET_ROOT}/.vibeskills/host-closure.json" 'host_closure_state' 2>/dev/null || true)"
+  if [[ -n "${closure_state}" ]]; then
+    if [[ "${closure_state}" == "closed_ready" ]]; then
+      echo "[OK] host closure state -> ${closure_state}"
+      PASS=$((PASS+1))
+    else
+      warn_note "host closure state -> ${closure_state}"
+    fi
+  fi
+  wrapper_launcher="$(json_query_scalar_from_file "${TARGET_ROOT}/.vibeskills/host-closure.json" 'specialist_wrapper.launcher_path' 2>/dev/null || true)"
+  if [[ -n "${wrapper_launcher}" ]]; then
+    check_path "specialist wrapper launcher" "${wrapper_launcher}"
   fi
 fi
 if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
@@ -851,10 +916,10 @@ if [[ "${DEEP}" == "true" ]]; then
       echo "[OK] vibe bootstrap doctor gate"
       PASS=$((PASS+1))
     elif [[ $? -eq 127 ]]; then
-      if ! command -v pwsh >/dev/null 2>&1; then
-        echo "[WARN] vibe bootstrap doctor gate skipped because neither the Python runtime-neutral doctor nor pwsh is available in this shell environment."
+      if ! pick_powershell >/dev/null 2>&1; then
+        echo "[WARN] vibe bootstrap doctor gate skipped because neither the Python runtime-neutral doctor nor a PowerShell host is available in this shell environment."
         WARN=$((WARN+1))
-      elif pwsh -NoProfile -File "${doctor_path}" -TargetRoot "${TARGET_ROOT}" -WriteArtifacts; then
+      elif run_powershell_file "${doctor_path}" -TargetRoot "${TARGET_ROOT}" -WriteArtifacts; then
         echo "[OK] vibe bootstrap doctor gate"
         PASS=$((PASS+1))
       else

--- a/bundled/skills/vibe/config/native-specialist-execution-policy.json
+++ b/bundled/skills/vibe/config/native-specialist-execution-policy.json
@@ -1,6 +1,6 @@
 {
-  "version": 1,
-  "updated_at": "2026-03-28",
+  "version": 2,
+  "updated_at": "2026-03-29",
   "enabled": true,
   "default_adapter_id": "codex",
   "enable_env": "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION",
@@ -31,6 +31,7 @@
     {
       "id": "codex",
       "enabled": true,
+      "invocation_kind": "direct",
       "executable_env": "VGO_CODEX_EXECUTABLE",
       "command": "codex",
       "arguments_prefix": [
@@ -40,6 +41,61 @@
         "--full-auto"
       ],
       "execution_driver": "codex_exec_native_specialist"
+    },
+    {
+      "id": "claude-code",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_CLAUDE_CODE_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
+    },
+    {
+      "id": "cursor",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_CURSOR_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
+    },
+    {
+      "id": "windsurf",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_WINDSURF_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
+    },
+    {
+      "id": "openclaw",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_OPENCLAW_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
+    },
+    {
+      "id": "opencode",
+      "enabled": true,
+      "invocation_kind": "python_runner",
+      "runner_script_path": "scripts/runtime/native_specialist_runner.py",
+      "bridge_executable_env": "VGO_OPENCODE_SPECIALIST_WRAPPER",
+      "bridge_contract": "vco_specialist_wrapper_v1",
+      "arguments_prefix": [],
+      "runner_arguments_prefix": [],
+      "execution_driver": "host_neutral_exec_native_specialist"
     }
   ]
 }

--- a/bundled/skills/vibe/config/phase-cleanup-policy.json
+++ b/bundled/skills/vibe/config/phase-cleanup-policy.json
@@ -22,6 +22,22 @@
     "attempt_node_zombie_cleanup_if_needed",
     "record_remaining_manual_actions"
   ],
+  "destructive_cleanup_guardrails": {
+    "forbid_blind_recursive_wipe": true,
+    "forbid_batch_delete_in_managed_roots": true,
+    "require_explicit_hazard_alert": true,
+    "require_receipt_backed_path_list": true,
+    "managed_roots": [
+      "config",
+      "docs",
+      "references",
+      "scripts",
+      "bundled",
+      "protocols",
+      "mcp",
+      "third_party"
+    ]
+  },
   "protected_document_policy": {
     "enabled": true,
     "extensions": [

--- a/bundled/skills/vibe/config/runtime-input-packet-policy.json
+++ b/bundled/skills/vibe/config/runtime-input-packet-policy.json
@@ -10,6 +10,7 @@
   "required_fields": [
     "run_id",
     "governance_scope",
+    "host_adapter",
     "hierarchy",
     "task",
     "runtime_mode",

--- a/bundled/skills/vibe/config/version-governance.json
+++ b/bundled/skills/vibe/config/version-governance.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
   "release": {
-    "version": "2.3.52",
-    "updated": "2026-03-29",
+    "version": "2.3.53",
+    "updated": "2026-03-30",
     "channel": "stable",
-    "notes": "Adds stage-aware memory activation to the main vibe runtime, wires governed Serena/ruflo/Cognee backend adapters into observable session artifacts, and keeps memory-scope boundaries explicit."
+    "notes": "Closes governed specialist dispatch and custom admission, hardens Windows PowerShell host resolution plus managed-host install guarantees, and tightens cleanup-truth safety wording."
   },
   "source_of_truth": {
     "canonical_root": ".",
@@ -106,6 +106,7 @@
         "scripts/runtime/Freeze-RuntimeInputPacket.ps1",
         "scripts/runtime/invoke-vibe-runtime.ps1",
         "scripts/runtime/Invoke-PlanExecute.ps1",
+        "scripts/runtime/native_specialist_runner.py",
         "scripts/runtime/memory_backend_driver.py",
         "scripts/verify/vibe-installed-runtime-freshness-gate.ps1",
         "scripts/verify/vibe-release-install-runtime-coherence-gate.ps1",

--- a/bundled/skills/vibe/docs/plans/2026-03-30-release-v2.3.53-plan.md
+++ b/bundled/skills/vibe/docs/plans/2026-03-30-release-v2.3.53-plan.md
@@ -1,0 +1,62 @@
+# 发布 v2.3.53 执行计划
+
+**日期**: 2026-03-30
+**需求文档**: [2026-03-30-release-v2.3.53.md](../requirements/2026-03-30-release-v2.3.53.md)
+**Internal Grade**: `L`
+
+## Wave Structure
+
+### Wave 1: Freeze Release Surface
+
+- 基于 `v2.3.52..main` 汇总本次版本主题与边界。
+- 新增 `docs/releases/v2.3.53.md`。
+- 更新 `docs/releases/README.md` 当前 release surface。
+- 更新 `config/version-governance.json` 的 release summary。
+- 预先对齐 `dist/*/manifest.json` 的 `source_release`。
+
+### Wave 2: Governed Version Cut
+
+- 运行 `scripts/governance/release-cut.ps1 -Version 2.3.53 -Updated 2026-03-30`。
+- 让脚本完成版本治理字段、maintenance section、changelog header、release ledger 写入。
+- 让脚本触发 `sync-bundled-vibe.ps1`，把 root 发布面同步到 bundled / nested bundled mirror。
+
+### Wave 3: Verification And Publish
+
+- 运行版本一致性、dist manifest、specialist dispatch closure 相关 gate。
+- 运行针对 custom admission、multi-host specialist execution、installed runtime scripts 的测试。
+- 审核 `git diff` 后提交、推送分支、合并到 `main`。
+- 在合并后的 `main` 上创建 `v2.3.53` tag 和 GitHub release。
+
+## Ownership Boundaries
+
+- Root governed lane: 版本号、release notes、验证、GitHub 发布。
+- Bundled / nested bundled mirrors: 仅通过 `sync-bundled-vibe.ps1` 同步，不做手工漂移编辑。
+
+## Verification Commands
+
+- `git diff --check`
+- `pytest -q tests/runtime_neutral/test_custom_admission_bridge.py tests/runtime_neutral/test_multi_host_specialist_execution.py tests/runtime_neutral/test_installed_runtime_scripts.py`
+- `pwsh -NoProfile -File scripts/verify/vibe-version-consistency-gate.ps1`
+- `pwsh -NoProfile -File scripts/verify/vibe-dist-manifest-gate.ps1`
+- `pwsh -NoProfile -File scripts/verify/vibe-specialist-dispatch-closure-gate.ps1`
+
+## Delivery Acceptance Plan
+
+- 版本说明必须能从 `v2.3.52..main` 的 commit 与 diff 中直接追溯。
+- 发布完成标准为：远端 `main` 含 release commit，`v2.3.53` tag 已存在，GitHub release 已创建。
+
+## Completion Language Rules
+
+- 验证未过或远端对象未创建前，只能说“已准备发布”。
+- 只有 tag 和 GitHub release 都落地后，才能说“已发布 v2.3.53”。
+
+## Rollback Rules
+
+- 若 gate 或测试失败，停止发布，不打 tag。
+- 若分支已推送但未合并，修复后复用同一发布分支，不重写历史 release note 版本号。
+- 若 tag 创建失败，不创建 GitHub release。
+
+## Cleanup Expectations
+
+- 不在版本提交中带入 `outputs/` 运行产物。
+- phase 结束后只保留受治理文档与版本面改动。

--- a/bundled/skills/vibe/docs/releases/README.md
+++ b/bundled/skills/vibe/docs/releases/README.md
@@ -10,7 +10,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ### Current Release Surface
 
-- [`v2.3.51.md`](v2.3.51.md): main-chain delivery acceptance / specialist dispatch governance closure / Windows specialist runtime handoff fix
+- [`v2.3.53.md`](v2.3.53.md): governed specialist dispatch and custom admission closure / Windows PowerShell host resolution / managed host install guarantees / cleanup-truth tightening
 
 ### Release Runtime / Proof Handoff
 
@@ -22,6 +22,8 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ## Recent Governed Releases
 
+- [`v2.3.53.md`](v2.3.53.md) - 2026-03-30 - governed specialist dispatch and custom admission closure / Windows PowerShell host resolution / managed host install guarantees / cleanup-truth tightening
+- [`v2.3.52.md`](v2.3.52.md) - 2026-03-29 - stage-aware memory activation / governed memory backend adapters / explicit memory-scope boundaries
 - [`v2.3.51.md`](v2.3.51.md) - 2026-03-28 - main-chain delivery acceptance / specialist dispatch governance closure / Windows specialist runtime handoff fix
 - [`v2.3.50.md`](v2.3.50.md) - 2026-03-26 - router AI connectivity probe / host-adapter expansion / single-entry install surface / Windows PowerShell default verification guidance
 - [`v2.3.49.md`](v2.3.49.md) - 2026-03-23 - shallow-worktree install/check hardening / installed-runtime adapter fallback / parent-path guard convergence

--- a/bundled/skills/vibe/docs/releases/v2.3.53.md
+++ b/bundled/skills/vibe/docs/releases/v2.3.53.md
@@ -1,0 +1,35 @@
+# VCO Release v2.3.53
+
+- Date: 2026-03-30
+- Commit(base): 4f5676f
+- Previous release: `v2.3.52`
+
+## Highlights
+
+- Closed the governed specialist-dispatch gap with explicit custom-admission handling and restored the missing delegated-lane / host-adapter metadata handoff. Router admission, confirm UI, runtime input packets, delegated lane payloads, and specialist execution now carry the same bounded-dispatch truth instead of relying on weaker implied behavior.
+- Hardened Windows PowerShell host resolution across install, check, and bootstrap surfaces, and tightened managed-host install guarantees across Claude Code, Cursor, Windsurf, OpenClaw, and OpenCode adapter lanes.
+- Tightened cleanup-truth wording and policy so public docs and runtime policy stop overstating what phase cleanup can guarantee, especially around no-false-cleanliness claims.
+
+## What Changed Compared With v2.3.52
+
+- `v2.3.52` pushed governed memory activation into the standard six-stage runtime and made backend memory activity observable.
+- `v2.3.53` shifts the focus back to release-facing reliability and truth alignment: specialist admission, specialist dispatch closure, host install guarantees, and cleanup-safety claims now line up more tightly across router, runtime, install, and adapter surfaces.
+- The important difference is not a new product lane. The difference is that governed execution and host-facing entrypoints now make fewer promises they cannot prove, while carrying stronger explicit proof for the promises they do make.
+
+## Validation Notes
+
+- Runtime / specialist dispatch coverage:
+  - `pytest -q tests/runtime_neutral/test_custom_admission_bridge.py tests/runtime_neutral/test_multi_host_specialist_execution.py`
+- Install / host-resolution coverage:
+  - `pytest -q tests/runtime_neutral/test_installed_runtime_scripts.py`
+- Release-surface and version consistency:
+  - `git diff --check`
+  - `pwsh -NoProfile -File scripts/verify/vibe-version-consistency-gate.ps1`
+  - `pwsh -NoProfile -File scripts/verify/vibe-dist-manifest-gate.ps1`
+  - `pwsh -NoProfile -File scripts/verify/vibe-specialist-dispatch-closure-gate.ps1`
+
+## Migration Notes
+
+- Operators on stock Windows PowerShell hosts should see more reliable install and runtime detection without needing ad-hoc shell overrides in normal supported setups.
+- Specialist-capable governed runs now expose stricter admission and dispatch behavior. Treat those receipts and gates as the source of truth rather than assuming older implicit dispatch behavior still applies.
+- This release improves closure and truth alignment. It does not claim any new broad host-native support tier beyond what the current adapter / distribution documents already state.

--- a/bundled/skills/vibe/docs/requirements/2026-03-30-release-v2.3.53.md
+++ b/bundled/skills/vibe/docs/requirements/2026-03-30-release-v2.3.53.md
@@ -1,0 +1,38 @@
+# 发布 v2.3.53 需求
+
+**日期**: 2026-03-30
+**目标**: 基于 GitHub 当前最新 `main`（`4f5676f`）切出新的稳定版本，完成受治理版本面更新、版本说明、tag / GitHub release 发布。
+
+## Intent Contract
+
+- Goal: 发布一个能准确反映 `v2.3.52..main` 真实变更范围的新稳定版本。
+- Deliverable: `v2.3.53` 的仓库版本更新、release notes、changelog / ledger 记录，以及 GitHub tag / release。
+- Constraints:
+  - 必须基于远端最新 `main`，不能基于本地脏工作树。
+  - 不能跳过仓库既有 release governance。
+  - 版本说明必须只陈述已经落在 `main` 上的事实。
+- Acceptance Criteria:
+  - `config/version-governance.json`、`SKILL.md`、`bundled/skills/vibe/SKILL.md` 与 `dist/*/manifest.json` 对齐到 `2.3.53 / 2026-03-30`。
+  - `docs/releases/v2.3.53.md` 完整描述本次变更与验证面。
+  - `references/changelog.md` 与 `references/release-ledger.jsonl` 新增 `v2.3.53` 记录。
+  - GitHub 上出现 `v2.3.53` tag 与 release。
+- Product Acceptance Criteria:
+  - 发布说明清楚覆盖 governed specialist dispatch / custom admission closure、Windows PowerShell host resolution 修复、managed host install guarantees 收紧、cleanup truth wording 收口。
+  - 不把 memory runtime 或未进 `main` 的事项错误归入本次版本。
+- Manual Spot Checks:
+  - 对照 `git log v2.3.52..main` 检查 release highlights。
+  - 对照 `git diff --stat v2.3.52..main` 检查说明未遗漏主要变更面。
+  - 在 GitHub release 页面确认标题、tag 和 notes 对齐。
+- Completion Language Policy:
+  - 只有在本地验证通过且远端 tag / release 已创建后，才允许使用“已发布”表述。
+- Delivery Truth Contract:
+  - 版本说明以仓库 `main` 上的合并结果为准，不把本地临时产物当成发布内容。
+  - 任何未验证或未推送的变更都不能写入完成声明。
+- Non-goals:
+  - 不在本轮引入新的功能开发。
+  - 不重写历史 release notes。
+  - 不改动与本次版本无关的发布流程设计。
+- Autonomy Mode: `interactive_governed`
+- Inferred Assumptions:
+  - 下一稳定版本按 patch 递增为 `v2.3.53`。
+  - 当前 GitHub 认证足以创建分支、PR、tag 和 release。

--- a/bundled/skills/vibe/install.ps1
+++ b/bundled/skills/vibe/install.ps1
@@ -6,6 +6,7 @@ param(
   [string]$TargetRoot = '',
   [switch]$InstallExternal,
   [switch]$StrictOffline,
+  [switch]$RequireClosedReady,
   [switch]$AllowExternalSkillFallback,
   [switch]$SkipRuntimeFreshnessGate
 )
@@ -332,6 +333,7 @@ Write-Host "Mode   : $($Adapter.install_mode)"
 Write-Host "Profile: $Profile"
 Write-Host "Target : $TargetRoot"
 Write-Host "StrictOffline: $StrictOffline"
+Write-Host "RequireClosedReady: $RequireClosedReady"
 Write-Host "AllowExternalSkillFallback: $AllowExternalSkillFallback"
 Write-Host "SkipRuntimeFreshnessGate: $SkipRuntimeFreshnessGate"
 $installGovernance = Get-InstallGovernance -RepoRoot $RepoRoot
@@ -345,13 +347,20 @@ $adapterInstallerPath = Join-Path $RepoRoot 'scripts\install\Install-VgoAdapter.
 if (-not (Test-Path -LiteralPath $adapterInstallerPath)) {
   throw "Adapter installer script missing: $adapterInstallerPath"
 }
-$adapterInstallResult = & $adapterInstallerPath -RepoRoot $RepoRoot -TargetRoot $TargetRoot -HostId $HostId -Profile $Profile -AllowExternalSkillFallback:$AllowExternalSkillFallback
+$adapterInstallResult = & $adapterInstallerPath -RepoRoot $RepoRoot -TargetRoot $TargetRoot -HostId $HostId -Profile $Profile -RequireClosedReady:$RequireClosedReady -AllowExternalSkillFallback:$AllowExternalSkillFallback
 $adapterInstallReceipt = $null
 if ($adapterInstallResult) {
   try {
     $adapterInstallReceipt = ($adapterInstallResult | Out-String) | ConvertFrom-Json
   } catch {
     $adapterInstallReceipt = $null
+  }
+}
+if ($RequireClosedReady -and $null -ne $adapterInstallReceipt) {
+  $effective = if ($adapterInstallReceipt.PSObject.Properties.Name -contains 'require_closed_ready_effective') { [bool]$adapterInstallReceipt.require_closed_ready_effective } else { $false }
+  $state = if ($adapterInstallReceipt.PSObject.Properties.Name -contains 'host_closure_state') { [string]$adapterInstallReceipt.host_closure_state } else { '' }
+  if ($effective -and $state -ne 'closed_ready') {
+    throw ("Install receipt is not closed_ready under RequireClosedReady (got '{0}')." -f $state)
   }
 }
 $externalFallbackUsed = New-Object System.Collections.Generic.List[string]
@@ -485,4 +494,19 @@ Invoke-CodexDuplicateSkillQuarantine -TargetRoot $TargetRoot -HostId $HostId
 Invoke-InstalledRuntimeFreshnessGate -RepoRoot $RepoRoot -TargetRoot $TargetRoot -SkipGate:$SkipRuntimeFreshnessGate
 Write-Host ""
 Write-Host "Installation complete." -ForegroundColor Green
-Write-Host "Run: powershell -ExecutionPolicy Bypass -File .\check.ps1 -Profile $Profile -TargetRoot `"$TargetRoot`""
+$checkShellPath = Get-VgoPowerShellCommand
+$checkShellLeaf = [System.IO.Path]::GetFileName($checkShellPath).ToLowerInvariant()
+$checkCommandParts = @($checkShellLeaf, '-NoProfile')
+if ($checkShellLeaf -like 'powershell*') {
+  $checkCommandParts += @('-ExecutionPolicy', 'Bypass')
+}
+$checkCommandParts += @('-File', '.\check.ps1', '-Profile', $Profile, '-TargetRoot', $TargetRoot)
+$checkCommand = ($checkCommandParts | ForEach-Object {
+  $text = [string]$_
+  if ($text -match '\s') {
+    '"' + ($text -replace '"', '\"') + '"'
+  } else {
+    $text
+  }
+}) -join ' '
+Write-Host ("Run: {0}" -f $checkCommand)

--- a/bundled/skills/vibe/install.sh
+++ b/bundled/skills/vibe/install.sh
@@ -5,6 +5,7 @@ PROFILE="full"
 HOST_ID="codex"
 INSTALL_EXTERNAL="false"
 STRICT_OFFLINE="false"
+REQUIRE_CLOSED_READY="false"
 ALLOW_EXTERNAL_SKILL_FALLBACK="false"
 SKIP_RUNTIME_FRESHNESS_GATE="false"
 TARGET_ROOT=""
@@ -28,6 +29,7 @@ while [[ $# -gt 0 ]]; do
     --target-root) TARGET_ROOT="$2"; shift 2 ;;
     --install-external) INSTALL_EXTERNAL="true"; shift ;;
     --strict-offline) STRICT_OFFLINE="true"; shift ;;
+    --require-closed-ready) REQUIRE_CLOSED_READY="true"; shift ;;
     --allow-external-skill-fallback) ALLOW_EXTERNAL_SKILL_FALLBACK="true"; shift ;;
     --skip-runtime-freshness-gate) SKIP_RUNTIME_FRESHNESS_GATE="true"; shift ;;
     *) echo "Unknown arg: $1"; exit 1 ;;
@@ -348,8 +350,8 @@ else:
     print(value)
 PY
     return $?
-  elif command -v pwsh >/dev/null 2>&1; then
-    pwsh -NoProfile -Command '
+  elif pick_powershell >/dev/null 2>&1; then
+    run_powershell_command '
 param([string]$Path,[string]$Expr)
 $raw = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
 $value = $raw | ConvertFrom-Json
@@ -391,6 +393,53 @@ pick_python() {
     return 0
   fi
   return 1
+}
+
+pick_powershell() {
+  local candidate resolved=""
+  for candidate in pwsh pwsh.exe powershell powershell.exe; do
+    if resolved="$(command -v "${candidate}" 2>/dev/null)"; then
+      if [[ -n "${resolved}" ]]; then
+        printf '%s' "${resolved}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+run_powershell_command() {
+  local command_text="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-Command" "${command_text}")
+  "${cmd[@]}" "$@"
+}
+
+run_powershell_file() {
+  local script_path="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-File" "${script_path}")
+  "${cmd[@]}" "$@"
 }
 
 adapter_query() {
@@ -442,11 +491,11 @@ run_runtime_freshness_gate() {
   if run_runtime_neutral_freshness_gate; then
     :
   elif [[ $? -eq 127 ]]; then
-    if ! command -v pwsh >/dev/null 2>&1; then
-      echo "[WARN] runtime freshness gate skipped: neither Python runtime-neutral gate nor pwsh fallback is available."
+    if ! pick_powershell >/dev/null 2>&1; then
+      echo "[WARN] runtime freshness gate skipped: neither Python runtime-neutral gate nor a PowerShell fallback is available."
       return 0
     fi
-    pwsh -NoProfile -File "${gate_path}" -TargetRoot "${TARGET_ROOT}" -WriteReceipt
+    run_powershell_file "${gate_path}" -TargetRoot "${TARGET_ROOT}" -WriteReceipt
   else
     return 1
   fi
@@ -467,6 +516,40 @@ copy_dir_content() {
   [[ -d "${src}" ]] || return 0
   mkdir -p "${dst}"
   cp -R "${src}/." "${dst}/"
+}
+
+remove_path_entry() {
+  local path="$1"
+  if [[ -L "${path}" || -f "${path}" ]]; then
+    rm -f "${path}"
+    return 0
+  fi
+  if [[ -d "${path}" ]]; then
+    rmdir "${path}"
+  fi
+}
+
+prune_dir_content_individually() {
+  local src="$1"
+  local dst="$2"
+  [[ -d "${src}" && -d "${dst}" ]] || return 0
+
+  local path="" rel="" src_equivalent=""
+  while IFS= read -r -d '' path; do
+    rel="${path#${dst}/}"
+    src_equivalent="${src}/${rel}"
+    if [[ ! -e "${src_equivalent}" ]]; then
+      remove_path_entry "${path}"
+    fi
+  done < <(find "${dst}" -mindepth 1 -depth -print0)
+}
+
+sync_dir_content_individually() {
+  local src="$1"
+  local dst="$2"
+  [[ -d "${src}" ]] || return 0
+  copy_dir_content "${src}" "${dst}"
+  prune_dir_content_individually "${src}" "${dst}"
 }
 
 sync_vibe_canonical_to_target() {
@@ -521,8 +604,7 @@ sync_vibe_canonical_to_target() {
   for rel in "${dirs[@]}"; do
     src="${canonical_root}/${rel}"
     dst="${target_vibe_root}/${rel}"
-    [[ -d "${dst}" ]] && rm -rf "${dst}"
-    copy_dir_content "${src}" "${dst}"
+    sync_dir_content_individually "${src}" "${dst}"
   done
 }
 
@@ -596,6 +678,7 @@ echo "Mode   : ${ADAPTER_INSTALL_MODE}"
 echo "Profile: ${PROFILE}"
 echo "Target : ${TARGET_ROOT}"
 echo "StrictOffline: ${STRICT_OFFLINE}"
+echo "RequireClosedReady: ${REQUIRE_CLOSED_READY}"
 echo "AllowExternalSkillFallback: ${ALLOW_EXTERNAL_SKILL_FALLBACK}"
 echo "SkipRuntimeFreshnessGate: ${SKIP_RUNTIME_FRESHNESS_GATE}"
 
@@ -612,6 +695,7 @@ ADAPTER_INSTALL_JSON="$("${PYTHON_BIN_FOR_ADAPTER}" "${ADAPTER_INSTALLER}" \
   --target-root "${TARGET_ROOT}" \
   --host "${HOST_ID}" \
   --profile "${PROFILE}" \
+  $([[ "${REQUIRE_CLOSED_READY}" == "true" ]] && printf '%s' '--require-closed-ready') \
   $([[ "${ALLOW_EXTERNAL_SKILL_FALLBACK}" == "true" ]] && printf '%s' '--allow-external-skill-fallback'))"
 if [[ -n "${ADAPTER_INSTALL_JSON}" ]]; then
   mapfile -t EXTERNAL_FALLBACK_USED < <(printf '%s\n' "${ADAPTER_INSTALL_JSON}" | "${PYTHON_BIN_FOR_ADAPTER}" -c 'import json,sys; data=json.load(sys.stdin); [print(x) for x in data.get("external_fallback_used", [])]')
@@ -683,12 +767,12 @@ if [[ "${STRICT_OFFLINE}" == "true" ]]; then
     echo "[FAIL] StrictOffline requested, but offline gate script is missing: ${OFFLINE_GATE}"
     exit 1
   fi
-  if ! command -v pwsh >/dev/null 2>&1; then
-    echo "[FAIL] StrictOffline requires pwsh to run offline gate"
+  if ! pick_powershell >/dev/null 2>&1; then
+    echo "[FAIL] StrictOffline requires an available PowerShell host to run the offline gate"
     exit 1
   fi
 
-  pwsh -NoProfile -File "${OFFLINE_GATE}" \
+  run_powershell_file "${OFFLINE_GATE}" \
     -SkillsRoot "${TARGET_ROOT}/skills" \
     -PackManifestPath "${SCRIPT_DIR}/config/pack-manifest.json" \
     -SkillsLockPath "${SCRIPT_DIR}/config/skills-lock.json"

--- a/bundled/skills/vibe/references/changelog.md
+++ b/bundled/skills/vibe/references/changelog.md
@@ -1,5 +1,13 @@
 # VCO Changelog
 
+## v2.3.53 (2026-03-30)
+
+- Closed governed specialist dispatch with explicit custom-admission handling, and restored delegated-lane payload plus host-adapter metadata continuity across router admission, runtime packets, and specialist execution closure gates.
+- Hardened Windows PowerShell host resolution for install, check, and bootstrap surfaces, and tightened managed-host install guarantees across the current preview / runtime-core adapter lanes.
+- Tightened cleanup-truth wording and policy so public release claims and runtime cleanup semantics stay aligned with what the governed runtime can actually prove.
+- Detailed release notes: `docs/releases/v2.3.53.md`.
+
+
 ## v2.3.52 (2026-03-29)
 
 - Landed stage-aware memory activation inside the standard six-stage `vibe` runtime, including per-run memory activation reports and bounded context injection into governed artifacts.

--- a/bundled/skills/vibe/references/release-ledger.jsonl
+++ b/bundled/skills/vibe/references/release-ledger.jsonl
@@ -30,3 +30,4 @@
 {"recorded_at":"2026-03-26T20:39:51","version":"2.3.50","updated":"2026-03-26","git_head":"d5da111","actor":null}
 {"recorded_at":"2026-03-28T00:00:00","version":"2.3.51","updated":"2026-03-28","git_head":"18e6b9c","actor":null}
 {"recorded_at":"2026-03-29T10:14:24","version":"2.3.52","updated":"2026-03-29","git_head":"870fd20","actor":null}
+{"recorded_at":"2026-03-30T00:28:44","version":"2.3.53","updated":"2026-03-30","git_head":"4f5676f","actor":null}

--- a/bundled/skills/vibe/scripts/bootstrap/one-shot-setup.ps1
+++ b/bundled/skills/vibe/scripts/bootstrap/one-shot-setup.ps1
@@ -193,7 +193,22 @@ switch ([string]$Adapter.bootstrap_mode) {
 
 Write-Host ''
 Write-Host 'One-shot setup completed.' -ForegroundColor Green
-Write-Host ('- Re-run deep doctor anytime with: pwsh -File "{0}" -Profile {1} -HostId {2} -TargetRoot "{3}" -Deep' -f $checkPath, $Profile, $HostId, $TargetRoot)
+$checkShellPath = Get-VgoPowerShellCommand
+$checkShellLeaf = [System.IO.Path]::GetFileName($checkShellPath).ToLowerInvariant()
+$checkCommandParts = @($checkShellLeaf, '-NoProfile')
+if ($checkShellLeaf -like 'powershell*') {
+    $checkCommandParts += @('-ExecutionPolicy', 'Bypass')
+}
+$checkCommandParts += @('-File', $checkPath, '-Profile', $Profile, '-HostId', $HostId, '-TargetRoot', $TargetRoot, '-Deep')
+$checkCommand = ($checkCommandParts | ForEach-Object {
+    $text = [string]$_
+    if ($text -match '\s') {
+        '"' + ($text -replace '"', '\"') + '"'
+    } else {
+        $text
+    }
+}) -join ' '
+Write-Host ('- Re-run deep doctor anytime with: {0}' -f $checkCommand)
 if ($Adapter.bootstrap_mode -eq 'governed') {
     Write-Host ('- MCP active file: {0}' -f (Join-Path $TargetRoot 'mcp\servers.active.json'))
 }

--- a/bundled/skills/vibe/scripts/bootstrap/one-shot-setup.sh
+++ b/bundled/skills/vibe/scripts/bootstrap/one-shot-setup.sh
@@ -222,6 +222,36 @@ pick_python() {
   return 1
 }
 
+pick_powershell() {
+  local candidate resolved=""
+  for candidate in pwsh pwsh.exe powershell powershell.exe; do
+    if resolved="$(command -v "${candidate}" 2>/dev/null)"; then
+      if [[ -n "${resolved}" ]]; then
+        printf '%s' "${resolved}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+run_powershell_file() {
+  local script_path="$1"
+  shift
+  local shell_path=""
+  shell_path="$(pick_powershell || true)"
+  [[ -n "${shell_path}" ]] || return 127
+
+  local leaf="${shell_path##*/}"
+  leaf="$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')"
+  local cmd=("${shell_path}" "-NoProfile")
+  if [[ "${leaf}" == "powershell" || "${leaf}" == "powershell.exe" ]]; then
+    cmd+=("-ExecutionPolicy" "Bypass")
+  fi
+  cmd+=("-File" "${script_path}")
+  "${cmd[@]}" "$@"
+}
+
 adapter_query() {
   local property="$1"
   local python_bin=""
@@ -319,7 +349,7 @@ materialize_mcp_profile_with_python() {
   local python_bin
 
   if ! python_bin="$(pick_python)"; then
-    echo "[FAIL] Python is required to materialize the MCP active profile when pwsh is unavailable." >&2
+    echo "[FAIL] Python is required to materialize the MCP active profile when no PowerShell host is available." >&2
     exit 1
   fi
 
@@ -425,8 +455,8 @@ if [[ "${ADAPTER_BOOTSTRAP_MODE}" == "governed" ]]; then
   fi
   if [[ -n "${resolved_openai_api_key}" ]]; then
     echo "[2/5] Seeding OPENAI settings into target settings.json..."
-    if command -v pwsh >/dev/null 2>&1; then
-      pwsh -NoProfile -File "${PERSIST_OPENAI_PS1}" -CodexRoot "${TARGET_ROOT}" -BaseUrl "${OPENAI_BASE_URL}" -ApiKey "${resolved_openai_api_key}"
+    if pick_powershell >/dev/null 2>&1; then
+      run_powershell_file "${PERSIST_OPENAI_PS1}" -CodexRoot "${TARGET_ROOT}" -BaseUrl "${OPENAI_BASE_URL}" -ApiKey "${resolved_openai_api_key}"
     else
       seed_settings_env_with_python "${TARGET_ROOT}" "openai" "${OPENAI_BASE_URL}" "${resolved_openai_api_key}"
     fi
@@ -439,8 +469,8 @@ if [[ "${ADAPTER_BOOTSTRAP_MODE}" == "governed" ]]; then
   echo "[3/5] Built-in AI governance now supports only OpenAI-compatible provider wiring; no secondary provider seeding is performed."
 
   echo "[4/5] Materializing MCP profile..."
-  if command -v pwsh >/dev/null 2>&1; then
-    pwsh -NoProfile -File "${MATERIALIZE_PS1}" -TargetRoot "${TARGET_ROOT}" -Force >/dev/null
+  if pick_powershell >/dev/null 2>&1; then
+    run_powershell_file "${MATERIALIZE_PS1}" -TargetRoot "${TARGET_ROOT}" -Force >/dev/null
   else
     materialize_mcp_profile_with_python "${REPO_ROOT}" "${TARGET_ROOT}" "${PROFILE}"
   fi
@@ -473,10 +503,10 @@ if [[ "${ADAPTER_BOOTSTRAP_MODE}" == "governed" ]]; then
   echo "- MCP active file: ${TARGET_ROOT}/mcp/servers.active.json"
 fi
 echo "- Doctor artifacts: ${REPO_ROOT}/outputs/verify"
-if ! command -v pwsh >/dev/null 2>&1; then
+if ! pick_powershell >/dev/null 2>&1; then
   if ! command -v python3 >/dev/null 2>&1 && ! command -v python >/dev/null 2>&1; then
-    echo "[WARN] Neither pwsh nor Python is available. Deep authoritative doctor coverage remains unavailable in this shell environment."
+    echo "[WARN] Neither a PowerShell host nor Python is available. Deep authoritative doctor coverage remains unavailable in this shell environment."
   else
-    echo "[INFO] pwsh is not installed, but the shell runtime-neutral verification path was used where supported."
+    echo "[INFO] No PowerShell host was found, but the shell runtime-neutral verification path was used where supported."
   fi
 fi

--- a/bundled/skills/vibe/scripts/install/Install-VgoAdapter.ps1
+++ b/bundled/skills/vibe/scripts/install/Install-VgoAdapter.ps1
@@ -3,6 +3,7 @@ param(
     [Parameter(Mandatory)] [string]$TargetRoot,
     [Parameter(Mandatory)] [string]$HostId,
     [ValidateSet('minimal', 'full')] [string]$Profile = 'full',
+    [switch]$RequireClosedReady,
     [switch]$AllowExternalSkillFallback
 )
 
@@ -11,6 +12,43 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $RepoRoot 'scripts\common\vibe-governance-helpers.ps1')
 . (Join-Path $RepoRoot 'scripts\common\Resolve-VgoAdapter.ps1')
+
+function Get-VgoPreferredPythonCommand {
+    foreach ($candidate in @('python', 'python3', 'py')) {
+        $command = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($null -ne $command) {
+            return [string]$command.Source
+        }
+    }
+    return $null
+}
+
+$pythonInstaller = Join-Path $RepoRoot 'scripts\install\install_vgo_adapter.py'
+$pythonCommand = Get-VgoPreferredPythonCommand
+if ((Test-Path -LiteralPath $pythonInstaller) -and -not [string]::IsNullOrWhiteSpace($pythonCommand)) {
+    $cmd = @($pythonCommand)
+    if ([System.IO.Path]::GetFileName($pythonCommand).ToLowerInvariant() -eq 'py') {
+        $cmd += '-3'
+    }
+    $cmd += @(
+        $pythonInstaller,
+        '--repo-root', $RepoRoot,
+        '--target-root', $TargetRoot,
+        '--host', $HostId,
+        '--profile', $Profile
+    )
+    if ($RequireClosedReady) {
+        $cmd += '--require-closed-ready'
+    }
+    if ($AllowExternalSkillFallback) {
+        $cmd += '--allow-external-skill-fallback'
+    }
+    & $cmd[0] @($cmd[1..($cmd.Count - 1)])
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Python adapter installer failed with exit code {0}." -f $LASTEXITCODE)
+    }
+    return
+}
 
 function Copy-DirContent {
     param(
@@ -38,6 +76,303 @@ function Restore-SkillEntryPointIfNeeded {
     }
 
     Move-Item -LiteralPath $mirrorPath -Destination $skillMd -Force
+}
+
+function Get-VgoPlatformTag {
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+        return 'windows'
+    }
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::OSX)) {
+        return 'macos'
+    }
+    return 'linux'
+}
+
+function Merge-JsonObject {
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [Parameter(Mandatory)] [hashtable]$Patch
+    )
+
+    $existing = @{}
+    if (Test-Path -LiteralPath $Path) {
+        try {
+            $parsed = Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json -AsHashtable
+            if ($null -ne $parsed) {
+                $existing = $parsed
+            }
+        } catch {
+            $existing = @{}
+        }
+    }
+
+    $merged = @{}
+    foreach ($key in $existing.Keys) {
+        $merged[$key] = $existing[$key]
+    }
+    foreach ($key in $Patch.Keys) {
+        $value = $Patch[$key]
+        if ($merged.ContainsKey($key) -and $merged[$key] -is [hashtable] -and $value -is [hashtable]) {
+            $next = @{}
+            foreach ($nestedKey in $merged[$key].Keys) {
+                $next[$nestedKey] = $merged[$key][$nestedKey]
+            }
+            foreach ($nestedKey in $value.Keys) {
+                $next[$nestedKey] = $value[$nestedKey]
+            }
+            $merged[$key] = $next
+        } else {
+            $merged[$key] = $value
+        }
+    }
+
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Path) | Out-Null
+    $merged | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Path -Encoding UTF8
+}
+
+function Get-VgoHostBridgeCommandEnvName {
+    param([string]$HostId)
+
+    switch ([string]$HostId) {
+        'claude-code' { return 'VGO_CLAUDE_CODE_SPECIALIST_BRIDGE_COMMAND' }
+        'cursor' { return 'VGO_CURSOR_SPECIALIST_BRIDGE_COMMAND' }
+        'windsurf' { return 'VGO_WINDSURF_SPECIALIST_BRIDGE_COMMAND' }
+        'openclaw' { return 'VGO_OPENCLAW_SPECIALIST_BRIDGE_COMMAND' }
+        'opencode' { return 'VGO_OPENCODE_SPECIALIST_BRIDGE_COMMAND' }
+        default { return $null }
+    }
+}
+
+function Resolve-VgoHostBridgeCommand {
+    param([string]$HostId)
+
+    $envName = Get-VgoHostBridgeCommandEnvName -HostId $HostId
+    if (-not [string]::IsNullOrWhiteSpace($envName)) {
+        $envValue = [Environment]::GetEnvironmentVariable($envName)
+        if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+            $command = Get-Command $envValue -ErrorAction SilentlyContinue
+            if ($null -ne $command) {
+                return [pscustomobject]@{
+                    command = [string]$command.Source
+                    source = "env:$envName"
+                    env_name = $envName
+                }
+            }
+            if (Test-Path -LiteralPath $envValue) {
+                return [pscustomobject]@{
+                    command = [System.IO.Path]::GetFullPath($envValue)
+                    source = "env:$envName"
+                    env_name = $envName
+                }
+            }
+        }
+    }
+
+    $candidates = switch ([string]$HostId) {
+        'claude-code' { @('claude', 'claude-code') }
+        'cursor' { @('cursor-agent', 'cursor') }
+        'windsurf' { @('windsurf', 'codeium') }
+        'openclaw' { @('openclaw') }
+        'opencode' { @('opencode') }
+        default { @() }
+    }
+    foreach ($candidate in $candidates) {
+        $command = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($null -ne $command) {
+            return [pscustomobject]@{
+                command = [string]$command.Source
+                source = "path:$candidate"
+                env_name = $envName
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        command = $null
+        source = $null
+        env_name = $envName
+    }
+}
+
+function New-VgoHostSpecialistWrapper {
+    param(
+        [Parameter(Mandatory)] [string]$TargetRoot,
+        [Parameter(Mandatory)] [string]$HostId,
+        [string]$BridgeCommand,
+        [string]$BridgeEnvName
+    )
+
+    $toolsRoot = Join-Path $TargetRoot '.vibeskills\bin'
+    New-Item -ItemType Directory -Force -Path $toolsRoot | Out-Null
+
+    $wrapperPy = Join-Path $toolsRoot ("{0}-specialist-wrapper.py" -f $HostId)
+    $embeddedCommand = if ([string]::IsNullOrWhiteSpace($BridgeCommand)) { '' } else { $BridgeCommand }
+    $pythonScript = @"
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+
+HOST_ID = $(ConvertTo-Json $HostId -Compress)
+TARGET_COMMAND = $(ConvertTo-Json $embeddedCommand -Compress)
+BRIDGE_ENV_NAME = $(ConvertTo-Json $BridgeEnvName -Compress)
+
+def main() -> int:
+    command = TARGET_COMMAND or os.environ.get(BRIDGE_ENV_NAME or "", "").strip()
+    if not command:
+        sys.stderr.write(f"host specialist bridge command unavailable for {HOST_ID}\n")
+        return 3
+    return subprocess.run([command, *sys.argv[1:]], check=False).returncode
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+"@
+    Set-Content -LiteralPath $wrapperPy -Value $pythonScript -Encoding UTF8
+
+    $platformTag = Get-VgoPlatformTag
+    if ($platformTag -eq 'windows') {
+        $launcherPath = Join-Path $toolsRoot ("{0}-specialist-wrapper.cmd" -f $HostId)
+        $cmdScript = @"
+@echo off
+setlocal
+set SCRIPT_DIR=%~dp0
+if exist "%LocalAppData%\Programs\Python\Python311\python.exe" (
+  set PY_CMD=%LocalAppData%\Programs\Python\Python311\python.exe
+) else if exist "%ProgramFiles%\Python311\python.exe" (
+  set PY_CMD=%ProgramFiles%\Python311\python.exe
+) else (
+  set PY_CMD=py -3
+)
+%PY_CMD% "%SCRIPT_DIR%$(Split-Path -Leaf $wrapperPy)" %*
+"@
+        Set-Content -LiteralPath $launcherPath -Value $cmdScript -Encoding ASCII
+    } else {
+        $launcherPath = Join-Path $toolsRoot ("{0}-specialist-wrapper.sh" -f $HostId)
+        $shScript = @"
+#!/usr/bin/env sh
+set -eu
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN=python3
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN=python
+else
+  echo 'python runtime unavailable for host specialist wrapper' >&2
+  exit 127
+fi
+exec "$PYTHON_BIN" "$SCRIPT_DIR/$(Split-Path -Leaf $wrapperPy)" "$@"
+"@
+        Set-Content -LiteralPath $launcherPath -Value $shScript -Encoding UTF8
+        try {
+            chmod +x $launcherPath
+            chmod +x $wrapperPy
+        } catch {
+        }
+    }
+
+    return [pscustomobject]@{
+        platform = $platformTag
+        launcher_path = [System.IO.Path]::GetFullPath($launcherPath)
+        script_path = [System.IO.Path]::GetFullPath($wrapperPy)
+        ready = -not [string]::IsNullOrWhiteSpace($BridgeCommand)
+        bridge_command = $BridgeCommand
+    }
+}
+
+function Set-VgoManagedHostSettings {
+    param(
+        [Parameter(Mandatory)] [string]$TargetRoot,
+        [Parameter(Mandatory)] [string]$HostId,
+        [Parameter(Mandatory)] [pscustomobject]$WrapperInfo
+    )
+
+    $materialized = New-Object System.Collections.Generic.List[string]
+    if ($HostId -in @('cursor', 'claude-code')) {
+        $settingsPath = Join-Path $TargetRoot 'settings.json'
+        Merge-JsonObject -Path $settingsPath -Patch @{
+            vibeskills = @{
+                host_id = $HostId
+                managed = $true
+                commands_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'commands'))
+                specialist_wrapper = [string]$WrapperInfo.launcher_path
+            }
+        }
+        $materialized.Add([System.IO.Path]::GetFullPath($settingsPath)) | Out-Null
+    } elseif ($HostId -eq 'opencode') {
+        $settingsPath = Join-Path $TargetRoot 'opencode.json'
+        Merge-JsonObject -Path $settingsPath -Patch @{
+            vibeskills = @{
+                host_id = $HostId
+                managed = $true
+                commands_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'commands'))
+                command_root_compat = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'command'))
+                agents_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'agents'))
+                agent_root_compat = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'agent'))
+                specialist_wrapper = [string]$WrapperInfo.launcher_path
+            }
+        }
+        $materialized.Add([System.IO.Path]::GetFullPath($settingsPath)) | Out-Null
+    } elseif ($HostId -in @('openclaw', 'windsurf')) {
+        $settingsPath = Join-Path $TargetRoot '.vibeskills\host-settings.json'
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $settingsPath) | Out-Null
+        @{
+            host_id = $HostId
+            managed = $true
+            commands_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'commands'))
+            workflow_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'global_workflows'))
+            mcp_config = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'mcp_config.json'))
+            specialist_wrapper = [string]$WrapperInfo.launcher_path
+        } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $settingsPath -Encoding UTF8
+        $materialized.Add([System.IO.Path]::GetFullPath($settingsPath)) | Out-Null
+    }
+
+    return @($materialized)
+}
+
+function Test-VgoClosedReadyRequiredForAdapter {
+    param([psobject]$Adapter)
+
+    return ([string]$Adapter.install_mode).ToLowerInvariant() -ne 'governed'
+}
+
+function Write-VgoHostClosure {
+    param(
+        [Parameter(Mandatory)] [string]$TargetRoot,
+        [Parameter(Mandatory)] [psobject]$Adapter
+    )
+
+    $bridgeResolution = Resolve-VgoHostBridgeCommand -HostId ([string]$Adapter.id)
+    $wrapperInfo = New-VgoHostSpecialistWrapper -TargetRoot $TargetRoot -HostId ([string]$Adapter.id) -BridgeCommand ([string]$bridgeResolution.command) -BridgeEnvName ([string]$bridgeResolution.env_name)
+    $settingsMaterialized = Set-VgoManagedHostSettings -TargetRoot $TargetRoot -HostId ([string]$Adapter.id) -WrapperInfo $wrapperInfo
+    $commandsRoot = Join-Path $TargetRoot 'commands'
+    $closureState = if ($wrapperInfo.ready) { 'closed_ready' } else { 'configured_offline_unready' }
+    $closure = [ordered]@{
+        schema_version = 1
+        host_id = [string]$Adapter.id
+        platform = Get-VgoPlatformTag
+        target_root = [System.IO.Path]::GetFullPath($TargetRoot)
+        install_mode = [string]$Adapter.install_mode
+        commands_root = [System.IO.Path]::GetFullPath($commandsRoot)
+        global_workflows_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'global_workflows'))
+        mcp_config_path = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'mcp_config.json'))
+        host_closure_state = $closureState
+        commands_materialized = (Test-Path -LiteralPath $commandsRoot -PathType Container)
+        settings_materialized = @($settingsMaterialized)
+        specialist_wrapper = [ordered]@{
+            launcher_path = [string]$wrapperInfo.launcher_path
+            script_path = [string]$wrapperInfo.script_path
+            ready = [bool]$wrapperInfo.ready
+            bridge_command = [string]$bridgeResolution.command
+            bridge_source = [string]$bridgeResolution.source
+        }
+    }
+    $closurePath = Join-Path $TargetRoot '.vibeskills\host-closure.json'
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $closurePath) | Out-Null
+    $closure | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $closurePath -Encoding UTF8
+    return [pscustomobject]@{
+        path = [System.IO.Path]::GetFullPath($closurePath)
+        data = [pscustomobject]$closure
+    }
 }
 
 function Ensure-SkillPresent {
@@ -273,9 +608,21 @@ switch ([string]$adapter.install_mode) {
     default { throw "Unsupported adapter install mode: $($adapter.install_mode)" }
 }
 
+$closureReceipt = Write-VgoHostClosure -TargetRoot $TargetRoot -Adapter $adapter
+$requireClosedReadyEffective = [bool]($RequireClosedReady -and (Test-VgoClosedReadyRequiredForAdapter -Adapter $adapter))
+if ($requireClosedReadyEffective -and [string]$closureReceipt.data.host_closure_state -ne 'closed_ready') {
+    throw ("Host closure for '{0}' is not closed_ready (got '{1}'). Configure the host specialist bridge command first, then retry install." -f [string]$adapter.id, [string]$closureReceipt.data.host_closure_state)
+}
+
 [pscustomobject]@{
     host_id = [string]$adapter.id
     install_mode = [string]$adapter.install_mode
     target_root = [System.IO.Path]::GetFullPath($TargetRoot)
     external_fallback_used = @($result.external_fallback_used)
+    host_closure_path = [string]$closureReceipt.path
+    host_closure_state = [string]$closureReceipt.data.host_closure_state
+    settings_materialized = @($closureReceipt.data.settings_materialized)
+    specialist_wrapper_ready = [bool]$closureReceipt.data.specialist_wrapper.ready
+    require_closed_ready_requested = [bool]$RequireClosedReady
+    require_closed_ready_effective = $requireClosedReadyEffective
 } | ConvertTo-Json -Depth 10

--- a/bundled/skills/vibe/scripts/install/install_vgo_adapter.py
+++ b/bundled/skills/vibe/scripts/install/install_vgo_adapter.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
+import stat
 import shutil
 import tempfile
 from pathlib import Path
@@ -26,6 +28,32 @@ OPTIONAL_WORKFLOW = [
     "receiving-code-review",
     "verification-before-completion",
 ]
+HOST_BRIDGE_COMMAND_CANDIDATES = {
+    "claude-code": ["claude", "claude-code"],
+    "cursor": ["cursor-agent", "cursor"],
+    "windsurf": ["windsurf", "codeium"],
+    "openclaw": ["openclaw"],
+    "opencode": ["opencode"],
+}
+HOST_BRIDGE_COMMAND_ENV = {
+    "claude-code": "VGO_CLAUDE_CODE_SPECIALIST_BRIDGE_COMMAND",
+    "cursor": "VGO_CURSOR_SPECIALIST_BRIDGE_COMMAND",
+    "windsurf": "VGO_WINDSURF_SPECIALIST_BRIDGE_COMMAND",
+    "openclaw": "VGO_OPENCLAW_SPECIALIST_BRIDGE_COMMAND",
+    "opencode": "VGO_OPENCODE_SPECIALIST_BRIDGE_COMMAND",
+}
+
+
+def detect_platform_tag() -> str:
+    if os.name == "nt":
+        return "windows"
+    if sys_platform().startswith("darwin"):
+        return "macos"
+    return "linux"
+
+
+def sys_platform() -> str:
+    return os.sys.platform.lower()
 
 
 def load_json(path: Path):
@@ -35,6 +63,11 @@ def load_json(path: Path):
 
 def write_json(data):
     print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def write_json_file(path: Path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def is_relative_to(path: Path, base: Path) -> bool:
@@ -96,6 +129,11 @@ def copy_file(src: Path, dst: Path):
         return
     dst.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dst)
+
+
+def ensure_executable(path: Path):
+    current = path.stat().st_mode
+    path.chmod(current | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def restore_skill_entrypoint_if_needed(skill_root: Path):
@@ -228,6 +266,238 @@ def resolve_adapter(repo_root: Path, host_id: str):
         if entry.get("id") == normalized:
             return entry
     raise SystemExit(f"Unsupported VGO host id: {host_id}")
+
+
+def resolve_target_root_for_adapter(adapter: dict, explicit_target_root: Path | None = None) -> Path:
+    if explicit_target_root is not None:
+        return explicit_target_root.resolve()
+
+    target_spec = adapter.get("default_target_root") or {}
+    env_name = target_spec.get("env") or ""
+    rel = target_spec.get("rel") or ""
+    env_value = os.environ.get(env_name, "").strip() if env_name else ""
+    if env_value:
+        return Path(env_value).expanduser().resolve()
+    if not rel:
+        raise SystemExit(f"Adapter '{adapter.get('id')}' does not define default_target_root.rel")
+    rel_path = Path(rel)
+    if rel_path.is_absolute():
+        return rel_path.resolve()
+    return (Path.home() / rel_path).expanduser().resolve()
+
+
+def load_specialist_policy(repo_root: Path):
+    return load_json(repo_root / "config" / "native-specialist-execution-policy.json")
+
+
+def resolve_specialist_policy_entry(repo_root: Path, host_id: str):
+    policy = load_specialist_policy(repo_root)
+    for entry in policy.get("adapters", []):
+        if entry.get("id") == host_id:
+            return entry
+    return None
+
+
+def resolve_bridge_command(host_id: str) -> tuple[str | None, str | None]:
+    env_name = HOST_BRIDGE_COMMAND_ENV.get(host_id)
+    if env_name:
+        env_value = os.environ.get(env_name, "").strip()
+        if env_value:
+            candidate = shutil.which(env_value)
+            if candidate:
+                return candidate, f"env:{env_name}"
+            path_candidate = Path(env_value).expanduser()
+            if path_candidate.exists():
+                return str(path_candidate.resolve()), f"env:{env_name}"
+
+    for candidate_name in HOST_BRIDGE_COMMAND_CANDIDATES.get(host_id, []):
+        resolved = shutil.which(candidate_name)
+        if resolved:
+            return resolved, f"path:{candidate_name}"
+
+    return None, None
+
+
+def materialize_host_specialist_wrapper(target_root: Path, host_id: str, bridge_command: str | None):
+    tools_root = target_root / ".vibeskills" / "bin"
+    tools_root.mkdir(parents=True, exist_ok=True)
+
+    wrapper_py = tools_root / f"{host_id}-specialist-wrapper.py"
+    embedded_command = json.dumps(bridge_command or "")
+    bridge_env_name = f"VGO_{host_id.upper().replace('-', '_')}_SPECIALIST_BRIDGE_COMMAND"
+    wrapper_py.write_text(
+        (
+            "#!/usr/bin/env python3\n"
+            "import os\n"
+            "import subprocess\n"
+            "import sys\n\n"
+            f"HOST_ID = {json.dumps(host_id)}\n"
+            f"TARGET_COMMAND = {embedded_command}\n\n"
+            "def main() -> int:\n"
+            f"    command = TARGET_COMMAND or os.environ.get({json.dumps(bridge_env_name)}, '').strip()\n"
+            "    if not command:\n"
+            "        sys.stderr.write(f'host specialist bridge command unavailable for {HOST_ID}\\n')\n"
+            "        return 3\n"
+            "    return subprocess.run([command, *sys.argv[1:]], check=False).returncode\n\n"
+            "if __name__ == '__main__':\n"
+            "    raise SystemExit(main())\n"
+        ),
+        encoding="utf-8",
+    )
+    ensure_executable(wrapper_py)
+
+    platform_tag = detect_platform_tag()
+    if platform_tag == "windows":
+        launcher = tools_root / f"{host_id}-specialist-wrapper.cmd"
+        launcher.write_text(
+            (
+                "@echo off\r\n"
+                "setlocal\r\n"
+                "set SCRIPT_DIR=%~dp0\r\n"
+                "if exist \"%LocalAppData%\\Programs\\Python\\Python311\\python.exe\" (\r\n"
+                "  set PY_CMD=%LocalAppData%\\Programs\\Python\\Python311\\python.exe\r\n"
+                ") else if exist \"%ProgramFiles%\\Python311\\python.exe\" (\r\n"
+                "  set PY_CMD=%ProgramFiles%\\Python311\\python.exe\r\n"
+                ") else (\r\n"
+                "  set PY_CMD=py -3\r\n"
+                ")\r\n"
+                "%PY_CMD% \"%SCRIPT_DIR%\\" + wrapper_py.name + "\" %*\r\n"
+            ),
+            encoding="utf-8",
+        )
+    else:
+        launcher = tools_root / f"{host_id}-specialist-wrapper.sh"
+        launcher.write_text(
+            (
+                "#!/usr/bin/env sh\n"
+                "set -eu\n"
+                "SCRIPT_DIR=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\n"
+                "if command -v python3 >/dev/null 2>&1; then\n"
+                "  PYTHON_BIN=python3\n"
+                "elif command -v python >/dev/null 2>&1; then\n"
+                "  PYTHON_BIN=python\n"
+                "else\n"
+                "  echo 'python runtime unavailable for host specialist wrapper' >&2\n"
+                "  exit 127\n"
+                "fi\n"
+                f"exec \"$PYTHON_BIN\" \"$SCRIPT_DIR/{wrapper_py.name}\" \"$@\"\n"
+            ),
+            encoding="utf-8",
+        )
+        ensure_executable(launcher)
+
+    return {
+        "platform": platform_tag,
+        "launcher_path": str(launcher.resolve()),
+        "script_path": str(wrapper_py.resolve()),
+        "ready": bool(bridge_command),
+        "bridge_command": bridge_command,
+    }
+
+
+def merge_json_object(path: Path, patch: dict):
+    existing = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            existing = {}
+    merged = dict(existing)
+    for key, value in patch.items():
+        if isinstance(value, dict) and isinstance(existing.get(key), dict):
+            next_value = dict(existing[key])
+            next_value.update(value)
+            merged[key] = next_value
+        else:
+            merged[key] = value
+    write_json_file(path, merged)
+
+
+def materialize_host_settings(target_root: Path, adapter: dict, wrapper_info: dict):
+    host_id = adapter["id"]
+    materialized = []
+    if host_id in {"cursor", "claude-code"}:
+        settings_path = target_root / "settings.json"
+        merge_json_object(
+            settings_path,
+            {
+                "vibeskills": {
+                    "host_id": host_id,
+                    "managed": True,
+                    "commands_root": str((target_root / "commands").resolve()),
+                    "specialist_wrapper": wrapper_info["launcher_path"],
+                }
+            },
+        )
+        materialized.append(str(settings_path.resolve()))
+    elif host_id == "opencode":
+        settings_path = target_root / "opencode.json"
+        merge_json_object(
+            settings_path,
+            {
+                "vibeskills": {
+                    "host_id": host_id,
+                    "managed": True,
+                    "commands_root": str((target_root / "commands").resolve()),
+                    "command_root_compat": str((target_root / "command").resolve()),
+                    "agents_root": str((target_root / "agents").resolve()),
+                    "agent_root_compat": str((target_root / "agent").resolve()),
+                    "specialist_wrapper": wrapper_info["launcher_path"],
+                }
+            },
+        )
+        materialized.append(str(settings_path.resolve()))
+    elif host_id in {"openclaw", "windsurf"}:
+        settings_path = target_root / ".vibeskills" / "host-settings.json"
+        write_json_file(
+            settings_path,
+            {
+                "host_id": host_id,
+                "managed": True,
+                "commands_root": str((target_root / "commands").resolve()),
+                "workflow_root": str((target_root / "global_workflows").resolve()),
+                "mcp_config": str((target_root / "mcp_config.json").resolve()),
+                "specialist_wrapper": wrapper_info["launcher_path"],
+            },
+        )
+        materialized.append(str(settings_path.resolve()))
+    return materialized
+
+
+def materialize_host_closure(repo_root: Path, target_root: Path, adapter: dict):
+    host_id = adapter["id"]
+    bridge_command, bridge_source = resolve_bridge_command(host_id)
+    wrapper_info = materialize_host_specialist_wrapper(target_root, host_id, bridge_command)
+    settings_materialized = materialize_host_settings(target_root, adapter, wrapper_info)
+    commands_root = target_root / "commands"
+    closure_state = "closed_ready" if wrapper_info["ready"] else "configured_offline_unready"
+    closure = {
+        "schema_version": 1,
+        "host_id": host_id,
+        "platform": detect_platform_tag(),
+        "target_root": str(target_root.resolve()),
+        "install_mode": adapter["install_mode"],
+        "commands_root": str(commands_root.resolve()),
+        "global_workflows_root": str((target_root / "global_workflows").resolve()),
+        "mcp_config_path": str((target_root / "mcp_config.json").resolve()),
+        "host_closure_state": closure_state,
+        "commands_materialized": commands_root.exists(),
+        "settings_materialized": settings_materialized,
+        "specialist_wrapper": {
+            "launcher_path": wrapper_info["launcher_path"],
+            "script_path": wrapper_info["script_path"],
+            "ready": wrapper_info["ready"],
+            "bridge_command": bridge_command,
+            "bridge_source": bridge_source,
+        },
+    }
+    closure_path = target_root / ".vibeskills" / "host-closure.json"
+    write_json_file(closure_path, closure)
+    return closure_path, closure
+
+
+def is_closed_ready_required(adapter: dict) -> bool:
+    return (adapter.get("install_mode") or "").strip().lower() != "governed"
 
 
 def sync_vibe_canonical(repo_root: Path, target_root: Path, target_rel: str):
@@ -379,6 +649,7 @@ def main():
     parser.add_argument("--host", required=True)
     parser.add_argument("--profile", choices=("minimal", "full"), default="full")
     parser.add_argument("--allow-external-skill-fallback", action="store_true")
+    parser.add_argument("--require-closed-ready", action="store_true")
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root).resolve()
@@ -401,12 +672,28 @@ def main():
     else:
         raise SystemExit(f"Unsupported adapter install mode: {mode}")
 
+    closure_path, closure = materialize_host_closure(repo_root, target_root, adapter)
+    require_closed_ready_effective = bool(args.require_closed_ready and is_closed_ready_required(adapter))
+    if require_closed_ready_effective and closure["host_closure_state"] != "closed_ready":
+        raise SystemExit(
+            "Host closure for "
+            f"'{adapter['id']}' is not closed_ready "
+            f"(got '{closure['host_closure_state']}'). "
+            "Configure the host specialist bridge command first, then retry install."
+        )
+
     write_json(
         {
             "host_id": adapter["id"],
             "install_mode": mode,
             "target_root": str(target_root),
             "external_fallback_used": external_used,
+            "host_closure_path": str(closure_path),
+            "host_closure_state": closure["host_closure_state"],
+            "settings_materialized": closure["settings_materialized"],
+            "specialist_wrapper_ready": bool(closure["specialist_wrapper"]["ready"]),
+            "require_closed_ready_requested": bool(args.require_closed_ready),
+            "require_closed_ready_effective": require_closed_ready_effective,
         }
     )
 

--- a/bundled/skills/vibe/scripts/runtime/Freeze-RuntimeInputPacket.ps1
+++ b/bundled/skills/vibe/scripts/runtime/Freeze-RuntimeInputPacket.ps1
@@ -547,6 +547,16 @@ $packet = [pscustomobject]@{
         unattended = [bool]$unattended
         route_script_path = $routerScriptPath
     }
+    host_adapter = [pscustomobject]@{
+        requested_host_id = if ($runtime.host_adapter -and -not [string]::IsNullOrWhiteSpace([string]$runtime.host_adapter.requested_id)) { [string]$runtime.host_adapter.requested_id } else { $routerHostId }
+        effective_host_id = if ($runtime.host_adapter -and -not [string]::IsNullOrWhiteSpace([string]$runtime.host_adapter.id)) { [string]$runtime.host_adapter.id } else { $routerHostId }
+        status = if ($runtime.host_adapter -and $runtime.host_adapter.PSObject.Properties.Name -contains 'status') { [string]$runtime.host_adapter.status } else { $null }
+        install_mode = if ($runtime.host_adapter -and $runtime.host_adapter.PSObject.Properties.Name -contains 'install_mode') { [string]$runtime.host_adapter.install_mode } else { $null }
+        check_mode = if ($runtime.host_adapter -and $runtime.host_adapter.PSObject.Properties.Name -contains 'check_mode') { [string]$runtime.host_adapter.check_mode } else { $null }
+        bootstrap_mode = if ($runtime.host_adapter -and $runtime.host_adapter.PSObject.Properties.Name -contains 'bootstrap_mode') { [string]$runtime.host_adapter.bootstrap_mode } else { $null }
+        target_root = $routerTargetRoot
+        closure_path = if ($runtime.host_closure) { [string]$runtime.host_closure.path } else { $null }
+    }
     route_snapshot = [pscustomobject]@{
         selected_pack = if ($routeResult.selected) { [string]$routeResult.selected.pack_id } else { $null }
         selected_skill = $routerSelectedSkill

--- a/bundled/skills/vibe/scripts/runtime/Invoke-DelegatedLaneUnit.ps1
+++ b/bundled/skills/vibe/scripts/runtime/Invoke-DelegatedLaneUnit.ps1
@@ -147,6 +147,10 @@ switch ($laneKind) {
 
 Write-VibeJsonArtifact -Path $receiptPath -Value $receipt
 $payload = [pscustomobject]@{
+    lane_id = [string]$laneSpec.lane_id
+    lane_kind = $laneKind
+    status = if ($receipt) { [string]$receipt.status } else { '' }
+    payload_written = $true
     lane_receipt_path = $receiptPath
     lane_notes_path = $notesPath
     lane_result_path = $resultPath
@@ -154,9 +158,4 @@ $payload = [pscustomobject]@{
 }
 Write-VibeJsonArtifact -Path $payloadPath -Value $payload
 
-[pscustomobject]@{
-    lane_id = [string]$laneSpec.lane_id
-    lane_kind = $laneKind
-    status = if ($receipt) { [string]$receipt.status } else { '' }
-    payload_written = $true
-} | ConvertTo-Json -Depth 20 -Compress
+$payload | ConvertTo-Json -Depth 20 -Compress

--- a/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/bundled/skills/vibe/scripts/runtime/Invoke-PlanExecute.ps1
@@ -5,6 +5,7 @@ param(
     [string]$RequirementDocPath = '',
     [string]$ExecutionPlanPath = '',
     [string]$RuntimeInputPacketPath = '',
+    [string]$ExecutionMemoryContextPath = '',
     [string]$ArtifactRoot = '',
     [AllowEmptyString()] [string]$GovernanceScope = '',
     [AllowEmptyString()] [string]$RootRunId = '',
@@ -137,6 +138,13 @@ function Wait-VibeDelegatedLaneProcess {
     }
 
     $payload = $payloadText | ConvertFrom-Json
+    if (-not ($payload.PSObject.Properties.Name -contains 'lane_receipt_path')) {
+        $payloadPath = Join-Path ([string]($Handle.lane_root)) 'lane-payload.json'
+        if (-not (Test-Path -LiteralPath $payloadPath)) {
+            throw ("Delegated lane payload missing lane_receipt_path and no lane-payload.json exists for {0}" -f ([string]($Handle.lane_id)))
+        }
+        $payload = Get-Content -LiteralPath $payloadPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    }
     $laneReceipt = Get-Content -LiteralPath ([string]($payload.lane_receipt_path)) -Raw -Encoding UTF8 | ConvertFrom-Json
     $laneResult = if ($payload.lane_result_path -and (Test-Path -LiteralPath ([string]($payload.lane_result_path)))) {
         Get-Content -LiteralPath ([string]($payload.lane_result_path)) -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -1096,6 +1104,7 @@ $executionManifest = [pscustomobject]@{
     execution_plan_path = $planPath
     execution_topology_path = $executionTopologyPath
     runtime_input_packet_path = $runtimeInputPath
+    execution_memory_context_path = if ([string]::IsNullOrWhiteSpace($ExecutionMemoryContextPath)) { $null } else { $ExecutionMemoryContextPath }
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     planned_wave_count = @($profile.waves).Count
     planned_unit_count = $plannedUnitCount
@@ -1124,6 +1133,8 @@ $executionManifest = [pscustomobject]@{
         runtime_selected_skill = if ($runtimeInputPacket) { [string]$runtimeInputPacket.authority_flags.explicit_runtime_skill } else { 'vibe' }
         skill_mismatch = if ($runtimeInputPacket) { [bool]$runtimeInputPacket.divergence_shadow.skill_mismatch } else { $false }
         confirm_required = if ($runtimeInputPacket) { [bool]$runtimeInputPacket.route_snapshot.confirm_required } else { $false }
+        requested_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'host_adapter' -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.requested_host_id } else { $null }
+        effective_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'host_adapter' -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.effective_host_id } else { $null }
     }
     execution_topology = [pscustomobject]@{
         path = $executionTopologyPath
@@ -1177,6 +1188,8 @@ $executionManifest = [pscustomobject]@{
         approved_dispatch = @($approvedDispatch)
         auto_approved_dispatch_count = @($autoApprovedDispatch).Count
         auto_approved_dispatch = @($autoApprovedDispatch)
+        requested_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'host_adapter' -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.requested_host_id } else { $null }
+        effective_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'host_adapter' -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.effective_host_id } else { $null }
         phase_binding_counts = [pscustomobject]@{
             pre_execution = @($approvedDispatch | Where-Object { [string]$_.dispatch_phase -eq 'pre_execution' }).Count
             in_execution = @($approvedDispatch | Where-Object { [string]$_.dispatch_phase -eq 'in_execution' }).Count
@@ -1297,6 +1310,7 @@ $receipt = [pscustomobject]@{
     requirement_doc_path = $requirementPath
     execution_plan_path = $planPath
     runtime_input_packet_path = $runtimeInputPath
+    execution_memory_context_path = if ([string]::IsNullOrWhiteSpace($ExecutionMemoryContextPath)) { $null } else { $ExecutionMemoryContextPath }
     plan_shadow_path = $planShadow.path
     execution_manifest_path = $executionManifestPath
     benchmark_proof_manifest_path = $proofManifestPath

--- a/config/version-governance.json
+++ b/config/version-governance.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
   "release": {
-    "version": "2.3.52",
-    "updated": "2026-03-29",
+    "version": "2.3.53",
+    "updated": "2026-03-30",
     "channel": "stable",
-    "notes": "Adds stage-aware memory activation to the main vibe runtime, wires governed Serena/ruflo/Cognee backend adapters into observable session artifacts, and keeps memory-scope boundaries explicit."
+    "notes": "Closes governed specialist dispatch and custom admission, hardens Windows PowerShell host resolution plus managed-host install guarantees, and tightens cleanup-truth safety wording."
   },
   "source_of_truth": {
     "canonical_root": ".",

--- a/dist/core/manifest.json
+++ b/dist/core/manifest.json
@@ -4,8 +4,8 @@
   "lane_kind": "universal-core",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.52",
-    "updated": "2026-03-29"
+    "version": "2.3.53",
+    "updated": "2026-03-30"
   },
   "summary": "Universal contracts only. No install/check runtime closure is promised by this lane.",
   "runtime_ownership": {

--- a/dist/host-claude-code/manifest.json
+++ b/dist/host-claude-code/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "claude-code",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.52",
-    "updated": "2026-03-29"
+    "version": "2.3.53",
+    "updated": "2026-03-30"
   },
   "summary": "Claude Code host adapter preview. The repo can now scaffold preview artifacts and run preview health checks, but still does not claim full governed closure.",
   "runtime_ownership": {

--- a/dist/host-codex/manifest.json
+++ b/dist/host-codex/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "codex",
   "stability": "supported-with-constraints",
   "source_release": {
-    "version": "2.3.52",
-    "updated": "2026-03-29"
+    "version": "2.3.53",
+    "updated": "2026-03-30"
   },
   "summary": "Codex host adapter lane. Uses the official runtime entrypoints, but remains honest about host-managed plugin and credential surfaces.",
   "runtime_ownership": {

--- a/dist/host-cursor/manifest.json
+++ b/dist/host-cursor/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "cursor",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.52",
-    "updated": "2026-03-29"
+    "version": "2.3.53",
+    "updated": "2026-03-30"
   },
   "summary": "Cursor host adapter preview. The repository can expose runtime-core payload and preview health checks, but does not claim full governed closure yet.",
   "runtime_ownership": {

--- a/dist/host-openclaw/manifest.json
+++ b/dist/host-openclaw/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "openclaw",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.52",
-    "updated": "2026-03-29"
+    "version": "2.3.53",
+    "updated": "2026-03-30"
   },
   "summary": "OpenClaw host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/host-opencode/manifest.json
+++ b/dist/host-opencode/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "opencode",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.52",
-    "updated": "2026-03-29"
+    "version": "2.3.53",
+    "updated": "2026-03-30"
   },
   "summary": "OpenCode host adapter preview. The repo can install runtime-core plus OpenCode-native command and agent wrapper payload into OpenCode roots, but final host config and platform closure remain incomplete.",
   "runtime_ownership": {

--- a/dist/host-windsurf/manifest.json
+++ b/dist/host-windsurf/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "windsurf",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.52",
-    "updated": "2026-03-29"
+    "version": "2.3.53",
+    "updated": "2026-03-30"
   },
   "summary": "Windsurf host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/official-runtime/manifest.json
+++ b/dist/official-runtime/manifest.json
@@ -4,8 +4,8 @@
   "lane_kind": "tier-1-official-runtime",
   "stability": "tier-1",
   "source_release": {
-    "version": "2.3.52",
-    "updated": "2026-03-29"
+    "version": "2.3.53",
+    "updated": "2026-03-30"
   },
   "summary": "Reference lane for the current governed official runtime. This dist pack points to it and must not rewrite it.",
   "runtime_ownership": {

--- a/docs/plans/2026-03-30-release-v2.3.53-plan.md
+++ b/docs/plans/2026-03-30-release-v2.3.53-plan.md
@@ -1,0 +1,62 @@
+# 发布 v2.3.53 执行计划
+
+**日期**: 2026-03-30
+**需求文档**: [2026-03-30-release-v2.3.53.md](../requirements/2026-03-30-release-v2.3.53.md)
+**Internal Grade**: `L`
+
+## Wave Structure
+
+### Wave 1: Freeze Release Surface
+
+- 基于 `v2.3.52..main` 汇总本次版本主题与边界。
+- 新增 `docs/releases/v2.3.53.md`。
+- 更新 `docs/releases/README.md` 当前 release surface。
+- 更新 `config/version-governance.json` 的 release summary。
+- 预先对齐 `dist/*/manifest.json` 的 `source_release`。
+
+### Wave 2: Governed Version Cut
+
+- 运行 `scripts/governance/release-cut.ps1 -Version 2.3.53 -Updated 2026-03-30`。
+- 让脚本完成版本治理字段、maintenance section、changelog header、release ledger 写入。
+- 让脚本触发 `sync-bundled-vibe.ps1`，把 root 发布面同步到 bundled / nested bundled mirror。
+
+### Wave 3: Verification And Publish
+
+- 运行版本一致性、dist manifest、specialist dispatch closure 相关 gate。
+- 运行针对 custom admission、multi-host specialist execution、installed runtime scripts 的测试。
+- 审核 `git diff` 后提交、推送分支、合并到 `main`。
+- 在合并后的 `main` 上创建 `v2.3.53` tag 和 GitHub release。
+
+## Ownership Boundaries
+
+- Root governed lane: 版本号、release notes、验证、GitHub 发布。
+- Bundled / nested bundled mirrors: 仅通过 `sync-bundled-vibe.ps1` 同步，不做手工漂移编辑。
+
+## Verification Commands
+
+- `git diff --check`
+- `pytest -q tests/runtime_neutral/test_custom_admission_bridge.py tests/runtime_neutral/test_multi_host_specialist_execution.py tests/runtime_neutral/test_installed_runtime_scripts.py`
+- `pwsh -NoProfile -File scripts/verify/vibe-version-consistency-gate.ps1`
+- `pwsh -NoProfile -File scripts/verify/vibe-dist-manifest-gate.ps1`
+- `pwsh -NoProfile -File scripts/verify/vibe-specialist-dispatch-closure-gate.ps1`
+
+## Delivery Acceptance Plan
+
+- 版本说明必须能从 `v2.3.52..main` 的 commit 与 diff 中直接追溯。
+- 发布完成标准为：远端 `main` 含 release commit，`v2.3.53` tag 已存在，GitHub release 已创建。
+
+## Completion Language Rules
+
+- 验证未过或远端对象未创建前，只能说“已准备发布”。
+- 只有 tag 和 GitHub release 都落地后，才能说“已发布 v2.3.53”。
+
+## Rollback Rules
+
+- 若 gate 或测试失败，停止发布，不打 tag。
+- 若分支已推送但未合并，修复后复用同一发布分支，不重写历史 release note 版本号。
+- 若 tag 创建失败，不创建 GitHub release。
+
+## Cleanup Expectations
+
+- 不在版本提交中带入 `outputs/` 运行产物。
+- phase 结束后只保留受治理文档与版本面改动。

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -10,7 +10,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ### Current Release Surface
 
-- [`v2.3.51.md`](v2.3.51.md): main-chain delivery acceptance / specialist dispatch governance closure / Windows specialist runtime handoff fix
+- [`v2.3.53.md`](v2.3.53.md): governed specialist dispatch and custom admission closure / Windows PowerShell host resolution / managed host install guarantees / cleanup-truth tightening
 
 ### Release Runtime / Proof Handoff
 
@@ -22,6 +22,8 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ## Recent Governed Releases
 
+- [`v2.3.53.md`](v2.3.53.md) - 2026-03-30 - governed specialist dispatch and custom admission closure / Windows PowerShell host resolution / managed host install guarantees / cleanup-truth tightening
+- [`v2.3.52.md`](v2.3.52.md) - 2026-03-29 - stage-aware memory activation / governed memory backend adapters / explicit memory-scope boundaries
 - [`v2.3.51.md`](v2.3.51.md) - 2026-03-28 - main-chain delivery acceptance / specialist dispatch governance closure / Windows specialist runtime handoff fix
 - [`v2.3.50.md`](v2.3.50.md) - 2026-03-26 - router AI connectivity probe / host-adapter expansion / single-entry install surface / Windows PowerShell default verification guidance
 - [`v2.3.49.md`](v2.3.49.md) - 2026-03-23 - shallow-worktree install/check hardening / installed-runtime adapter fallback / parent-path guard convergence

--- a/docs/releases/v2.3.53.md
+++ b/docs/releases/v2.3.53.md
@@ -1,0 +1,35 @@
+# VCO Release v2.3.53
+
+- Date: 2026-03-30
+- Commit(base): 4f5676f
+- Previous release: `v2.3.52`
+
+## Highlights
+
+- Closed the governed specialist-dispatch gap with explicit custom-admission handling and restored the missing delegated-lane / host-adapter metadata handoff. Router admission, confirm UI, runtime input packets, delegated lane payloads, and specialist execution now carry the same bounded-dispatch truth instead of relying on weaker implied behavior.
+- Hardened Windows PowerShell host resolution across install, check, and bootstrap surfaces, and tightened managed-host install guarantees across Claude Code, Cursor, Windsurf, OpenClaw, and OpenCode adapter lanes.
+- Tightened cleanup-truth wording and policy so public docs and runtime policy stop overstating what phase cleanup can guarantee, especially around no-false-cleanliness claims.
+
+## What Changed Compared With v2.3.52
+
+- `v2.3.52` pushed governed memory activation into the standard six-stage runtime and made backend memory activity observable.
+- `v2.3.53` shifts the focus back to release-facing reliability and truth alignment: specialist admission, specialist dispatch closure, host install guarantees, and cleanup-safety claims now line up more tightly across router, runtime, install, and adapter surfaces.
+- The important difference is not a new product lane. The difference is that governed execution and host-facing entrypoints now make fewer promises they cannot prove, while carrying stronger explicit proof for the promises they do make.
+
+## Validation Notes
+
+- Runtime / specialist dispatch coverage:
+  - `pytest -q tests/runtime_neutral/test_custom_admission_bridge.py tests/runtime_neutral/test_multi_host_specialist_execution.py`
+- Install / host-resolution coverage:
+  - `pytest -q tests/runtime_neutral/test_installed_runtime_scripts.py`
+- Release-surface and version consistency:
+  - `git diff --check`
+  - `pwsh -NoProfile -File scripts/verify/vibe-version-consistency-gate.ps1`
+  - `pwsh -NoProfile -File scripts/verify/vibe-dist-manifest-gate.ps1`
+  - `pwsh -NoProfile -File scripts/verify/vibe-specialist-dispatch-closure-gate.ps1`
+
+## Migration Notes
+
+- Operators on stock Windows PowerShell hosts should see more reliable install and runtime detection without needing ad-hoc shell overrides in normal supported setups.
+- Specialist-capable governed runs now expose stricter admission and dispatch behavior. Treat those receipts and gates as the source of truth rather than assuming older implicit dispatch behavior still applies.
+- This release improves closure and truth alignment. It does not claim any new broad host-native support tier beyond what the current adapter / distribution documents already state.

--- a/docs/requirements/2026-03-30-release-v2.3.53.md
+++ b/docs/requirements/2026-03-30-release-v2.3.53.md
@@ -1,0 +1,38 @@
+# 发布 v2.3.53 需求
+
+**日期**: 2026-03-30
+**目标**: 基于 GitHub 当前最新 `main`（`4f5676f`）切出新的稳定版本，完成受治理版本面更新、版本说明、tag / GitHub release 发布。
+
+## Intent Contract
+
+- Goal: 发布一个能准确反映 `v2.3.52..main` 真实变更范围的新稳定版本。
+- Deliverable: `v2.3.53` 的仓库版本更新、release notes、changelog / ledger 记录，以及 GitHub tag / release。
+- Constraints:
+  - 必须基于远端最新 `main`，不能基于本地脏工作树。
+  - 不能跳过仓库既有 release governance。
+  - 版本说明必须只陈述已经落在 `main` 上的事实。
+- Acceptance Criteria:
+  - `config/version-governance.json`、`SKILL.md`、`bundled/skills/vibe/SKILL.md` 与 `dist/*/manifest.json` 对齐到 `2.3.53 / 2026-03-30`。
+  - `docs/releases/v2.3.53.md` 完整描述本次变更与验证面。
+  - `references/changelog.md` 与 `references/release-ledger.jsonl` 新增 `v2.3.53` 记录。
+  - GitHub 上出现 `v2.3.53` tag 与 release。
+- Product Acceptance Criteria:
+  - 发布说明清楚覆盖 governed specialist dispatch / custom admission closure、Windows PowerShell host resolution 修复、managed host install guarantees 收紧、cleanup truth wording 收口。
+  - 不把 memory runtime 或未进 `main` 的事项错误归入本次版本。
+- Manual Spot Checks:
+  - 对照 `git log v2.3.52..main` 检查 release highlights。
+  - 对照 `git diff --stat v2.3.52..main` 检查说明未遗漏主要变更面。
+  - 在 GitHub release 页面确认标题、tag 和 notes 对齐。
+- Completion Language Policy:
+  - 只有在本地验证通过且远端 tag / release 已创建后，才允许使用“已发布”表述。
+- Delivery Truth Contract:
+  - 版本说明以仓库 `main` 上的合并结果为准，不把本地临时产物当成发布内容。
+  - 任何未验证或未推送的变更都不能写入完成声明。
+- Non-goals:
+  - 不在本轮引入新的功能开发。
+  - 不重写历史 release notes。
+  - 不改动与本次版本无关的发布流程设计。
+- Autonomy Mode: `interactive_governed`
+- Inferred Assumptions:
+  - 下一稳定版本按 patch 递增为 `v2.3.53`。
+  - 当前 GitHub 认证足以创建分支、PR、tag 和 release。

--- a/references/changelog.md
+++ b/references/changelog.md
@@ -1,5 +1,13 @@
 # VCO Changelog
 
+## v2.3.53 (2026-03-30)
+
+- Closed governed specialist dispatch with explicit custom-admission handling, and restored delegated-lane payload plus host-adapter metadata continuity across router admission, runtime packets, and specialist execution closure gates.
+- Hardened Windows PowerShell host resolution for install, check, and bootstrap surfaces, and tightened managed-host install guarantees across the current preview / runtime-core adapter lanes.
+- Tightened cleanup-truth wording and policy so public release claims and runtime cleanup semantics stay aligned with what the governed runtime can actually prove.
+- Detailed release notes: `docs/releases/v2.3.53.md`.
+
+
 ## v2.3.52 (2026-03-29)
 
 - Landed stage-aware memory activation inside the standard six-stage `vibe` runtime, including per-run memory activation reports and bounded context injection into governed artifacts.

--- a/references/release-ledger.jsonl
+++ b/references/release-ledger.jsonl
@@ -30,3 +30,4 @@
 {"recorded_at":"2026-03-26T20:39:51","version":"2.3.50","updated":"2026-03-26","git_head":"d5da111","actor":null}
 {"recorded_at":"2026-03-28T00:00:00","version":"2.3.51","updated":"2026-03-28","git_head":"18e6b9c","actor":null}
 {"recorded_at":"2026-03-29T10:14:24","version":"2.3.52","updated":"2026-03-29","git_head":"870fd20","actor":null}
+{"recorded_at":"2026-03-30T00:28:44","version":"2.3.53","updated":"2026-03-30","git_head":"4f5676f","actor":null}

--- a/scripts/runtime/Freeze-RuntimeInputPacket.ps1
+++ b/scripts/runtime/Freeze-RuntimeInputPacket.ps1
@@ -547,6 +547,16 @@ $packet = [pscustomobject]@{
         unattended = [bool]$unattended
         route_script_path = $routerScriptPath
     }
+    host_adapter = [pscustomobject]@{
+        requested_host_id = if ($runtime.host_adapter -and -not [string]::IsNullOrWhiteSpace([string]$runtime.host_adapter.requested_id)) { [string]$runtime.host_adapter.requested_id } else { $routerHostId }
+        effective_host_id = if ($runtime.host_adapter -and -not [string]::IsNullOrWhiteSpace([string]$runtime.host_adapter.id)) { [string]$runtime.host_adapter.id } else { $routerHostId }
+        status = if ($runtime.host_adapter -and $runtime.host_adapter.PSObject.Properties.Name -contains 'status') { [string]$runtime.host_adapter.status } else { $null }
+        install_mode = if ($runtime.host_adapter -and $runtime.host_adapter.PSObject.Properties.Name -contains 'install_mode') { [string]$runtime.host_adapter.install_mode } else { $null }
+        check_mode = if ($runtime.host_adapter -and $runtime.host_adapter.PSObject.Properties.Name -contains 'check_mode') { [string]$runtime.host_adapter.check_mode } else { $null }
+        bootstrap_mode = if ($runtime.host_adapter -and $runtime.host_adapter.PSObject.Properties.Name -contains 'bootstrap_mode') { [string]$runtime.host_adapter.bootstrap_mode } else { $null }
+        target_root = $routerTargetRoot
+        closure_path = if ($runtime.host_closure) { [string]$runtime.host_closure.path } else { $null }
+    }
     route_snapshot = [pscustomobject]@{
         selected_pack = if ($routeResult.selected) { [string]$routeResult.selected.pack_id } else { $null }
         selected_skill = $routerSelectedSkill

--- a/scripts/runtime/Invoke-DelegatedLaneUnit.ps1
+++ b/scripts/runtime/Invoke-DelegatedLaneUnit.ps1
@@ -147,6 +147,10 @@ switch ($laneKind) {
 
 Write-VibeJsonArtifact -Path $receiptPath -Value $receipt
 $payload = [pscustomobject]@{
+    lane_id = [string]$laneSpec.lane_id
+    lane_kind = $laneKind
+    status = if ($receipt) { [string]$receipt.status } else { '' }
+    payload_written = $true
     lane_receipt_path = $receiptPath
     lane_notes_path = $notesPath
     lane_result_path = $resultPath
@@ -154,9 +158,4 @@ $payload = [pscustomobject]@{
 }
 Write-VibeJsonArtifact -Path $payloadPath -Value $payload
 
-[pscustomobject]@{
-    lane_id = [string]$laneSpec.lane_id
-    lane_kind = $laneKind
-    status = if ($receipt) { [string]$receipt.status } else { '' }
-    payload_written = $true
-} | ConvertTo-Json -Depth 20 -Compress
+$payload | ConvertTo-Json -Depth 20 -Compress

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -5,6 +5,7 @@ param(
     [string]$RequirementDocPath = '',
     [string]$ExecutionPlanPath = '',
     [string]$RuntimeInputPacketPath = '',
+    [string]$ExecutionMemoryContextPath = '',
     [string]$ArtifactRoot = '',
     [AllowEmptyString()] [string]$GovernanceScope = '',
     [AllowEmptyString()] [string]$RootRunId = '',
@@ -137,6 +138,13 @@ function Wait-VibeDelegatedLaneProcess {
     }
 
     $payload = $payloadText | ConvertFrom-Json
+    if (-not ($payload.PSObject.Properties.Name -contains 'lane_receipt_path')) {
+        $payloadPath = Join-Path ([string]($Handle.lane_root)) 'lane-payload.json'
+        if (-not (Test-Path -LiteralPath $payloadPath)) {
+            throw ("Delegated lane payload missing lane_receipt_path and no lane-payload.json exists for {0}" -f ([string]($Handle.lane_id)))
+        }
+        $payload = Get-Content -LiteralPath $payloadPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    }
     $laneReceipt = Get-Content -LiteralPath ([string]($payload.lane_receipt_path)) -Raw -Encoding UTF8 | ConvertFrom-Json
     $laneResult = if ($payload.lane_result_path -and (Test-Path -LiteralPath ([string]($payload.lane_result_path)))) {
         Get-Content -LiteralPath ([string]($payload.lane_result_path)) -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -1096,6 +1104,7 @@ $executionManifest = [pscustomobject]@{
     execution_plan_path = $planPath
     execution_topology_path = $executionTopologyPath
     runtime_input_packet_path = $runtimeInputPath
+    execution_memory_context_path = if ([string]::IsNullOrWhiteSpace($ExecutionMemoryContextPath)) { $null } else { $ExecutionMemoryContextPath }
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     planned_wave_count = @($profile.waves).Count
     planned_unit_count = $plannedUnitCount
@@ -1124,6 +1133,8 @@ $executionManifest = [pscustomobject]@{
         runtime_selected_skill = if ($runtimeInputPacket) { [string]$runtimeInputPacket.authority_flags.explicit_runtime_skill } else { 'vibe' }
         skill_mismatch = if ($runtimeInputPacket) { [bool]$runtimeInputPacket.divergence_shadow.skill_mismatch } else { $false }
         confirm_required = if ($runtimeInputPacket) { [bool]$runtimeInputPacket.route_snapshot.confirm_required } else { $false }
+        requested_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'host_adapter' -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.requested_host_id } else { $null }
+        effective_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'host_adapter' -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.effective_host_id } else { $null }
     }
     execution_topology = [pscustomobject]@{
         path = $executionTopologyPath
@@ -1177,6 +1188,8 @@ $executionManifest = [pscustomobject]@{
         approved_dispatch = @($approvedDispatch)
         auto_approved_dispatch_count = @($autoApprovedDispatch).Count
         auto_approved_dispatch = @($autoApprovedDispatch)
+        requested_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'host_adapter' -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.requested_host_id } else { $null }
+        effective_host_adapter_id = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'host_adapter' -and $runtimeInputPacket.host_adapter) { [string]$runtimeInputPacket.host_adapter.effective_host_id } else { $null }
         phase_binding_counts = [pscustomobject]@{
             pre_execution = @($approvedDispatch | Where-Object { [string]$_.dispatch_phase -eq 'pre_execution' }).Count
             in_execution = @($approvedDispatch | Where-Object { [string]$_.dispatch_phase -eq 'in_execution' }).Count
@@ -1297,6 +1310,7 @@ $receipt = [pscustomobject]@{
     requirement_doc_path = $requirementPath
     execution_plan_path = $planPath
     runtime_input_packet_path = $runtimeInputPath
+    execution_memory_context_path = if ([string]::IsNullOrWhiteSpace($ExecutionMemoryContextPath)) { $null } else { $ExecutionMemoryContextPath }
     plan_shadow_path = $planShadow.path
     execution_manifest_path = $executionManifestPath
     benchmark_proof_manifest_path = $proofManifestPath


### PR DESCRIPTION
## Summary
- cut governed release v2.3.53 from latest main
- add release notes, requirement and plan docs
- update governed version surfaces and dist manifests
- fix plan_execute runtime regressions blocking specialist-dispatch verification

## Verification
- git diff --check
- pytest -q tests/runtime_neutral/test_custom_admission_bridge.py tests/runtime_neutral/test_multi_host_specialist_execution.py tests/runtime_neutral/test_installed_runtime_scripts.py
- pwsh -NoProfile -File ./scripts/verify/vibe-version-consistency-gate.ps1
- pwsh -NoProfile -File ./scripts/verify/vibe-dist-manifest-gate.ps1
- pwsh -NoProfile -File ./scripts/verify/vibe-specialist-dispatch-closure-gate.ps1