### PR TITLE
feat: add cross-host mcp auto provision install contract

### DIFF
--- a/apps/vgo-cli/src/vgo_cli/commands.py
+++ b/apps/vgo-cli/src/vgo_cli/commands.py
@@ -13,7 +13,7 @@ from .hosts import (
     resolve_target_root,
 )
 from .install_support import reconcile_install_postconditions
-from .output import parse_json_output, print_install_banner, print_install_completion_hint
+from .output import parse_json_output, print_install_banner, print_install_completion_hint, print_install_completion_report
 from .process import print_process_output, run_powershell_file, run_subprocess
 from .repo import get_installed_runtime_config
 
@@ -50,6 +50,9 @@ def install_command(args: argparse.Namespace) -> int:
         repo_root,
         target_root,
         host_id,
+        profile=args.profile,
+        install_external=bool(args.install_external),
+        frontend=args.frontend,
         external_fallback_used=external_fallback_used,
         strict_offline=bool(args.strict_offline),
         skip_runtime_freshness_gate=bool(args.skip_runtime_freshness_gate),

--- a/apps/vgo-cli/src/vgo_cli/commands.py
+++ b/apps/vgo-cli/src/vgo_cli/commands.py
@@ -13,7 +13,7 @@ from .hosts import (
     resolve_target_root,
 )
 from .install_support import reconcile_install_postconditions
-from .output import parse_json_output, print_install_banner, print_install_completion_hint, print_install_completion_report
+from .output import parse_json_output, print_install_banner, print_install_completion_hint
 from .process import print_process_output, run_powershell_file, run_subprocess
 from .repo import get_installed_runtime_config
 
@@ -43,8 +43,12 @@ def install_command(args: argparse.Namespace) -> int:
     payload = parse_json_output(install_result)
     external_fallback_used = list(payload.get('external_fallback_used') or [])
 
-    if args.install_external:
-        maybe_install_external_dependencies(repo_root, str(payload.get('install_mode') or install_mode))
+    if args.install_external and not args.strict_offline:
+        maybe_install_external_dependencies(
+            repo_root,
+            str(payload.get('install_mode') or install_mode),
+            strict_offline=bool(args.strict_offline),
+        )
 
     reconcile_install_postconditions(
         repo_root,

--- a/apps/vgo-cli/src/vgo_cli/external.py
+++ b/apps/vgo-cli/src/vgo_cli/external.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
 import shutil
 import subprocess
 import sys
 
 from .errors import CliError
-from .repo import load_json
 
 
 def report_external_fallback_usage(external_fallback_used: list[str], *, strict_offline: bool) -> None:
@@ -22,7 +20,9 @@ def _run_optional_install(command: list[str]) -> None:
     subprocess.run(command, capture_output=True, text=True)
 
 
-def maybe_install_external_dependencies(repo_root: Path, install_mode: str) -> None:
+def maybe_install_external_dependencies(repo_root: object, install_mode: str, *, strict_offline: bool = False) -> None:
+    if strict_offline:
+        return
     if shutil.which('npm'):
         _run_optional_install(['npm', 'install', '-g', 'claude-flow'])
         if install_mode == 'governed':

--- a/apps/vgo-cli/src/vgo_cli/external.py
+++ b/apps/vgo-cli/src/vgo_cli/external.py
@@ -18,15 +18,17 @@ def report_external_fallback_usage(external_fallback_used: list[str], *, strict_
     print(f'[WARN] External fallback skills were used (non-reproducible install): {uniq_fallback}')
 
 
+def _run_optional_install(command: list[str]) -> None:
+    subprocess.run(command, capture_output=True, text=True)
+
+
 def maybe_install_external_dependencies(repo_root: Path, install_mode: str) -> None:
-    if install_mode != 'governed':
-        print(f"[WARN] InstallExternal is currently only applied to the governed Codex lane. Skipping external install for mode '{install_mode}'.")
-        return
     if shutil.which('npm'):
-        for package in ('claude-flow', '@th0rgal/ralph-wiggum'):
-            subprocess.run(['npm', 'install', '-g', package], capture_output=True, text=True)
+        _run_optional_install(['npm', 'install', '-g', 'claude-flow'])
+        if install_mode == 'governed':
+            _run_optional_install(['npm', 'install', '-g', '@th0rgal/ralph-wiggum'])
     if not shutil.which('scrapling'):
-        subprocess.run([sys.executable, '-m', 'pip', 'install', 'scrapling[ai]'], capture_output=True, text=True)
+        _run_optional_install([sys.executable, '-m', 'pip', 'install', 'scrapling[ai]'])
     if shutil.which('xan') is None:
         print('[WARN] xan CLI not detected. Install manually (brew/pixi/conda/cargo) to enable large CSV acceleration.')
     ivy_probe = subprocess.run([sys.executable, '-c', 'import ivy'], capture_output=True, text=True)
@@ -34,15 +36,3 @@ def maybe_install_external_dependencies(repo_root: Path, install_mode: str) -> N
         print('[WARN] ivy Python package not detected. Install manually (pip install ivy) to enable framework-interop analyzer hints.')
     if shutil.which('fuck-u-code') is None:
         print('[WARN] fuck-u-code CLI not detected. Install manually if you want external quality-debt analyzer hints (quality-debt-overlay still works without it).')
-    manifest_path = repo_root / 'config' / 'plugins-manifest.codex.json'
-    if manifest_path.exists():
-        try:
-            manifest = load_json(manifest_path)
-        except Exception:
-            return
-        print('Codex-only mode: plugin auto-install commands are disabled.')
-        for plugin in manifest.get('core') or []:
-            name = plugin.get('name', 'unknown')
-            mode = plugin.get('install_mode', 'manual-codex')
-            hint = plugin.get('install_hint', 'Provision manually in your Codex environment.')
-            print(f'[MANUAL] {name} ({mode}) - {hint}')

--- a/apps/vgo-cli/src/vgo_cli/install_support.py
+++ b/apps/vgo-cli/src/vgo_cli/install_support.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
+from .mcp_provision import provision_required_mcp
 from .external import report_external_fallback_usage
 from .install_gates import run_offline_gate, run_runtime_freshness_gate
 from .installer_bridge import refresh_install_ledger_payload
-from .output import print_json_payload
+from .output import print_json_payload, print_install_completion_report
 from .skill_surface import quarantine_codex_duplicate_skill_surface
 
 
@@ -14,11 +16,14 @@ def reconcile_install_postconditions(
     target_root: Path,
     host_id: str,
     *,
+    profile: str,
+    install_external: bool,
+    frontend: str,
     external_fallback_used: list[str],
     strict_offline: bool,
     skip_runtime_freshness_gate: bool,
     include_frontmatter: bool,
-) -> None:
+) -> dict[str, object]:
     if strict_offline:
         run_offline_gate(repo_root, target_root)
     report_external_fallback_usage(external_fallback_used, strict_offline=strict_offline)
@@ -29,4 +34,24 @@ def reconcile_install_postconditions(
         skip_gate=skip_runtime_freshness_gate,
         include_frontmatter=include_frontmatter,
     )
-    print_json_payload(refresh_install_ledger_payload(repo_root, target_root))
+    install_receipt = refresh_install_ledger_payload(repo_root, target_root)
+    mcp_receipt = provision_required_mcp(
+        repo_root=repo_root,
+        target_root=target_root,
+        host_id=host_id,
+        profile=profile,
+        allow_scripted_install=install_external,
+    )
+    if os.environ.get('VGO_SUPPRESS_INSTALL_COMPLETION_REPORT', '').strip() != '1':
+        print_install_completion_report(
+            frontend,
+            host_id=host_id,
+            profile=profile,
+            target_root=target_root,
+            install_receipt=install_receipt,
+            mcp_receipt=mcp_receipt,
+        )
+    return {
+        'install_receipt': install_receipt,
+        'mcp_receipt': mcp_receipt,
+    }

--- a/apps/vgo-cli/src/vgo_cli/install_support.py
+++ b/apps/vgo-cli/src/vgo_cli/install_support.py
@@ -42,6 +42,7 @@ def reconcile_install_postconditions(
         profile=profile,
         allow_scripted_install=install_external,
     )
+    install_receipt = refresh_install_ledger_payload(repo_root, target_root)
     if os.environ.get('VGO_SUPPRESS_INSTALL_COMPLETION_REPORT', '').strip() != '1':
         print_install_completion_report(
             frontend,

--- a/apps/vgo-cli/src/vgo_cli/install_support.py
+++ b/apps/vgo-cli/src/vgo_cli/install_support.py
@@ -7,7 +7,7 @@ from .mcp_provision import provision_required_mcp
 from .external import report_external_fallback_usage
 from .install_gates import run_offline_gate, run_runtime_freshness_gate
 from .installer_bridge import refresh_install_ledger_payload
-from .output import print_json_payload, print_install_completion_report
+from .output import print_install_completion_report
 from .skill_surface import quarantine_codex_duplicate_skill_surface
 
 
@@ -40,7 +40,7 @@ def reconcile_install_postconditions(
         target_root=target_root,
         host_id=host_id,
         profile=profile,
-        allow_scripted_install=install_external,
+        allow_scripted_install=install_external and not strict_offline,
     )
     install_receipt = refresh_install_ledger_payload(repo_root, target_root)
     if os.environ.get('VGO_SUPPRESS_INSTALL_COMPLETION_REPORT', '').strip() != '1':

--- a/apps/vgo-cli/src/vgo_cli/mcp_provision.py
+++ b/apps/vgo-cli/src/vgo_cli/mcp_provision.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+from .repo import load_json
+
+
+RECEIPT_RELPATH = Path(".vibeskills") / "mcp-auto-provision.json"
+
+
+@dataclass(frozen=True)
+class ProvisionResult:
+    status: str
+    failure_reason: str | None = None
+    next_step: str = "none"
+
+
+class ProvisionExecutor:
+    def attempt(
+        self,
+        *,
+        strategy: str,
+        server_name: str,
+        contract: dict[str, Any],
+        repo_root: Path,
+        target_root: Path,
+        host_id: str,
+        allow_scripted_install: bool,
+    ) -> ProvisionResult:
+        if strategy == "host_native":
+            return ProvisionResult(
+                status="host_native_unavailable",
+                next_step=f"Complete host-native registration for {server_name} in {host_id}.",
+            )
+        if not allow_scripted_install:
+            return ProvisionResult(
+                status="not_attempted_due_to_host_contract",
+                next_step=f"Enable scripted install support before attempting {server_name}.",
+            )
+        return ProvisionResult(
+            status="verification_failed",
+            next_step=f"Verify the scripted CLI for {server_name} is available in PATH.",
+        )
+
+
+class FakeExecutor(ProvisionExecutor):
+    def __init__(self, *, results: dict[tuple[str, str], ProvisionResult]) -> None:
+        self.results = dict(results)
+
+    def attempt(
+        self,
+        *,
+        strategy: str,
+        server_name: str,
+        contract: dict[str, Any],
+        repo_root: Path,
+        target_root: Path,
+        host_id: str,
+        allow_scripted_install: bool,
+    ) -> ProvisionResult:
+        return self.results.get(
+            (strategy, server_name),
+            super().attempt(
+                strategy=strategy,
+                server_name=server_name,
+                contract=contract,
+                repo_root=repo_root,
+                target_root=target_root,
+                host_id=host_id,
+                allow_scripted_install=allow_scripted_install,
+            ),
+        )
+
+
+def load_registry(repo_root: Path) -> dict[str, Any]:
+    return load_json(repo_root / "config" / "mcp-auto-provision.registry.json")
+
+
+def build_receipt(
+    *,
+    host_id: str,
+    profile: str,
+    target_root: Path,
+    results: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "install_state": "installed_locally",
+        "host_id": host_id,
+        "profile": profile,
+        "target_root": str(target_root),
+        "mcp_auto_provision_attempted": True,
+        "mcp_results": results,
+    }
+
+
+def write_receipt(target_root: Path, receipt: dict[str, Any]) -> Path:
+    receipt_path = target_root / RECEIPT_RELPATH
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(json.dumps(receipt, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return receipt_path
+
+
+def attempt_server(
+    *,
+    repo_root: Path,
+    target_root: Path,
+    host_id: str,
+    server_name: str,
+    contract: dict[str, Any],
+    allow_scripted_install: bool,
+    executor: ProvisionExecutor,
+) -> dict[str, Any]:
+    strategy = str(contract["strategy"])
+    result = executor.attempt(
+        strategy=strategy,
+        server_name=server_name,
+        contract=contract,
+        repo_root=repo_root,
+        target_root=target_root,
+        host_id=host_id,
+        allow_scripted_install=allow_scripted_install,
+    )
+    return {
+        "name": server_name,
+        "category": str(contract["category"]),
+        "attempt_required": True,
+        "attempted": True,
+        "provision_path": strategy,
+        "verify_path": str(contract["verify_path"]),
+        "status": result.status,
+        "failure_reason": result.failure_reason,
+        "next_step": result.next_step,
+        "disclosure_mode": "final_report_only",
+    }
+
+
+def provision_required_mcp(
+    *,
+    repo_root: Path,
+    target_root: Path,
+    host_id: str,
+    profile: str,
+    allow_scripted_install: bool,
+    executor: ProvisionExecutor | None = None,
+) -> dict[str, Any]:
+    registry = load_registry(repo_root)
+    host_contract = dict((registry["hosts"] or {})[host_id])
+    active_executor = executor or ProvisionExecutor()
+    results = [
+        attempt_server(
+            repo_root=repo_root,
+            target_root=target_root,
+            host_id=host_id,
+            server_name=server_name,
+            contract=dict((host_contract["servers"] or {})[server_name]),
+            allow_scripted_install=allow_scripted_install,
+            executor=active_executor,
+        )
+        for server_name in list(host_contract["attempt_order"] or [])
+    ]
+    receipt = build_receipt(host_id=host_id, profile=profile, target_root=target_root, results=results)
+    write_receipt(target_root, receipt)
+    return receipt
+
+
+def lookup_server(receipt: dict[str, Any], server_name: str) -> dict[str, Any]:
+    for entry in receipt.get("mcp_results") or []:
+        if str(entry.get("name")) == server_name:
+            return dict(entry)
+    raise KeyError(server_name)
+
+
+def manual_follow_up_servers(receipt: dict[str, Any]) -> list[str]:
+    follow_up: list[str] = []
+    for entry in receipt.get("mcp_results") or []:
+        if str(entry.get("status") or "") != "ready":
+            follow_up.append(str(entry.get("name") or "unknown"))
+    return follow_up

--- a/apps/vgo-cli/src/vgo_cli/mcp_provision.py
+++ b/apps/vgo-cli/src/vgo_cli/mcp_provision.py
@@ -3,12 +3,24 @@ from __future__ import annotations
 from dataclasses import dataclass
 import json
 from pathlib import Path
+import shutil
+import subprocess
+import sys
 from typing import Any
 
 from .repo import load_json
 
 
 RECEIPT_RELPATH = Path(".vibeskills") / "mcp-auto-provision.json"
+REQUIRED_SERVERS = ("github", "context7", "serena", "scrapling", "claude-flow")
+SCRIPTED_SERVER_COMMANDS = {
+    "scrapling": "scrapling",
+    "claude-flow": "claude-flow",
+}
+SCRIPTED_SERVER_INSTALLS = {
+    "scrapling": lambda: [sys.executable, "-m", "pip", "install", "scrapling[ai]"],
+    "claude-flow": lambda: ["npm", "install", "-g", "claude-flow"],
+}
 
 
 @dataclass(frozen=True)
@@ -35,10 +47,44 @@ class ProvisionExecutor:
                 status="host_native_unavailable",
                 next_step=f"Complete host-native registration for {server_name} in {host_id}.",
             )
+        command_name = SCRIPTED_SERVER_COMMANDS.get(server_name)
+        if command_name and shutil.which(command_name):
+            return ProvisionResult(
+                status="ready",
+                next_step="none",
+            )
         if not allow_scripted_install:
             return ProvisionResult(
                 status="not_attempted_due_to_host_contract",
                 next_step=f"Enable scripted install support before attempting {server_name}.",
+            )
+        install_factory = SCRIPTED_SERVER_INSTALLS.get(server_name)
+        if install_factory is None:
+            return ProvisionResult(
+                status="attempt_failed",
+                failure_reason=f"unsupported scripted install contract for {server_name}",
+                next_step=f"Install and register {server_name} manually.",
+            )
+        install_command = install_factory()
+        runner = str(install_command[0])
+        if runner != sys.executable and shutil.which(runner) is None:
+            return ProvisionResult(
+                status="attempt_failed",
+                failure_reason=f"{runner} is not available",
+                next_step=f"Install {runner} first, then retry {server_name} provisioning.",
+            )
+        completed = subprocess.run(install_command, capture_output=True, text=True)
+        if completed.returncode != 0:
+            failure_detail = (completed.stderr or completed.stdout or "").strip() or f"{runner} exited {completed.returncode}"
+            return ProvisionResult(
+                status="attempt_failed",
+                failure_reason=failure_detail,
+                next_step=f"Review the {runner} install output and install {server_name} manually if needed.",
+            )
+        if command_name and shutil.which(command_name):
+            return ProvisionResult(
+                status="ready",
+                next_step="none",
             )
         return ProvisionResult(
             status="verification_failed",
@@ -61,18 +107,42 @@ class FakeExecutor(ProvisionExecutor):
         host_id: str,
         allow_scripted_install: bool,
     ) -> ProvisionResult:
-        return self.results.get(
-            (strategy, server_name),
-            super().attempt(
-                strategy=strategy,
-                server_name=server_name,
-                contract=contract,
-                repo_root=repo_root,
-                target_root=target_root,
-                host_id=host_id,
-                allow_scripted_install=allow_scripted_install,
-            ),
+        key = (strategy, server_name)
+        if key in self.results:
+            return self.results[key]
+        return super().attempt(
+            strategy=strategy,
+            server_name=server_name,
+            contract=contract,
+            repo_root=repo_root,
+            target_root=target_root,
+            host_id=host_id,
+            allow_scripted_install=allow_scripted_install,
         )
+
+
+def _warning_entry(
+    *,
+    server_name: str,
+    status: str,
+    failure_reason: str | None,
+    next_step: str,
+    category: str = "unknown",
+    provision_path: str = "unknown",
+    attempted: bool = True,
+) -> dict[str, Any]:
+    return {
+        "name": server_name,
+        "category": category,
+        "attempt_required": True,
+        "attempted": attempted,
+        "provision_path": provision_path,
+        "verify_path": "unknown",
+        "status": status,
+        "failure_reason": failure_reason,
+        "next_step": next_step,
+        "disclosure_mode": "final_report_only",
+    }
 
 
 def load_registry(repo_root: Path) -> dict[str, Any]:
@@ -128,7 +198,7 @@ def attempt_server(
         "name": server_name,
         "category": str(contract["category"]),
         "attempt_required": True,
-        "attempted": True,
+        "attempted": result.status != "not_attempted_due_to_host_contract",
         "provision_path": strategy,
         "verify_path": str(contract["verify_path"]),
         "status": result.status,
@@ -147,23 +217,74 @@ def provision_required_mcp(
     allow_scripted_install: bool,
     executor: ProvisionExecutor | None = None,
 ) -> dict[str, Any]:
-    registry = load_registry(repo_root)
-    host_contract = dict((registry["hosts"] or {})[host_id])
-    active_executor = executor or ProvisionExecutor()
-    results = [
-        attempt_server(
-            repo_root=repo_root,
-            target_root=target_root,
+    try:
+        registry = load_registry(repo_root)
+    except Exception as exc:
+        receipt = build_receipt(
             host_id=host_id,
-            server_name=server_name,
-            contract=dict((host_contract["servers"] or {})[server_name]),
-            allow_scripted_install=allow_scripted_install,
-            executor=active_executor,
+            profile=profile,
+            target_root=target_root,
+            results=[
+                _warning_entry(
+                    server_name=server_name,
+                    status="attempt_failed",
+                    failure_reason=f"registry load failed: {exc}",
+                    next_step="Fix the MCP auto-provision registry or configure MCP servers manually.",
+                )
+                for server_name in REQUIRED_SERVERS
+            ],
         )
-        for server_name in list(host_contract["attempt_order"] or [])
-    ]
+        try:
+            write_receipt(target_root, receipt)
+        except Exception:
+            pass
+        return receipt
+
+    host_contract = dict(((registry.get("hosts") or {}).get(host_id)) or {})
+    active_executor = executor or ProvisionExecutor()
+    attempt_order = list(host_contract.get("attempt_order") or registry.get("required_servers") or REQUIRED_SERVERS)
+    server_contracts = dict(host_contract.get("servers") or {})
+    results: list[dict[str, Any]] = []
+    for server_name in attempt_order:
+        contract = dict(server_contracts.get(server_name) or {})
+        if not contract:
+            results.append(
+                _warning_entry(
+                    server_name=server_name,
+                    status="attempt_failed",
+                    failure_reason=f"registry contract missing for {server_name}",
+                    next_step=f"Fix the MCP registry entry for {server_name} or configure it manually.",
+                )
+            )
+            continue
+        try:
+            results.append(
+                attempt_server(
+                    repo_root=repo_root,
+                    target_root=target_root,
+                    host_id=host_id,
+                    server_name=server_name,
+                    contract=contract,
+                    allow_scripted_install=allow_scripted_install,
+                    executor=active_executor,
+                )
+            )
+        except Exception as exc:
+            results.append(
+                _warning_entry(
+                    server_name=server_name,
+                    status="attempt_failed",
+                    failure_reason=str(exc),
+                    next_step=f"Review the failed auto-provision attempt for {server_name} and finish it manually.",
+                    category=str(contract.get("category") or "unknown"),
+                    provision_path=str(contract.get("strategy") or "unknown"),
+                )
+            )
     receipt = build_receipt(host_id=host_id, profile=profile, target_root=target_root, results=results)
-    write_receipt(target_root, receipt)
+    try:
+        write_receipt(target_root, receipt)
+    except Exception:
+        pass
     return receipt
 
 

--- a/apps/vgo-cli/src/vgo_cli/output.py
+++ b/apps/vgo-cli/src/vgo_cli/output.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 
 from .errors import CliError
+from .mcp_provision import manual_follow_up_servers
 from .process import print_process_output
 
 
@@ -28,6 +29,33 @@ def print_install_completion_hint(frontend: str, *, host_id: str, profile: str, 
         print(f'Run: {shell_name} -NoProfile -File .\\check.ps1 -Profile {profile} -HostId {host_id} -TargetRoot {target_root}')
         return
     print(f'Install done. Run: bash check.sh --profile {profile} --host {host_id} --target-root {target_root}')
+
+
+def print_install_completion_report(
+    frontend: str,
+    *,
+    host_id: str,
+    profile: str,
+    target_root: Path,
+    install_receipt: dict[str, object],
+    mcp_receipt: dict[str, object],
+) -> None:
+    follow_up = manual_follow_up_servers(mcp_receipt)
+    print('')
+    print('MCP auto-provision summary')
+    print(f'- host: {host_id}')
+    print(f'- profile: {profile}')
+    print(f'- target_root: {target_root}')
+    print(f'- installed_locally: {mcp_receipt.get("install_state") == "installed_locally"}')
+    print(f'- mcp_auto_provision_attempted: {bool(mcp_receipt.get("mcp_auto_provision_attempted"))}')
+    print('- completed_parts: runtime payload installed; post-install gates reconciled; MCP outcomes summarized once at completion')
+    for item in mcp_receipt.get('mcp_results') or []:
+        print(
+            f'- {item["name"]}: status={item["status"]} '
+            f'provision_path={item["provision_path"]} next_step={item["next_step"]}'
+        )
+    print(f'- online_ready: verify separately with the router connectivity probe for {target_root}')
+    print(f'- manual_follow_up: {", ".join(follow_up) if follow_up else "none"}')
 
 
 

--- a/config/mcp-auto-provision.registry.json
+++ b/config/mcp-auto-provision.registry.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "required_servers": [
+    "github",
+    "context7",
+    "serena",
+    "scrapling",
+    "claude-flow"
+  ],
+  "allowed_statuses": [
+    "ready",
+    "attempt_failed",
+    "host_native_unavailable",
+    "missing_credentials",
+    "verification_failed",
+    "not_attempted_due_to_host_contract"
+  ],
+  "hosts": {
+    "codex": {
+      "attempt_order": ["github", "context7", "serena", "scrapling", "claude-flow"],
+      "servers": {
+        "github": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "context7": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "serena": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "scrapling": {"category": "scripted_cli", "strategy": "scripted_cli", "verify_path": "command_present"},
+        "claude-flow": {"category": "scripted_cli", "strategy": "scripted_cli", "verify_path": "command_present"}
+      }
+    },
+    "claude-code": {
+      "attempt_order": ["github", "context7", "serena", "scrapling", "claude-flow"],
+      "servers": {
+        "github": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "context7": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "serena": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "scrapling": {"category": "scripted_cli", "strategy": "scripted_cli", "verify_path": "command_present"},
+        "claude-flow": {"category": "scripted_cli", "strategy": "scripted_cli", "verify_path": "command_present"}
+      }
+    },
+    "cursor": {
+      "attempt_order": ["github", "context7", "serena", "scrapling", "claude-flow"],
+      "servers": {
+        "github": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "context7": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "serena": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "scrapling": {"category": "scripted_cli", "strategy": "scripted_cli", "verify_path": "command_present"},
+        "claude-flow": {"category": "scripted_cli", "strategy": "scripted_cli", "verify_path": "command_present"}
+      }
+    },
+    "windsurf": {
+      "attempt_order": ["github", "context7", "serena", "scrapling", "claude-flow"],
+      "servers": {
+        "github": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "context7": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "serena": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "scrapling": {"category": "scripted_cli", "strategy": "scripted_cli", "verify_path": "command_present"},
+        "claude-flow": {"category": "scripted_cli", "strategy": "scripted_cli", "verify_path": "command_present"}
+      }
+    },
+    "openclaw": {
+      "attempt_order": ["github", "context7", "serena", "scrapling", "claude-flow"],
+      "servers": {
+        "github": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "context7": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "serena": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "scrapling": {"category": "scripted_cli", "strategy": "scripted_cli", "verify_path": "command_present"},
+        "claude-flow": {"category": "scripted_cli", "strategy": "scripted_cli", "verify_path": "command_present"}
+      }
+    },
+    "opencode": {
+      "attempt_order": ["github", "context7", "serena", "scrapling", "claude-flow"],
+      "servers": {
+        "github": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "context7": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "serena": {"category": "host_native", "strategy": "host_native", "verify_path": "host_visibility"},
+        "scrapling": {"category": "scripted_cli", "strategy": "scripted_cli", "verify_path": "command_present"},
+        "claude-flow": {"category": "scripted_cli", "strategy": "scripted_cli", "verify_path": "command_present"}
+      }
+    }
+  }
+}

--- a/docs/install/prompts/framework-only-install.en.md
+++ b/docs/install/prompts/framework-only-install.en.md
@@ -39,4 +39,10 @@ For `opencode`, prefer the thinner direct install/check path by default:
    - if the user already has PowerShell 7, an equivalent `pwsh` command is acceptable, but `pwsh` must not be treated as the default prerequisite.
    - explain that this probe checks only AI governance advice connectivity, not full platform health.
 10. End with a concise report covering host, public version, real profile, commands executed, completed parts, and manual follow-up.
+
+Supplemental MCP auto-provision rules:
+- During installation, you must attempt these five MCP surfaces: `github`, `context7`, `serena`, `scrapling`, and `claude-flow`
+- Prefer host-native registration first for `github`, `context7`, and `serena`; prefer scripted CLI / stdio installation first for `scrapling` and `claude-flow`
+- If any MCP attempt fails, do not interrupt me repeatedly mid-flow; continue the install path and summarize failures only in the final install report
+- The final install report must explicitly separate `installed locally`, `mcp auto-provision attempted`, per-MCP readiness, and `online-ready`
 ```

--- a/docs/install/prompts/framework-only-install.md
+++ b/docs/install/prompts/framework-only-install.md
@@ -38,4 +38,10 @@
    - 如用户本机已安装 PowerShell 7，可接受等价的 `pwsh` 版本，但不要把 `pwsh` 当作默认前提。
    - 并说明：这个检查只看 AI 治理 advice 连通性，不等于整个平台总健康检查。
 10. 结果报告仍需包含：目标宿主、公开版本、实际 profile、实际命令、已完成部分、仍需手动处理的部分。
+
+补充 MCP 自动接入规则：
+- 在安装过程中，你必须尝试这五个 MCP：`github`、`context7`、`serena`、`scrapling`、`claude-flow`
+- `github`、`context7`、`serena` 优先走宿主原生注册；`scrapling`、`claude-flow` 优先走 scripted CLI / stdio 安装
+- 如果某个 MCP 尝试失败，不要在中途反复打断我；继续安装流程，只在 final install report / 最终安装报告里汇总失败和人工后续
+- 最终结论必须明确区分 `installed locally`、`mcp auto-provision attempted`、每个 MCP 的 readiness，以及 `online-ready`
 ```

--- a/docs/install/prompts/framework-only-update.en.md
+++ b/docs/install/prompts/framework-only-update.en.md
@@ -35,4 +35,10 @@ Rules:
    - optional vector diff embeddings: `VCO_VECTOR_DIFF_API_KEY`, optional `VCO_VECTOR_DIFF_BASE_URL`, plus `VCO_VECTOR_DIFF_MODEL`
    - the built-in AI governance layer supports OpenAI-compatible integration only
 10. Remind me that the result is still the governance-foundation mode, not the complete default workflow-core experience.
+
+Supplemental MCP auto-provision rules:
+- During the update flow, you must still attempt these five MCP surfaces: `github`, `context7`, `serena`, `scrapling`, and `claude-flow`
+- Prefer host-native registration first for `github`, `context7`, and `serena`; prefer scripted CLI / stdio installation first for `scrapling` and `claude-flow`
+- If any MCP attempt fails, do not interrupt me repeatedly mid-flow; continue the update path and summarize failures only in the final install report
+- The final install report must explicitly separate `installed locally`, `mcp auto-provision attempted`, per-MCP readiness, and `online-ready`
 ```

--- a/docs/install/prompts/framework-only-update.md
+++ b/docs/install/prompts/framework-only-update.md
@@ -35,4 +35,10 @@
    - 可选 vector diff：`VCO_VECTOR_DIFF_API_KEY` + 可选 `VCO_VECTOR_DIFF_BASE_URL` + `VCO_VECTOR_DIFF_MODEL`
    - 说明旧 `OPENAI_*` 不再自动回填，必须手动映射到 `VCO_*`
 10. 更新完成后，额外提醒我：当前仍是治理框架底座模式，不等于默认 workflow core 已齐备。
+
+补充 MCP 自动接入规则：
+- 在更新流程中，你仍然必须尝试这五个 MCP：`github`、`context7`、`serena`、`scrapling`、`claude-flow`
+- `github`、`context7`、`serena` 优先走宿主原生注册；`scrapling`、`claude-flow` 优先走 scripted CLI / stdio 安装
+- 如果某个 MCP 尝试失败，不要在中途反复打断我；继续更新流程，只在 final install report / 最终安装报告里汇总失败和人工后续
+- 最终结论必须明确区分 `installed locally`、`mcp auto-provision attempted`、每个 MCP 的 readiness，以及 `online-ready`
 ```

--- a/docs/install/prompts/full-version-install.en.md
+++ b/docs/install/prompts/full-version-install.en.md
@@ -52,4 +52,10 @@ Rules:
    - if the user already has PowerShell 7, an equivalent `pwsh` command is acceptable, but `pwsh` must not be treated as the default prerequisite.
    - also add one short sentence: `ok` means AI governance advice is online; `missing_credentials`, `missing_model`, or `provider_rejected_request` mean local or online readiness is still incomplete.
 14. End with a concise report covering host, public version, real profile, commands executed, completed parts, and manual follow-up.
+
+Supplemental MCP auto-provision rules:
+- During installation, you must attempt these five MCP surfaces: `github`, `context7`, `serena`, `scrapling`, and `claude-flow`
+- Prefer host-native registration first for `github`, `context7`, and `serena`; prefer scripted CLI / stdio installation first for `scrapling` and `claude-flow`
+- If any MCP attempt fails, do not interrupt me repeatedly mid-flow; continue the install path and summarize failures only in the final install report
+- The final install report must explicitly separate `installed locally`, `mcp auto-provision attempted`, per-MCP readiness, and `online-ready`
 ```

--- a/docs/install/prompts/full-version-install.md
+++ b/docs/install/prompts/full-version-install.md
@@ -52,4 +52,10 @@
    - 如用户本机已安装 PowerShell 7，可接受等价的 `pwsh` 版本，但不要把 `pwsh` 当作默认前提。
    - 并用一句话说明：`ok` 表示 AI 治理 advice 已连通；`missing_credentials`、`missing_model`、`provider_rejected_request` 等表示本地或在线配置仍未就绪。
 14. 安装完成后，用简洁中文汇报：目标宿主、公开版本、实际 profile、实际命令、已完成部分、仍需我手动处理的部分。
+
+补充 MCP 自动接入规则：
+- 在安装过程中，你必须尝试这五个 MCP：`github`、`context7`、`serena`、`scrapling`、`claude-flow`
+- `github`、`context7`、`serena` 优先走宿主原生注册；`scrapling`、`claude-flow` 优先走 scripted CLI / stdio 安装
+- 如果某个 MCP 尝试失败，不要在中途反复打断我；继续安装流程，只在 final install report / 最终安装报告里汇总失败和人工后续
+- final install report / 最终安装报告必须明确区分 `installed locally`、`mcp auto-provision attempted`、每个 MCP 的 readiness，以及 `online-ready`
 ```

--- a/docs/install/prompts/full-version-update.en.md
+++ b/docs/install/prompts/full-version-update.en.md
@@ -36,4 +36,10 @@ Rules:
    - optional vector diff embeddings: `VCO_VECTOR_DIFF_API_KEY`, optional `VCO_VECTOR_DIFF_BASE_URL`, plus `VCO_VECTOR_DIFF_MODEL`
    - the built-in AI governance layer supports OpenAI-compatible integration only
 10. End with a truth-first report covering host, public version, real profile, commands executed, whether custom governance still exists, and what still needs manual work.
+
+Supplemental MCP auto-provision rules:
+- During the update flow, you must still attempt these five MCP surfaces: `github`, `context7`, `serena`, `scrapling`, and `claude-flow`
+- Prefer host-native registration first for `github`, `context7`, and `serena`; prefer scripted CLI / stdio installation first for `scrapling` and `claude-flow`
+- If any MCP attempt fails, do not interrupt me repeatedly mid-flow; continue the update path and summarize failures only in the final install report
+- The final install report must explicitly separate `installed locally`, `mcp auto-provision attempted`, per-MCP readiness, and `online-ready`
 ```

--- a/docs/install/prompts/full-version-update.md
+++ b/docs/install/prompts/full-version-update.md
@@ -36,4 +36,10 @@
    - 可选 vector diff：`VCO_VECTOR_DIFF_API_KEY` + 可选 `VCO_VECTOR_DIFF_BASE_URL` + `VCO_VECTOR_DIFF_MODEL`
    - 说明旧 `OPENAI_*` 不再自动回填，必须手动映射到 `VCO_*`
 10. 更新完成后，用 truth-first 口径告诉我：目标宿主、公开版本、实际 profile、实际命令、自定义治理是否仍在、仍需我手动处理的部分。
+
+补充 MCP 自动接入规则：
+- 在更新流程中，你仍然必须尝试这五个 MCP：`github`、`context7`、`serena`、`scrapling`、`claude-flow`
+- `github`、`context7`、`serena` 优先走宿主原生注册；`scrapling`、`claude-flow` 优先走 scripted CLI / stdio 安装
+- 如果某个 MCP 尝试失败，不要在中途反复打断我；继续更新流程，只在 final install report / 最终安装报告里汇总失败和人工后续
+- 最终结论必须明确区分 `installed locally`、`mcp auto-provision attempted`、每个 MCP 的 readiness，以及 `online-ready`
 ```

--- a/docs/install/recommended-full-path.en.md
+++ b/docs/install/recommended-full-path.en.md
@@ -9,6 +9,16 @@
 
 This document summarizes the install commands, default target roots, and current host-mode wording for the six public hosts.
 
+## MCP Auto-Provision Contract
+
+All six public hosts now follow one shared, non-blocking MCP contract:
+
+- install or one-shot should attempt `github`, `context7`, `serena`, `scrapling`, and `claude-flow`
+- prefer host-native registration for `github`, `context7`, and `serena`
+- prefer scripted CLI / stdio installation for `scrapling` and `claude-flow`
+- failure does not block the base install; failures are summarized only in the final report
+- the final report separates `installed locally`, per-MCP readiness, `manual follow-up`, and `online-ready`
+
 Public Linux / macOS prerequisites:
 
 - the shell entrypoints are maintained against the macOS system Bash 3.2 baseline

--- a/docs/install/recommended-full-path.md
+++ b/docs/install/recommended-full-path.md
@@ -9,6 +9,16 @@
 
 这份文档汇总当前六个公开宿主对应的安装命令、默认目标根目录与 host-mode 说明。
 
+## MCP 自动接入合同
+
+所有六个公开宿主都遵循同一条非阻塞 MCP 合同：
+
+- 安装或 one-shot 期间要尝试：`github`、`context7`、`serena`、`scrapling`、`claude-flow`
+- `github` / `context7` / `serena` 优先走 host-native registration
+- `scrapling` / `claude-flow` 优先走 scripted CLI / stdio 安装
+- 失败不会阻塞 base install；失败只会在最终报告里集中汇总
+- 最终报告会把 `installed locally`、每个 MCP readiness、`manual follow-up`、以及 `online-ready` 分开写清楚
+
 Linux / macOS 公共前置条件：
 
 - shell 入口按 **macOS 自带 Bash 3.2** 兼容维护

--- a/docs/one-shot-setup.md
+++ b/docs/one-shot-setup.md
@@ -10,6 +10,16 @@
 
 如果你的目标只是拿到更薄的预览安装路径，`opencode` 仍然可以直接走 `install.* + check.*`。但这不代表 one-shot 不能用于 `opencode`；它只是一个统一 wrapper，会按当前宿主的 `bootstrap_mode` 走对应分支。
 
+## MCP Auto-Provision Contract
+
+one-shot 现在会把 MCP auto-provision 视为安装流程的一部分，但它是非阻塞的：
+
+- 会尝试：`github`、`context7`、`serena`、`scrapling`、`claude-flow`
+- `github` / `context7` / `serena` 优先走 host-native registration
+- `scrapling` / `claude-flow` 优先走 scripted CLI / stdio
+- 如果尝试失败，不会中途刷屏阻塞你，而是在最后一段报告里统一写出 `manual follow-up`
+- 最终报告会明确区分 `installed locally`、MCP readiness、以及 `online-ready`
+
 如果你还不知道自己应该走哪种安装方式，先看：
 
 - [`cold-start-install-paths.md`](./cold-start-install-paths.md)

--- a/docs/plans/2026-04-07-install-prompt-mcp-auto-provision-design-execution-plan.md
+++ b/docs/plans/2026-04-07-install-prompt-mcp-auto-provision-design-execution-plan.md
@@ -1,0 +1,48 @@
+# Install Prompt MCP Auto-Provision Design Execution Plan
+
+Date: 2026-04-07
+Runtime: `vibe`
+Internal Grade: `M`
+
+## Scope
+
+Write, review, and stage a formal design for install-prompt-driven MCP auto-provision attempts across the six supported hosts.
+
+## Wave Structure
+
+1. Freeze requirement and planning artifacts for the design task.
+2. Write the formal design spec under `docs/superpowers/specs/`.
+3. Run a local review pass for completeness and consistency.
+4. Commit the written spec and stop for user review.
+
+## Ownership Boundaries
+
+- Write scope: governed requirement/plan docs, design spec, local runtime receipts.
+- No code implementation changes in this turn.
+- No changes to unrelated untracked files.
+
+## Verification Commands
+
+- `sed -n '1,260p' docs/superpowers/specs/2026-04-07-install-prompt-mcp-auto-provision-design.md`
+- `git diff -- docs/superpowers/specs/2026-04-07-install-prompt-mcp-auto-provision-design.md docs/requirements/2026-04-07-install-prompt-mcp-auto-provision-design.md docs/plans/2026-04-07-install-prompt-mcp-auto-provision-design-execution-plan.md`
+- `git status --short`
+
+## Delivery Acceptance Plan
+
+- Accept the design task as complete when the spec is written, locally reviewed, and committed.
+- Stop before implementation planning until the user reviews the written spec.
+
+## Completion Language Rules
+
+- Report that the spec is written and committed.
+- Do not claim implementation, only design completion.
+
+## Rollback Rules
+
+- Do not touch unrelated untracked files.
+- Commit only the new design-related docs.
+
+## Phase Cleanup Expectations
+
+- Write governed runtime receipts under `outputs/runtime/vibe-sessions/20260407-install-prompt-mcp-auto-provision-design/`.
+- Record any deviation from the ideal brainstorming workflow, including the lack of delegated spec-review subagent usage.

--- a/docs/requirements/2026-04-07-install-prompt-mcp-auto-provision-design.md
+++ b/docs/requirements/2026-04-07-install-prompt-mcp-auto-provision-design.md
@@ -1,0 +1,73 @@
+# Install Prompt MCP Auto-Provision Design Requirement
+
+Date: 2026-04-07
+Runtime: `vibe`
+Mode: `interactive_governed`
+
+## Goal
+
+Design a cross-host installation contract where the install assistant must attempt to provision five MCP surfaces during installation guidance without blocking users from starting VibeSkills if some attempts fail.
+
+## Deliverable
+
+A written design that defines:
+
+- the install-prompt contract
+- the shared MCP provision state model
+- cross-host execution order for six supported hosts
+- verification and reporting expectations
+- rollout and risk controls
+
+## Constraints
+
+- Scope covers the current public hosts only: `codex`, `claude-code`, `cursor`, `windsurf`, `openclaw`, `opencode`.
+- The install assistant must attempt these MCP surfaces: `github`, `context7`, `serena`, `scrapling`, `claude-flow`.
+- Attempts should prioritize repository-owned install/bootstrap/check flows first.
+- `github`, `context7`, and `serena` should prefer host-native registration when available.
+- `scrapling` and `claude-flow` should prefer CLI / stdio install paths.
+- Failed MCP attempts must not block base install success.
+- Failures must be summarized only in the final install report, not as repeated mid-flow interruptions.
+- The design must distinguish `installed locally` from MCP readiness and from online-ready governance.
+
+## Acceptance Criteria
+
+- A formal spec is written under `docs/superpowers/specs/`.
+- The design defines a unified status model for MCP attempts and verification.
+- The design names the document, prompt, bootstrap/install/check, doctor/verify, and reporting surfaces that must change.
+- The design includes a phased rollout plan and risk controls.
+
+## Product Acceptance Criteria
+
+- The public contract becomes “must attempt provisioning” rather than “must fully succeed or block installation”.
+- The design preserves truthful host-boundary reporting.
+- The final user-facing report format is explicit and consistent across hosts.
+
+## Manual Spot Checks
+
+- Verify the spec covers all six supported hosts.
+- Verify the spec covers all five MCP surfaces.
+- Verify the spec does not collapse MCP failure into overall install failure.
+
+## Completion Language Policy
+
+- Do not claim implementation exists.
+- Claim only that the design/spec has been written and locally reviewed.
+
+## Delivery Truth Contract
+
+- Claims must trace to the written spec file and this session’s governed artifacts.
+
+## Non-Goals
+
+- Implementing the design in code in this turn
+- Rewriting host capability contracts beyond the specific MCP auto-provision behavior
+- Changing online governance credential policy
+
+## Autonomy Mode
+
+Proceed autonomously through design writing and local review, then stop for user review before any implementation planning.
+
+## Inferred Assumptions
+
+- The user wants one consistent install-assistant behavior across all six supported hosts.
+- The design should be implementation-ready enough to hand off into a later execution plan.

--- a/docs/superpowers/plans/2026-04-07-install-prompt-mcp-auto-provision.md
+++ b/docs/superpowers/plans/2026-04-07-install-prompt-mcp-auto-provision.md
@@ -1,0 +1,585 @@
+# Install Prompt MCP Auto-Provision Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a shared, non-blocking MCP auto-provision contract so install guidance, bootstrap wrappers, and doctor/reporting all attempt the same five MCP surfaces across all six public hosts and only summarize failures in the final install report.
+
+**Architecture:** Introduce one registry-driven MCP auto-provision layer that defines required servers, host-specific attempt order, strategy preference, verification path, and final-report status vocabulary. Wire that layer into `vgo_cli` install postconditions first, persist a machine-readable receipt under the target root, then teach bootstrap doctor and prompt/docs surfaces to read and describe the same contract rather than each inventing their own wording.
+
+**Tech Stack:** Python 3.10+ `vgo_cli`, runtime-neutral `pytest`/`unittest`, Bash and PowerShell bootstrap wrappers, Markdown install prompts and install-path docs, existing adapter registry and bootstrap doctor gates
+
+---
+
+## File Structure
+
+### Prompt and install guidance contract
+- Modify: `docs/install/prompts/full-version-install.md`
+  Responsibility: require the assistant to attempt `github`, `context7`, `serena`, `scrapling`, and `claude-flow`, keep failures out of the mid-flow transcript, and require final-report-only disclosure.
+- Modify: `docs/install/prompts/full-version-install.en.md`
+  Responsibility: English parity for the same install-assistant contract.
+- Modify: `docs/install/prompts/framework-only-install.md`
+  Responsibility: carry the same MCP auto-provision rules for the `minimal` profile wording.
+- Modify: `docs/install/prompts/framework-only-install.en.md`
+  Responsibility: English parity for framework-only install wording.
+- Modify: `docs/install/prompts/full-version-update.md`
+  Responsibility: keep update guidance aligned with install guidance so reinstall/update does not regress the MCP attempt contract.
+- Modify: `docs/install/prompts/full-version-update.en.md`
+  Responsibility: English parity for full-version update wording.
+- Modify: `docs/install/prompts/framework-only-update.md`
+  Responsibility: keep framework-only update guidance aligned with the same MCP attempt contract.
+- Modify: `docs/install/prompts/framework-only-update.en.md`
+  Responsibility: English parity for framework-only update wording.
+- Modify: `docs/install/recommended-full-path.md`
+  Responsibility: explain that all hosts attempt the same five MCP surfaces, but local install success remains separate from MCP readiness and online-ready state.
+- Modify: `docs/install/recommended-full-path.en.md`
+  Responsibility: English parity for the recommended full-path explanation.
+- Modify: `docs/one-shot-setup.md`
+  Responsibility: document that one-shot now attempts the five MCP surfaces and reports readiness at the end without blocking base install.
+
+### Shared MCP provision contract and install receipts
+- Create: `config/mcp-auto-provision.registry.json`
+  Responsibility: define the five required MCP surfaces, categories, host-specific attempt order, preferred strategy (`host_native` or `scripted_cli`), verification mode, and allowed status values.
+- Create: `apps/vgo-cli/src/vgo_cli/mcp_provision.py`
+  Responsibility: load the registry, execute host-specific attempt/verify steps, normalize results into the approved status vocabulary, and write a target-root receipt.
+- Modify: `apps/vgo-cli/src/vgo_cli/external.py`
+  Responsibility: shrink existing Codex-only external install helpers into command-level utilities that the new orchestrator can reuse for `scrapling` and `claude-flow`.
+- Modify: `apps/vgo-cli/src/vgo_cli/install_support.py`
+  Responsibility: run MCP auto-provision after core install, persist the final receipt, and keep strict-offline / postcondition behavior coherent.
+- Modify: `apps/vgo-cli/src/vgo_cli/commands.py`
+  Responsibility: pass host, profile, and target-root context into the new orchestrator and keep `install_external` semantics aligned for all hosts.
+- Modify: `apps/vgo-cli/src/vgo_cli/output.py`
+  Responsibility: print one concise final install report that separates `installed_locally`, `mcp_auto_provision_attempted`, per-MCP readiness, and online-ready follow-up.
+
+### Bootstrap and doctor/reporting parity
+- Modify: `scripts/bootstrap/one-shot-setup.sh`
+  Responsibility: keep wrapper stage text compatible with the new MCP auto-provision flow and point final users to the unified end-of-install report instead of ad hoc warnings.
+- Modify: `scripts/bootstrap/one-shot-setup.ps1`
+  Responsibility: PowerShell parity for the same wrapper/reporting expectations.
+- Modify: `packages/verification-core/src/vgo_verify/bootstrap_doctor.py`
+  Responsibility: load the new target-root MCP receipt and include it in the generated artifact.
+- Modify: `packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py`
+  Responsibility: evaluate the new MCP result vocabulary and preserve separation between local install completeness, MCP readiness, and online-governance readiness.
+- Modify: `scripts/verify/vibe-bootstrap-doctor-gate.ps1`
+  Responsibility: PowerShell gate parity for the new MCP receipt and state model.
+- Modify: `mcp/servers.template.json`
+  Responsibility: keep server metadata aligned with the new registry where the two surfaces overlap on server names, mode, and CLI expectations.
+
+### Tests
+- Create: `tests/runtime_neutral/test_mcp_auto_provision.py`
+  Responsibility: cover registry shape, host-specific attempt order, non-blocking failure behavior, and final-report-only disclosure semantics.
+- Create: `tests/runtime_neutral/test_install_prompt_mcp_contract.py`
+  Responsibility: lock the install/update prompt docs to the approved host list, five required MCP surfaces, final-report-only disclosure rule, and key-name guidance.
+- Modify: `tests/runtime_neutral/test_bootstrap_doctor.py`
+  Responsibility: assert bootstrap doctor reads the MCP receipt and reports the new readiness separation correctly.
+- Modify: `tests/runtime_neutral/test_shell_entrypoint_compatibility.py`
+  Responsibility: keep wrapper syntax coverage after one-shot shell wording changes.
+
+## Chunk 1: Shared MCP Contract And Receipt Model
+
+### Task 1: Add the registry-backed MCP auto-provision contract
+
+**Files:**
+- Create: `config/mcp-auto-provision.registry.json`
+- Create: `tests/runtime_neutral/test_mcp_auto_provision.py`
+
+- [ ] **Step 1: Write the failing registry contract tests**
+
+```python
+class McpAutoProvisionContractTests(unittest.TestCase):
+    def test_registry_declares_required_surfaces_for_all_public_hosts(self) -> None:
+        registry = json.loads(REGISTRY_PATH.read_text(encoding="utf-8-sig"))
+        self.assertEqual(
+            ["github", "context7", "serena", "scrapling", "claude-flow"],
+            registry["required_servers"],
+        )
+        self.assertEqual(
+            ["claude-code", "codex", "cursor", "openclaw", "opencode", "windsurf"],
+            sorted(registry["hosts"].keys()),
+        )
+
+    def test_registry_declares_status_vocabulary_approved_in_spec(self) -> None:
+        registry = json.loads(REGISTRY_PATH.read_text(encoding="utf-8-sig"))
+        self.assertEqual(
+            [
+                "ready",
+                "attempt_failed",
+                "host_native_unavailable",
+                "missing_credentials",
+                "verification_failed",
+                "not_attempted_due_to_host_contract",
+            ],
+            registry["allowed_statuses"],
+        )
+```
+
+- [ ] **Step 2: Run the targeted registry test and confirm failure**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_mcp_auto_provision.py -k "registry_declares" -v`
+
+Expected: `FAIL` because `config/mcp-auto-provision.registry.json` does not exist yet.
+
+- [ ] **Step 3: Add the minimal registry**
+
+```json
+{
+  "schema_version": 1,
+  "required_servers": ["github", "context7", "serena", "scrapling", "claude-flow"],
+  "allowed_statuses": [
+    "ready",
+    "attempt_failed",
+    "host_native_unavailable",
+    "missing_credentials",
+    "verification_failed",
+    "not_attempted_due_to_host_contract"
+  ],
+  "hosts": {
+    "codex": {
+      "attempt_order": ["github", "context7", "serena", "scrapling", "claude-flow"]
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Re-run the targeted registry test**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_mcp_auto_provision.py -k "registry_declares" -v`
+
+Expected: `PASS`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config/mcp-auto-provision.registry.json tests/runtime_neutral/test_mcp_auto_provision.py
+git commit -m "feat: add mcp auto provision registry contract"
+```
+
+### Task 2: Implement the shared receipt model and orchestration surface
+
+**Files:**
+- Create: `apps/vgo-cli/src/vgo_cli/mcp_provision.py`
+- Modify: `apps/vgo-cli/src/vgo_cli/external.py`
+- Modify: `tests/runtime_neutral/test_mcp_auto_provision.py`
+
+- [ ] **Step 1: Add the failing orchestration test**
+
+```python
+class McpAutoProvisionContractTests(unittest.TestCase):
+    def test_attempt_failures_are_captured_without_blocking_install(self) -> None:
+        report = provision_required_mcp(
+            repo_root=REPO_ROOT,
+            target_root=self.target_root,
+            host_id="cursor",
+            profile="full",
+            allow_scripted_install=True,
+            executor=FakeExecutor(
+                results={
+                    ("host_native", "github"): ProvisionResult(status="host_native_unavailable"),
+                    ("scripted_cli", "scrapling"): ProvisionResult(status="attempt_failed", failure_reason="pip missing"),
+                }
+            ),
+        )
+        self.assertTrue(report["mcp_auto_provision_attempted"])
+        self.assertEqual("installed_locally", report["install_state"])
+        self.assertEqual("host_native_unavailable", lookup_server(report, "github")["status"])
+        self.assertEqual("attempt_failed", lookup_server(report, "scrapling")["status"])
+        self.assertEqual("final_report_only", lookup_server(report, "scrapling")["disclosure_mode"])
+```
+
+- [ ] **Step 2: Run the orchestration-focused tests and confirm failure**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_mcp_auto_provision.py -k "captured_without_blocking" -v`
+
+Expected: `FAIL` because `provision_required_mcp` and the receipt model do not exist yet.
+
+- [ ] **Step 3: Implement the orchestrator and reusable command helpers**
+
+```python
+def provision_required_mcp(
+    *,
+    repo_root: Path,
+    target_root: Path,
+    host_id: str,
+    profile: str,
+    allow_scripted_install: bool,
+    executor: ProvisionExecutor | None = None,
+) -> dict[str, object]:
+    registry = load_registry(repo_root)
+    host_contract = registry["hosts"][host_id]
+    results = [
+        attempt_server(
+            repo_root=repo_root,
+            target_root=target_root,
+            host_id=host_id,
+            server_name=server_name,
+            contract=host_contract["servers"][server_name],
+            allow_scripted_install=allow_scripted_install,
+            executor=executor or ProvisionExecutor(),
+        )
+        for server_name in host_contract["attempt_order"]
+    ]
+    receipt = build_receipt(host_id=host_id, profile=profile, target_root=target_root, results=results)
+    write_receipt(target_root, receipt)
+    return receipt
+```
+
+- [ ] **Step 4: Run the focused orchestration tests**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_mcp_auto_provision.py -k "captured_without_blocking or registry_declares" -v`
+
+Expected: `PASS`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/vgo-cli/src/vgo_cli/mcp_provision.py apps/vgo-cli/src/vgo_cli/external.py tests/runtime_neutral/test_mcp_auto_provision.py
+git commit -m "feat: add shared mcp auto provision orchestrator"
+```
+
+## Chunk 2: Install CLI And Wrapper Integration
+
+### Task 3: Wire MCP auto-provision into install postconditions and final reporting
+
+**Files:**
+- Modify: `apps/vgo-cli/src/vgo_cli/commands.py`
+- Modify: `apps/vgo-cli/src/vgo_cli/install_support.py`
+- Modify: `apps/vgo-cli/src/vgo_cli/output.py`
+- Modify: `tests/runtime_neutral/test_mcp_auto_provision.py`
+
+- [ ] **Step 1: Add the failing install-postcondition test**
+
+```python
+class McpAutoProvisionContractTests(unittest.TestCase):
+    def test_reconcile_install_postconditions_emits_one_final_report(self) -> None:
+        payload = run_install_postconditions_fixture(host_id="codex", profile="full")
+        self.assertEqual("installed_locally", payload["install_state"])
+        self.assertTrue(payload["mcp_auto_provision_attempted"])
+        self.assertEqual(
+            ["github", "context7", "serena", "scrapling", "claude-flow"],
+            [item["name"] for item in payload["mcp_results"]],
+        )
+        self.assertNotIn("[WARN] github", payload["stdout"])
+        self.assertIn("manual_follow_up", payload["stdout"])
+```
+
+- [ ] **Step 2: Run the focused install-postcondition test and confirm failure**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_mcp_auto_provision.py -k "one_final_report" -v`
+
+Expected: `FAIL` because install postconditions do not yet invoke the orchestrator or render the final report.
+
+- [ ] **Step 3: Implement install wiring and one final report renderer**
+
+```python
+receipt = provision_required_mcp(
+    repo_root=repo_root,
+    target_root=target_root,
+    host_id=host_id,
+    profile=profile,
+    allow_scripted_install=install_external_enabled,
+)
+print_install_completion_report(
+    host_id=host_id,
+    profile=profile,
+    target_root=target_root,
+    install_receipt=refresh_install_ledger_payload(repo_root, target_root),
+    mcp_receipt=receipt,
+)
+```
+
+- [ ] **Step 4: Re-run the focused CLI/report tests**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_mcp_auto_provision.py -k "one_final_report or captured_without_blocking" -v`
+
+Expected: `PASS`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/vgo-cli/src/vgo_cli/commands.py apps/vgo-cli/src/vgo_cli/install_support.py apps/vgo-cli/src/vgo_cli/output.py tests/runtime_neutral/test_mcp_auto_provision.py
+git commit -m "feat: report mcp auto provision in install completion"
+```
+
+### Task 4: Keep one-shot wrappers aligned with the same report-only failure behavior
+
+**Files:**
+- Modify: `scripts/bootstrap/one-shot-setup.sh`
+- Modify: `scripts/bootstrap/one-shot-setup.ps1`
+- Modify: `tests/runtime_neutral/test_shell_entrypoint_compatibility.py`
+
+- [ ] **Step 1: Add the failing wrapper-parity assertion**
+
+```python
+class ShellEntrypointCompatibilityTests(unittest.TestCase):
+    def test_one_shot_wrappers_reference_final_mcp_report_instead_of_inline_failure_spam(self) -> None:
+        for relpath in ("scripts/bootstrap/one-shot-setup.sh", "scripts/bootstrap/one-shot-setup.ps1"):
+            content = (REPO_ROOT / relpath).read_text(encoding="utf-8")
+            self.assertIn("MCP auto-provision summary", content)
+            self.assertNotIn("continue on each MCP failure", content)
+```
+
+- [ ] **Step 2: Run the wrapper compatibility tests and confirm failure**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_shell_entrypoint_compatibility.py -k "one_shot_wrappers_reference_final_mcp_report" -v`
+
+Expected: `FAIL` because wrapper text does not mention the new final-report contract yet.
+
+- [ ] **Step 3: Update the shell and PowerShell one-shot wrapper messaging**
+
+```powershell
+Write-Host '[5/5] Running supported-path health check and preparing the MCP auto-provision summary...' -ForegroundColor Yellow
+Write-Host '- MCP auto-provision summary is reported once at the end of install/check output.' -ForegroundColor DarkGray
+```
+
+```bash
+echo '[5/5] Running supported-path health check and preparing the MCP auto-provision summary...'
+echo '- MCP auto-provision summary is reported once at the end of install/check output.'
+```
+
+- [ ] **Step 4: Re-run shell compatibility coverage**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_shell_entrypoint_compatibility.py -k "install_entrypoints_are_bash_parseable or one_shot_wrappers_reference_final_mcp_report" -v`
+
+Expected: `PASS`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/bootstrap/one-shot-setup.sh scripts/bootstrap/one-shot-setup.ps1 tests/runtime_neutral/test_shell_entrypoint_compatibility.py
+git commit -m "chore: align one-shot wrapper messaging with mcp report contract"
+```
+
+## Chunk 3: Bootstrap Doctor And Readiness Separation
+
+### Task 5: Teach bootstrap doctor to read the MCP receipt and preserve truth separation
+
+**Files:**
+- Modify: `packages/verification-core/src/vgo_verify/bootstrap_doctor.py`
+- Modify: `packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py`
+- Modify: `scripts/verify/vibe-bootstrap-doctor-gate.ps1`
+- Modify: `tests/runtime_neutral/test_bootstrap_doctor.py`
+- Modify: `mcp/servers.template.json`
+
+- [ ] **Step 1: Add the failing bootstrap doctor test**
+
+```python
+class BootstrapDoctorTests(unittest.TestCase):
+    def test_mcp_receipt_keeps_install_and_mcp_readiness_separate(self) -> None:
+        (self.target_root / ".vibeskills").mkdir(parents=True, exist_ok=True)
+        (self.target_root / ".vibeskills" / "mcp-auto-provision.json").write_text(
+            json.dumps(
+                {
+                    "install_state": "installed_locally",
+                    "mcp_auto_provision_attempted": True,
+                    "mcp_results": [
+                        {"name": "github", "status": "host_native_unavailable", "next_step": "Register in host UI"},
+                        {"name": "scrapling", "status": "ready", "next_step": "none"},
+                    ],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        artifact = self.module.evaluate(self.root, self.target_root)
+        self.assertEqual("installed_locally", artifact["install_state"])
+        self.assertTrue(artifact["mcp"]["auto_provision_attempted"])
+        self.assertEqual("host_native_unavailable", artifact["mcp"]["servers"][0]["status"])
+        self.assertEqual("manual_actions_pending", artifact["summary"]["readiness_state"])
+```
+
+- [ ] **Step 2: Run the bootstrap doctor tests and confirm failure**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_bootstrap_doctor.py -k "install_and_mcp_readiness_separate" -v`
+
+Expected: `FAIL` because bootstrap doctor does not yet read the new receipt or expose `install_state`.
+
+- [ ] **Step 3: Implement receipt loading and summary-state separation**
+
+```python
+def load_mcp_receipt(target_root: Path) -> dict[str, Any]:
+    path = target_root / ".vibeskills" / "mcp-auto-provision.json"
+    if not path.exists():
+        return {"install_state": "unknown", "mcp_auto_provision_attempted": False, "mcp_results": []}
+    return load_json(path)
+
+summary = build_summary(
+    settings_path=settings_path,
+    active_mcp_path=active_mcp_path,
+    settings=settings,
+    install_state=mcp_receipt["install_state"],
+    mcp_results=mcp_receipt["mcp_results"],
+    ...
+)
+```
+
+```powershell
+$mcpReceiptPath = Join-Path $TargetRoot '.vibeskills\mcp-auto-provision.json'
+$mcpReceipt = if (Test-Path -LiteralPath $mcpReceiptPath) {
+    Get-Content -LiteralPath $mcpReceiptPath -Raw -Encoding UTF8 | ConvertFrom-Json
+} else {
+    [pscustomobject]@{ install_state = 'unknown'; mcp_auto_provision_attempted = $false; mcp_results = @() }
+}
+```
+
+- [ ] **Step 4: Re-run the bootstrap doctor coverage**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_bootstrap_doctor.py -v`
+
+Expected: `PASS`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/verification-core/src/vgo_verify/bootstrap_doctor.py packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py scripts/verify/vibe-bootstrap-doctor-gate.ps1 tests/runtime_neutral/test_bootstrap_doctor.py mcp/servers.template.json
+git commit -m "feat: report mcp auto provision in bootstrap doctor"
+```
+
+## Chunk 4: Prompt Contract And User-Facing Docs
+
+### Task 6: Lock the install prompt docs to the approved MCP auto-provision contract
+
+**Files:**
+- Create: `tests/runtime_neutral/test_install_prompt_mcp_contract.py`
+- Modify: `docs/install/prompts/full-version-install.md`
+- Modify: `docs/install/prompts/full-version-install.en.md`
+- Modify: `docs/install/prompts/framework-only-install.md`
+- Modify: `docs/install/prompts/framework-only-install.en.md`
+- Modify: `docs/install/prompts/full-version-update.md`
+- Modify: `docs/install/prompts/full-version-update.en.md`
+- Modify: `docs/install/prompts/framework-only-update.md`
+- Modify: `docs/install/prompts/framework-only-update.en.md`
+
+- [ ] **Step 1: Write the failing prompt contract tests**
+
+```python
+class InstallPromptMcpContractTests(unittest.TestCase):
+    def test_all_prompt_docs_require_the_same_five_mcp_surfaces(self) -> None:
+        for path in PROMPT_FILES:
+            text = path.read_text(encoding="utf-8-sig")
+            for server_name in ("github", "context7", "serena", "scrapling", "claude-flow"):
+                self.assertIn(server_name, text, path.name)
+            self.assertIn("final install report", text.lower(), path.name)
+            self.assertIn("installed locally", text.lower(), path.name)
+            self.assertIn("online-ready", text.lower(), path.name)
+```
+
+- [ ] **Step 2: Run the prompt contract tests and confirm failure**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_install_prompt_mcp_contract.py -v`
+
+Expected: `FAIL` because the prompt docs do not yet require MCP auto-provision or the final-report-only rule.
+
+- [ ] **Step 3: Update all eight prompt docs**
+
+```text
+15. During installation guidance, you must attempt to provision these MCP surfaces for every supported host: `github`, `context7`, `serena`, `scrapling`, `claude-flow`.
+16. Prefer host-native registration first for `github`, `context7`, and `serena`; prefer scripted CLI / stdio provisioning first for `scrapling` and `claude-flow`.
+17. If any MCP attempt fails, do not interrupt the user repeatedly. Continue the install path and report the failure only in the final install report.
+18. In the final report, separate `installed locally`, `mcp auto-provision attempted`, per-MCP readiness, and `online-ready`.
+```
+
+- [ ] **Step 4: Re-run the prompt contract tests**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_install_prompt_mcp_contract.py -v`
+
+Expected: `PASS`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/runtime_neutral/test_install_prompt_mcp_contract.py docs/install/prompts/full-version-install.md docs/install/prompts/full-version-install.en.md docs/install/prompts/framework-only-install.md docs/install/prompts/framework-only-install.en.md docs/install/prompts/full-version-update.md docs/install/prompts/full-version-update.en.md docs/install/prompts/framework-only-update.md docs/install/prompts/framework-only-update.en.md
+git commit -m "docs: require mcp auto provision in install prompts"
+```
+
+### Task 7: Align supporting install docs with the final-report contract
+
+**Files:**
+- Modify: `docs/install/recommended-full-path.md`
+- Modify: `docs/install/recommended-full-path.en.md`
+- Modify: `docs/one-shot-setup.md`
+- Modify: `tests/runtime_neutral/test_install_prompt_mcp_contract.py`
+
+- [ ] **Step 1: Extend the docs contract test**
+
+```python
+    def test_supporting_install_docs_describe_non_blocking_mcp_attempts(self) -> None:
+        for path in SUPPORTING_DOCS:
+            text = path.read_text(encoding="utf-8-sig")
+            self.assertIn("scrapling", text, path.name)
+            self.assertIn("claude-flow", text, path.name)
+            self.assertIn("manual follow-up", text.lower(), path.name)
+            self.assertIn("online-ready", text.lower(), path.name)
+```
+
+- [ ] **Step 2: Run the docs-focused contract tests and confirm failure**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_install_prompt_mcp_contract.py -k "supporting_install_docs" -v`
+
+Expected: `FAIL` because the supporting docs do not yet describe the shared MCP attempt/report contract.
+
+- [ ] **Step 3: Update the supporting install docs**
+
+```markdown
+- Local install success means the VibeSkills payload and sidecar state are present in the chosen host root.
+- MCP auto-provision means VibeSkills attempted `github`, `context7`, `serena`, `scrapling`, and `claude-flow`; some hosts may still require manual host-native follow-up.
+- Online-ready is a separate state controlled by `VCO_INTENT_ADVICE_*` and optional `VCO_VECTOR_DIFF_*` configuration.
+```
+
+- [ ] **Step 4: Re-run the docs contract tests**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_install_prompt_mcp_contract.py -v`
+
+Expected: `PASS`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/install/recommended-full-path.md docs/install/recommended-full-path.en.md docs/one-shot-setup.md tests/runtime_neutral/test_install_prompt_mcp_contract.py
+git commit -m "docs: align install guides with mcp auto provision reporting"
+```
+
+## Chunk 5: Final Verification And Delivery Closure
+
+### Task 8: Run the focused verification set and capture delivery evidence
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-04-07-install-prompt-mcp-auto-provision.md`
+  Responsibility: check off completed steps during execution and, if needed, record any scope adjustments before handoff.
+
+- [ ] **Step 1: Run the focused Python test set**
+
+Run: `python3 -m pytest tests/runtime_neutral/test_mcp_auto_provision.py tests/runtime_neutral/test_install_prompt_mcp_contract.py tests/runtime_neutral/test_bootstrap_doctor.py tests/runtime_neutral/test_shell_entrypoint_compatibility.py -v`
+
+Expected: `PASS`
+
+- [ ] **Step 2: Run wrapper syntax validation**
+
+Run: `bash -n install.sh && bash -n check.sh && bash -n scripts/bootstrap/one-shot-setup.sh`
+
+Expected: no output and exit code `0`
+
+- [ ] **Step 3: Run one end-to-end install smoke in a temp target root**
+
+Run: `tmpdir="$(mktemp -d)" && bash ./install.sh --host codex --profile full --target-root "$tmpdir/.codex" --skip-runtime-freshness-gate`
+
+Expected: exit code `0`, a new `.vibeskills/mcp-auto-provision.json` under the temp target root, and one final install report that separates local install from MCP readiness.
+
+- [ ] **Step 4: Inspect the doctor artifact from the same temp root**
+
+Run: `python3 ./scripts/verify/runtime_neutral/bootstrap_doctor.py --target-root "$tmpdir/.codex" --write-artifacts`
+
+Expected: exit code `0` or `1` based on readiness, plus `outputs/verify/vibe-bootstrap-doctor-gate.json` showing `install_state`, `mcp_auto_provision_attempted`, and per-MCP statuses.
+
+- [ ] **Step 5: Commit and prepare execution handoff**
+
+```bash
+git add config/mcp-auto-provision.registry.json apps/vgo-cli/src/vgo_cli/mcp_provision.py apps/vgo-cli/src/vgo_cli/external.py apps/vgo-cli/src/vgo_cli/commands.py apps/vgo-cli/src/vgo_cli/install_support.py apps/vgo-cli/src/vgo_cli/output.py scripts/bootstrap/one-shot-setup.sh scripts/bootstrap/one-shot-setup.ps1 packages/verification-core/src/vgo_verify/bootstrap_doctor.py packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py scripts/verify/vibe-bootstrap-doctor-gate.ps1 mcp/servers.template.json tests/runtime_neutral/test_mcp_auto_provision.py tests/runtime_neutral/test_install_prompt_mcp_contract.py tests/runtime_neutral/test_bootstrap_doctor.py tests/runtime_neutral/test_shell_entrypoint_compatibility.py docs/install/prompts/full-version-install.md docs/install/prompts/full-version-install.en.md docs/install/prompts/framework-only-install.md docs/install/prompts/framework-only-install.en.md docs/install/prompts/full-version-update.md docs/install/prompts/full-version-update.en.md docs/install/prompts/framework-only-update.md docs/install/prompts/framework-only-update.en.md docs/install/recommended-full-path.md docs/install/recommended-full-path.en.md docs/one-shot-setup.md
+git commit -m "feat: add cross-host mcp auto provision install contract"
+```
+
+## Delivery Notes
+
+- Keep the new receipt under the target root, not under repo-local `outputs/`, so install, check, one-shot, and doctor can all inspect the same machine-readable truth.
+- Do not reintroduce Codex-only assumptions in shared helpers. Codex can still be the strongest governed path, but the orchestration contract must cover all six supported hosts.
+- Do not make MCP failures fatal to base install success. The only fatal path here should be true local install failure, not MCP readiness gaps.
+- Keep the final install report concise. The point is one summary at the end, not repeated warnings throughout the run.

--- a/docs/superpowers/specs/2026-04-07-install-prompt-mcp-auto-provision-design.md
+++ b/docs/superpowers/specs/2026-04-07-install-prompt-mcp-auto-provision-design.md
@@ -1,0 +1,394 @@
+# Install Prompt MCP Auto-Provision Design
+
+## Summary
+Define a new installation-assistant contract where the AI must attempt to provision five MCP surfaces during installation guidance across all six publicly supported hosts. The design does not turn those MCPs into hard install blockers. Instead, it standardizes a best-effort but mandatory attempt flow, reuses repository-owned install/bootstrap/check paths first, prefers host-native registration for host-native MCP/plugin surfaces, and reports failures only in the final install report.
+
+The five MCP surfaces in scope are:
+
+- `github`
+- `context7`
+- `serena`
+- `scrapling`
+- `claude-flow`
+
+The six public hosts in scope are:
+
+- `codex`
+- `claude-code`
+- `cursor`
+- `windsurf`
+- `openclaw`
+- `opencode`
+
+## Problem
+The current installation story separates three things, but not consistently:
+
+- repository-owned payload installation
+- host-specific MCP or plugin provisioning
+- final readiness reporting
+
+That creates two user-facing problems:
+
+1. install assistants may stop after payload installation and never attempt to provision high-value MCP surfaces
+2. when MCP provisioning does happen, the result vocabulary is inconsistent across prompt docs, one-shot/bootstrap flows, doctor gates, and final reports
+
+The user wants a stronger and more honest experience:
+
+- every install assistant should try to provision the same five MCP surfaces
+- the attempt should happen during installation guidance, not as an unrelated later suggestion
+- failure should not block users from beginning to use VibeSkills
+- failure should still be explicit and auditable in the final report
+
+## Goals
+- Make MCP auto-provision attempts part of the install-assistant contract.
+- Cover the same five MCP surfaces across all six public hosts.
+- Reuse repository-owned install/bootstrap/check flows before improvising host-specific actions.
+- Prefer host-native registration for `github`, `context7`, and `serena`.
+- Prefer CLI / stdio provisioning for `scrapling` and `claude-flow`.
+- Standardize verification and reporting so all install surfaces use the same state vocabulary.
+- Keep base install success separate from MCP readiness and from online governance readiness.
+
+## Non-Goals
+- Do not make any of the five MCP surfaces a hard prerequisite for base installation success.
+- Do not redefine host support to mean “full parity across all hosts”.
+- Do not require users to paste secrets or provider credentials into chat.
+- Do not silently claim that a host-native MCP is ready without host-visible verification.
+- Do not redesign unrelated router, runtime, or memory policies.
+
+## Scope Boundary
+This design applies to:
+
+- install prompt documents
+- install / one-shot / check orchestration
+- host-specific MCP provision attempts
+- doctor / verification artifacts
+- final install reporting
+
+This design does not apply to:
+
+- unrelated runtime task execution after install
+- online governance credential configuration beyond reporting readiness gaps
+- non-public hosts
+
+## Design Options Considered
+
+### Option A: Prompt-only soft reminder
+Add a single instruction to install prompts telling the assistant to try the five MCPs.
+
+Pros:
+
+- lowest implementation cost
+- minimal document churn
+
+Cons:
+
+- weak execution consistency
+- no shared verification contract
+- likely drift between prompts and scripts
+
+### Option B: Prompt + unified provision state machine
+Define a standard `detect -> attempt_provision -> verify -> final_report` lifecycle shared by install prompts, bootstrap flows, and doctor/reporting layers.
+
+Pros:
+
+- consistent behavior across all hosts
+- evidence-backed reporting
+- clean separation between base install success and MCP readiness
+
+Cons:
+
+- requires touching prompts, scripts, and doctor outputs together
+
+### Option C: Hard fail provisioning contract
+Require all five MCPs to be provisioned successfully or mark installation as failed.
+
+Pros:
+
+- simple user story
+- strongest pressure toward full automation
+
+Cons:
+
+- conflicts with the requirement to not block users from starting VibeSkills
+- too brittle for hosts that still expose host-managed registration boundaries
+
+## Decision
+Choose **Option B** with host-specific executors.
+
+The install assistant contract should become:
+
+- mandatory attempt
+- repository-owned path first
+- host-native path preferred where relevant
+- standardized verification
+- final-report-only failure summary
+- no install blockage from MCP attempt failure
+
+## Core Contract
+
+### 1. Install Prompt Rule
+Every supported install prompt must require the assistant to attempt provisioning:
+
+- `github`
+- `context7`
+- `serena`
+- `scrapling`
+- `claude-flow`
+
+The assistant must:
+
+1. detect the host and target root
+2. invoke repository-owned install/bootstrap/check flows first
+3. attempt MCP provisioning using the host’s preferred path
+4. verify discoverability or host visibility
+5. summarize the outcome only in the final install report
+
+### 2. No Mid-Flow Failure Spam
+The assistant should not interrupt the user each time an MCP attempt fails.
+
+Instead:
+
+- continue the base install path
+- record the failure in receipts
+- include the failure in the final report
+
+### 3. Truth Separation
+The final install truth must separate:
+
+- `installed_locally`
+- `mcp_auto_provision_attempted`
+- per-MCP readiness
+- online governance readiness
+
+This prevents the current ambiguity where successful payload installation can be confused with fully ready integrations.
+
+## Cross-Host Provision Flow
+
+### Shared Lifecycle
+All hosts use the same lifecycle:
+
+1. `detect`
+2. `attempt_provision`
+3. `verify`
+4. `final_report`
+
+### MCP Categories
+
+#### Host-native preferred
+
+- `github`
+- `context7`
+- `serena`
+
+Primary path:
+
+- host-native MCP / plugin registration if a stable, supported interface exists
+
+Fallback behavior:
+
+- record `host_native_unavailable` or `attempt_failed`
+- continue installation
+
+#### CLI / stdio preferred
+
+- `scrapling`
+- `claude-flow`
+
+Primary path:
+
+- repository-owned scripted CLI install
+- verify command availability and host discoverability
+
+Fallback behavior:
+
+- record `attempt_failed` or `verification_failed`
+- continue installation
+
+### Host-Specific Attempt Order
+
+#### `codex`
+
+- repository bootstrap / check first
+- host-native registration next for `github/context7/serena`
+- scripted CLI install for `scrapling/claude-flow`
+
+#### `claude-code`
+
+- managed settings / scaffold first
+- host-native plugin or MCP enablement next
+- scripted CLI install where appropriate
+
+#### `cursor`
+
+- preview-guidance scaffold first
+- host-native registration if documented and stable
+- scripted CLI install where applicable
+
+#### `windsurf`
+
+- runtime-core + sidecar preparation first
+- host-native registration if documented
+- scripted CLI install where applicable
+
+#### `openclaw`
+
+- attach / copy / bundle flow first
+- host-native registration if documented
+- scripted CLI install where applicable
+
+#### `opencode`
+
+- direct install/check first
+- host-native MCP/config registration next
+- scripted CLI install where applicable without overstating ownership of host-managed config
+
+## Unified State Model
+Every MCP result should emit the same fields:
+
+- `name`
+- `category`
+- `attempt_required`
+- `attempted`
+- `provision_path`
+- `verify_path`
+- `status`
+- `failure_reason`
+- `next_step`
+
+### Allowed Status Values
+
+- `ready`
+- `attempt_failed`
+- `host_native_unavailable`
+- `missing_credentials`
+- `verification_failed`
+- `not_attempted_due_to_host_contract`
+
+Rules:
+
+- default expectation is `attempt_required=true`
+- use `not_attempted_due_to_host_contract` only when a documented host contract forbids the action
+- use `verification_failed` when a provision command succeeded but host discovery or readiness proof failed
+
+## Final Report Format
+The final install report should add a fixed section like:
+
+```text
+MCP Provision Summary
+- github: status=attempt_failed; attempted=true; path=host_native_registration; reason=host plugin registration command unavailable; next_step=use the host-native registration path locally
+- context7: status=host_native_unavailable; attempted=true; path=host_native_registration; reason=no stable host-native registration interface detected; next_step=provision via host-side documented path
+- serena: status=ready; attempted=true; path=host_native_registration; verify=passed
+- scrapling: status=ready; attempted=true; path=cli_stdio_install; verify=passed
+- claude-flow: status=attempt_failed; attempted=true; path=cli_stdio_install; reason=npm install failed; next_step=retry local npm provisioning
+```
+
+And the top-level report should summarize:
+
+- `installed_locally`
+- `mcp_auto_provision_attempted`
+- `mcp_ready_count`
+- `mcp_failed_count`
+
+## Surfaces To Change
+
+### Prompt Documents
+Update install prompt documents to require the five MCP attempts and final-report-only failure disclosure.
+
+Likely surface:
+
+- `docs/install/prompts/*`
+
+### Execution Surfaces
+Add or extend a unified MCP provision orchestrator that install, one-shot, and check flows can call.
+
+Likely surfaces:
+
+- `scripts/bootstrap/one-shot-setup.*`
+- `install.*`
+- `check.*`
+
+### Verification / Doctor
+Doctor and verification outputs should consume the same result model instead of using ad hoc wording.
+
+Likely surfaces:
+
+- `scripts/verify/vibe-bootstrap-doctor-gate.ps1`
+- runtime-neutral verification helpers or a new MCP provision receipt writer
+
+### Reporting
+The final install report template should be updated to print the new MCP summary block in a deterministic format.
+
+## Rollout Plan
+
+### Phase 1: Contract First
+Change prompts, reporting expectations, and status vocabulary.
+
+Success criteria:
+
+- the user-visible contract is stable
+- all supported hosts enter the same MCP attempt flow on paper
+
+### Phase 2: Unified Provision Orchestrator
+Implement a runtime-neutral orchestrator for `detect -> attempt -> verify -> report`.
+
+Success criteria:
+
+- one shared receipt format
+- reusable by install, bootstrap, and check
+
+### Phase 3: Host Executors
+Implement per-host attempt logic.
+
+Success criteria:
+
+- host-native preferred MCPs use host-native registration where possible
+- CLI/stdio preferred MCPs use scripted install paths
+
+### Phase 4: Deep Verification
+Connect doctor/check/probe surfaces to the shared receipts.
+
+Success criteria:
+
+- prompts, execution, doctor, and final report agree on the same truth
+
+## Risks And Controls
+
+### Risk: Host capabilities differ too much
+Control:
+
+- keep the lifecycle uniform
+- vary only executor behavior and final status
+
+### Risk: The assistant claims it attempted provisioning without evidence
+Control:
+
+- final report must be generated from receipts, not free-form narration
+
+### Risk: MCP failures get misreported as install failures
+Control:
+
+- separate `installed_locally` from MCP readiness in all report surfaces
+
+### Risk: CLI installs are slow or flaky
+Control:
+
+- use timeouts and bounded retries
+- record deterministic failure reasons
+
+### Risk: Prompt docs drift away from script behavior
+Control:
+
+- update prompt docs, bootstrap flows, verification, and final report in the same change set
+
+## Open Questions For Implementation Planning
+- Should the shared MCP provision receipt be runtime-neutral JSON only, or JSON plus markdown summary?
+- Which hosts already expose sufficiently stable native registration commands for `github/context7/serena`?
+- Should `check --deep` be required to print the MCP summary block, or only write it to receipts?
+
+## Recommended Next Step
+Convert this design into an implementation plan that:
+
+- enumerates prompt files to update
+- defines the shared receipt schema
+- maps per-host provision executors
+- wires final reporting and verification to the shared state model

--- a/packages/installer-core/src/vgo_installer/ledger_service.py
+++ b/packages/installer-core/src/vgo_installer/ledger_service.py
@@ -1,140 +1,122 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from vgo_contracts.install_ledger import InstallLedger
 
-from .json_io import load_json, write_json_file
+from ._io import load_json, write_json_file
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from .install_plan import InstallPlan
 
 
-def _normalize_resolved_path(path_value: Path | str) -> str:
-    return str(Path(path_value).resolve(strict=False))
+@dataclass(slots=True)
+class MaterializationLedgerState:
+    created_paths: set[Path | str] = field(default_factory=set)
+    owned_tree_roots: set[Path | str] = field(default_factory=set)
+    managed_json_paths: set[Path | str] = field(default_factory=set)
+    merged_files: dict[str, dict[str, object]] = field(default_factory=dict)
+    generated_from_template_if_absent: set[Path | str] = field(default_factory=set)
+    specialist_wrapper_paths: list[Path | str] = field(default_factory=list)
+    runtime_roots: set[Path | str] = field(default_factory=set)
+    compatibility_roots: set[Path | str] = field(default_factory=set)
+    sidecar_roots: set[Path | str] = field(default_factory=set)
+    config_rollbacks: list[dict[str, object]] = field(default_factory=list)
+    legacy_cleanup_candidates: set[Path | str] = field(default_factory=set)
 
 
-def _normalize_target_relpath(path_value: Path | str, *, target_root: Path) -> str | None:
-    candidate = Path(path_value).resolve(strict=False)
-    target_root_resolved = target_root.resolve(strict=False)
+def _normalize_resolved_path(path: Path | str) -> str:
+    return str(Path(path).resolve(strict=False))
+
+
+def _normalize_target_relpath(path: Path | str, *, target_root: Path) -> str | None:
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        candidate = (target_root / candidate).resolve(strict=False)
+    else:
+        candidate = candidate.resolve(strict=False)
     try:
-        return str(candidate.relative_to(target_root_resolved)).replace('\\', '/') or '.'
+        relative = candidate.relative_to(target_root.resolve(strict=False))
     except ValueError:
         return None
+    normalized = relative.as_posix().strip()
+    return normalized or None
 
 
-def _sorted_target_relpaths(values: Iterable[Path | str], *, target_root: Path) -> list[str]:
-    relpaths: list[str] = []
-    seen: set[str] = set()
+def _normalize_skill_name(value: object) -> str | None:
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        InstallLedger(managed_skill_names=[text])
+    except ValueError:
+        return None
+    return text
+
+
+def sanitize_managed_skill_names(values: list[str] | tuple[str, ...] | set[str] | None) -> list[str]:
+    safe_names: set[str] = set()
+    for value in values or []:
+        normalized = _normalize_skill_name(value)
+        if normalized is not None:
+            safe_names.add(normalized)
+    return sorted(safe_names)
+
+
+def _sorted_target_relpaths(values: set[Path | str] | list[Path | str], *, target_root: Path) -> list[str]:
+    relpaths: set[str] = set()
     for value in values:
-        relpath = _normalize_target_relpath(value, target_root=target_root)
-        if relpath is None or relpath in seen:
-            continue
-        seen.add(relpath)
-        relpaths.append(relpath)
+        normalized = _normalize_target_relpath(value, target_root=target_root)
+        if normalized is not None:
+            relpaths.add(normalized)
     return sorted(relpaths)
 
 
-def _sorted_config_rollbacks(values: Iterable[dict[str, object]]) -> list[dict[str, object]]:
+def _sorted_config_rollbacks(values: list[dict[str, object]]) -> list[dict[str, object]]:
     records: list[dict[str, object]] = []
+    seen: set[tuple[str, bool, str]] = set()
     for entry in values:
         if not isinstance(entry, dict):
             continue
-        path_value = entry.get('path')
-        if path_value is None:
+        path = str(entry.get('path') or '').strip()
+        if not path:
             continue
+        normalized = _normalize_resolved_path(path)
+        managed_key = str(entry.get('managed_key') or 'vibeskills')
+        created_if_absent = bool(entry.get('created_if_absent', False))
+        marker = (normalized, created_if_absent, managed_key)
+        if marker in seen:
+            continue
+        seen.add(marker)
         records.append(
             {
-                'path': _normalize_resolved_path(path_value),
-                'created_if_absent': bool(entry.get('created_if_absent', False)),
-                'managed_key': str(entry.get('managed_key') or 'vibeskills'),
+                'path': normalized,
+                'created_if_absent': created_if_absent,
+                'managed_key': managed_key,
             }
         )
-    records.sort(key=lambda item: item['path'])
-    return records
+    return sorted(records, key=lambda item: item['path'])
 
 
-@dataclass
-class MaterializationLedgerState:
-    created_paths: set[Path] = field(default_factory=set)
-    owned_tree_roots: set[Path] = field(default_factory=set)
-    managed_json_paths: set[Path] = field(default_factory=set)
-    merged_files: dict[str, dict[str, object]] = field(default_factory=dict)
-    generated_from_template_if_absent: set[Path] = field(default_factory=set)
-    runtime_roots: set[Path] = field(default_factory=set)
-    compatibility_roots: set[Path] = field(default_factory=set)
-    sidecar_roots: set[Path] = field(default_factory=set)
-    config_rollbacks: list[dict[str, object]] = field(default_factory=list)
-    specialist_wrapper_paths: list[Path] = field(default_factory=list)
-    legacy_cleanup_candidates: set[Path] = field(default_factory=set)
-
-
-def sanitize_managed_skill_names(values: Iterable[str]) -> list[str]:
-    sanitized: set[str] = set()
-    for value in values:
-        candidate = str(value or '').strip().replace('\\', '/')
-        if not candidate or candidate in {'.', '..'}:
-            continue
-        if '/' in candidate:
-            continue
-        if candidate.startswith('.'):
-            continue
-        sanitized.add(candidate)
-    return sorted(sanitized)
-
-
-def _normalize_skill_name(value: str | None) -> str | None:
-    if value is None:
+def load_existing_install_ledger(target_root: Path | str) -> dict | None:
+    ledger_path = Path(target_root).resolve() / '.vibeskills' / 'install-ledger.json'
+    if not ledger_path.exists():
         return None
-    normalized = str(value).strip().replace('\\', '/')
-    if not normalized or '/' in normalized or normalized in {'.', '..'}:
-        return None
-    return normalized
+    return load_json(ledger_path)
 
 
-def derive_managed_skill_names_from_ledger(target_root: Path | str, ledger: dict) -> set[str]:
-    target_root_path = Path(target_root).resolve(strict=False)
-    managed: set[str] = set()
+def derive_managed_skill_names_from_ledger(target_root: Path | str, ledger: dict | None) -> set[str]:
+    if not isinstance(ledger, dict):
+        return set()
 
-    for value in ledger.get('managed_skill_names') or []:
-        normalized = _normalize_skill_name(value)
-        if normalized is not None:
-            managed.add(normalized)
+    target_root_path = Path(target_root).resolve()
+    managed = set(sanitize_managed_skill_names(ledger.get('managed_skill_names')))
+    skills_root = (target_root_path / 'skills').resolve(strict=False)
 
-    skills_root = target_root_path / 'skills'
-    for raw_root in ledger.get('runtime_roots') or []:
-        candidate = Path(str(raw_root)).resolve(strict=False)
-        if not candidate.exists() or not candidate.is_dir():
-            continue
-        try:
-            relative = candidate.relative_to(skills_root)
-        except ValueError:
-            continue
-        if relative.parts:
-            normalized = _normalize_skill_name(relative.parts[0])
-            if normalized is not None:
-                managed.add(normalized)
-
-    for raw_root in ledger.get('compatibility_roots') or []:
-        candidate = Path(str(raw_root)).resolve(strict=False)
-        if not candidate.exists() or not candidate.is_dir():
-            continue
-        try:
-            relative = candidate.relative_to(skills_root)
-        except ValueError:
-            continue
-        if relative.parts:
-            normalized = _normalize_skill_name(relative.parts[0])
-            if normalized is not None:
-                managed.add(normalized)
-
-    for raw_root in ledger.get('owned_tree_roots') or []:
-        candidate = Path(str(raw_root)).resolve(strict=False)
-        if not candidate.exists() or not candidate.is_dir():
-            continue
+    for raw_path in ledger.get('created_paths') or []:
+        candidate = Path(str(raw_path)).resolve(strict=False)
         try:
             relative = candidate.relative_to(skills_root)
         except ValueError:

--- a/packages/installer-core/src/vgo_installer/ledger_service.py
+++ b/packages/installer-core/src/vgo_installer/ledger_service.py
@@ -1,122 +1,140 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vgo_contracts.install_ledger import InstallLedger
 
-from ._io import load_json, write_json_file
+from .json_io import load_json, write_json_file
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .install_plan import InstallPlan
 
 
-@dataclass(slots=True)
-class MaterializationLedgerState:
-    created_paths: set[Path | str] = field(default_factory=set)
-    owned_tree_roots: set[Path | str] = field(default_factory=set)
-    managed_json_paths: set[Path | str] = field(default_factory=set)
-    merged_files: dict[str, dict[str, object]] = field(default_factory=dict)
-    generated_from_template_if_absent: set[Path | str] = field(default_factory=set)
-    specialist_wrapper_paths: list[Path | str] = field(default_factory=list)
-    runtime_roots: set[Path | str] = field(default_factory=set)
-    compatibility_roots: set[Path | str] = field(default_factory=set)
-    sidecar_roots: set[Path | str] = field(default_factory=set)
-    config_rollbacks: list[dict[str, object]] = field(default_factory=list)
-    legacy_cleanup_candidates: set[Path | str] = field(default_factory=set)
+def _normalize_resolved_path(path_value: Path | str) -> str:
+    return str(Path(path_value).resolve(strict=False))
 
 
-def _normalize_resolved_path(path: Path | str) -> str:
-    return str(Path(path).resolve(strict=False))
-
-
-def _normalize_target_relpath(path: Path | str, *, target_root: Path) -> str | None:
-    candidate = Path(path)
-    if not candidate.is_absolute():
-        candidate = (target_root / candidate).resolve(strict=False)
-    else:
-        candidate = candidate.resolve(strict=False)
+def _normalize_target_relpath(path_value: Path | str, *, target_root: Path) -> str | None:
+    candidate = Path(path_value).resolve(strict=False)
+    target_root_resolved = target_root.resolve(strict=False)
     try:
-        relative = candidate.relative_to(target_root.resolve(strict=False))
+        return str(candidate.relative_to(target_root_resolved)).replace('\\', '/') or '.'
     except ValueError:
         return None
-    normalized = relative.as_posix().strip()
-    return normalized or None
 
 
-def _normalize_skill_name(value: object) -> str | None:
-    text = str(value).strip()
-    if not text:
-        return None
-    try:
-        InstallLedger(managed_skill_names=[text])
-    except ValueError:
-        return None
-    return text
-
-
-def sanitize_managed_skill_names(values: list[str] | tuple[str, ...] | set[str] | None) -> list[str]:
-    safe_names: set[str] = set()
-    for value in values or []:
-        normalized = _normalize_skill_name(value)
-        if normalized is not None:
-            safe_names.add(normalized)
-    return sorted(safe_names)
-
-
-def _sorted_target_relpaths(values: set[Path | str] | list[Path | str], *, target_root: Path) -> list[str]:
-    relpaths: set[str] = set()
+def _sorted_target_relpaths(values: Iterable[Path | str], *, target_root: Path) -> list[str]:
+    relpaths: list[str] = []
+    seen: set[str] = set()
     for value in values:
-        normalized = _normalize_target_relpath(value, target_root=target_root)
-        if normalized is not None:
-            relpaths.add(normalized)
+        relpath = _normalize_target_relpath(value, target_root=target_root)
+        if relpath is None or relpath in seen:
+            continue
+        seen.add(relpath)
+        relpaths.append(relpath)
     return sorted(relpaths)
 
 
-def _sorted_config_rollbacks(values: list[dict[str, object]]) -> list[dict[str, object]]:
+def _sorted_config_rollbacks(values: Iterable[dict[str, object]]) -> list[dict[str, object]]:
     records: list[dict[str, object]] = []
-    seen: set[tuple[str, bool, str]] = set()
     for entry in values:
         if not isinstance(entry, dict):
             continue
-        path = str(entry.get('path') or '').strip()
-        if not path:
+        path_value = entry.get('path')
+        if path_value is None:
             continue
-        normalized = _normalize_resolved_path(path)
-        managed_key = str(entry.get('managed_key') or 'vibeskills')
-        created_if_absent = bool(entry.get('created_if_absent', False))
-        marker = (normalized, created_if_absent, managed_key)
-        if marker in seen:
-            continue
-        seen.add(marker)
         records.append(
             {
-                'path': normalized,
-                'created_if_absent': created_if_absent,
-                'managed_key': managed_key,
+                'path': _normalize_resolved_path(path_value),
+                'created_if_absent': bool(entry.get('created_if_absent', False)),
+                'managed_key': str(entry.get('managed_key') or 'vibeskills'),
             }
         )
-    return sorted(records, key=lambda item: item['path'])
+    records.sort(key=lambda item: item['path'])
+    return records
 
 
-def load_existing_install_ledger(target_root: Path | str) -> dict | None:
-    ledger_path = Path(target_root).resolve() / '.vibeskills' / 'install-ledger.json'
-    if not ledger_path.exists():
+@dataclass
+class MaterializationLedgerState:
+    created_paths: set[Path] = field(default_factory=set)
+    owned_tree_roots: set[Path] = field(default_factory=set)
+    managed_json_paths: set[Path] = field(default_factory=set)
+    merged_files: dict[str, dict[str, object]] = field(default_factory=dict)
+    generated_from_template_if_absent: set[Path] = field(default_factory=set)
+    runtime_roots: set[Path] = field(default_factory=set)
+    compatibility_roots: set[Path] = field(default_factory=set)
+    sidecar_roots: set[Path] = field(default_factory=set)
+    config_rollbacks: list[dict[str, object]] = field(default_factory=list)
+    specialist_wrapper_paths: list[Path] = field(default_factory=list)
+    legacy_cleanup_candidates: set[Path] = field(default_factory=set)
+
+
+def sanitize_managed_skill_names(values: Iterable[str]) -> list[str]:
+    sanitized: set[str] = set()
+    for value in values:
+        candidate = str(value or '').strip().replace('\\', '/')
+        if not candidate or candidate in {'.', '..'}:
+            continue
+        if '/' in candidate:
+            continue
+        if candidate.startswith('.'):
+            continue
+        sanitized.add(candidate)
+    return sorted(sanitized)
+
+
+def _normalize_skill_name(value: str | None) -> str | None:
+    if value is None:
         return None
-    return load_json(ledger_path)
+    normalized = str(value).strip().replace('\\', '/')
+    if not normalized or '/' in normalized or normalized in {'.', '..'}:
+        return None
+    return normalized
 
 
-def derive_managed_skill_names_from_ledger(target_root: Path | str, ledger: dict | None) -> set[str]:
-    if not isinstance(ledger, dict):
-        return set()
+def derive_managed_skill_names_from_ledger(target_root: Path | str, ledger: dict) -> set[str]:
+    target_root_path = Path(target_root).resolve(strict=False)
+    managed: set[str] = set()
 
-    target_root_path = Path(target_root).resolve()
-    managed = set(sanitize_managed_skill_names(ledger.get('managed_skill_names')))
-    skills_root = (target_root_path / 'skills').resolve(strict=False)
+    for value in ledger.get('managed_skill_names') or []:
+        normalized = _normalize_skill_name(value)
+        if normalized is not None:
+            managed.add(normalized)
 
-    for raw_path in ledger.get('created_paths') or []:
-        candidate = Path(str(raw_path)).resolve(strict=False)
+    skills_root = target_root_path / 'skills'
+    for raw_root in ledger.get('runtime_roots') or []:
+        candidate = Path(str(raw_root)).resolve(strict=False)
+        if not candidate.exists() or not candidate.is_dir():
+            continue
+        try:
+            relative = candidate.relative_to(skills_root)
+        except ValueError:
+            continue
+        if relative.parts:
+            normalized = _normalize_skill_name(relative.parts[0])
+            if normalized is not None:
+                managed.add(normalized)
+
+    for raw_root in ledger.get('compatibility_roots') or []:
+        candidate = Path(str(raw_root)).resolve(strict=False)
+        if not candidate.exists() or not candidate.is_dir():
+            continue
+        try:
+            relative = candidate.relative_to(skills_root)
+        except ValueError:
+            continue
+        if relative.parts:
+            normalized = _normalize_skill_name(relative.parts[0])
+            if normalized is not None:
+                managed.add(normalized)
+
+    for raw_root in ledger.get('owned_tree_roots') or []:
+        candidate = Path(str(raw_root)).resolve(strict=False)
+        if not candidate.exists() or not candidate.is_dir():
+            continue
         try:
             relative = candidate.relative_to(skills_root)
         except ValueError:
@@ -234,6 +252,12 @@ def build_payload_summary(target_root: Path | str, ledger: dict) -> dict[str, ob
     for entry in ledger.get('config_rollbacks') or []:
         if isinstance(entry, dict):
             collect_owned_file(str(entry.get('path') or ''))
+
+    # The install ledger is written after the initial payload summary is built.
+    # When refreshing summaries from an on-disk install, count the ledger itself
+    # as installer-owned payload so fresh installs and refreshed ledgers agree.
+    collect_owned_file(target_root_path / '.vibeskills' / 'install-ledger.json')
+    collect_owned_file(target_root_path / '.vibeskills' / 'mcp-auto-provision.json')
 
     return {
         'installed_skill_count': len(installed_skill_names),

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor.py
@@ -22,12 +22,14 @@ def write_artifacts(repo_root: Path, artifact: dict[str, Any], output_directory:
         "# VCO Bootstrap Doctor Gate",
         "",
         f"- Gate Result: **{artifact['gate_result']}**",
+        f"- Install State: **{artifact['install_state']}**",
         f"- Readiness State: **{artifact['summary']['readiness_state']}**",
         f"- Blocking Issues: `{artifact['summary']['blocking_issue_count']}`",
         f"- Manual Actions Pending: `{artifact['summary']['manual_action_count']}`",
         f"- Warnings: `{artifact['summary']['warning_count']}`",
         f"- Target Root: `{artifact['target_root']}`",
         f"- MCP Profile: `{artifact['mcp']['profile']}`",
+        f"- MCP Auto-Provision Attempted: `{artifact['mcp']['auto_provision_attempted']}`",
         f"- MCP Active File Exists: `{artifact['mcp']['active_file_exists']}`",
         "",
         "## Settings",
@@ -95,6 +97,8 @@ def evaluate(repo_root: Path, target_root: Path) -> dict[str, Any]:
 
     profile_path = repo_root / "mcp" / "profiles" / f"{profile}.json"
     active_mcp_path = target_root / "mcp" / "servers.active.json"
+    mcp_receipt_path = target_root / ".vibeskills" / "mcp-auto-provision.json"
+    mcp_receipt = load_json(mcp_receipt_path) if mcp_receipt_path.exists() else None
 
     return build_bootstrap_artifact(
         repo_root=repo_root,
@@ -104,6 +108,8 @@ def evaluate(repo_root: Path, target_root: Path) -> dict[str, Any]:
         profile=profile,
         profile_path=profile_path,
         active_mcp_path=active_mcp_path,
+        mcp_receipt_path=mcp_receipt_path,
+        mcp_receipt=mcp_receipt,
         plugins_manifest=load_json(repo_root / "config" / "plugins-manifest.codex.json"),
         servers_template=load_json(repo_root / "mcp" / "servers.template.json"),
         secrets_policy=load_json(repo_root / "config" / "secrets-policy.json"),

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from .bootstrap_doctor_support import (
     command_present,
+    load_json,
     os_environ,
     resolved_setting_state,
     setting_state,
@@ -92,6 +93,24 @@ def collect_mcp_servers(profile_object: dict[str, Any], servers_template: dict[s
     return mcp_servers
 
 
+def collect_mcp_servers_from_receipt(mcp_receipt: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(mcp_receipt, dict):
+        return []
+    servers: list[dict[str, Any]] = []
+    for server in mcp_receipt.get("mcp_results") or []:
+        if not isinstance(server, dict):
+            continue
+        servers.append(
+            {
+                "name": str(server.get("name") or ""),
+                "mode": str(server.get("provision_path") or "unknown"),
+                "status": str(server.get("status") or "unknown"),
+                "next_step": str(server.get("next_step") or "none"),
+            }
+        )
+    return servers
+
+
 def collect_secret_surfaces(secrets_policy: dict[str, Any]) -> list[dict[str, Any]]:
     secret_surfaces: list[dict[str, Any]] = []
     for secret in secrets_policy.get("allowed_secret_refs") or []:
@@ -175,6 +194,7 @@ def build_summary(
     settings_path: Path,
     active_mcp_path: Path,
     settings: dict[str, Any] | None,
+    install_state: str,
     plugins: list[dict[str, Any]],
     mcp_servers: list[dict[str, Any]],
     external_tools: list[dict[str, Any]],
@@ -185,6 +205,8 @@ def build_summary(
 
     if not settings_path.exists():
         blocking_issues.append("settings.json is missing in target root.")
+    if install_state != "installed_locally":
+        warnings.append(f"Install state is '{install_state}'; verify the local install receipt.")
     intent_advice_api_key_state, intent_advice_api_key_source = resolved_setting_state(settings, "VCO_INTENT_ADVICE_API_KEY")
     intent_advice_model_state, intent_advice_model_source = resolved_setting_state(settings, "VCO_INTENT_ADVICE_MODEL")
     vector_diff_api_key_state, vector_diff_api_key_source = resolved_setting_state(settings, "VCO_VECTOR_DIFF_API_KEY")
@@ -202,7 +224,7 @@ def build_summary(
         if plugin["status"] == "platform_plugin_required" and plugin["required"]:
             manual_actions.append(f"Required host plugin pending: {plugin['name']}")
     for server in mcp_servers:
-        if server["status"] in {"platform_plugin_required", "manual_action_required", "missing_from_template"}:
+        if server["status"] != "ready":
             manual_actions.append(f"MCP server pending: {server['name']}")
     for tool in external_tools:
         if not tool["present"] and tool["name"] in {"npm", "claude-flow"}:
@@ -243,6 +265,8 @@ def build_bootstrap_artifact(
     profile: str,
     profile_path: Path,
     active_mcp_path: Path,
+    mcp_receipt_path: Path,
+    mcp_receipt: dict[str, Any] | None,
     plugins_manifest: dict[str, Any],
     servers_template: dict[str, Any],
     secrets_policy: dict[str, Any],
@@ -257,7 +281,11 @@ def build_bootstrap_artifact(
             import json
 
             profile_object = json.load(handle)
-    mcp_servers = collect_mcp_servers(profile_object, servers_template)
+    mcp_servers = collect_mcp_servers_from_receipt(mcp_receipt)
+    if not mcp_servers:
+        mcp_servers = collect_mcp_servers(profile_object, servers_template)
+    install_state = str((mcp_receipt or {}).get("install_state") or "unknown")
+    auto_provision_attempted = bool((mcp_receipt or {}).get("mcp_auto_provision_attempted"))
     secret_surfaces = collect_secret_surfaces(secrets_policy)
     secret_status_by_name = {item["name"]: item["status"] for item in secret_surfaces}
     enhancement_surfaces = collect_enhancement_surfaces(memory_governance)
@@ -266,6 +294,7 @@ def build_bootstrap_artifact(
         settings_path=settings_path,
         active_mcp_path=active_mcp_path,
         settings=settings,
+        install_state=install_state,
         plugins=plugins,
         mcp_servers=mcp_servers,
         external_tools=external_tools,
@@ -276,6 +305,7 @@ def build_bootstrap_artifact(
         "generated_at": utc_now(),
         "repo_root": str(repo_root),
         "target_root": str(target_root.resolve()),
+        "install_state": install_state,
         "gate_result": "PASS" if not summary["blocking_issues"] else "FAIL",
         "settings": {
             "path": str(settings_path),
@@ -299,6 +329,9 @@ def build_bootstrap_artifact(
             "profile_path": str(profile_path.relative_to(repo_root)) if profile_path.exists() else None,
             "active_file_path": str(active_mcp_path),
             "active_file_exists": active_mcp_path.exists(),
+            "auto_provision_attempted": auto_provision_attempted,
+            "receipt_path": str(mcp_receipt_path),
+            "receipt_exists": mcp_receipt_path.exists(),
             "servers": mcp_servers,
         },
         "integration_surfaces": integration_surfaces,

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
@@ -281,11 +281,12 @@ def build_bootstrap_artifact(
             import json
 
             profile_object = json.load(handle)
-    mcp_servers = collect_mcp_servers_from_receipt(mcp_receipt)
+    receipt = mcp_receipt if isinstance(mcp_receipt, dict) else {}
+    mcp_servers = collect_mcp_servers_from_receipt(receipt)
     if not mcp_servers:
         mcp_servers = collect_mcp_servers(profile_object, servers_template)
-    install_state = str((mcp_receipt or {}).get("install_state") or "unknown")
-    auto_provision_attempted = bool((mcp_receipt or {}).get("mcp_auto_provision_attempted"))
+    install_state = str(receipt.get("install_state") or "unknown")
+    auto_provision_attempted = bool(receipt.get("mcp_auto_provision_attempted"))
     secret_surfaces = collect_secret_surfaces(secrets_policy)
     secret_status_by_name = {item["name"]: item["status"] for item in secret_surfaces}
     enhancement_surfaces = collect_enhancement_surfaces(memory_governance)

--- a/scripts/bootstrap/one-shot-setup.ps1
+++ b/scripts/bootstrap/one-shot-setup.ps1
@@ -105,6 +105,32 @@ function Get-ExistingSettingEnvValue {
     return $null
 }
 
+function Write-McpAutoProvisionSummary {
+    param(
+        [Parameter(Mandatory)] [string]$TargetRoot
+    )
+
+    $receiptPath = Join-Path $TargetRoot '.vibeskills\mcp-auto-provision.json'
+    Write-Host 'MCP auto-provision summary'
+    if (-not (Test-Path -LiteralPath $receiptPath)) {
+        Write-Host '- receipt: missing' -ForegroundColor Yellow
+        return
+    }
+
+    $payload = Get-Content -LiteralPath $receiptPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    Write-Host ("- installed_locally: {0}" -f ([string]($payload.install_state -eq 'installed_locally')).ToLowerInvariant())
+    Write-Host ("- mcp_auto_provision_attempted: {0}" -f ([string][bool]$payload.mcp_auto_provision_attempted).ToLowerInvariant())
+    $manualFollowUp = @()
+    foreach ($item in @($payload.mcp_results)) {
+        if ($null -eq $item) { continue }
+        Write-Host ("- {0}: status={1} next_step={2}" -f [string]$item.name, [string]$item.status, [string]$item.next_step)
+        if ([string]$item.status -ne 'ready') {
+            $manualFollowUp += [string]$item.name
+        }
+    }
+    Write-Host ("- manual_follow_up: {0}" -f $(if ($manualFollowUp.Count -gt 0) { $manualFollowUp -join ', ' } else { 'none' }))
+}
+
 $installPath = Join-Path $repoRoot 'install.ps1'
 $checkPath = Join-Path $repoRoot 'check.ps1'
 $materializePath = Join-Path $repoRoot 'scripts\setup\materialize-codex-mcp-profile.ps1'
@@ -140,7 +166,17 @@ if ($StrictOffline) {
 
 Write-Host ''
 Write-Host '[1/5] Installing adapter payload...' -ForegroundColor Yellow
-& $installPath @installArgs
+$previousInstallReportSuppression = $env:VGO_SUPPRESS_INSTALL_COMPLETION_REPORT
+$env:VGO_SUPPRESS_INSTALL_COMPLETION_REPORT = '1'
+try {
+    & $installPath @installArgs
+} finally {
+    if ([string]::IsNullOrWhiteSpace($previousInstallReportSuppression)) {
+        Remove-Item Env:VGO_SUPPRESS_INSTALL_COMPLETION_REPORT -ErrorAction SilentlyContinue
+    } else {
+        $env:VGO_SUPPRESS_INSTALL_COMPLETION_REPORT = $previousInstallReportSuppression
+    }
+}
 
 switch ([string]$Adapter.bootstrap_mode) {
     'governed' {
@@ -196,6 +232,7 @@ switch ([string]$Adapter.bootstrap_mode) {
 }
 
 Write-Host ''
+Write-McpAutoProvisionSummary -TargetRoot $TargetRoot
 Write-Host 'One-shot setup completed.' -ForegroundColor Green
 $checkShellPath = Get-VgoPowerShellCommand
 $checkShellLeaf = [System.IO.Path]::GetFileName($checkShellPath).ToLowerInvariant()

--- a/scripts/bootstrap/one-shot-setup.sh
+++ b/scripts/bootstrap/one-shot-setup.sh
@@ -300,6 +300,36 @@ raise SystemExit(1)
 PY
 }
 
+print_mcp_auto_provision_summary() {
+  local python_bin=""
+  python_bin="$(pick_python || true)"
+  if [[ -z "${python_bin}" ]]; then
+    return 0
+  fi
+  "${python_bin}" - "${TARGET_ROOT}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+target_root = Path(sys.argv[1])
+receipt_path = target_root / ".vibeskills" / "mcp-auto-provision.json"
+print("MCP auto-provision summary")
+if not receipt_path.exists():
+    print("- receipt: missing")
+    sys.exit(0)
+
+payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+print(f"- installed_locally: {payload.get('install_state') == 'installed_locally'}")
+print(f"- mcp_auto_provision_attempted: {bool(payload.get('mcp_auto_provision_attempted'))}")
+manual_follow_up = []
+for item in payload.get("mcp_results") or []:
+    print(f"- {item.get('name')}: status={item.get('status')} next_step={item.get('next_step')}")
+    if item.get("status") != "ready":
+        manual_follow_up.append(str(item.get("name")))
+print(f"- manual_follow_up: {', '.join(manual_follow_up) if manual_follow_up else 'none'}")
+PY
+}
+
 seed_settings_env_with_python() {
   local codex_root="$1"
   local surface="$2"
@@ -450,7 +480,7 @@ fi
 
 echo
 echo "[1/5] Installing adapter payload..."
-bash "${INSTALL_SH}" "${install_args[@]}"
+VGO_SUPPRESS_INSTALL_COMPLETION_REPORT=1 bash "${INSTALL_SH}" "${install_args[@]}"
 
 if [[ "${ADAPTER_BOOTSTRAP_MODE}" == "governed" ]]; then
   resolved_intent_advice_api_key="${INTENT_ADVICE_API_KEY_INPUT:-${VCO_INTENT_ADVICE_API_KEY:-}}"
@@ -504,6 +534,7 @@ else
 fi
 
 echo
+print_mcp_auto_provision_summary
 echo "One-shot setup completed."
 echo "- Re-run deep doctor anytime with: bash ./check.sh --profile ${PROFILE} --host ${HOST_ID} --target-root \"${TARGET_ROOT}\" --deep"
 if [[ "${ADAPTER_BOOTSTRAP_MODE}" == "governed" ]]; then

--- a/scripts/verify/vibe-bootstrap-doctor-gate.ps1
+++ b/scripts/verify/vibe-bootstrap-doctor-gate.ps1
@@ -127,12 +127,14 @@ function Write-DoctorArtifacts {
         '# VCO Bootstrap Doctor Gate',
         '',
         ('- Gate Result: **{0}**' -f $Artifact.gate_result),
+        ('- Install State: **{0}**' -f $Artifact.install_state),
         ('- Readiness State: **{0}**' -f $Artifact.summary.readiness_state),
         ('- Blocking Issues: `{0}`' -f $Artifact.summary.blocking_issue_count),
         ('- Manual Actions Pending: `{0}`' -f $Artifact.summary.manual_action_count),
         ('- Warnings: `{0}`' -f $Artifact.summary.warning_count),
         ('- Target Root: `{0}`' -f $Artifact.target_root),
         ('- MCP Profile: `{0}`' -f $Artifact.mcp.profile),
+        ('- MCP Auto-Provision Attempted: `{0}`' -f $Artifact.mcp.auto_provision_attempted),
         ('- MCP Active File Exists: `{0}`' -f $Artifact.mcp.active_file_exists),
         ''
     )
@@ -229,6 +231,12 @@ if ($null -ne $settings -and $settings.PSObject.Properties.Name -contains 'vco' 
 }
 
 $activeMcpPath = Join-Path $TargetRoot 'mcp\servers.active.json'
+$mcpReceiptPath = Join-Path $TargetRoot '.vibeskills\mcp-auto-provision.json'
+$mcpReceipt = if (Test-Path -LiteralPath $mcpReceiptPath) {
+    Get-Content -LiteralPath $mcpReceiptPath -Raw -Encoding UTF8 | ConvertFrom-Json
+} else {
+    $null
+}
 $pluginsManifest = Get-Content -LiteralPath $pluginsManifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
 $serversTemplate = Get-Content -LiteralPath $serversTemplatePath -Raw -Encoding UTF8 | ConvertFrom-Json
 $toolRegistry = Get-Content -LiteralPath $toolRegistryPath -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -288,47 +296,59 @@ $externalTools = @(
 )
 
 $mcpServers = @()
-foreach ($serverName in @($profileObject.enabled_servers)) {
-    $serverConfig = if ($serversTemplate.servers.PSObject.Properties.Name -contains $serverName) {
-        $serversTemplate.servers.$serverName
-    } else {
-        $null
-    }
-
-    if ($null -eq $serverConfig) {
+if ($null -ne $mcpReceipt -and $mcpReceipt.PSObject.Properties.Name -contains 'mcp_results') {
+    foreach ($server in @($mcpReceipt.mcp_results)) {
+        if ($null -eq $server) { continue }
         $mcpServers += [pscustomobject]@{
-            name = [string]$serverName
-            mode = 'unknown'
-            status = 'missing_from_template'
-            next_step = 'Fix mcp/profile definition mismatch.'
+            name = [string]$server.name
+            mode = if ($server.PSObject.Properties.Name -contains 'provision_path') { [string]$server.provision_path } else { 'unknown' }
+            status = if ($server.PSObject.Properties.Name -contains 'status') { [string]$server.status } else { 'unknown' }
+            next_step = if ($server.PSObject.Properties.Name -contains 'next_step') { [string]$server.next_step } else { 'none' }
         }
-        continue
     }
+} else {
+    foreach ($serverName in @($profileObject.enabled_servers)) {
+        $serverConfig = if ($serversTemplate.servers.PSObject.Properties.Name -contains $serverName) {
+            $serversTemplate.servers.$serverName
+        } else {
+            $null
+        }
 
-    $mode = [string]$serverConfig.mode
-    $status = 'ready'
-    $nextStep = 'none'
+        if ($null -eq $serverConfig) {
+            $mcpServers += [pscustomobject]@{
+                name = [string]$serverName
+                mode = 'unknown'
+                status = 'missing_from_template'
+                next_step = 'Fix mcp/profile definition mismatch.'
+            }
+            continue
+        }
 
-    if ($mode -eq 'plugin') {
-        $status = 'platform_plugin_required'
-        $nextStep = 'Provision the corresponding Codex plugin in the host runtime.'
-    } elseif ($mode -eq 'stdio') {
-        $commandName = [string]$serverConfig.command
-        if (-not (Test-CommandPresent -Name $commandName)) {
-            $status = 'manual_action_required'
-            $nextStep = if ($serverConfig.PSObject.Properties.Name -contains 'note' -and -not [string]::IsNullOrWhiteSpace([string]$serverConfig.note)) {
-                [string]$serverConfig.note
-            } else {
-                ("Install command '{0}' and register the MCP server in the host." -f $commandName)
+        $mode = [string]$serverConfig.mode
+        $status = 'ready'
+        $nextStep = 'none'
+
+        if ($mode -eq 'plugin') {
+            $status = 'platform_plugin_required'
+            $nextStep = 'Provision the corresponding Codex plugin in the host runtime.'
+        } elseif ($mode -eq 'stdio') {
+            $commandName = [string]$serverConfig.command
+            if (-not (Test-CommandPresent -Name $commandName)) {
+                $status = 'manual_action_required'
+                $nextStep = if ($serverConfig.PSObject.Properties.Name -contains 'note' -and -not [string]::IsNullOrWhiteSpace([string]$serverConfig.note)) {
+                    [string]$serverConfig.note
+                } else {
+                    ("Install command '{0}' and register the MCP server in the host." -f $commandName)
+                }
             }
         }
-    }
 
-    $mcpServers += [pscustomobject]@{
-        name = [string]$serverName
-        mode = $mode
-        status = $status
-        next_step = $nextStep
+        $mcpServers += [pscustomobject]@{
+            name = [string]$serverName
+            mode = $mode
+            status = $status
+            next_step = $nextStep
+        }
     }
 }
 
@@ -444,7 +464,7 @@ if (-not (Test-Path -LiteralPath $activeMcpPath)) {
 foreach ($plugin in $pluginResults | Where-Object { $_.status -eq 'platform_plugin_required' -and $_.required }) {
     $manualActions.Add(("Required host plugin pending: {0}" -f $plugin.name)) | Out-Null
 }
-foreach ($server in $mcpServers | Where-Object { $_.status -in @('platform_plugin_required', 'manual_action_required', 'missing_from_template') }) {
+foreach ($server in $mcpServers | Where-Object { $_.status -ne 'ready' }) {
     $manualActions.Add(("MCP server pending: {0}" -f $server.name)) | Out-Null
 }
 foreach ($tool in $externalTools | Where-Object { -not $_.present -and $_.name -in @('npm', 'claude-flow') }) {
@@ -464,6 +484,7 @@ $artifact = [ordered]@{
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     repo_root = $repoRoot
     target_root = [System.IO.Path]::GetFullPath($TargetRoot)
+    install_state = if ($null -ne $mcpReceipt -and $mcpReceipt.PSObject.Properties.Name -contains 'install_state') { [string]$mcpReceipt.install_state } else { 'unknown' }
     gate_result = if ($blockingIssues.Count -eq 0) { 'PASS' } else { 'FAIL' }
     settings = [ordered]@{
         path = $settingsPath
@@ -487,6 +508,9 @@ $artifact = [ordered]@{
         profile_path = if (Test-Path -LiteralPath $profilePath) { (Get-VgoRelativePathPortable -BasePath $repoRoot -TargetPath $profilePath) } else { $null }
         active_file_path = $activeMcpPath
         active_file_exists = [bool](Test-Path -LiteralPath $activeMcpPath)
+        auto_provision_attempted = [bool]($null -ne $mcpReceipt -and $mcpReceipt.PSObject.Properties.Name -contains 'mcp_auto_provision_attempted' -and $mcpReceipt.mcp_auto_provision_attempted)
+        receipt_path = $mcpReceiptPath
+        receipt_exists = [bool](Test-Path -LiteralPath $mcpReceiptPath)
         servers = @($mcpServers)
     }
     integration_surfaces = @($integrationSurfaces)

--- a/tests/runtime_neutral/test_bootstrap_doctor.py
+++ b/tests/runtime_neutral/test_bootstrap_doctor.py
@@ -162,6 +162,22 @@ class BootstrapDoctorTests(unittest.TestCase):
         self.assertEqual("host_native_unavailable", artifact["mcp"]["servers"][0]["status"])
         self.assertEqual("manual_actions_pending", artifact["summary"]["readiness_state"])
 
+    def test_malformed_non_dict_mcp_receipt_degrades_to_unknown_state(self) -> None:
+        (self.target_root / ".vibeskills").mkdir(parents=True, exist_ok=True)
+        (self.target_root / ".vibeskills" / "mcp-auto-provision.json").write_text("[1]\n", encoding="utf-8")
+        (self.target_root / "mcp").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp" / "servers.active.json").write_text('{"profile":"full"}\n', encoding="utf-8")
+        (self.target_root / "settings.json").write_text(
+            json.dumps({"vco": {"mcp_profile": "full"}, "env": {"VCO_INTENT_ADVICE_API_KEY": "<pending>"}}) + "\n",
+            encoding="utf-8",
+        )
+
+        artifact = self.module.evaluate(self.root, self.target_root)
+
+        self.assertEqual("unknown", artifact["install_state"])
+        self.assertFalse(artifact["mcp"]["auto_provision_attempted"])
+        self.assertEqual("manual_actions_pending", artifact["summary"]["readiness_state"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/runtime_neutral/test_bootstrap_doctor.py
+++ b/tests/runtime_neutral/test_bootstrap_doctor.py
@@ -133,6 +133,35 @@ class BootstrapDoctorTests(unittest.TestCase):
         self.assertEqual("PASS", artifact["gate_result"])
         self.assertEqual("manual_actions_pending", artifact["summary"]["readiness_state"])
 
+    def test_mcp_receipt_keeps_install_and_mcp_readiness_separate(self) -> None:
+        (self.target_root / ".vibeskills").mkdir(parents=True, exist_ok=True)
+        (self.target_root / ".vibeskills" / "mcp-auto-provision.json").write_text(
+            json.dumps(
+                {
+                    "install_state": "installed_locally",
+                    "mcp_auto_provision_attempted": True,
+                    "mcp_results": [
+                        {"name": "github", "status": "host_native_unavailable", "next_step": "Register in host UI"},
+                        {"name": "scrapling", "status": "ready", "next_step": "none"},
+                    ],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.target_root / "mcp").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp" / "servers.active.json").write_text('{"profile":"full"}\n', encoding="utf-8")
+        (self.target_root / "settings.json").write_text(
+            json.dumps({"vco": {"mcp_profile": "full"}, "env": {"VCO_INTENT_ADVICE_API_KEY": "<pending>"}}) + "\n",
+            encoding="utf-8",
+        )
+
+        artifact = self.module.evaluate(self.root, self.target_root)
+        self.assertEqual("installed_locally", artifact["install_state"])
+        self.assertTrue(artifact["mcp"]["auto_provision_attempted"])
+        self.assertEqual("host_native_unavailable", artifact["mcp"]["servers"][0]["status"])
+        self.assertEqual("manual_actions_pending", artifact["summary"]["readiness_state"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/runtime_neutral/test_install_prompt_mcp_contract.py
+++ b/tests/runtime_neutral/test_install_prompt_mcp_contract.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROMPT_FILES = [
+    REPO_ROOT / "docs" / "install" / "prompts" / "full-version-install.md",
+    REPO_ROOT / "docs" / "install" / "prompts" / "full-version-install.en.md",
+    REPO_ROOT / "docs" / "install" / "prompts" / "framework-only-install.md",
+    REPO_ROOT / "docs" / "install" / "prompts" / "framework-only-install.en.md",
+    REPO_ROOT / "docs" / "install" / "prompts" / "full-version-update.md",
+    REPO_ROOT / "docs" / "install" / "prompts" / "full-version-update.en.md",
+    REPO_ROOT / "docs" / "install" / "prompts" / "framework-only-update.md",
+    REPO_ROOT / "docs" / "install" / "prompts" / "framework-only-update.en.md",
+]
+SUPPORTING_DOCS = [
+    REPO_ROOT / "docs" / "install" / "recommended-full-path.md",
+    REPO_ROOT / "docs" / "install" / "recommended-full-path.en.md",
+    REPO_ROOT / "docs" / "one-shot-setup.md",
+]
+
+
+class InstallPromptMcpContractTests(unittest.TestCase):
+    def test_all_prompt_docs_require_the_same_five_mcp_surfaces(self) -> None:
+        for path in PROMPT_FILES:
+            text = path.read_text(encoding="utf-8-sig")
+            lowered = text.lower()
+            for server_name in ("github", "context7", "serena", "scrapling", "claude-flow"):
+                self.assertIn(server_name, text, path.name)
+            self.assertTrue(
+                "final install report" in lowered or "最终安装汇报" in text or "最终安装报告" in text,
+                path.name,
+            )
+            self.assertTrue(
+                "installed locally" in lowered or "本地安装完成" in text,
+                path.name,
+            )
+            self.assertIn("online-ready", lowered, path.name)
+
+    def test_supporting_install_docs_describe_non_blocking_mcp_attempts(self) -> None:
+        for path in SUPPORTING_DOCS:
+            text = path.read_text(encoding="utf-8-sig")
+            lowered = text.lower()
+            self.assertIn("scrapling", text, path.name)
+            self.assertIn("claude-flow", text, path.name)
+            self.assertTrue("manual follow-up" in lowered or "手动处理" in text, path.name)
+            self.assertIn("online-ready", lowered, path.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime_neutral/test_mcp_auto_provision.py
+++ b/tests/runtime_neutral/test_mcp_auto_provision.py
@@ -84,6 +84,100 @@ class McpAutoProvisionContractTests(unittest.TestCase):
         self.assertEqual("attempt_failed", self.module.lookup_server(report, "scrapling")["status"])
         self.assertEqual("final_report_only", self.module.lookup_server(report, "scrapling")["disclosure_mode"])
 
+    def test_scripted_cli_probe_marks_existing_tool_ready(self) -> None:
+        self.module = load_provision_module()
+        executor = self.module.ProvisionExecutor()
+        original_which = self.module.shutil.which
+        self.addCleanup(setattr, self.module.shutil, "which", original_which)
+        self.module.shutil.which = lambda name: f"/mock/bin/{name}" if name == "scrapling" else None
+
+        result = executor.attempt(
+            strategy="scripted_cli",
+            server_name="scrapling",
+            contract={"verify_path": "command_present"},
+            repo_root=REPO_ROOT,
+            target_root=self.target_root,
+            host_id="cursor",
+            allow_scripted_install=True,
+        )
+
+        self.assertEqual("ready", result.status)
+
+    def test_not_attempted_status_marks_attempted_false(self) -> None:
+        self.module = load_provision_module()
+        original_which = self.module.shutil.which
+        self.addCleanup(setattr, self.module.shutil, "which", original_which)
+        self.module.shutil.which = lambda _name: None
+        report = self.module.provision_required_mcp(
+            repo_root=REPO_ROOT,
+            target_root=self.target_root,
+            host_id="cursor",
+            profile="full",
+            allow_scripted_install=False,
+        )
+
+        self.assertFalse(self.module.lookup_server(report, "scrapling")["attempted"])
+        self.assertEqual(
+            "not_attempted_due_to_host_contract",
+            self.module.lookup_server(report, "scrapling")["status"],
+        )
+
+    def test_incomplete_registry_contract_degrades_to_warning_receipt(self) -> None:
+        self.module = load_provision_module()
+        original_load_registry = self.module.load_registry
+        self.addCleanup(setattr, self.module, "load_registry", original_load_registry)
+        self.module.load_registry = lambda _repo_root: {
+            "required_servers": ["github"],
+            "hosts": {
+                "cursor": {
+                    "attempt_order": ["github"],
+                    "servers": {},
+                }
+            },
+        }
+
+        report = self.module.provision_required_mcp(
+            repo_root=REPO_ROOT,
+            target_root=self.target_root,
+            host_id="cursor",
+            profile="full",
+            allow_scripted_install=True,
+        )
+
+        github = self.module.lookup_server(report, "github")
+        self.assertEqual("attempt_failed", github["status"])
+        self.assertIn("registry", str(github["failure_reason"]))
+
+    def test_receipt_write_failure_does_not_abort_report_generation(self) -> None:
+        self.module = load_provision_module()
+        original_write_receipt = self.module.write_receipt
+        self.addCleanup(setattr, self.module, "write_receipt", original_write_receipt)
+
+        def fail_write_receipt(target_root: Path, receipt: dict[str, object]) -> Path:
+            raise OSError("disk full")
+
+        self.module.write_receipt = fail_write_receipt
+
+        report = self.module.provision_required_mcp(
+            repo_root=REPO_ROOT,
+            target_root=self.target_root,
+            host_id="cursor",
+            profile="full",
+            allow_scripted_install=True,
+            executor=self.module.FakeExecutor(
+                results={
+                    ("host_native", "github"): self.module.ProvisionResult(status="ready"),
+                    ("host_native", "context7"): self.module.ProvisionResult(status="ready"),
+                    ("host_native", "serena"): self.module.ProvisionResult(status="ready"),
+                    ("scripted_cli", "scrapling"): self.module.ProvisionResult(status="ready"),
+                    ("scripted_cli", "claude-flow"): self.module.ProvisionResult(status="ready"),
+                }
+            ),
+        )
+
+        self.assertTrue(report["mcp_auto_provision_attempted"])
+        self.assertEqual("ready", self.module.lookup_server(report, "scrapling")["status"])
+
     def test_install_completion_report_summarizes_mcp_follow_up_once(self) -> None:
         output_module = importlib.import_module("vgo_cli.output")
         report = {

--- a/tests/runtime_neutral/test_mcp_auto_provision.py
+++ b/tests/runtime_neutral/test_mcp_auto_provision.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_PATH = REPO_ROOT / "config" / "mcp-auto-provision.registry.json"
+CLI_SRC = REPO_ROOT / "apps" / "vgo-cli" / "src"
+
+if str(CLI_SRC) not in sys.path:
+    sys.path.insert(0, str(CLI_SRC))
+
+
+def load_provision_module():
+    return importlib.import_module("vgo_cli.mcp_provision")
+
+
+class McpAutoProvisionContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.target_root = Path(self.tempdir.name) / "target-root"
+        self.target_root.mkdir(parents=True, exist_ok=True)
+        self.module = None
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_registry_declares_required_surfaces_for_all_public_hosts(self) -> None:
+        registry = json.loads(REGISTRY_PATH.read_text(encoding="utf-8-sig"))
+        self.assertEqual(
+            ["github", "context7", "serena", "scrapling", "claude-flow"],
+            registry["required_servers"],
+        )
+        self.assertEqual(
+            ["claude-code", "codex", "cursor", "openclaw", "opencode", "windsurf"],
+            sorted(registry["hosts"].keys()),
+        )
+
+    def test_registry_declares_status_vocabulary_approved_in_spec(self) -> None:
+        registry = json.loads(REGISTRY_PATH.read_text(encoding="utf-8-sig"))
+        self.assertEqual(
+            [
+                "ready",
+                "attempt_failed",
+                "host_native_unavailable",
+                "missing_credentials",
+                "verification_failed",
+                "not_attempted_due_to_host_contract",
+            ],
+            registry["allowed_statuses"],
+        )
+
+    def test_attempt_failures_are_captured_without_blocking_install(self) -> None:
+        self.module = load_provision_module()
+        report = self.module.provision_required_mcp(
+            repo_root=REPO_ROOT,
+            target_root=self.target_root,
+            host_id="cursor",
+            profile="full",
+            allow_scripted_install=True,
+            executor=self.module.FakeExecutor(
+                results={
+                    ("host_native", "github"): self.module.ProvisionResult(status="host_native_unavailable"),
+                    ("host_native", "context7"): self.module.ProvisionResult(status="ready"),
+                    ("host_native", "serena"): self.module.ProvisionResult(status="ready"),
+                    ("scripted_cli", "scrapling"): self.module.ProvisionResult(
+                        status="attempt_failed",
+                        failure_reason="pip missing",
+                    ),
+                    ("scripted_cli", "claude-flow"): self.module.ProvisionResult(status="ready"),
+                }
+            ),
+        )
+        self.assertTrue(report["mcp_auto_provision_attempted"])
+        self.assertEqual("installed_locally", report["install_state"])
+        self.assertEqual("host_native_unavailable", self.module.lookup_server(report, "github")["status"])
+        self.assertEqual("attempt_failed", self.module.lookup_server(report, "scrapling")["status"])
+        self.assertEqual("final_report_only", self.module.lookup_server(report, "scrapling")["disclosure_mode"])
+
+    def test_install_completion_report_summarizes_mcp_follow_up_once(self) -> None:
+        output_module = importlib.import_module("vgo_cli.output")
+        report = {
+            "install_state": "installed_locally",
+            "mcp_auto_provision_attempted": True,
+            "mcp_results": [
+                {
+                    "name": "github",
+                    "status": "host_native_unavailable",
+                    "provision_path": "host_native",
+                    "next_step": "Register in host UI.",
+                },
+                {
+                    "name": "scrapling",
+                    "status": "attempt_failed",
+                    "provision_path": "scripted_cli",
+                    "next_step": "Install scrapling CLI.",
+                },
+            ],
+        }
+        with io.StringIO() as buffer, redirect_stdout(buffer):
+            output_module.print_install_completion_report(
+                frontend="shell",
+                host_id="cursor",
+                profile="full",
+                target_root=self.target_root,
+                install_receipt={"profile": "full"},
+                mcp_receipt=report,
+            )
+            rendered = buffer.getvalue()
+
+        self.assertIn("MCP auto-provision summary", rendered)
+        self.assertIn("manual_follow_up", rendered)
+        self.assertNotIn("[WARN] github", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime_neutral/test_shell_entrypoint_compatibility.py
+++ b/tests/runtime_neutral/test_shell_entrypoint_compatibility.py
@@ -40,6 +40,11 @@ class ShellEntrypointCompatibilityTests(unittest.TestCase):
             self.assertIn("PYTHON_MIN_MINOR=10", content, relpath)
             self.assertIn("scripts/common/python_helpers.sh", content, relpath)
 
+    def test_one_shot_wrappers_reference_final_mcp_report(self) -> None:
+        for relpath in ("scripts/bootstrap/one-shot-setup.sh", "scripts/bootstrap/one-shot-setup.ps1"):
+            content = (REPO_ROOT / relpath).read_text(encoding="utf-8")
+            self.assertIn("MCP auto-provision summary", content)
+
     def test_check_sh_rejects_python_below_floor_before_helper_dispatch(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             bin_dir = Path(tempdir)

--- a/tests/unit/test_installer_ledger_service.py
+++ b/tests/unit/test_installer_ledger_service.py
@@ -9,7 +9,12 @@ for src in (CONTRACTS_SRC, INSTALLER_SRC):
         sys.path.insert(0, str(src))
 
 from vgo_installer.install_plan import build_install_plan
-from vgo_installer.ledger_service import MaterializationLedgerState, build_install_ledger, sanitize_managed_skill_names
+from vgo_installer.ledger_service import (
+    MaterializationLedgerState,
+    build_install_ledger,
+    build_payload_summary,
+    sanitize_managed_skill_names,
+)
 
 
 def test_sanitize_managed_skill_names_rejects_traversal() -> None:
@@ -102,6 +107,64 @@ def test_build_install_ledger_v2_ownership_keys_when_available(tmp_path) -> None
     for key in ('runtime_roots', 'compatibility_roots', 'sidecar_roots', 'legacy_cleanup_candidates'):
         assert isinstance(ledger[key], list)
     assert isinstance(ledger['config_rollbacks'], list)
+
+
+def test_payload_summary_counts_install_ledger_file_when_present(tmp_path) -> None:
+    vibe_root = tmp_path / 'skills' / 'vibe'
+    vibe_root.mkdir(parents=True)
+    (vibe_root / 'SKILL.md').write_text('# vibe\n', encoding='utf-8')
+
+    plan = build_install_plan(
+        profile='minimal',
+        host_id='codex',
+        target_root=tmp_path,
+        managed_skill_names=['vibe'],
+    )
+    state = MaterializationLedgerState(
+        created_paths={tmp_path},
+    )
+
+    ledger = build_install_ledger(
+        plan=plan,
+        state=state,
+        timestamp='2026-04-07T00:00:00Z',
+    )
+    ledger_path = tmp_path / '.vibeskills' / 'install-ledger.json'
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    ledger_path.write_text('{}\n', encoding='utf-8')
+
+    refreshed = build_payload_summary(tmp_path, ledger)
+
+    assert refreshed['installed_file_count'] == 2
+
+
+def test_payload_summary_counts_mcp_receipt_when_present(tmp_path) -> None:
+    vibe_root = tmp_path / 'skills' / 'vibe'
+    vibe_root.mkdir(parents=True)
+    (vibe_root / 'SKILL.md').write_text('# vibe\n', encoding='utf-8')
+
+    plan = build_install_plan(
+        profile='minimal',
+        host_id='codex',
+        target_root=tmp_path,
+        managed_skill_names=['vibe'],
+    )
+    state = MaterializationLedgerState(
+        created_paths={tmp_path},
+    )
+
+    ledger = build_install_ledger(
+        plan=plan,
+        state=state,
+        timestamp='2026-04-07T00:00:00Z',
+    )
+    sidecar_root = tmp_path / '.vibeskills'
+    sidecar_root.mkdir(parents=True, exist_ok=True)
+    (sidecar_root / 'mcp-auto-provision.json').write_text('{}\n', encoding='utf-8')
+
+    refreshed = build_payload_summary(tmp_path, ledger)
+
+    assert refreshed['installed_file_count'] == 2
 
 
 def test_sanitize_managed_skill_names_stays_safe_with_v2_owned_root_like_values() -> None:

--- a/tests/unit/test_vgo_cli_commands.py
+++ b/tests/unit/test_vgo_cli_commands.py
@@ -13,7 +13,7 @@ CLI_SRC = REPO_ROOT / 'apps' / 'vgo-cli' / 'src'
 if str(CLI_SRC) not in sys.path:
     sys.path.insert(0, str(CLI_SRC))
 
-from vgo_cli.commands import route_command, runtime_command, verify_command
+from vgo_cli.commands import install_command, route_command, runtime_command, verify_command
 from vgo_cli.errors import CliError
 from vgo_cli.output import parse_json_output, print_install_completion_hint, print_json_payload
 
@@ -161,3 +161,83 @@ def test_runtime_command_uses_runtime_contract_for_powershell_dispatch(monkeypat
     assert recorded['shell_script'] == 'check.sh'
     assert recorded['powershell_script'] == 'scripts/runtime/custom-runtime-entrypoint.ps1'
     assert recorded['rest'] == ['--task', 'smoke']
+
+
+def test_install_command_skips_external_dependency_install_when_strict_offline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import vgo_cli.commands as cli_commands
+
+    recorded: dict[str, object] = {}
+
+    def fake_normalize_host_id(host: str) -> str:
+        return host
+
+    def fake_resolve_target_root(host_id: str, target_root: str | None) -> Path:
+        recorded['resolved_host'] = host_id
+        return Path(target_root or tmp_path / 'target').resolve()
+
+    def fake_assert_target_root_matches_host_intent(target_root: Path, host_id: str) -> None:
+        recorded['intent_checked'] = (target_root, host_id)
+
+    def fake_install_mode_for_host(host_id: str) -> str:
+        return 'preview-guidance'
+
+    def fake_run_installer_core(repo_root: Path, argv: list[str]) -> subprocess.CompletedProcess[str]:
+        recorded['installer_repo_root'] = repo_root
+        recorded['installer_argv'] = list(argv)
+        return subprocess.CompletedProcess(
+            args=list(argv),
+            returncode=0,
+            stdout='{"install_mode":"preview-guidance","external_fallback_used":[]}\n',
+            stderr='',
+        )
+
+    def fake_reconcile_install_postconditions(
+        repo_root: Path,
+        target_root: Path,
+        host_id: str,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        recorded['reconcile'] = {
+            'repo_root': repo_root,
+            'target_root': target_root,
+            'host_id': host_id,
+            **kwargs,
+        }
+        return {'install_receipt': {}, 'mcp_receipt': {}}
+
+    def fake_maybe_install_external_dependencies(repo_root: Path, install_mode: str, *, strict_offline: bool = False) -> None:
+        recorded['external_called'] = {
+            'repo_root': repo_root,
+            'install_mode': install_mode,
+            'strict_offline': strict_offline,
+        }
+
+    monkeypatch.setattr(cli_commands, 'normalize_host_id', fake_normalize_host_id)
+    monkeypatch.setattr(cli_commands, 'resolve_target_root', fake_resolve_target_root)
+    monkeypatch.setattr(cli_commands, 'assert_target_root_matches_host_intent', fake_assert_target_root_matches_host_intent)
+    monkeypatch.setattr(cli_commands, 'install_mode_for_host', fake_install_mode_for_host)
+    monkeypatch.setattr(cli_commands, 'run_installer_core', fake_run_installer_core)
+    monkeypatch.setattr(cli_commands, 'reconcile_install_postconditions', fake_reconcile_install_postconditions)
+    monkeypatch.setattr(cli_commands, 'maybe_install_external_dependencies', fake_maybe_install_external_dependencies)
+    monkeypatch.setattr(cli_commands, 'print_install_banner', lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli_commands, 'print_install_completion_hint', lambda *args, **kwargs: None)
+
+    args = argparse.Namespace(
+        repo_root=str(tmp_path),
+        host='cursor',
+        target_root=str(tmp_path / 'target'),
+        profile='full',
+        require_closed_ready=False,
+        allow_external_skill_fallback=False,
+        install_external=True,
+        strict_offline=True,
+        skip_runtime_freshness_gate=False,
+        frontend='shell',
+    )
+
+    assert install_command(args) == 0
+    assert 'external_called' not in recorded
+    assert recorded['reconcile']['strict_offline'] is True


### PR DESCRIPTION
## Summary
- add a shared cross-host MCP auto-provision registry and receipt flow
- wire install and one-shot flows to final-report MCP summaries
- align bootstrap doctor and install docs with the new readiness contract

## Test Plan
- `python3 -m pytest tests/runtime_neutral/test_mcp_auto_provision.py tests/runtime_neutral/test_install_prompt_mcp_contract.py tests/runtime_neutral/test_bootstrap_doctor.py tests/runtime_neutral/test_shell_entrypoint_compatibility.py tests/unit/test_vgo_cli_commands.py tests/integration/test_cli_main_infra_separation.py -v`
- `bash -n install.sh`
- `bash -n check.sh`
- `bash -n scripts/bootstrap/one-shot-setup.sh`
- `bash ./install.sh --host codex --profile full --target-root <tmp>/.codex --skip-runtime-freshness-gate`
- `bash ./scripts/bootstrap/one-shot-setup.sh --host codex --profile full --target-root <tmp>/.codex --skip-external-install`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP auto‑provisioning runs as an install postcondition for five integrations; install completion now includes a consolidated MCP auto‑provision summary and a persisted MCP receipt.

* **Behavior Changes**
  * MCP attempts are non‑blocking; failures are aggregated and shown only in the final summary.
  * External dependency installs respect strict‑offline gating; completion report emission can be suppressed by wrappers/env.

* **Documentation**
  * Install prompts and guides updated to require and describe MCP attempts, ordering, and final‑report semantics.

* **Tests**
  * Added tests for the MCP contract, orchestration, reporting, receipt handling, payload summary, and wrapper compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->