### PR TITLE
Align skill-only host installs, uninstalls, and docs

### DIFF
--- a/check.ps1
+++ b/check.ps1
@@ -500,23 +500,16 @@ function Invoke-AdapterSpecificChecks {
   }
   if ([string]$Adapter.check_mode -eq 'preview-guidance') {
     if ([string]$Adapter.id -eq 'opencode') {
-      Warn-Note -Message 'opencode preview keeps the real opencode.json host-managed; only skills, commands, agents, and an example config scaffold are verified'
-    } elseif ([string]$Adapter.id -eq 'cursor') {
-      Write-Host '[INFO] cursor preview now materializes managed commands, host-closure state, and a minimal settings surface; deeper host-native workflow remains preview-scoped' -ForegroundColor Cyan
+      Write-Host '[INFO] opencode preview now runs as skills-only activation; the real opencode.json stays untouched and sidecar state is verified' -ForegroundColor Cyan
     } else {
-      Write-Host ("[INFO] {0} preview hook/settings scaffold remains intentionally unavailable while the author works through compatibility issues; this is a current product boundary, not an install failure" -f $Adapter.id) -ForegroundColor Cyan
+      Write-Host ("[INFO] {0} preview now runs as skills-only activation; host-native config files stay untouched and sidecar state is verified" -f $Adapter.id) -ForegroundColor Cyan
     }
   }
   if ([string]$Adapter.check_mode -eq 'runtime-core') {
-    $commandsRoot = Join-Path $RepoRoot 'commands'
-    if (Test-Path -LiteralPath $commandsRoot) {
-      Check-Path -Label "global workflows" -Path (Join-Path $TargetRoot 'global_workflows')
-    }
-
-    $mcpTemplatePath = Join-Path $RepoRoot 'mcp\servers.template.json'
-    if (Test-Path -LiteralPath $mcpTemplatePath) {
-      Check-Path -Label "mcp_config.json" -Path (Join-Path $TargetRoot 'mcp_config.json')
-    }
+    Write-Host ("[INFO] {0} runtime-core now verifies skill-native activation and sidecar state only; host-native workflow/config files are intentionally absent" -f $Adapter.id) -ForegroundColor Cyan
+  }
+  if ([string]$Adapter.id -in @('claude-code', 'cursor', 'windsurf', 'openclaw', 'opencode')) {
+    Check-Path -Label "host settings sidecar" -Path (Join-Path $TargetRoot '.vibeskills\host-settings.json')
   }
   if ([string]$Adapter.check_mode -eq 'governed') {
     Check-Path -Label "plugins manifest" -Path (Join-Path $TargetRoot 'config\plugins-manifest.codex.json')

--- a/check.sh
+++ b/check.sh
@@ -787,20 +787,16 @@ if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
 fi
 if [[ "${ADAPTER_CHECK_MODE}" == "preview-guidance" ]]; then
   if [[ "${HOST_ID}" == "opencode" ]]; then
-    warn_note "opencode preview keeps the real opencode.json host-managed; only skills, commands, agents, and an example config scaffold are verified"
-  elif [[ "${HOST_ID}" == "cursor" ]]; then
-    info_note "cursor preview now materializes managed commands, host-closure state, and a minimal settings surface; deeper host-native workflow remains preview-scoped"
+    info_note "opencode preview now runs as skills-only activation; the real opencode.json stays untouched and sidecar state is verified"
   else
-    info_note "${HOST_ID} preview hook/settings scaffold remains intentionally unavailable while the author works through compatibility issues; this is a current product boundary, not an install failure"
+    info_note "${HOST_ID} preview now runs as skills-only activation; host-native config files stay untouched and sidecar state is verified"
   fi
 fi
 if [[ "${ADAPTER_CHECK_MODE}" == "runtime-core" ]]; then
-  if [[ -d "${SCRIPT_DIR}/commands" ]]; then
-    check_path "global workflows" "${TARGET_ROOT}/global_workflows"
-  fi
-  if [[ -f "${SCRIPT_DIR}/mcp/servers.template.json" ]]; then
-    check_path "mcp_config.json" "${TARGET_ROOT}/mcp_config.json"
-  fi
+  info_note "${HOST_ID} runtime-core now verifies skill-native activation and sidecar state only; host-native workflow/config files are intentionally absent"
+fi
+if [[ "${HOST_ID}" == "claude-code" || "${HOST_ID}" == "cursor" || "${HOST_ID}" == "windsurf" || "${HOST_ID}" == "openclaw" || "${HOST_ID}" == "opencode" ]]; then
+  check_path "host settings sidecar" "${TARGET_ROOT}/.vibeskills/host-settings.json"
 fi
 check_path "host closure manifest" "${TARGET_ROOT}/.vibeskills/host-closure.json"
 if [[ -f "${TARGET_ROOT}/.vibeskills/host-closure.json" ]]; then

--- a/docs/audits/2026-03-30-cross-host-startup-regression-audit.md
+++ b/docs/audits/2026-03-30-cross-host-startup-regression-audit.md
@@ -1,0 +1,126 @@
+# Cross-Host Startup Regression Audit
+
+**日期**: 2026-03-30
+**需求**: [../requirements/2026-03-30-cross-host-startup-regression-audit.md](../requirements/2026-03-30-cross-host-startup-regression-audit.md)
+**计划**: [../plans/2026-03-30-cross-host-startup-regression-audit-plan.md](../plans/2026-03-30-cross-host-startup-regression-audit-plan.md)
+
+## Summary
+
+排查结论分两类：
+
+- 与 OpenCode 同类的“真实配置被写坏后宿主直接拒绝解析并无法启动”问题，当前**只在 `opencode` 上确认复现**。
+- `windsurf`、`openclaw` 在当前仓库代码下，**已确认不具备与 OpenCode 同类的故障入口**。
+- `claude-code`、`cursor` 当前**不能再写成 `confirmed-safe`**：
+  - `claude-code`：已证明 `claude agents` 会读取 `settings.json`，且该命令面对 `vibeskills`、明显未知键、坏 JSON 时仍返回成功；但这只能证明该命令面的容忍性，**不能外推出整个宿主都安全**。
+  - `cursor`：当前 CLI 探针还**没有证明任何已测命令会读取 `settings.json`**，因此之前基于 `cursor-agent about` 的“safe”结论不成立，只能写成**未证实同类回归，但也未证实安全**。
+
+## Host-by-Host Result
+
+### `claude-code`
+
+- Classification: `settings-surface-read-confirmed-command-level-tolerance-observed`
+- Shared config written: `settings.json` 顶层 `vibeskills`
+- Probe:
+  - baseline read proof:
+    - `HOME=<tmp> CLAUDE_HOME=<tmp>/.claude`
+    - `printf '{}' > "$CLAUDE_HOME/settings.json"`
+    - `strace -f -e trace=openat claude agents`
+  - tolerance probe:
+    - `claude agents` with `settings.json = {"vibeskills": {...}}`
+    - `claude agents` with `settings.json = {"definitely_unknown_root_key_for_probe": 1}`
+    - `claude agents` with malformed `settings.json`
+  - control probe:
+    - `claude --help` with the same three config variants
+- Evidence:
+  - `strace` 明确显示 `claude agents` 多次打开 `"$CLAUDE_HOME/settings.json"`
+  - `claude agents` 在三种配置下都返回 `4 active agents`，`rc=0`
+  - `claude --help` 在三种配置下也都成功返回帮助文本，`rc=0`
+  - 这说明之前“`claude agents` 成功返回，所以它可能根本没读配置”的推断是错的；它**确实读了配置**
+- Conclusion:
+  - 可以证明的是：`claude` CLI 至少在 `agents` 这个已验证命令面上，会读取 `settings.json`，且对 `vibeskills`、明显未知键、坏 JSON 表现出容忍
+  - 不能证明的是：整个 Claude Code 宿主在所有启动/运行路径上都安全接受顶层 `vibeskills`
+  - 因此这里**不能再写 `confirmed-safe`**，只能写成“已确认读取 + 已观察到命令级容忍，未证实同类启动回归”
+
+### `cursor`
+
+- Classification: `not-proven-with-current-probe`
+- Shared config written: `settings.json` 顶层 `vibeskills`
+- Probe:
+  - read-surface probe:
+    - `HOME=<tmp> CURSOR_HOME=<tmp>/.cursor`
+    - `printf '{}' > "$CURSOR_HOME/settings.json"`
+    - `strace -f -e trace=openat cursor-agent about`
+    - `strace -f -e trace=openat cursor-agent models`
+    - `strace -f -e trace=openat cursor-agent status`
+    - `strace -f -e trace=openat cursor-agent ls`
+  - tolerance probe:
+    - `cursor-agent about` / `cursor-agent models` with `settings.json = {"vibeskills": {...}}`
+    - `cursor-agent about` / `cursor-agent models` with `settings.json = {"definitely_unknown_root_key_for_probe": 1}`
+    - `cursor-agent about` / `cursor-agent models` with malformed `settings.json`
+- Evidence:
+  - `cursor-agent about`、`models`、`status`、`ls` 的 `strace` 结果里，目前只稳定看到 `agent-cli-state.json`，**没有抓到 `settings.json` 读取证据**
+  - `cursor-agent about` 在 `vibeskills`、明显未知键、坏 JSON 下都成功返回 `About Cursor CLI`，`rc=0`
+  - `cursor-agent models` 在上述三种配置下都成功返回 `No models available for this account.`，`rc=0`
+  - 这说明之前“`about` 成功返回，所以 Cursor 安全接受 `vibeskills`”的结论没有证据支撑，因为**尚未证明 `about` 会读 `settings.json`**
+- Conclusion:
+  - 当前只能证明：已测 `cursor-agent` 命令**没有像 OpenCode 那样立刻因为顶层 `vibeskills` 或坏 JSON 报错退出**
+  - 当前不能证明：这些命令真的读取了 `settings.json`
+  - 因此这里**不能再写 `confirmed-safe`**，只能写成“未证实同类回归，但安全性也未被当前探针证明”
+
+### `windsurf`
+
+- Classification: `confirmed-safe-against-same-class-regression`
+- Shared config written: 否
+- Host state written:
+  - `.vibeskills/host-settings.json`
+  - `mcp_config.json`
+  - `global_workflows/**`
+- Probe:
+  - baseline: `HOME=<tmp> WINDSURF_HOME=<tmp>/.codeium/windsurf windsurf --status --user-data-dir <tmp>/userdata`
+  - after install: `bash ./install.sh --host windsurf --target-root <tmp>/.codeium/windsurf --profile full`
+  - post-install: same `windsurf --status ...`
+- Evidence:
+  - baseline 与 post-install 都返回同一条警告：`--status argument can only be used if Windsurf is already running`
+  - 安装根下没有 `settings.json`
+  - 只写 `.vibeskills/host-settings.json` 与 `mcp_config.json`
+- Conclusion:
+  - 当前仓库不写 Windsurf 的共享 settings surface，因此不存在与 OpenCode 同类的“真实配置键非法”风险前提
+  - 本地最小 CLI 探针前后行为一致，未见启动链退化
+
+### `openclaw`
+
+- Classification: `confirmed-safe-against-same-class-regression`
+- Shared config written: 否
+- Host state written:
+  - `.vibeskills/host-settings.json`
+  - `mcp_config.json`
+  - `global_workflows/**`
+- Probe:
+  - baseline: `HOME=<tmp> OPENCLAW_HOME=<tmp>/.openclaw openclaw config validate`
+  - baseline: `HOME=<tmp> OPENCLAW_HOME=<tmp>/.openclaw openclaw skills list`
+  - after install: `bash ./install.sh --host openclaw --target-root <tmp>/.openclaw --profile full`
+  - post-install: repeat the same two commands
+- Evidence:
+  - `config validate` 安装前后都返回相同结果：缺少宿主自己的 `openclaw.json`
+  - `skills list` 安装前后都能正常运行并列出 skills
+  - 安装根下没有 `settings.json`
+  - 只写 `.vibeskills/host-settings.json` 与 `mcp_config.json`
+- Conclusion:
+  - 当前仓库不写 OpenClaw 的共享 settings surface，因此不存在与 OpenCode 同类的“真实配置键非法”风险前提
+  - 本地 CLI 探针前后行为一致，未见启动链退化
+
+## Overall Conclusion
+
+- `opencode`: 已确认存在并已修复
+- `claude-code`: 已确认 `settings.json` 被读取；已验证命令面未复现 OpenCode 式解析炸裂；**但不能写成 confirmed-safe**
+- `cursor`: 已测 CLI 命令面未复现 OpenCode 式报错退出；**但尚未证明会读取 `settings.json`，因此不能写成 confirmed-safe**
+- `windsurf`: 当前未发现同类启动回归
+- `openclaw`: 当前未发现同类启动回归
+
+更精确地说：
+
+- 真正需要警惕的是“宿主真实配置文件语法/字段 schema 很严格，且安装器往里面写了宿主不认识的键”
+- 当前这类高风险前提只在 `opencode` 上被证实
+- `claude-code`：当前只证明某些已测命令会读取并容忍该配置；证据等级不足以支撑“宿主整体安全”
+- `cursor`：当前只证明若干命令没有立刻炸；证据等级不足以支撑“命令已读配置且安全接受”
+- `windsurf/openclaw` 当前根本不写共享 `settings.json`，所以不具备与 OpenCode 同类的故障入口

--- a/docs/cold-start-install-paths.en.md
+++ b/docs/cold-start-install-paths.en.md
@@ -89,13 +89,13 @@ What you get:
 
 - shared runtime payload
 - a runtime-core preview install under `~/.codeium/windsurf`
-- optional `mcp_config.json` materialization
-- optional `global_workflows/` materialization
+- `.vibeskills/host-settings.json` and `.vibeskills/host-closure.json`
+- a skills-only activation path that stays dormant until Vibe is explicitly invoked
 
 What you do not get:
 
 - full closure
-- automatic takeover of host-local configuration
+- automatic takeover of host-local config files
 
 ## OpenClaw
 
@@ -108,6 +108,7 @@ What you get:
 
 - shared runtime payload
 - an OpenClaw runtime-core preview install path, with default target root from `OPENCLAW_HOME` or `~/.openclaw`
+- `.vibeskills/host-settings.json` and `.vibeskills/host-closure.json`
 - explicit attach / copy / bundle path semantics:
   - attach: connect and validate an existing `OPENCLAW_HOME` (or `~/.openclaw`) target root
   - copy: use install/check entrypoints to copy runtime-core payload into the target root
@@ -130,8 +131,8 @@ bash ./check.sh --host opencode
 What you get:
 
 - runtime-core payload
-- VibeSkills skill payload
-- OpenCode command / agent wrappers
+- Vibe-Skills skill payload
+- `.vibeskills/host-settings.json` and `.vibeskills/host-closure.json`
 - `opencode.json.example`
 
 What you do not get:

--- a/docs/cold-start-install-paths.md
+++ b/docs/cold-start-install-paths.md
@@ -94,13 +94,13 @@ bash ./check.sh --host windsurf --profile full --deep
 
 - shared runtime payload
 - `~/.codeium/windsurf` 下的 runtime-core 预览安装结果
-- 按需物化 `mcp_config.json`
-- 按需物化 `global_workflows/`
+- `.vibeskills/host-settings.json` 与 `.vibeskills/host-closure.json`
+- 只在显式调用 Vibe skill 时生效的 skill-only activation 路径
 
 你不会得到：
 
 - full closure
-- 宿主侧本地配置的自动代管
+- 宿主侧本地配置文件的自动代管
 
 ## OpenClaw
 
@@ -113,6 +113,7 @@ bash ./check.sh --host openclaw --profile full --deep
 
 - shared runtime payload
 - OpenClaw runtime-core 预览安装路径，默认目标根目录为 `OPENCLAW_HOME` 或 `~/.openclaw`
+- `.vibeskills/host-settings.json` 与 `.vibeskills/host-closure.json`
 - attach / copy / bundle 三路径口径：
   - attach：把已有 `OPENCLAW_HOME`（或 `~/.openclaw`）作为目标根目录进行接入与校验
   - copy：通过 install/check 入口把 runtime-core payload 复制到目标根目录
@@ -135,8 +136,8 @@ bash ./check.sh --host opencode
 你会得到：
 
 - runtime-core payload
-- VibeSkills skill payload
-- OpenCode command / agent wrappers
+- Vibe-Skills skill payload
+- `.vibeskills/host-settings.json` 与 `.vibeskills/host-closure.json`
 - `opencode.json.example`
 
 你不会得到：

--- a/docs/install/README.en.md
+++ b/docs/install/README.en.md
@@ -10,7 +10,8 @@ This directory contains the public install, upgrade, and custom-integration docs
 
 ### Public Uninstall Entry
 
-- [`uninstall.ps1` / `uninstall.sh` (root)](../uninstall.ps1) + [`docs/uninstall-governance.md`](../uninstall-governance.md): the owned-only uninstall contract; these scripts mirror `install.*` arguments and only remove Vibe-managed payloads recorded in the install ledger or closure metadata.
+- [`../../uninstall.ps1`](../../uninstall.ps1) / [`../../uninstall.sh`](../../uninstall.sh): the symmetric uninstall entry after install; it mirrors `install.*` arguments and only removes Vibe-managed payloads recorded by the install ledger, host closure, or conservative legacy rules
+- [`../uninstall-governance.md`](../uninstall-governance.md): the owned-only uninstall contract; shared JSON cleanup is limited to Vibe-managed nodes and does not roll back host-managed login state, provider credentials, or plugin state by default
 
 ### Reference Docs
 

--- a/docs/install/host-plugin-policy.en.md
+++ b/docs/install/host-plugin-policy.en.md
@@ -52,7 +52,7 @@ Other agents should not currently be described as having a supported install pat
 
 - supported install-and-use path
 - default root is `~/.codeium/windsurf`
-- the repo currently owns only shared install content plus optional materialization of `mcp_config.json` and `global_workflows/`
+- the repo currently owns only shared install content plus sidecar state such as `.vibeskills/host-settings.json` and `.vibeskills/host-closure.json`
 - Windsurf-native local settings remain managed on the Windsurf side
 
 ## OpenClaw
@@ -66,7 +66,7 @@ Other agents should not currently be described as having a supported install pat
 
 - supported install-and-use path
 - default target root is `OPENCODE_HOME` or `~/.config/opencode`
-- direct install/check writes skills, command/agent wrappers, and `opencode.json.example`
+- direct install/check writes skills, `.vibeskills/*` sidecars, and `opencode.json.example`
 - the real `opencode.json`, provider credentials, plugin installation, and MCP trust remain managed on the OpenCode side
 
 ## Recommended Community Wording

--- a/docs/install/host-plugin-policy.md
+++ b/docs/install/host-plugin-policy.md
@@ -52,7 +52,7 @@
 
 - 提供支持的安装与使用路径
 - 默认根目录是 `~/.codeium/windsurf`
-- 当前仓库只负责共享安装内容，以及按需物化 `mcp_config.json` 和 `global_workflows/`
+- 当前仓库只负责共享安装内容，以及 `.vibeskills/host-settings.json` / `.vibeskills/host-closure.json` 这类 sidecar 状态
 - Windsurf 宿主本地设置仍按 Windsurf 自身方式管理
 
 ## OpenClaw
@@ -66,7 +66,7 @@
 
 - 提供支持的安装与使用路径
 - 默认目标根目录是 `OPENCODE_HOME` 或 `~/.config/opencode`
-- direct install/check 会写入 skills、command/agent wrappers 与 `opencode.json.example`
+- direct install/check 会写入 skills、`.vibeskills/*` sidecar 与 `opencode.json.example`
 - 真实 `opencode.json`、provider 凭据、plugin 安装与 MCP 信任仍按宿主自身方式管理
 
 ## 推荐的社区表述

--- a/docs/install/installation-rules.en.md
+++ b/docs/install/installation-rules.en.md
@@ -84,7 +84,7 @@ If the user chooses `windsurf`:
 - run `--host windsurf`
 - state clearly that it has a supported install-and-use path
 - the default host root is `~/.codeium/windsurf`
-- the repo currently owns only shared install content plus optional materialization of `mcp_config.json` and `global_workflows/`
+- the repo currently owns only shared install content plus sidecar state such as `.vibeskills/host-settings.json` and `.vibeskills/host-closure.json`
 - make it clear that Windsurf-local settings still need to be managed on the Windsurf side
 
 ## Rule 11: Describe OpenClaw as a supported install-and-use path
@@ -104,7 +104,7 @@ If the user chooses `opencode`:
 - run `--host opencode`
 - state clearly that it has a supported install-and-use path
 - the default target root is `OPENCODE_HOME`, otherwise `~/.config/opencode`
-- direct install/check writes skills, command/agent wrappers, and `opencode.json.example`
+- direct install/check writes skills, `.vibeskills/*` sidecars, and `opencode.json.example`
 - do not claim ownership of the real `opencode.json`
 - keep provider credentials, plugin installation, and MCP trust on the host-managed side
 

--- a/docs/install/installation-rules.md
+++ b/docs/install/installation-rules.md
@@ -84,7 +84,7 @@
 - 运行 `--host windsurf`
 - 明确说明当前提供支持的安装与使用路径
 - 默认宿主根目录是 `~/.codeium/windsurf`
-- 当前仓库只负责共享安装内容，以及按需物化 `mcp_config.json` 与 `global_workflows/`
+- 当前仓库只负责共享安装内容，以及 `.vibeskills/host-settings.json` / `.vibeskills/host-closure.json` 这类 sidecar 状态
 - Windsurf 宿主本地设置仍由用户在宿主侧完成
 
 ## 规则 11：OpenClaw 按“支持的安装与使用路径”口径描述
@@ -104,7 +104,7 @@
 - 运行 `--host opencode`
 - 明确说明当前提供支持的安装与使用路径
 - 默认目标根目录是 `OPENCODE_HOME`，否则是 `~/.config/opencode`
-- direct install/check 会写入 skills、command/agent wrappers 与 `opencode.json.example`
+- direct install/check 会写入 skills、`.vibeskills/*` sidecar 与 `opencode.json.example`
 - 真实 `opencode.json`、provider 凭据、plugin 安装和 MCP 信任仍由宿主侧本地完成
 
 ## 规则 13：AI 治理在线配置要优先说真实推荐键名

--- a/docs/install/manual-copy-install.en.md
+++ b/docs/install/manual-copy-install.en.md
@@ -31,16 +31,16 @@ Copy these into the target root:
 
 If the target is `windsurf`, also note:
 
-- mirror `commands/` into `global_workflows/` if you want parity with the scripted result
-- copy `mcp/servers.template.json` to `mcp_config.json` when it is missing
+- if you need exact parity with the current scripted result, prefer rerunning `install.* --host windsurf`
+- the current public contract uses `.vibeskills/host-settings.json` and `.vibeskills/host-closure.json` as the host sidecars instead of `mcp_config.json` / `global_workflows/`
 
 If the target is `opencode`, switch to the OpenCode preview payload:
 
 - `skills/`
-- `commands/*.md`
-- `command/*.md`
-- `agents/*.md`
-- `agent/*.md`
+- `.vibeskills/host-settings.json`
+- `.vibeskills/host-closure.json`
+- `.vibeskills/install-ledger.json`
+- `.vibeskills/bin/*-specialist-wrapper.*`
 - `opencode.json.example`
 
 Then use [`opencode-path.en.md`](./opencode-path.en.md) for the preview-adapter follow-up steps.
@@ -70,7 +70,7 @@ Then use [`opencode-path.en.md`](./opencode-path.en.md) for the preview-adapter 
 
 ### Windsurf
 
-- confirm `mcp_config.json` and `global_workflows/` under `~/.codeium/windsurf`
+- confirm `.vibeskills/host-settings.json` and `.vibeskills/host-closure.json` under `~/.codeium/windsurf`
 - finish host-local configuration inside Windsurf itself
 
 ### OpenClaw

--- a/docs/install/manual-copy-install.md
+++ b/docs/install/manual-copy-install.md
@@ -31,16 +31,16 @@
 
 如果目标是 `windsurf`，还要额外注意：
 
-- 如需对齐脚本安装结果，把 `commands/` 同步到 `global_workflows/`
-- 如目标目录缺少 `mcp_config.json`，可由 `mcp/servers.template.json` 复制得到
+- 如需与当前脚本安装结果严格对齐，优先重新运行 `install.* --host windsurf`
+- 当前公开合同下，宿主侧 sidecar 以 `.vibeskills/host-settings.json` 与 `.vibeskills/host-closure.json` 为准，而不是 `mcp_config.json` / `global_workflows/`
 
 如果目标是 `opencode`，请改用 OpenCode 预览载荷：
 
 - `skills/`
-- `commands/*.md`
-- `command/*.md`
-- `agents/*.md`
-- `agent/*.md`
+- `.vibeskills/host-settings.json`
+- `.vibeskills/host-closure.json`
+- `.vibeskills/install-ledger.json`
+- `.vibeskills/bin/*-specialist-wrapper.*`
 - `opencode.json.example`
 
 并结合 [`opencode-path.md`](./opencode-path.md) 处理 preview adapter 的后续步骤。
@@ -70,7 +70,7 @@
 
 ### Windsurf
 
-- 确认 `~/.codeium/windsurf` 下的 `mcp_config.json` 与 `global_workflows/`
+- 确认 `~/.codeium/windsurf` 下的 `.vibeskills/host-settings.json` 与 `.vibeskills/host-closure.json`
 - 宿主侧本地配置仍需在 Windsurf 内完成
 
 ### OpenClaw

--- a/docs/install/opencode-path.en.md
+++ b/docs/install/opencode-path.en.md
@@ -10,8 +10,9 @@
 
 - repo-distributed content
 - Vibe-Skills skill content
-- OpenCode command wrappers
-- OpenCode agent wrappers
+- `.vibeskills/host-settings.json`
+- `.vibeskills/host-closure.json`
+- `.vibeskills/bin/*-specialist-wrapper.*`
 - an `opencode.json.example` scaffold
 
 ## What Still Stays Host-Local
@@ -62,17 +63,14 @@ For the framework-only variant, also append `-Profile minimal` explicitly.
 The install writes:
 
 - `skills/**`
-- `commands/*.md`
-- `command/*.md`
-- `agents/*.md`
-- `agent/*.md`
+- `.vibeskills/host-settings.json`
+- `.vibeskills/host-closure.json`
+- `.vibeskills/install-ledger.json`
+- `.vibeskills/bin/*-specialist-wrapper.*`
 - `opencode.json.example`
 
 The install does not create a new real `opencode.json`, and it does not take ownership of that file.
-If install sees a legacy top-level `vibeskills` node that an older Vibe build wrote by mistake, it removes only that Vibe-owned node and preserves the user's `$schema`, `mcp`, and other host-managed settings.
 If you need to change native OpenCode settings, keep doing that on the host side.
-
-Plural and singular command/agent directories are both materialized because the current OpenCode docs treat plural directories as the primary layout while still supporting singular names for backwards compatibility.
 
 ## How To Use
 
@@ -86,6 +84,8 @@ You can also invoke the skill directly in chat, for example:
 
 - `Use the vibe skill to plan this change.`
 - `Use the vibe skill to implement the approved plan.`
+
+These entrypoints stay skill-native. When Vibe is not explicitly invoked, the sidecar state remains silent and does not try to take over native OpenCode configuration.
 
 Custom agents installed by this path:
 

--- a/docs/install/opencode-path.md
+++ b/docs/install/opencode-path.md
@@ -10,8 +10,9 @@
 
 - 仓库分发内容
 - Vibe-Skills 技能内容
-- OpenCode 命令包装器
-- OpenCode agent 包装器
+- `.vibeskills/host-settings.json`
+- `.vibeskills/host-closure.json`
+- `.vibeskills/bin/*-specialist-wrapper.*`
 - `opencode.json.example` 示例配置
 
 ## 仍由宿主本地完成
@@ -62,17 +63,14 @@ PowerShell 对应参数为 `-TargetRoot .\.opencode`。
 当前安装会写入：
 
 - `skills/**`
-- `commands/*.md`
-- `command/*.md`
-- `agents/*.md`
-- `agent/*.md`
+- `.vibeskills/host-settings.json`
+- `.vibeskills/host-closure.json`
+- `.vibeskills/install-ledger.json`
+- `.vibeskills/bin/*-specialist-wrapper.*`
 - `opencode.json.example`
 
 当前安装不会创建新的真实 `opencode.json`，也不会接管它。
-如果安装时发现旧版本 Vibe 曾错误写入顶层 `vibeskills` 节点，安装器只会移除这个 Vibe 自己写入的节点，并保留用户已有的 `$schema`、`mcp` 与其他宿主配置。
 如果你需要调整 OpenCode 原生配置，请继续在宿主侧自行维护真实 `opencode.json`。
-
-当前会同时写入 plural 和 singular 的 command/agent 目录，因为 OpenCode 官方配置文档以 plural 目录为主，同时说明 singular 目录仍保留向后兼容支持。
 
 ## 使用方式
 
@@ -81,6 +79,8 @@ PowerShell 对应参数为 `-TargetRoot .\.opencode`。
 - `/vibe`
 - `/vibe-implement`
 - `/vibe-review`
+
+这些入口走的是宿主原生 skill 调用；未显式调用 Vibe 时，sidecar 配置会保持静默，不会主动接管 OpenCode 原生配置。
 
 也可以直接在对话里显式要求：
 

--- a/docs/install/prompts/full-version-install.en.md
+++ b/docs/install/prompts/full-version-install.en.md
@@ -21,13 +21,13 @@ Rules:
 4. For `codex`, run `--host codex --profile full` and describe it as the strongest governed path, while making clear that hooks remain frozen.
 5. For `claude-code`, run `--host claude-code --profile full` and describe it as a supported install-and-use path that does not overwrite the real `~/.claude/settings.json`.
 6. For `cursor`, run `--host cursor --profile full` and describe it as a supported install-and-use path with no takeover of the real `~/.cursor/settings.json`.
-7. For `windsurf`, run `--host windsurf --profile full` and describe it as a supported install-and-use path with runtime-adapter integration; mention the default root `~/.codeium/windsurf` and that the repo only owns shared runtime payload plus optional `mcp_config.json` / `global_workflows/` materialization.
+7. For `windsurf`, run `--host windsurf --profile full` and describe it as a supported install-and-use path with runtime-adapter integration; mention the default root `~/.codeium/windsurf` and that the repo only owns shared runtime payload plus `.vibeskills/*` sidecar state.
 8. For `openclaw`, run `--host openclaw --profile full` and describe it with the `preview` / `runtime-core-preview` / `runtime-core` wording; mention the default target root `OPENCLAW_HOME` or `~/.openclaw`, plus the attach / copy / bundle paths.
 9. For `opencode`, use direct install/check instead of one-shot bootstrap:
    - Windows: `pwsh -NoProfile -File .\\install.ps1 -HostId opencode -Profile full` and `pwsh -NoProfile -File .\\check.ps1 -HostId opencode -Profile full`
    - Linux / macOS: `bash ./install.sh --host opencode --profile full` and `bash ./check.sh --host opencode --profile full`
    - describe it as a preview-adapter path with default root `OPENCODE_HOME`, otherwise `~/.config/opencode`
-   - state clearly that direct install/check writes skills, command/agent wrappers, and `opencode.json.example`, but does not take ownership of the real `opencode.json`, provider credentials, plugin installation, or MCP trust
+   - state clearly that direct install/check writes skills, `.vibeskills/*` sidecars, and `opencode.json.example`, but does not take ownership of the real `opencode.json`, provider credentials, plugin installation, or MCP trust
 10. Never ask me to paste secrets, URLs, or model names into chat.
 11. If I later want AI-governance online capability, you must recommend the real key names first:
    - OpenAI-compatible: `OPENAI_API_KEY`, optional `OPENAI_BASE_URL` / `OPENAI_API_BASE`, plus `VCO_RUCNLPIR_MODEL`

--- a/docs/install/prompts/full-version-install.md
+++ b/docs/install/prompts/full-version-install.md
@@ -21,13 +21,13 @@
 4. 如果我选 `codex`，使用 `--host codex --profile full`；明确说明这是当前最完整的 governed 路径，但 hook 仍冻结。
 5. 如果我选 `claude-code`，使用 `--host claude-code --profile full`；明确说明当前提供支持的安装与使用路径，不覆盖真实 `~/.claude/settings.json`。
 6. 如果我选 `cursor`，使用 `--host cursor --profile full`；明确说明当前提供支持的安装与使用路径，也不接管真实 `~/.cursor/settings.json`。
-7. 如果我选 `windsurf`，使用 `--host windsurf --profile full`；明确说明当前提供支持的安装与使用路径，且已接入 runtime adapter，默认根目录是 `~/.codeium/windsurf`，repo 只负责 shared runtime payload 和按需物化 `mcp_config.json` / `global_workflows/`。
+7. 如果我选 `windsurf`，使用 `--host windsurf --profile full`；明确说明当前提供支持的安装与使用路径，且已接入 runtime adapter，默认根目录是 `~/.codeium/windsurf`，repo 只负责 shared runtime payload 与 `.vibeskills/*` sidecar 状态。
 8. 如果我选 `openclaw`，使用 `--host openclaw --profile full`；明确说明当前按 `preview` / `runtime-core-preview` / `runtime-core` 路径接入，默认目标根目录是 `OPENCLAW_HOME` 或 `~/.openclaw`，并说明 attach / copy / bundle 三路径。
 9. 如果我选 `opencode`，使用 direct install/check，不走 one-shot bootstrap：
    - Windows：`pwsh -NoProfile -File .\\install.ps1 -HostId opencode -Profile full` 与 `pwsh -NoProfile -File .\\check.ps1 -HostId opencode -Profile full`
    - Linux / macOS：`bash ./install.sh --host opencode --profile full` 与 `bash ./check.sh --host opencode --profile full`
    - 明确说明当前按 preview adapter 路径接入，默认目标根目录是 `OPENCODE_HOME`，否则是 `~/.config/opencode`
-   - 明确说明 direct install/check 会写入 skills、command/agent wrappers 与 `opencode.json.example`，但不接管真实 `opencode.json`、provider 凭据、plugin 安装和 MCP 信任
+   - 明确说明 direct install/check 会写入 skills、`.vibeskills/*` sidecar 与 `opencode.json.example`，但不接管真实 `opencode.json`、provider 凭据、plugin 安装和 MCP 信任
 10. 对六个宿主，都不要要求我把密钥、URL 或 model 粘贴到聊天里；只告诉我去本地 settings 或本地环境变量里配置。
 11. 如果我后续要补 AI 治理 online 能力，你必须优先告诉我真实推荐键名：
    - OpenAI-compatible：`OPENAI_API_KEY`，可选 `OPENAI_BASE_URL` / `OPENAI_API_BASE`，以及 `VCO_RUCNLPIR_MODEL`

--- a/docs/install/recommended-full-path.en.md
+++ b/docs/install/recommended-full-path.en.md
@@ -142,7 +142,7 @@ git checkout vX.Y.Z
 ### Windsurf
 
 - the default root is `~/.codeium/windsurf`
-- the repo currently owns only shared runtime payload plus optional materialization of `mcp_config.json` and `global_workflows/`
+- the repo currently owns only shared runtime payload plus sidecar state such as `.vibeskills/host-settings.json` and `.vibeskills/host-closure.json`
 - Windsurf-native local settings remain managed on the Windsurf side
 
 ### OpenClaw
@@ -154,6 +154,6 @@ git checkout vX.Y.Z
 ### OpenCode
 
 - the default target root is `OPENCODE_HOME`, otherwise `~/.config/opencode`
-- direct install/check writes skills, command/agent wrappers, and `opencode.json.example`
+- direct install/check writes skills, `.vibeskills/*` sidecars, and `opencode.json.example`
 - the real `opencode.json`, provider credentials, plugin installation, and MCP trust remain host-managed
 - use `--target-root ./.opencode` when you want project-local isolation

--- a/docs/install/recommended-full-path.md
+++ b/docs/install/recommended-full-path.md
@@ -142,7 +142,7 @@ git checkout vX.Y.Z
 ### Windsurf
 
 - 默认根目录是 `~/.codeium/windsurf`
-- repo 当前只负责 shared runtime payload，以及按需物化 `mcp_config.json` 与 `global_workflows/`
+- repo 当前只负责 shared runtime payload，以及 `.vibeskills/host-settings.json` / `.vibeskills/host-closure.json` 这类 sidecar 状态
 - Windsurf 宿主自身的本地设置仍按 Windsurf 自身方式管理
 
 ### OpenClaw
@@ -154,6 +154,6 @@ git checkout vX.Y.Z
 ### OpenCode
 
 - 默认目标根目录是 `OPENCODE_HOME`，否则是 `~/.config/opencode`
-- direct install/check 会写入 skills、command/agent wrappers 与 `opencode.json.example`
+- direct install/check 会写入 skills、`.vibeskills/*` sidecar 与 `opencode.json.example`
 - 真实 `opencode.json`、provider 凭据、plugin 安装和 MCP 信任仍按宿主自身方式管理
 - 如需项目内隔离安装，使用 `--target-root ./.opencode`

--- a/docs/plans/2026-03-30-cross-host-startup-regression-audit-plan.md
+++ b/docs/plans/2026-03-30-cross-host-startup-regression-audit-plan.md
@@ -1,0 +1,90 @@
+# Cross-Host Startup Regression Audit Plan
+
+**日期**: 2026-03-30
+**需求文档**: [../requirements/2026-03-30-cross-host-startup-regression-audit.md](../requirements/2026-03-30-cross-host-startup-regression-audit.md)
+**Internal Grade**: `L`
+
+## Audit Frames
+
+将宿主分成两组：
+
+1. 共享配置组
+   - `claude-code`
+   - `cursor`
+   - 风险点：安装器会向真实 `settings.json` 写入 `vibeskills`
+
+2. 非共享配置组
+   - `windsurf`
+   - `openclaw`
+   - 风险点：主要是 runtime-core 写面是否误触 undocumented settings surface
+
+## Execution Waves
+
+### Wave 1: 静态写面审计
+
+- 检查：
+  - `scripts/install/install_vgo_adapter.py`
+  - `scripts/install/Install-VgoAdapter.ps1`
+  - `adapters/*/settings-map.json`
+  - `adapters/*/closure.json`
+  - 相关 runtime-neutral tests
+
+目标：
+
+- 明确每个宿主到底写哪些真实宿主面
+- 先判断谁存在与 OpenCode 同类的“共享配置被修改”风险前提
+
+### Wave 2: 真实 CLI 隔离探针
+
+- 对 `claude-code`、`cursor`、`windsurf`、`openclaw` 分别建立隔离 HOME / host root
+- 先跑宿主 CLI baseline
+- 再执行对应 `install.* --host ...`
+- 再跑同一宿主 CLI 的最小探针，观察是否出现配置解析失败或基础命令失效
+
+优先证明面：
+
+- `claude-code`: 能证明配置加载的最小非交互命令
+- `cursor`: 能证明配置加载的最小非交互命令
+- `windsurf`: 基础 CLI 启动/帮助 + 结构写面核对
+- `openclaw`: `config validate` / `skills` / `agent` 之类不会触发外部依赖的探针
+
+### Wave 3: 结论与必要修复
+
+- 若无问题：
+  - 输出逐宿主结论与证据
+  - 标明验证边界
+
+- 若发现问题：
+  - 立即实现修复
+  - 补测试/验证
+  - 更新文档 truth
+
+## Verification
+
+至少执行：
+
+```bash
+pytest -q tests/runtime_neutral/test_claude_preview_scaffold.py
+pytest -q tests/runtime_neutral/test_cursor_managed_preview.py
+pytest -q tests/runtime_neutral/test_windsurf_runtime_core.py
+pytest -q tests/runtime_neutral/test_openclaw_runtime_core.py
+git diff --check
+```
+
+若新增审计脚本或修复，再补对应验证。
+
+## Completion Rules
+
+- 只有当每个宿主都拿到明确证据后，才能做“逐一排查完成”的表述。
+- 对 CLI 面不足的宿主，必须用 `not-provable-with-current-cli-surface` 明示，而不是默认安全。
+
+## Cleanup
+
+阶段结束后执行：
+
+```powershell
+pwsh -NoProfile -File scripts/governance/Invoke-NodeProcessAudit.ps1 -RepoRoot .
+pwsh -NoProfile -File scripts/governance/Invoke-NodeZombieCleanup.ps1 -RepoRoot .
+```
+
+并清理隔离 HOME / host root 临时目录。

--- a/docs/plans/2026-03-30-explicit-vibe-sidecar-first-runtime-plan.md
+++ b/docs/plans/2026-03-30-explicit-vibe-sidecar-first-runtime-plan.md
@@ -1,0 +1,260 @@
+# Explicit Vibe Sidecar-First Runtime Plan
+
+**日期**: 2026-03-30
+**需求文档**: [../requirements/2026-03-30-explicit-vibe-sidecar-first-runtime.md](../requirements/2026-03-30-explicit-vibe-sidecar-first-runtime.md)
+**Internal Grade**: `L`
+
+## Design Decision
+
+冻结以下主设计：
+
+- `entry is skill-native, state is sidecar-native`
+- 默认行为是：
+  - 未显式调用 `vibe` 时，Vibe 不主动注入、不主动启动、不抢宿主默认控制权
+  - 显式调用 `$vibe` / `/vibe` / 宿主 skill 入口时，完整装载 Vibe 路由与 runtime
+- 默认不写入宿主真实配置文件
+
+## Canonical Layering
+
+### 1. Host Entry Layer
+
+职责：
+
+- 只负责把显式 `vibe` skill 调用转交给 Vibe runtime entry
+- 不承载 Vibe 主状态
+- 不承载复杂治理配置
+
+允许形式：
+
+- `skills/vibe/**`
+- 宿主原生支持的 skill 调用目录
+- Vibe skill 内部引用的本地运行入口
+
+设计要求：
+
+- 这是最薄的一层
+- 未显式调用 `vibe` 时不应产生运行时副作用
+- 不允许依赖宿主原生配置文件完成 skill 注册
+
+### 2. Canonical Runtime State Layer
+
+canonical 文件：
+
+- `.vibeskills/host-settings.json`
+
+职责：
+
+- 承载显式 `vibe` 调用所需的宿主本地 runtime state
+- 作为 Vibe 路由层与 runtime 层的首选输入面
+
+建议字段：
+
+- `schema_version`
+- `host_id`
+- `managed`
+- `skills_root`
+- `runtime_skill_entry`
+- `commands_root`
+- `agents_root`
+- `workflow_root`
+- `mcp_config_path`
+- `specialist_wrapper`
+- `runtime_mode_defaults`
+- `explicit_vibe_skill_invocation`
+- `feature_flags`
+
+关键规则：
+
+- 宿主原生配置文件不是 canonical truth
+- sidecar 中缺失字段时可以降级报错，但不能自动回退为宿主配置桥接
+
+### 3. Install / Audit Receipt Layer
+
+canonical 文件：
+
+- `.vibeskills/host-closure.json`
+- `.vibeskills/install-ledger.json`
+
+职责：
+
+- 记录安装产物
+- 记录 wrapper readiness
+- 支撑 uninstall / doctor / audit / support
+
+关键规则：
+
+- `host-closure.json` 不再承担长期 canonical runtime state 角色
+- 它保留为 receipt / reconciliation / proof surface
+
+## Runtime Activation Contract
+
+### Idle State
+
+- 未显式调用 `vibe` 时：
+  - Vibe 不应抢占宿主默认路由
+  - Vibe 不应要求宿主主动读取 `.vibeskills/host-settings.json`
+  - 宿主保持自然静默是正确行为
+
+### Explicit Vibe State
+
+- 当用户显式输入 `$vibe` / `/vibe` / 宿主等价入口时：
+  - Host Entry Layer 通过宿主 skill 调用把请求交给 Vibe runtime entry
+  - wrapper 读取 `.vibeskills/host-settings.json`
+  - Vibe 再装载：
+    - 路由策略
+    - runtime context
+    - specialist bridge
+    - commands / agents / workflow pointers
+  - 若 `host-settings.json` 缺失，则输出明确的 install / repair guidance，而不是回退到宿主原生配置猜测
+
+## Host Classification Under This Design
+
+### Group A: 优先迁移到 sidecar-first
+
+- `claude-code`
+- `cursor`
+- `opencode`
+- `windsurf`
+- `openclaw`
+
+原因：
+
+- 用户已明确要求这些宿主不再触碰原生配置文件
+- 这些宿主被假定原生支持 skill 调用
+- 可显著降低共享配置 schema 风险与启动回归风险
+
+### Group B: 范围外宿主
+
+- `codex`
+
+原因：
+
+- 本轮新设计以“目标宿主原生支持 skill 调用”为前提
+- `codex` 是否按完全相同方式收缩，不在本轮强制冻结
+
+## Migration Waves
+
+### Wave 1: Runtime Truth Freeze
+
+- 冻结原则：
+  - `.vibeskills/host-settings.json` 升为 canonical runtime state
+  - `.vibeskills/host-closure.json` 降为 receipt
+  - 宿主原生配置文件退出默认安装面
+- 更新文档 truth：
+  - install matrix
+  - host capability matrix
+  - uninstall governance
+  - install docs
+
+### Wave 2: Runtime Reader Migration
+
+- 调整 runtime 读取顺序：
+  1. `host-settings.json`
+  2. `host-closure.json` 仅作 receipt / readiness / reconciliation
+  3. 明确错误，不隐式猜测宿主真实 settings
+
+### Wave 3: Preview Host Installer Migration
+
+- `claude-code` / `cursor`：
+  - 不再写真实 `settings.json`
+  - 改写 `.vibeskills/host-settings.json`
+  - 仅安装 `skills/vibe/**` 与 Vibe-owned sidecar/receipt/runtime payload
+
+- `opencode`：
+  - 不再写真实 `opencode.json`
+  - sidecar 承载 runtime state
+  - 仅安装 `skills/vibe/**` 与 Vibe-owned sidecar/receipt/runtime payload
+
+- `windsurf` / `openclaw`：
+  - 对齐统一 sidecar schema
+  - 保持 skill-native 入口模型
+
+### Wave 4: Verification And Safety Gates
+
+- 新增验证点：
+  - 未显式调用 `vibe` 时不产生宿主启动副作用
+  - 显式 `vibe` 调用时能从 sidecar 完整装载 runtime
+  - uninstall 只删 owned-only surfaces
+  - 缺少 sidecar 时报错清晰
+
+### Wave 5: Codex Decision Gate
+
+- 单独评估 `codex`
+- 只在以下条件满足后才考虑迁移：
+  - skill-native activation 有真实证据
+  - sidecar-first 不降低当前 closure
+  - route/runtime activation 不退化
+
+## Risks
+
+### Risk 1: 入口存在，但 sidecar 缺失
+
+处置：
+
+- wrapper 明确报 bootstrap missing
+- 指向安装/doctor/repair
+
+### Risk 2: sidecar 与 receipt 漂移
+
+处置：
+
+- `host-closure.json` 保留 readiness / artifact proof
+- 引入 doctor / check 一致性检查
+
+### Risk 3: 宿主没有稳定的显式入口挂载位
+
+处置：
+
+- 标记该宿主不满足本设计前提
+- 不允许偷偷回退到宿主配置文件写入
+
+### Risk 4: 测试仍绑定真实 `settings.json`
+
+处置：
+
+- 将相关测试改为：
+  - canonical sidecar assertions
+  - skill-native activation assertions
+  - zero-native-config-write assertions
+
+## Verification
+
+设计冻结后，后续实现至少应验证：
+
+```bash
+pytest -q tests/runtime_neutral/test_claude_preview_scaffold.py
+pytest -q tests/runtime_neutral/test_cursor_managed_preview.py
+pytest -q tests/runtime_neutral/test_windsurf_runtime_core.py
+pytest -q tests/runtime_neutral/test_openclaw_runtime_core.py
+pytest -q tests/runtime_neutral/test_installed_runtime_uninstall.py
+git diff --check
+```
+
+并新增：
+
+- explicit vibe skill activation tests
+- host-settings canonical read tests
+- idle-no-side-effects tests
+- zero-native-config-write tests
+
+## Completion Rules
+
+- 不能把“skill-native activation”写成“宿主会在未显式调用时主动读取 sidecar”。
+- 不能把“零宿主配置写入”写成“默认不写但允许静默回退”。
+- 设计完成的标准是：
+  - canonical state
+  - receipt layer
+  - skill-native entry
+  - host grouping
+  - migration waves
+  - verification strategy
+  全部明确。
+
+## Cleanup
+
+阶段结束后执行：
+
+```powershell
+pwsh -NoProfile -File scripts/governance/Invoke-NodeProcessAudit.ps1 -RepoRoot .
+pwsh -NoProfile -File scripts/governance/Invoke-NodeZombieCleanup.ps1 -RepoRoot .
+```

--- a/docs/requirements/2026-03-30-cross-host-startup-regression-audit.md
+++ b/docs/requirements/2026-03-30-cross-host-startup-regression-audit.md
@@ -1,0 +1,42 @@
+# Cross-Host Startup Regression Audit Requirement
+
+**日期**: 2026-03-30
+**目标**: 对 `opencode` 之外的宿主适配器逐一排查，确认是否存在与 OpenCode 相同或同类的“安装器写入宿主真实配置后导致宿主启动、配置解析或基础命令失效”的回归风险。
+
+## Intent Contract
+
+- Goal: 基于仓库当前代码与本机可用宿主 CLI，对 `claude-code`、`cursor`、`windsurf`、`openclaw` 逐个完成真实验证，给出每个宿主是否存在同类启动回归的结论与证据。
+- Deliverable:
+  - 单一需求文档与执行计划
+  - 每个宿主的配置写面审计结论
+  - 每个宿主可获得的真实 CLI 证据或无法验证时的边界说明
+  - 若发现问题，给出根因、修复方案与必要实现
+- Constraints:
+  - 必须区分“写共享配置但宿主可容忍”和“写共享配置即破坏宿主解析”两类风险。
+  - 任何“没有问题”的结论都必须有本地命令或结构证据支撑，不能只依据文档文案。
+  - 不得把 `windsurf/openclaw` 这类 runtime-core 宿主与 `claude-code/cursor` 这类共享 `settings.json` 宿主混为一谈。
+  - 若宿主 CLI 缺少可用于证明配置解析的非交互命令，必须明确标注验证边界。
+- Acceptance Criteria:
+  - 对 `claude-code`、`cursor`、`windsurf`、`openclaw` 各自产出明确结论：`confirmed-safe`、`confirmed-regression`、或 `not-provable-with-current-cli-surface`。
+  - 每个结论都附带本地命令输出或仓库写面证据。
+  - 若发现新问题，必须给出修复范围和验证方案，且不能破坏既有 OpenCode 修复。
+- Product Acceptance Criteria:
+  - 能回答“除了 OpenCode 以外，其他宿主是否也会因为 Vibe 写入内容而启动不了”这个问题，并能指出具体宿主与证据。
+  - 用户支持可以据此给不同宿主提供不同处置建议，而不是统一口径。
+- Manual Spot Checks:
+  - 隔离根安装后，观察真实共享配置文件是否被写入
+  - 运行宿主 CLI 的最小启动/配置探针
+  - 核对现有 runtime-neutral tests 与 adapter settings-map/closure truth
+- Completion Language Policy:
+  - 在没有真实本地 CLI 证据时，不能说“确认安全”，只能说“当前仓库写面未见同类风险”或“当前 CLI 面不足以证明”。
+  - 若发现问题但未修复完成，不能说“已解决”。
+- Delivery Truth Contract:
+  - 本轮允许新增需求/计划文档、验证脚本、测试与必要修复。
+  - 对宿主 CLI 行为的判断必须以本机命令输出为准。
+- Non-goals:
+  - 不在本轮扩展新的宿主能力或重做适配器架构。
+  - 不对 OpenCode 已定位问题重复做文档性复述。
+- Autonomy Mode: `interactive_governed`
+- Inferred Assumptions:
+  - `windsurf/openclaw` 因为不写共享 `settings.json`，大概率不具备与 OpenCode 同类的配置解析风险。
+  - `claude-code/cursor` 因为写共享 `settings.json` 的 `vibeskills` 节点，仍需真实 CLI 验证其宿主是否容忍该字段。

--- a/docs/requirements/2026-03-30-explicit-vibe-sidecar-first-runtime.md
+++ b/docs/requirements/2026-03-30-explicit-vibe-sidecar-first-runtime.md
@@ -1,0 +1,54 @@
+# Explicit Vibe Sidecar-First Runtime Requirement
+
+**日期**: 2026-03-30
+**目标**: 为 Vibe 设计一套“未显式调用时完全沉默、显式 `$vibe` / `/vibe` 以 skill 形式调用时完整启用”的 sidecar-first 架构，并彻底移除对宿主原生配置文件的默认依赖。
+
+## Intent Contract
+
+- Goal: 冻结一套统一架构，使 Vibe 的路由层与 runtime 只在显式 `vibe` skill 调用时完整启用，且默认与目标宿主的原生配置文件完全解耦。
+- Deliverable:
+  - 单一需求文档
+  - 单一设计/迁移计划文档
+  - 明确的状态分层、入口分层、宿主适配边界与迁移策略
+- Constraints:
+  - 默认路径必须是 `sidecar-first + skills-only activation`，而不是继续向任何宿主真实配置文件写入 `vibeskills`。
+  - “未显式调用 `vibe` 时保持沉默”必须被视为正确行为，而不是能力缺陷。
+  - “显式调用 `vibe` 时完整启用”必须同时覆盖路由层与 runtime 层，不允许只启用其一。
+  - 不能把“宿主 skill 调用入口”与“Vibe 主状态存储”混为一谈。
+  - 对目标宿主，安装器不得修改 `settings.json`、`opencode.json` 或其他宿主原生配置文件。
+  - 设计必须以“目标宿主原生支持 skill 调用”为前提，不得偷偷回退到 command/agent/config 桥接。
+  - 必须保留安装/卸载安全性，不能让 sidecar-first 迁移破坏现有 owned-only uninstall 合同。
+- Acceptance Criteria:
+  - 明确区分以下三层：
+    - 宿主 skill 调用入口层
+    - Vibe canonical runtime state
+    - 安装/审计收据层
+  - 明确回答：
+    - 为什么 sidecar 可以承担运行时主状态
+    - 为什么显式 skill 调用可以替代默认注入/常驻激活
+    - 哪些宿主可以直接迁移到 skills-only sidecar-first
+    - 哪些现有 install/test truth 需要同步收缩
+  - 给出可执行迁移波次，而不是只给抽象原则。
+- Product Acceptance Criteria:
+  - 用户能够得到一个清晰结论：Vibe 在未来应当“默认沉默 + 显式 skill 启用 + sidecar-first + 零宿主配置写入”。
+  - 后续实现可以直接按该设计推进，而不需要重新争论 `settings.json` / `opencode.json` 是否应参与默认安装。
+- Manual Spot Checks:
+  - 核对当前 runtime 是否读取 `.vibeskills/host-closure.json`
+  - 核对当前安装器对 `claude-code` / `cursor` / `windsurf` / `openclaw` 的真实写面
+  - 核对安装矩阵与 host capability matrix 中的宿主 truth wording
+- Completion Language Policy:
+  - 不得把“零宿主配置写入”弱化成“默认关闭但仍保留桥接”。
+  - 若某个宿主当前证据不足以证明 skill-only 激活可用，必须标注为“需要迁移验证”，不能直接宣称零退化。
+- Delivery Truth Contract:
+  - 本轮交付设计，不默认宣称实现已完成。
+  - 本轮允许冻结需求与计划文档，不要求同步修改安装器实现。
+- Non-goals:
+  - 不在本轮直接实现全部宿主迁移。
+  - 不在本轮提升任何宿主支持等级。
+  - 不把 sidecar-first 错写成“宿主会在未显式调用时主动读取 `.vibeskills` 状态”。
+- Autonomy Mode: `interactive_governed`
+- Inferred Assumptions:
+  - 用户认可“未显式调用 `vibe` 时完全沉默”是正确行为。
+  - 用户希望显式 `vibe` skill 调用时，所有 Vibe 路由/治理/runtime 功能完整启用。
+  - 目标宿主原生支持 skill 调用，因此不需要通过原生配置文件注入 `vibe`。
+  - `.vibeskills/host-settings.json` 比宿主真实配置文件更适合作为跨宿主统一状态面。

--- a/docs/universalization/install-matrix.md
+++ b/docs/universalization/install-matrix.md
@@ -22,7 +22,7 @@ It does **not** promise that all host dependencies can be installed in one shot.
 | `host-windsurf` | `install.* --host windsurf` | `check.* --host windsurf` | runtime-core-preview | documented host root with shared runtime-core payload only |
 | `host-openclaw` | `install.* --host openclaw` | `check.* --host openclaw` | runtime-core-preview | documented host root with shared runtime-core payload only |
 | `generic` | `install.* --host generic` | `check.* --host generic` | runtime-core-only | neutral target root only |
-| `host-opencode` | `install.* --host opencode` | `check.* --host opencode` | preview-scaffold | writes skills + command/agent wrappers + example config into OpenCode roots, but does not own the real `opencode.json` |
+| `host-opencode` | `install.* --host opencode` | `check.* --host opencode` | preview-scaffold | writes skills + `.vibeskills/*` sidecars + example config into OpenCode roots, but does not own the real `opencode.json` |
 | `core` | none | none | none | contracts only |
 
 ## Host-Managed Boundaries

--- a/scripts/install/Install-VgoAdapter.ps1
+++ b/scripts/install/Install-VgoAdapter.ps1
@@ -64,6 +64,7 @@ function Copy-DirContent {
     }
     New-Item -ItemType Directory -Force -Path $Destination | Out-Null
     Copy-Item -Path (Join-Path $Source '*') -Destination $Destination -Recurse -Force
+    Add-VgoCreatedPath -Path $Destination
 }
 
 function Restore-SkillEntryPointIfNeeded {
@@ -128,6 +129,62 @@ function Merge-JsonObject {
 
     New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Path) | Out-Null
     $merged | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Path -Encoding UTF8
+}
+
+function Test-VgoSkillOnlyActivationHost {
+    param([string]$HostId)
+
+    return $HostId -in @('claude-code', 'cursor', 'windsurf', 'openclaw', 'opencode')
+}
+
+$script:VgoCreatedPaths = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$script:VgoManagedJsonPaths = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$script:VgoTemplateGeneratedPaths = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$script:VgoSpecialistWrapperPaths = [System.Collections.Generic.List[string]]::new()
+
+function Add-VgoTrackedPath {
+    param(
+        [Parameter(Mandatory)] [string]$Path,
+        [Parameter(Mandatory)] [System.Collections.Generic.HashSet[string]]$Set
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return
+    }
+
+    $resolved = [System.IO.Path]::GetFullPath($Path)
+    [void]$Set.Add($resolved)
+}
+
+function Add-VgoCreatedPath {
+    param([Parameter(Mandatory)] [string]$Path)
+
+    Add-VgoTrackedPath -Path $Path -Set $script:VgoCreatedPaths
+}
+
+function Add-VgoManagedJsonPath {
+    param([Parameter(Mandatory)] [string]$Path)
+
+    Add-VgoTrackedPath -Path $Path -Set $script:VgoManagedJsonPaths
+}
+
+function Add-VgoTemplateGeneratedPath {
+    param([Parameter(Mandatory)] [string]$Path)
+
+    Add-VgoTrackedPath -Path $Path -Set $script:VgoTemplateGeneratedPaths
+}
+
+function Add-VgoSpecialistWrapperPath {
+    param([Parameter(Mandatory)] [string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return
+    }
+
+    $resolved = [System.IO.Path]::GetFullPath($Path)
+    if (-not $script:VgoSpecialistWrapperPaths.Contains($resolved)) {
+        [void]$script:VgoSpecialistWrapperPaths.Add($resolved)
+    }
 }
 
 function Test-VgoPathInsideTargetRoot {
@@ -312,6 +369,7 @@ function New-VgoHostSpecialistWrapper {
 
     $toolsRoot = Join-Path $TargetRoot '.vibeskills\bin'
     New-Item -ItemType Directory -Force -Path $toolsRoot | Out-Null
+    Add-VgoCreatedPath -Path $toolsRoot
 
     $wrapperPy = Join-Path $toolsRoot ("{0}-specialist-wrapper.py" -f $HostId)
     $embeddedCommand = if ([string]::IsNullOrWhiteSpace($BridgeCommand)) { '' } else { $BridgeCommand }
@@ -336,6 +394,8 @@ if __name__ == "__main__":
     raise SystemExit(main())
 "@
     Set-Content -LiteralPath $wrapperPy -Value $pythonScript -Encoding UTF8
+    Add-VgoCreatedPath -Path $wrapperPy
+    Add-VgoSpecialistWrapperPath -Path $wrapperPy
 
     $platformTag = Get-VgoPlatformTag
     if ($platformTag -eq 'windows') {
@@ -378,6 +438,8 @@ exec "$PYTHON_BIN" "$SCRIPT_DIR/__WRAPPER_FILE__" "$@"
         } catch {
         }
     }
+    Add-VgoCreatedPath -Path $launcherPath
+    Add-VgoSpecialistWrapperPath -Path $launcherPath
 
     return [pscustomobject]@{
         platform = $platformTag
@@ -396,28 +458,41 @@ function Set-VgoManagedHostSettings {
     )
 
     $materialized = New-Object System.Collections.Generic.List[string]
-    if ($HostId -in @('cursor', 'claude-code')) {
-        $settingsPath = Join-Path $TargetRoot 'settings.json'
-        Merge-JsonObject -Path $settingsPath -Patch @{
-            vibeskills = @{
-                host_id = $HostId
-                managed = $true
-                commands_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'commands'))
-                specialist_wrapper = [string]$WrapperInfo.launcher_path
-            }
-        }
-        $materialized.Add([System.IO.Path]::GetFullPath($settingsPath)) | Out-Null
-    } elseif ($HostId -in @('openclaw', 'windsurf')) {
+    if (Test-VgoSkillOnlyActivationHost -HostId $HostId) {
         $settingsPath = Join-Path $TargetRoot '.vibeskills\host-settings.json'
         New-Item -ItemType Directory -Force -Path (Split-Path -Parent $settingsPath) | Out-Null
-        @{
+        $payload = [ordered]@{
+            schema_version = 1
             host_id = $HostId
             managed = $true
-            commands_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'commands'))
-            workflow_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'global_workflows'))
-            mcp_config = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'mcp_config.json'))
-            specialist_wrapper = [string]$WrapperInfo.launcher_path
-        } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $settingsPath -Encoding UTF8
+            skills_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'skills'))
+            runtime_skill_entry = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'skills\vibe\SKILL.md'))
+            explicit_vibe_skill_invocation = @('$vibe', '/vibe')
+            specialist_wrapper = [ordered]@{
+                launcher_path = [string]$WrapperInfo.launcher_path
+                script_path = [string]$WrapperInfo.script_path
+                ready = [bool]$WrapperInfo.ready
+            }
+        }
+        $commandsRoot = Join-Path $TargetRoot 'commands'
+        $agentsRoot = Join-Path $TargetRoot 'agents'
+        $workflowRoot = Join-Path $TargetRoot 'global_workflows'
+        $mcpConfigPath = Join-Path $TargetRoot 'mcp_config.json'
+        if (Test-Path -LiteralPath $commandsRoot -PathType Container) {
+            $payload.commands_root = [System.IO.Path]::GetFullPath($commandsRoot)
+        }
+        if (Test-Path -LiteralPath $agentsRoot -PathType Container) {
+            $payload.agents_root = [System.IO.Path]::GetFullPath($agentsRoot)
+        }
+        if (Test-Path -LiteralPath $workflowRoot -PathType Container) {
+            $payload.workflow_root = [System.IO.Path]::GetFullPath($workflowRoot)
+        }
+        if (Test-Path -LiteralPath $mcpConfigPath -PathType Leaf) {
+            $payload.mcp_config = [System.IO.Path]::GetFullPath($mcpConfigPath)
+        }
+        $payload | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $settingsPath -Encoding UTF8
+        Add-VgoCreatedPath -Path $settingsPath
+        Add-VgoManagedJsonPath -Path $settingsPath
         $materialized.Add([System.IO.Path]::GetFullPath($settingsPath)) | Out-Null
     }
 
@@ -447,6 +522,8 @@ function Write-VgoHostClosure {
         platform = Get-VgoPlatformTag
         target_root = [System.IO.Path]::GetFullPath($TargetRoot)
         install_mode = [string]$Adapter.install_mode
+        skills_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'skills'))
+        runtime_skill_entry = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'skills\vibe\SKILL.md'))
         commands_root = [System.IO.Path]::GetFullPath($commandsRoot)
         global_workflows_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'global_workflows'))
         mcp_config_path = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'mcp_config.json'))
@@ -464,10 +541,42 @@ function Write-VgoHostClosure {
     $closurePath = Join-Path $TargetRoot '.vibeskills\host-closure.json'
     New-Item -ItemType Directory -Force -Path (Split-Path -Parent $closurePath) | Out-Null
     $closure | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $closurePath -Encoding UTF8
+    Add-VgoCreatedPath -Path $closurePath
     return [pscustomobject]@{
         path = [System.IO.Path]::GetFullPath($closurePath)
         data = [pscustomobject]$closure
     }
+}
+
+function Write-VgoInstallLedger {
+    param(
+        [Parameter(Mandatory)] [psobject]$Adapter,
+        [Parameter(Mandatory)] [string]$Profile,
+        [string[]]$ExternalFallbackUsed = @()
+    )
+
+    $ledgerPath = Join-Path $TargetRoot '.vibeskills\install-ledger.json'
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $ledgerPath) | Out-Null
+
+    $ledger = [ordered]@{
+        schema_version = 1
+        host_id = [string]$Adapter.id
+        install_mode = [string]$Adapter.install_mode
+        profile = [string]$Profile
+        target_root = [System.IO.Path]::GetFullPath($TargetRoot)
+        runtime_root = [System.IO.Path]::GetFullPath($TargetRoot)
+        canonical_vibe_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'skills\vibe'))
+        created_paths = @($script:VgoCreatedPaths | Sort-Object)
+        managed_json_paths = @($script:VgoManagedJsonPaths | Sort-Object)
+        generated_from_template_if_absent = @($script:VgoTemplateGeneratedPaths | Sort-Object)
+        specialist_wrapper_paths = @($script:VgoSpecialistWrapperPaths)
+        external_fallback_used = @($ExternalFallbackUsed | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } | Sort-Object -Unique)
+        timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        ownership_source = 'install-ledger'
+    }
+
+    $ledger | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $ledgerPath -Encoding UTF8
+    return [System.IO.Path]::GetFullPath($ledgerPath)
 }
 
 function Ensure-SkillPresent {
@@ -634,11 +743,14 @@ function Install-RuntimeCorePayload {
     $governancePath = Join-Path $RepoRoot 'config\version-governance.json'
     $governance = Get-Content -LiteralPath $governancePath -Raw -Encoding UTF8 | ConvertFrom-Json
 
-    foreach ($dir in @($packaging.directories)) {
+    $includeCommandSurfaces = -not (Test-VgoSkillOnlyActivationHost -HostId ([string]$Adapter.id))
+    $runtimeDirectories = @($packaging.directories | Where-Object { $includeCommandSurfaces -or [string]$_ -ne 'commands' })
+    foreach ($dir in $runtimeDirectories) {
         New-Item -ItemType Directory -Force -Path (Join-Path $TargetRoot ([string]$dir)) | Out-Null
     }
 
-    foreach ($entry in @($packaging.copy_directories)) {
+    $copyDirectories = @($packaging.copy_directories | Where-Object { $includeCommandSurfaces -or [string]$_.target -ne 'commands' })
+    foreach ($entry in $copyDirectories) {
         $src = Join-Path $RepoRoot ([string]$entry.source)
         $dst = Join-Path $TargetRoot ([string]$entry.target)
         Copy-DirContent -Source $src -Destination $dst
@@ -741,12 +853,17 @@ function Install-GovernedCodexPayload {
     Copy-DirContent -Source (Join-Path $RepoRoot 'agents\templates') -Destination (Join-Path $TargetRoot 'agents\templates')
     Copy-DirContent -Source (Join-Path $RepoRoot 'mcp') -Destination (Join-Path $TargetRoot 'mcp')
     New-Item -ItemType Directory -Force -Path (Join-Path $TargetRoot 'config') | Out-Null
+    Add-VgoCreatedPath -Path (Join-Path $TargetRoot 'config')
     Copy-Item -LiteralPath (Join-Path $RepoRoot 'config\plugins-manifest.codex.json') -Destination (Join-Path $TargetRoot 'config\plugins-manifest.codex.json') -Force
+    Add-VgoCreatedPath -Path (Join-Path $TargetRoot 'config\plugins-manifest.codex.json')
 
     $settingsPath = Join-Path $TargetRoot 'settings.json'
     if (-not (Test-Path -LiteralPath $settingsPath)) {
         Copy-Item -LiteralPath (Join-Path $RepoRoot 'config\settings.template.codex.json') -Destination $settingsPath -Force
+        Add-VgoTemplateGeneratedPath -Path $settingsPath
     }
+    Add-VgoCreatedPath -Path $settingsPath
+    Add-VgoManagedJsonPath -Path $settingsPath
 }
 
 function Install-ClaudeGuidancePayload {
@@ -754,30 +871,39 @@ function Install-ClaudeGuidancePayload {
 }
 
 function Install-OpenCodeGuidancePayload {
-    Copy-DirContent -Source (Join-Path $RepoRoot 'config\opencode\commands') -Destination (Join-Path $TargetRoot 'commands')
-    Copy-DirContent -Source (Join-Path $RepoRoot 'config\opencode\commands') -Destination (Join-Path $TargetRoot 'command')
-    Copy-DirContent -Source (Join-Path $RepoRoot 'config\opencode\agents') -Destination (Join-Path $TargetRoot 'agents')
-    Copy-DirContent -Source (Join-Path $RepoRoot 'config\opencode\agents') -Destination (Join-Path $TargetRoot 'agent')
-
     $exampleConfig = Join-Path $RepoRoot 'config\opencode\opencode.json.example'
     if (Test-Path -LiteralPath $exampleConfig) {
-        Copy-Item -LiteralPath $exampleConfig -Destination (Join-Path $TargetRoot 'opencode.json.example') -Force
+        $destination = Join-Path $TargetRoot 'opencode.json.example'
+        Copy-Item -LiteralPath $exampleConfig -Destination $destination -Force
+        Add-VgoCreatedPath -Path $destination
     }
 }
 
 function Install-RuntimeCoreModePayload {
+    param([psobject]$Adapter)
+
+    if (Test-VgoSkillOnlyActivationHost -HostId ([string]$Adapter.id)) {
+        return
+    }
+
     $commandsRoot = Join-Path $RepoRoot 'commands'
     if (Test-Path -LiteralPath $commandsRoot) {
-        Copy-DirContent -Source $commandsRoot -Destination (Join-Path $TargetRoot 'global_workflows')
+        $workflowRoot = Join-Path $TargetRoot 'global_workflows'
+        Copy-DirContent -Source $commandsRoot -Destination $workflowRoot
+        Add-VgoCreatedPath -Path $workflowRoot
     }
 
     $mcpTemplate = Join-Path $RepoRoot 'mcp\servers.template.json'
     $mcpConfigPath = Join-Path $TargetRoot 'mcp_config.json'
     if ((Test-Path -LiteralPath $mcpTemplate) -and -not (Test-Path -LiteralPath $mcpConfigPath)) {
         Copy-Item -LiteralPath $mcpTemplate -Destination $mcpConfigPath -Force
+        Add-VgoCreatedPath -Path $mcpConfigPath
+        Add-VgoManagedJsonPath -Path $mcpConfigPath
+        Add-VgoTemplateGeneratedPath -Path $mcpConfigPath
     }
 }
 
+Add-VgoCreatedPath -Path $TargetRoot
 $adapter = Resolve-VgoAdapterDescriptor -RepoRoot $RepoRoot -HostId $HostId
 $result = Install-RuntimeCorePayload -Adapter $adapter
 $legacyOpenCodeConfigCleanup = $null
@@ -786,7 +912,6 @@ switch ([string]$adapter.install_mode) {
     'preview-guidance' {
         if ([string]$adapter.id -eq 'opencode') {
             Install-OpenCodeGuidancePayload
-            $legacyOpenCodeConfigCleanup = Repair-VgoLegacyOpenCodeConfig -TargetRoot $TargetRoot
         } elseif ([string]$adapter.id -eq 'claude-code' -or [string]$adapter.id -eq 'cursor') {
             Install-ClaudeGuidancePayload
         } else {
@@ -794,7 +919,7 @@ switch ([string]$adapter.install_mode) {
         }
     }
     'runtime-core' {
-        Install-RuntimeCoreModePayload
+        Install-RuntimeCoreModePayload -Adapter $adapter
     }
     default { throw "Unsupported adapter install mode: $($adapter.install_mode)" }
 }
@@ -804,6 +929,7 @@ $requireClosedReadyEffective = [bool]($RequireClosedReady -and (Test-VgoClosedRe
 if ($requireClosedReadyEffective -and [string]$closureReceipt.data.host_closure_state -ne 'closed_ready') {
     throw ("Host closure for '{0}' is not closed_ready (got '{1}'). Configure the host specialist bridge command first, then retry install." -f [string]$adapter.id, [string]$closureReceipt.data.host_closure_state)
 }
+$installLedgerPath = Write-VgoInstallLedger -Adapter $adapter -Profile $Profile -ExternalFallbackUsed @($result.external_fallback_used)
 
 [pscustomobject]@{
     host_id = [string]$adapter.id
@@ -812,6 +938,7 @@ if ($requireClosedReadyEffective -and [string]$closureReceipt.data.host_closure_
     external_fallback_used = @($result.external_fallback_used)
     host_closure_path = [string]$closureReceipt.path
     host_closure_state = [string]$closureReceipt.data.host_closure_state
+    install_ledger_path = [string]$installLedgerPath
     settings_materialized = @($closureReceipt.data.settings_materialized)
     legacy_opencode_config_cleanup = $legacyOpenCodeConfigCleanup
     specialist_wrapper_ready = [bool]$closureReceipt.data.specialist_wrapper.ready

--- a/scripts/install/install_vgo_adapter.py
+++ b/scripts/install/install_vgo_adapter.py
@@ -29,6 +29,13 @@ OPTIONAL_WORKFLOW = [
     "receiving-code-review",
     "verification-before-completion",
 ]
+SKILL_ONLY_ACTIVATION_HOSTS = {
+    "claude-code",
+    "cursor",
+    "windsurf",
+    "openclaw",
+    "opencode",
+}
 HOST_BRIDGE_COMMAND_CANDIDATES = {
     "claude-code": ["claude", "claude-code"],
     "cursor": ["cursor-agent", "cursor"],
@@ -118,6 +125,10 @@ def write_json(data):
 def write_json_file(path: Path, data):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def uses_skill_only_activation(host_id: str) -> bool:
+    return (host_id or "").strip().lower() in SKILL_ONLY_ACTIVATION_HOSTS
 
 
 def is_relative_to(path: Path, base: Path) -> bool:
@@ -546,35 +557,34 @@ def sanitize_legacy_opencode_config(target_root: Path) -> dict[str, object]:
 def materialize_host_settings(target_root: Path, adapter: dict, wrapper_info: dict):
     host_id = adapter["id"]
     materialized = []
-    if host_id in {"cursor", "claude-code"}:
-        settings_path = target_root / "settings.json"
-        merge_json_object(
-            settings_path,
-            {
-                "vibeskills": {
-                    "host_id": host_id,
-                    "managed": True,
-                    "commands_root": str((target_root / "commands").resolve()),
-                    "specialist_wrapper": wrapper_info["launcher_path"],
-                }
-            },
-        )
-        materialized.append(str(settings_path.resolve()))
-        record_managed_json(settings_path)
-        track_created_path(settings_path)
-    elif host_id in {"openclaw", "windsurf"}:
+    if uses_skill_only_activation(host_id):
         settings_path = target_root / ".vibeskills" / "host-settings.json"
-        write_json_file(
-            settings_path,
-            {
-                "host_id": host_id,
-                "managed": True,
-                "commands_root": str((target_root / "commands").resolve()),
-                "workflow_root": str((target_root / "global_workflows").resolve()),
-                "mcp_config": str((target_root / "mcp_config.json").resolve()),
-                "specialist_wrapper": wrapper_info["launcher_path"],
+        host_settings = {
+            "schema_version": 1,
+            "host_id": host_id,
+            "managed": True,
+            "skills_root": str((target_root / "skills").resolve()),
+            "runtime_skill_entry": str((target_root / "skills" / "vibe" / "SKILL.md").resolve()),
+            "explicit_vibe_skill_invocation": ["$vibe", "/vibe"],
+            "specialist_wrapper": {
+                "launcher_path": wrapper_info["launcher_path"],
+                "script_path": wrapper_info["script_path"],
+                "ready": wrapper_info["ready"],
             },
-        )
+        }
+        commands_root = target_root / "commands"
+        agents_root = target_root / "agents"
+        workflow_root = target_root / "global_workflows"
+        mcp_config = target_root / "mcp_config.json"
+        if commands_root.exists():
+            host_settings["commands_root"] = str(commands_root.resolve())
+        if agents_root.exists():
+            host_settings["agents_root"] = str(agents_root.resolve())
+        if workflow_root.exists():
+            host_settings["workflow_root"] = str(workflow_root.resolve())
+        if mcp_config.exists():
+            host_settings["mcp_config"] = str(mcp_config.resolve())
+        write_json_file(settings_path, host_settings)
         materialized.append(str(settings_path.resolve()))
         record_managed_json(settings_path)
         track_created_path(settings_path)
@@ -594,6 +604,8 @@ def materialize_host_closure(repo_root: Path, target_root: Path, adapter: dict):
         "platform": detect_platform_tag(),
         "target_root": str(target_root.resolve()),
         "install_mode": adapter["install_mode"],
+        "skills_root": str((target_root / "skills").resolve()),
+        "runtime_skill_entry": str((target_root / "skills" / "vibe" / "SKILL.md").resolve()),
         "commands_root": str(commands_root.resolve()),
         "global_workflows_root": str((target_root / "global_workflows").resolve()),
         "mcp_config_path": str((target_root / "mcp_config.json").resolve()),
@@ -748,13 +760,22 @@ def ensure_skill_present(target_root: Path, name: str, required: bool, allow_fal
         missing.add(name)
 
 
-def install_runtime_core(repo_root: Path, target_root: Path, profile: str, allow_fallback: bool):
+def install_runtime_core(repo_root: Path, target_root: Path, profile: str, allow_fallback: bool, adapter: dict):
     packaging = load_json(repo_root / "config" / "runtime-core-packaging.json")
     governance = load_json(repo_root / "config" / "version-governance.json")
-    for rel in packaging["directories"]:
+    include_command_surfaces = not uses_skill_only_activation(adapter["id"])
+    runtime_directories = [
+        rel for rel in packaging["directories"]
+        if include_command_surfaces or rel != "commands"
+    ]
+    for rel in runtime_directories:
         (target_root / rel).mkdir(parents=True, exist_ok=True)
         track_created_path(target_root / rel)
-    for entry in packaging["copy_directories"]:
+    copy_directories = [
+        entry for entry in packaging["copy_directories"]
+        if include_command_surfaces or entry["target"] != "commands"
+    ]
+    for entry in copy_directories:
         copy_tree(repo_root / entry["source"], target_root / entry["target"])
         if entry["target"] == "skills":
             for skill_dir in (target_root / "skills").iterdir():
@@ -846,22 +867,13 @@ def install_claude_guidance_payload(repo_root: Path, target_root: Path):
 
 
 def install_opencode_guidance_payload(repo_root: Path, target_root: Path):
-    commands_root = repo_root / "config" / "opencode" / "commands"
-    agents_root = repo_root / "config" / "opencode" / "agents"
     example_config = repo_root / "config" / "opencode" / "opencode.json.example"
-
-    copy_tree(commands_root, target_root / "commands")
-    track_created_path(target_root / "commands")
-    copy_tree(commands_root, target_root / "command")
-    track_created_path(target_root / "command")
-    copy_tree(agents_root, target_root / "agents")
-    track_created_path(target_root / "agents")
-    copy_tree(agents_root, target_root / "agent")
-    track_created_path(target_root / "agent")
     if example_config.exists():
         copy_file(example_config, target_root / "opencode.json.example")
 
-def install_runtime_core_mode_payload(repo_root: Path, target_root: Path):
+def install_runtime_core_mode_payload(repo_root: Path, target_root: Path, adapter: dict):
+    if uses_skill_only_activation(adapter["id"]):
+        return
     commands_root = repo_root / "commands"
     if commands_root.exists():
         copy_tree(commands_root, target_root / "global_workflows")
@@ -892,7 +904,7 @@ def main():
     target_root.mkdir(parents=True, exist_ok=True)
     track_created_path(target_root)
     adapter = resolve_adapter(repo_root, args.host)
-    external_used = install_runtime_core(repo_root, target_root, args.profile, args.allow_external_skill_fallback)
+    external_used = install_runtime_core(repo_root, target_root, args.profile, args.allow_external_skill_fallback, adapter)
     mode = adapter["install_mode"]
     legacy_opencode_config_cleanup = None
     if mode == "governed":
@@ -900,13 +912,12 @@ def main():
     elif mode == "preview-guidance":
         if adapter["id"] == "opencode":
             install_opencode_guidance_payload(repo_root, target_root)
-            legacy_opencode_config_cleanup = sanitize_legacy_opencode_config(target_root)
         elif adapter["id"] in {"claude-code", "cursor"}:
             install_claude_guidance_payload(repo_root, target_root)
         else:
             raise SystemExit(f"Unsupported preview-guidance adapter id: {adapter['id']}")
     elif mode == "runtime-core":
-        install_runtime_core_mode_payload(repo_root, target_root)
+        install_runtime_core_mode_payload(repo_root, target_root, adapter)
     else:
         raise SystemExit(f"Unsupported adapter install mode: {mode}")
 

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -283,6 +283,20 @@ function Resolve-VibeBridgeExecutable {
         }
     }
 
+    if ([string]::IsNullOrWhiteSpace($resolvedCommandPath) -and $null -ne $Runtime -and $Runtime.PSObject.Properties.Name -contains 'host_settings' -and $null -ne $Runtime.host_settings) {
+        $hostSettings = $Runtime.host_settings
+        if ($hostSettings.PSObject.Properties.Name -contains 'data' -and $null -ne $hostSettings.data) {
+            $specialistWrapper = if ($hostSettings.data.PSObject.Properties.Name -contains 'specialist_wrapper') { $hostSettings.data.specialist_wrapper } else { $null }
+            if ($null -ne $specialistWrapper) {
+                $ready = if ($specialistWrapper.PSObject.Properties.Name -contains 'ready') { [bool]$specialistWrapper.ready } else { $false }
+                $launcherPath = if ($specialistWrapper.PSObject.Properties.Name -contains 'launcher_path') { [string]$specialistWrapper.launcher_path } else { '' }
+                if ($ready -and -not [string]::IsNullOrWhiteSpace($launcherPath) -and (Test-Path -LiteralPath $launcherPath -PathType Leaf)) {
+                    $resolvedCommandPath = [System.IO.Path]::GetFullPath($launcherPath)
+                }
+            }
+        }
+    }
+
     if ([string]::IsNullOrWhiteSpace($resolvedCommandPath) -and $null -ne $Runtime -and $Runtime.PSObject.Properties.Name -contains 'host_closure' -and $null -ne $Runtime.host_closure) {
         $hostClosure = $Runtime.host_closure
         if ($hostClosure.PSObject.Properties.Name -contains 'data' -and $null -ne $hostClosure.data) {

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -178,6 +178,22 @@ function New-VibeRuntimeHostAdapterProjection {
         -EffectivePropertyName 'id' `
         -FallbackHostId $FallbackHostId
 
+    $hostSettingsPath = $null
+    if ($Runtime -and (Test-VibeObjectHasProperty -InputObject $Runtime -PropertyName 'host_settings')) {
+        $hostSettings = $Runtime.host_settings
+        if ($null -ne $hostSettings -and (Test-VibeObjectHasProperty -InputObject $hostSettings -PropertyName 'path') -and -not [string]::IsNullOrWhiteSpace($hostSettings.path)) {
+            $hostSettingsPath = [string]$hostSettings.path
+        }
+    }
+
+    $hostClosurePath = $null
+    if ($Runtime -and (Test-VibeObjectHasProperty -InputObject $Runtime -PropertyName 'host_closure')) {
+        $hostClosure = $Runtime.host_closure
+        if ($null -ne $hostClosure -and (Test-VibeObjectHasProperty -InputObject $hostClosure -PropertyName 'path') -and -not [string]::IsNullOrWhiteSpace($hostClosure.path)) {
+            $hostClosurePath = [string]$hostClosure.path
+        }
+    }
+
     return [pscustomobject]@{
         requested_id = $identity.requested_id
         id = $identity.id
@@ -188,7 +204,8 @@ function New-VibeRuntimeHostAdapterProjection {
         check_mode = if ($Runtime.host_adapter -and (Test-VibeObjectHasProperty -InputObject $Runtime.host_adapter -PropertyName 'check_mode')) { [string]$Runtime.host_adapter.check_mode } else { $null }
         bootstrap_mode = if ($Runtime.host_adapter -and (Test-VibeObjectHasProperty -InputObject $Runtime.host_adapter -PropertyName 'bootstrap_mode')) { [string]$Runtime.host_adapter.bootstrap_mode } else { $null }
         target_root = if ([string]::IsNullOrWhiteSpace($TargetRoot)) { $null } else { [string]$TargetRoot }
-        closure_path = if ($Runtime.host_closure) { [string]$Runtime.host_closure.path } else { $null }
+        host_settings_path = $hostSettingsPath
+        closure_path = $hostClosurePath
     }
 }
 
@@ -218,6 +235,34 @@ function New-VibeRouteRuntimeAlignmentProjection {
         confirm_required = if ($null -ne $RuntimeInputPacket) { [bool]$RuntimeInputPacket.route_snapshot.confirm_required } else { $false }
         requested_host_adapter_id = $hostAdapterIdentity.requested_host_id
         effective_host_adapter_id = $hostAdapterIdentity.effective_host_id
+    }
+}
+
+function Get-VibeHostSettingsRecord {
+    param(
+        [Parameter(Mandatory)] [object]$HostAdapter
+    )
+
+    $targetRoot = Resolve-VibeHostTargetRoot -HostAdapter $HostAdapter
+    if ([string]::IsNullOrWhiteSpace($targetRoot)) {
+        return $null
+    }
+
+    $settingsPath = Join-Path $targetRoot '.vibeskills\host-settings.json'
+    if (-not (Test-Path -LiteralPath $settingsPath -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        $settings = Get-Content -LiteralPath $settingsPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+
+    return [pscustomobject]@{
+        target_root = $targetRoot
+        path = $settingsPath
+        data = $settings
     }
 }
 
@@ -262,6 +307,7 @@ function Get-VibeRuntimeContext {
         repo_root = $repoRoot
         governance_context = $governanceContext
         host_adapter = $hostAdapter
+        host_settings = Get-VibeHostSettingsRecord -HostAdapter $hostAdapter
         host_closure = Get-VibeHostClosureRecord -HostAdapter $hostAdapter
         runtime_contract = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-contract.json') -Raw -Encoding UTF8 | ConvertFrom-Json
         runtime_modes = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-modes.json') -Raw -Encoding UTF8 | ConvertFrom-Json

--- a/scripts/uninstall/uninstall_vgo_adapter.py
+++ b/scripts/uninstall/uninstall_vgo_adapter.py
@@ -359,11 +359,6 @@ def plan_uninstall(repo_root: Path, target_root: Path, adapter: dict) -> dict[st
     managed_json_paths = parse_managed_json_paths(ledger.get("managed_json_paths") if isinstance(ledger, dict) else None, target_root)
     merged_files = parse_merged_files(ledger.get("merged_files") if isinstance(ledger, dict) else None, target_root)
 
-    if host_id in {"claude-code", "cursor"}:
-        managed_json_paths.setdefault("settings.json", {"managed_key": "vibeskills", "created_if_absent": False})
-    if host_id == "opencode":
-        managed_json_paths.setdefault("opencode.json", {"managed_key": "vibeskills", "created_if_absent": False})
-
     return {
         "managed_files": {entry for entry in managed_files if entry and not any(entry == deleted or entry.startswith(f"{deleted}/") for deleted in deleted_dirs)},
         "deleted_dirs": deleted_dirs,

--- a/tests/runtime_neutral/test_claude_preview_scaffold.py
+++ b/tests/runtime_neutral/test_claude_preview_scaffold.py
@@ -113,11 +113,14 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
 
         settings_path = self.target_root / 'settings.json'
         closure_path = self.target_root / '.vibeskills' / 'host-closure.json'
+        host_settings_path = self.target_root / '.vibeskills' / 'host-settings.json'
         settings = json.loads(settings_path.read_text(encoding='utf-8'))
         self.assertEqual(self.existing_settings['env'], settings['env'])
         self.assertEqual(self.existing_settings['model'], settings['model'])
-        self.assertEqual('claude-code', settings['vibeskills']['host_id'])
+        self.assertNotIn('vibeskills', settings)
         self.assertTrue(closure_path.exists())
+        self.assertTrue(host_settings_path.exists())
+        self.assertFalse((self.target_root / 'commands').exists())
         self.assertEqual('preview-guidance', payload['install_mode'])
         self.assertEqual(str(closure_path), payload['host_closure_path'])
 
@@ -150,7 +153,9 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
         settings = json.loads((self.target_root / 'settings.json').read_text(encoding='utf-8'))
         self.assertEqual(self.existing_settings['env'], settings['env'])
         self.assertEqual(self.existing_settings['model'], settings['model'])
-        self.assertEqual('claude-code', settings['vibeskills']['host_id'])
+        self.assertNotIn('vibeskills', settings)
+        self.assertTrue((self.target_root / '.vibeskills' / 'host-settings.json').exists())
+        self.assertFalse((self.target_root / 'commands').exists())
 
 
 if __name__ == '__main__':

--- a/tests/runtime_neutral/test_cursor_managed_preview.py
+++ b/tests/runtime_neutral/test_cursor_managed_preview.py
@@ -13,7 +13,7 @@ INSTALLER = REPO_ROOT / "scripts" / "install" / "install_vgo_adapter.py"
 
 
 class CursorManagedPreviewTests(unittest.TestCase):
-    def test_python_installer_materializes_cursor_host_closure_and_settings_surface(self) -> None:
+    def test_python_installer_materializes_cursor_host_closure_and_sidecar_only_surface(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             target_root = Path(tempdir)
             result = subprocess.run(
@@ -35,21 +35,23 @@ class CursorManagedPreviewTests(unittest.TestCase):
             )
             payload = json.loads(result.stdout)
             closure_path = target_root / ".vibeskills" / "host-closure.json"
-            settings_path = target_root / "settings.json"
+            host_settings_path = target_root / ".vibeskills" / "host-settings.json"
 
             self.assertEqual("cursor", payload["host_id"])
             self.assertEqual("preview-guidance", payload["install_mode"])
             self.assertTrue(closure_path.exists())
-            self.assertTrue(settings_path.exists())
-            self.assertTrue((target_root / "commands" / "vibe.md").exists())
+            self.assertTrue(host_settings_path.exists())
+            self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
+            self.assertFalse((target_root / "settings.json").exists())
+            self.assertFalse((target_root / "commands").exists())
 
             closure = json.loads(closure_path.read_text(encoding="utf-8"))
-            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+            host_settings = json.loads(host_settings_path.read_text(encoding="utf-8"))
 
             self.assertEqual("cursor", closure["host_id"])
             self.assertEqual(str(target_root.resolve()), closure["target_root"])
-            self.assertIn("vibeskills", settings)
-            self.assertEqual("cursor", settings["vibeskills"]["host_id"])
+            self.assertEqual("cursor", host_settings["host_id"])
+            self.assertEqual(str((target_root / "skills").resolve()), host_settings["skills_root"])
             self.assertIn("specialist_wrapper_ready", payload)
             self.assertIsInstance(payload["specialist_wrapper_ready"], bool)
 

--- a/tests/runtime_neutral/test_installed_runtime_scripts.py
+++ b/tests/runtime_neutral/test_installed_runtime_scripts.py
@@ -318,7 +318,8 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         self.assertIn("Host                  : openclaw", bootstrap_result.stdout)
         self.assertIn("One-shot setup completed.", bootstrap_result.stdout)
         self.assertTrue((installed_root / "SKILL.md").exists())
-        self.assertTrue((self.target_root / "mcp_config.json").exists())
+        self.assertTrue((self.target_root / ".vibeskills" / "host-settings.json").exists())
+        self.assertFalse((self.target_root / "mcp_config.json").exists())
 
     def test_shell_install_prunes_stale_managed_entries_without_recursive_dir_wipe(self) -> None:
         self.install_shell_runtime()
@@ -342,7 +343,7 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         install_script = (self.target_root / "skills" / "vibe" / "install.sh").read_text(encoding="utf-8")
         self.assertNotIn("rm -rf", install_script)
 
-    def test_shell_install_repairs_legacy_opencode_config_without_touching_user_settings(self) -> None:
+    def test_shell_install_preserves_existing_opencode_config_without_mutation(self) -> None:
         self.target_root.mkdir(parents=True, exist_ok=True)
         settings_path = self.target_root / "opencode.json"
         settings_path.write_text(
@@ -386,10 +387,116 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         )
 
         self.assertIn("Install done.", result.stdout)
-        repaired = json.loads(settings_path.read_text(encoding="utf-8"))
-        self.assertNotIn("vibeskills", repaired)
-        self.assertIn("mcp", repaired)
+        preserved = json.loads(settings_path.read_text(encoding="utf-8"))
+        self.assertIn("vibeskills", preserved)
+        self.assertIn("mcp", preserved)
         self.assertTrue((self.target_root / "opencode.json.example").exists())
+
+    def test_powershell_fallback_install_writes_sidecars_and_ledger_for_openclaw(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        target_root = self.root / "pwsh-fallback-openclaw"
+        target_root.mkdir(parents=True, exist_ok=True)
+        env = self.strict_install_env(powershell=powershell)
+
+        result = subprocess.run(
+            [
+                powershell,
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(REPO_ROOT / "install.ps1"),
+                "-HostId",
+                "openclaw",
+                "-Profile",
+                "full",
+                "-TargetRoot",
+                str(target_root),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+
+        host_settings_path = target_root / ".vibeskills" / "host-settings.json"
+        closure_path = target_root / ".vibeskills" / "host-closure.json"
+        ledger_path = target_root / ".vibeskills" / "install-ledger.json"
+        self.assertIn("Installation complete.", result.stdout)
+        self.assertTrue(host_settings_path.exists())
+        self.assertTrue(closure_path.exists())
+        self.assertTrue(ledger_path.exists())
+        self.assertFalse((target_root / "mcp_config.json").exists())
+        self.assertFalse((target_root / "global_workflows").exists())
+
+        ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+        self.assertEqual("openclaw", ledger["host_id"])
+        self.assertEqual("runtime-core", ledger["install_mode"])
+        self.assertIn(str(host_settings_path.resolve()), ledger["managed_json_paths"])
+        self.assertNotIn(str((target_root / "mcp_config.json").resolve()), ledger["managed_json_paths"])
+        self.assertTrue(ledger["specialist_wrapper_paths"])
+
+    def test_powershell_fallback_install_preserves_existing_opencode_config_without_mutation(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        target_root = self.root / "pwsh-fallback-opencode"
+        target_root.mkdir(parents=True, exist_ok=True)
+        settings_path = target_root / "opencode.json"
+        original = {
+            "$schema": "https://opencode.ai/config.json",
+            "mcp": {
+                "playwright": {
+                    "enabled": True,
+                    "type": "local",
+                    "command": ["npx", "@playwright/mcp@latest"],
+                }
+            },
+            "vibeskills": {
+                "host_id": "opencode",
+                "managed": True,
+                "commands_root": str((target_root / "commands").resolve()),
+                "agents_root": str((target_root / "agents").resolve()),
+            },
+        }
+        settings_path.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8")
+
+        env = self.strict_install_env(powershell=powershell)
+        result = subprocess.run(
+            [
+                powershell,
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(REPO_ROOT / "install.ps1"),
+                "-HostId",
+                "opencode",
+                "-Profile",
+                "full",
+                "-TargetRoot",
+                str(target_root),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+
+        ledger_path = target_root / ".vibeskills" / "install-ledger.json"
+        self.assertIn("Installation complete.", result.stdout)
+        self.assertEqual(original, json.loads(settings_path.read_text(encoding="utf-8")))
+        self.assertTrue((target_root / "opencode.json.example").exists())
+        self.assertTrue(ledger_path.exists())
+
+        ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+        self.assertEqual("opencode", ledger["host_id"])
+        self.assertNotIn(str(settings_path.resolve()), ledger["managed_json_paths"])
+        self.assertIn(str((target_root / ".vibeskills" / "host-settings.json").resolve()), ledger["managed_json_paths"])
 
     def test_shell_install_require_closed_ready_fails_without_bridge_command(self) -> None:
         for host_id, _env_name in STRICT_READY_HOSTS:

--- a/tests/runtime_neutral/test_installed_runtime_uninstall.py
+++ b/tests/runtime_neutral/test_installed_runtime_uninstall.py
@@ -74,40 +74,34 @@ class InstalledRuntimeUninstallTests(unittest.TestCase):
         target_root = self.root / "claude-root"
         self.install_host("claude-code", target_root)
         settings_path = target_root / "settings.json"
-        settings = json.loads(settings_path.read_text(encoding="utf-8"))
-        settings["user.keep"] = True
-        settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
         sentinel = target_root / "commands" / "user.md"
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
         sentinel.write_text("user\n", encoding="utf-8")
 
         self.uninstall_host("claude-code", target_root)
 
         self.assertFalse((target_root / ".vibeskills").exists())
         self.assertTrue(sentinel.exists())
-        if settings_path.exists():
-            remaining = json.loads(settings_path.read_text(encoding="utf-8"))
-            self.assertNotIn("vibeskills", remaining)
-            self.assertTrue(remaining["user.keep"])
+        self.assertFalse(settings_path.exists())
 
     def test_cursor_uninstall_removes_vibe_managed_surface(self) -> None:
         target_root = self.root / "cursor-root"
         self.install_host("cursor", target_root)
         sentinel = target_root / "commands" / "user.md"
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
         sentinel.write_text("user\n", encoding="utf-8")
 
         self.uninstall_host("cursor", target_root)
 
         self.assertFalse((target_root / ".vibeskills").exists())
         self.assertTrue(sentinel.exists())
-        settings_path = target_root / "settings.json"
-        if settings_path.exists():
-            remaining = json.loads(settings_path.read_text(encoding="utf-8"))
-            self.assertNotIn("vibeskills", remaining)
+        self.assertFalse((target_root / "settings.json").exists())
 
     def test_windsurf_uninstall_removes_runtime_core_preview_host_payload(self) -> None:
         target_root = self.root / "windsurf-root"
         self.install_host("windsurf", target_root)
         sentinel = target_root / "commands" / "user.md"
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
         sentinel.write_text("user\n", encoding="utf-8")
 
         self.uninstall_host("windsurf", target_root)
@@ -120,6 +114,7 @@ class InstalledRuntimeUninstallTests(unittest.TestCase):
         target_root = self.root / "openclaw-root"
         self.install_host("openclaw", target_root)
         sentinel = target_root / "commands" / "user.md"
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
         sentinel.write_text("user\n", encoding="utf-8")
 
         self.uninstall_host("openclaw", target_root)
@@ -148,6 +143,7 @@ class InstalledRuntimeUninstallTests(unittest.TestCase):
             encoding="utf-8",
         )
         sentinel = target_root / "commands" / "user.md"
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
         sentinel.write_text("user\n", encoding="utf-8")
 
         self.uninstall_host("opencode", target_root)
@@ -157,10 +153,10 @@ class InstalledRuntimeUninstallTests(unittest.TestCase):
         self.assertFalse((target_root / "agents" / "vibe-plan.md").exists())
         self.assertFalse((target_root / "opencode.json.example").exists())
         self.assertTrue(sentinel.exists())
-        if settings_path.exists():
-            remaining = json.loads(settings_path.read_text(encoding="utf-8"))
-            self.assertNotIn("vibeskills", remaining)
-            self.assertTrue(remaining["user.keep"])
+        self.assertTrue(settings_path.exists())
+        remaining = json.loads(settings_path.read_text(encoding="utf-8"))
+        self.assertIn("vibeskills", remaining)
+        self.assertTrue(remaining["user.keep"])
 
 
 if __name__ == "__main__":

--- a/tests/runtime_neutral/test_openclaw_runtime_core.py
+++ b/tests/runtime_neutral/test_openclaw_runtime_core.py
@@ -74,10 +74,11 @@ class OpenClawRuntimeCoreTests(unittest.TestCase):
             self.assertIn("host_closure_path", payload)
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
             self.assertTrue((target_root / "skills" / "brainstorming" / "SKILL.md").exists())
-            self.assertTrue((target_root / "commands").exists())
-            self.assertTrue((target_root / "commands" / "vibe.md").exists())
-            self.assertTrue((target_root / "mcp_config.json").exists())
+            self.assertTrue((target_root / ".vibeskills" / "host-settings.json").exists())
             self.assertTrue((target_root / ".vibeskills" / "host-closure.json").exists())
+            self.assertFalse((target_root / "commands").exists())
+            self.assertFalse((target_root / "global_workflows").exists())
+            self.assertFalse((target_root / "mcp_config.json").exists())
             self.assertFalse((target_root / "settings.json").exists())
             self.assertFalse((target_root / "config" / "plugins-manifest.codex.json").exists())
 
@@ -102,11 +103,11 @@ class OpenClawRuntimeCoreTests(unittest.TestCase):
             self.assertIn("Host   : openclaw", install_result.stdout)
             self.assertIn("Mode   : runtime-core", install_result.stdout)
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
-            self.assertTrue((target_root / "commands").exists())
-            self.assertTrue((target_root / "commands" / "vibe.md").exists())
-            self.assertTrue((target_root / "global_workflows" / "vibe.md").exists())
-            self.assertTrue((target_root / "mcp_config.json").exists())
+            self.assertTrue((target_root / ".vibeskills" / "host-settings.json").exists())
             self.assertTrue((target_root / ".vibeskills" / "host-closure.json").exists())
+            self.assertFalse((target_root / "commands").exists())
+            self.assertFalse((target_root / "global_workflows").exists())
+            self.assertFalse((target_root / "mcp_config.json").exists())
             self.assertFalse((target_root / "settings.json").exists())
 
             check_result = subprocess.run(
@@ -130,6 +131,7 @@ class OpenClawRuntimeCoreTests(unittest.TestCase):
             self.assertIn("[OK] npm check skipped for non-governed adapter mode", check_result.stdout)
             self.assertNotIn("[FAIL] settings.json", check_result.stdout)
             self.assertNotIn("[FAIL] config/plugins-manifest.codex.json", check_result.stdout)
+            self.assertNotIn("[FAIL] mcp_config.json", check_result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/runtime_neutral/test_opencode_managed_preview.py
+++ b/tests/runtime_neutral/test_opencode_managed_preview.py
@@ -43,15 +43,16 @@ class OpenCodeManagedPreviewTests(unittest.TestCase):
             self.assertTrue(closure_path.exists())
             self.assertFalse(settings_path.exists())
             self.assertTrue(example_path.exists())
-            self.assertTrue((target_root / "commands" / "vibe.md").exists())
-            self.assertTrue((target_root / "command" / "vibe.md").exists())
-            self.assertTrue((target_root / "agents").exists())
-            self.assertTrue((target_root / "agent").exists())
+            self.assertTrue((target_root / ".vibeskills" / "host-settings.json").exists())
+            self.assertFalse((target_root / "commands").exists())
+            self.assertFalse((target_root / "command").exists())
+            self.assertFalse((target_root / "agents").exists())
+            self.assertFalse((target_root / "agent").exists())
             closure = json.loads(closure_path.read_text(encoding="utf-8"))
-            self.assertEqual([], closure["settings_materialized"])
-            self.assertEqual("not-present", payload["legacy_opencode_config_cleanup"]["status"])
+            self.assertEqual([str((target_root / ".vibeskills" / "host-settings.json").resolve())], closure["settings_materialized"])
+            self.assertIsNone(payload["legacy_opencode_config_cleanup"])
 
-    def test_python_installer_repairs_legacy_vibe_node_without_touching_user_keys(self) -> None:
+    def test_python_installer_leaves_existing_opencode_config_untouched(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             target_root = Path(tempdir)
             settings_path = target_root / "opencode.json"
@@ -98,11 +99,10 @@ class OpenCodeManagedPreviewTests(unittest.TestCase):
             )
 
             payload = json.loads(result.stdout)
-            repaired = json.loads(settings_path.read_text(encoding="utf-8"))
-            self.assertNotIn("vibeskills", repaired)
-            self.assertIn("mcp", repaired)
-            self.assertEqual("removed-owned-node", payload["legacy_opencode_config_cleanup"]["status"])
-            self.assertEqual(["$schema", "mcp"], payload["legacy_opencode_config_cleanup"]["preserved_keys"])
+            preserved = json.loads(settings_path.read_text(encoding="utf-8"))
+            self.assertIn("vibeskills", preserved)
+            self.assertIn("mcp", preserved)
+            self.assertIsNone(payload["legacy_opencode_config_cleanup"])
 
 
 if __name__ == "__main__":

--- a/tests/runtime_neutral/test_runtime_contract_schema.py
+++ b/tests/runtime_neutral/test_runtime_contract_schema.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RUNTIME_COMMON = REPO_ROOT / "scripts" / "runtime" / "VibeRuntime.Common.ps1"
+EXECUTION_COMMON = REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1"
 RUNTIME_ENTRY = REPO_ROOT / "scripts" / "runtime" / "invoke-vibe-runtime.ps1"
 SPECIALIST_TASK = "I have a failing test and a stack trace. Help me debug systematically before proposing fixes."
 
@@ -111,7 +112,7 @@ class RuntimeContractSchemaTests(unittest.TestCase):
         self.assertEqual("cursor", payload["requested_host_id"])
         self.assertEqual("windsurf", payload["effective_host_id"])
 
-    def test_runtime_projection_maps_status_modes_and_closure(self) -> None:
+    def test_runtime_projection_maps_status_modes_closure_and_host_settings(self) -> None:
         payload = run_ps_json(
             "& { "
             f". {_ps_single_quote(str(RUNTIME_COMMON))}; "
@@ -124,7 +125,8 @@ class RuntimeContractSchemaTests(unittest.TestCase):
             "check_mode = 'audit'; "
             "bootstrap_mode = 'bounded' "
             "}; "
-            "host_closure = [pscustomobject]@{ path = '/tmp/host-closure.json' } "
+            "host_closure = [pscustomobject]@{ path = '/tmp/host-closure.json' }; "
+            "host_settings = [pscustomobject]@{ path = '/tmp/host-settings.json' } "
             "}; "
             "$result = New-VibeRuntimeHostAdapterProjection "
             "-Runtime $runtime "
@@ -141,6 +143,7 @@ class RuntimeContractSchemaTests(unittest.TestCase):
         self.assertEqual("bounded", payload["bootstrap_mode"])
         self.assertEqual("/tmp/openclaw-home", payload["target_root"])
         self.assertEqual("/tmp/host-closure.json", payload["closure_path"])
+        self.assertEqual("/tmp/host-settings.json", payload["host_settings_path"])
 
     def test_runtime_packet_alignment_helper_reads_frozen_projection(self) -> None:
         payload = run_ps_json(
@@ -155,6 +158,34 @@ class RuntimeContractSchemaTests(unittest.TestCase):
 
         self.assertEqual("openclaw", payload["requested_host_id"])
         self.assertEqual("windsurf", payload["effective_host_id"])
+
+    def test_bridge_resolution_can_use_host_settings_sidecar(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_path = Path(tempdir)
+            launcher = temp_path / "openclaw-wrapper.sh"
+            launcher.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+
+            payload = run_ps_json(
+                "& { "
+                f". {_ps_single_quote(str(EXECUTION_COMMON))}; "
+                "$adapter = [pscustomobject]@{ id = 'openclaw'; bridge_executable_env = ''; bridge_command = '' }; "
+                "$runtime = [pscustomobject]@{ "
+                "host_settings = [pscustomobject]@{ "
+                f"path = {_ps_single_quote(str(temp_path / '.vibeskills' / 'host-settings.json'))}; "
+                "data = [pscustomobject]@{ "
+                "specialist_wrapper = [pscustomobject]@{ "
+                f"launcher_path = {_ps_single_quote(str(launcher))}; "
+                "ready = $true "
+                "} "
+                "} "
+                "} "
+                "}; "
+                "$result = Resolve-VibeBridgeExecutable -Adapter $adapter -Runtime $runtime; "
+                "$result | ConvertTo-Json -Depth 10 }"
+            )
+
+        self.assertEqual(str(launcher), payload["command_path"])
+        self.assertEqual("native_specialist_bridge_ready", payload["reason"])
 
     def test_hierarchy_projection_preserves_root_and_child_fields(self) -> None:
         payload = run_ps_json(

--- a/tests/runtime_neutral/test_uninstall_vgo_adapter.py
+++ b/tests/runtime_neutral/test_uninstall_vgo_adapter.py
@@ -182,9 +182,48 @@ class UnifiedUninstallTests(unittest.TestCase):
         _, payload = self.run_python_uninstall(host="cursor")
 
         self.assertFalse((self.target_root / ".vibeskills").exists())
+        remaining = json.loads(settings_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            {
+                "editor.fontSize": 14,
+                "vibeskills": {"managed": True, "host_id": "cursor"},
+            },
+            remaining,
+        )
+        self.assertIn("host-closure", payload["ownership_source"])
+        self.assertNotIn("settings.json", payload["mutated_json_paths"])
+
+    def test_planner_mutates_shared_json_when_ledger_marks_it_owned(self) -> None:
+        ledger_path = self.target_root / ".vibeskills" / "install-ledger.json"
+        settings_path = self.target_root / "settings.json"
+        write_json(
+            ledger_path,
+            {
+                "schema_version": 1,
+                "host_id": "cursor",
+                "target_root": str(self.target_root.resolve()),
+                "install_mode": "preview-guidance",
+                "profile": "full",
+                "created_paths": [],
+                "managed_json_paths": ["settings.json"],
+                "generated_from_template_if_absent": [],
+                "specialist_wrapper_paths": [],
+                "runtime_root": "skills/vibe",
+                "canonical_vibe_root": "skills/vibe",
+            },
+        )
+        write_json(
+            settings_path,
+            {
+                "editor.fontSize": 14,
+                "vibeskills": {"managed": True, "host_id": "cursor"},
+            },
+        )
+
+        _, payload = self.run_python_uninstall(host="cursor")
+
         mutated = json.loads(settings_path.read_text(encoding="utf-8"))
         self.assertEqual({"editor.fontSize": 14}, mutated)
-        self.assertIn("host-closure", payload["ownership_source"])
         self.assertIn("settings.json", payload["mutated_json_paths"])
 
     def test_planner_uses_legacy_owned_only_fallback_for_repo_managed_surfaces(self) -> None:
@@ -215,7 +254,7 @@ class UnifiedUninstallTests(unittest.TestCase):
         _, payload = self.run_python_uninstall(host="cursor")
 
         self.assertTrue(settings_path.exists())
-        self.assertTrue(payload["warnings"])
+        self.assertFalse(payload["warnings"])
 
     def test_receipt_and_empty_directory_purge_are_written(self) -> None:
         managed_file = self.target_root / "commands" / "vibe.md"

--- a/tests/runtime_neutral/test_windsurf_runtime_core.py
+++ b/tests/runtime_neutral/test_windsurf_runtime_core.py
@@ -62,10 +62,11 @@ class WindsurfRuntimeCoreTests(unittest.TestCase):
             self.assertIn("host_closure_path", payload)
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
             self.assertTrue((target_root / "skills" / "brainstorming" / "SKILL.md").exists())
-            self.assertTrue((target_root / "commands" / "vibe.md").exists())
-            self.assertTrue((target_root / "global_workflows" / "vibe.md").exists())
-            self.assertTrue((target_root / "mcp_config.json").exists())
+            self.assertTrue((target_root / ".vibeskills" / "host-settings.json").exists())
             self.assertTrue((target_root / ".vibeskills" / "host-closure.json").exists())
+            self.assertFalse((target_root / "commands").exists())
+            self.assertFalse((target_root / "global_workflows").exists())
+            self.assertFalse((target_root / "mcp_config.json").exists())
             self.assertFalse((target_root / "settings.json").exists())
             self.assertFalse((target_root / "config" / "plugins-manifest.codex.json").exists())
 
@@ -90,10 +91,11 @@ class WindsurfRuntimeCoreTests(unittest.TestCase):
             self.assertIn("Host   : windsurf", install_result.stdout)
             self.assertIn("Mode   : runtime-core", install_result.stdout)
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
-            self.assertTrue((target_root / "commands" / "vibe.md").exists())
-            self.assertTrue((target_root / "global_workflows" / "vibe.md").exists())
-            self.assertTrue((target_root / "mcp_config.json").exists())
+            self.assertTrue((target_root / ".vibeskills" / "host-settings.json").exists())
             self.assertTrue((target_root / ".vibeskills" / "host-closure.json").exists())
+            self.assertFalse((target_root / "commands").exists())
+            self.assertFalse((target_root / "global_workflows").exists())
+            self.assertFalse((target_root / "mcp_config.json").exists())
             self.assertFalse((target_root / "settings.json").exists())
 
             check_result = subprocess.run(
@@ -114,6 +116,7 @@ class WindsurfRuntimeCoreTests(unittest.TestCase):
             self.assertIn("Host: windsurf", check_result.stdout)
             self.assertIn("[OK] host closure manifest", check_result.stdout)
             self.assertNotIn("[FAIL] settings.json", check_result.stdout)
+            self.assertNotIn("[FAIL] mcp_config.json", check_result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request aligns the host integration contract around a skill-only, sidecar-first runtime model and removes the remaining sources of native host configuration coupling.

The user-visible problem behind this change was twofold. First, some host integrations could still write or depend on host-native configuration files, which increased startup regression risk and made installation and uninstall behavior harder to reason about. Second, uninstall behavior was not strictly limited to artifacts that Vibe itself created, which weakened the ownership boundary and made cleanup less predictable.

The root cause was that the install, runtime, uninstall, and documentation layers were not all using the same source of truth. Different paths still partially relied on host-managed JSON, fallback installers did not fully emit the same ownership ledger metadata, and uninstall behavior could infer too much from closure state instead of requiring explicit ledger evidence before touching shared JSON.

This change tightens that contract. Skill-only hosts now avoid writing native host configuration files and instead use `.vibeskills/host-settings.json` as the canonical runtime state. Ownership tracking is normalized through `.vibeskills/host-closure.json` and `.vibeskills/install-ledger.json`. The uninstall path is now ledger-first and owned-only, meaning shared JSON is only modified when the ledger explicitly records that Vibe wrote that content. The PowerShell fallback installer now emits the same ledger and closure artifacts as the primary path so both installation routes converge on the same cleanup semantics.

The documentation has been updated to match the actual runtime contract. Installation guidance now documents the uninstall entry points in both Chinese and English, and the public installation and host-policy documents now describe the sidecar-only, explicit-skill activation model rather than the older host-config-writing behavior.

Validation was done with targeted runtime-neutral regression coverage across all affected hosts and lifecycle paths. The following suite passed locally: `pytest -q tests/runtime_neutral/test_claude_preview_scaffold.py tests/runtime_neutral/test_cursor_managed_preview.py tests/runtime_neutral/test_opencode_managed_preview.py tests/runtime_neutral/test_windsurf_runtime_core.py tests/runtime_neutral/test_openclaw_runtime_core.py tests/runtime_neutral/test_installed_runtime_uninstall.py tests/runtime_neutral/test_installed_runtime_scripts.py tests/runtime_neutral/test_runtime_contract_schema.py tests/runtime_neutral/test_multi_host_specialist_execution.py tests/runtime_neutral/test_uninstall_vgo_adapter.py` with `61 passed, 14 subtests passed`. `git diff --check` also passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced sidecar-native host settings files for isolated runtime configuration.
  * Added support for specialist wrapper launcher paths in runtime execution.
  * Implemented install ledger tracking for managed file cleanup.

* **Bug Fixes**
  * Removed legacy shared configuration modifications to prevent cross-host startup conflicts.
  * Simplified preview guidance messaging across adapters.

* **Documentation**
  * Updated installation path documentation to reflect new sidecar file layout.
  * Added cross-host startup regression audit and explicit sidecar-first runtime design documentation.

* **Tests**
  * Updated runtime-neutral tests to validate new sidecar configuration structure and file absence expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->