### PR TITLE
Tighten host and MCP readiness reporting

### DIFF
--- a/apps/vgo-cli/src/vgo_cli/installer_bridge.py
+++ b/apps/vgo-cli/src/vgo_cli/installer_bridge.py
@@ -9,9 +9,11 @@ from .workspace import extend_workspace_package_path
 def refresh_install_ledger_payload(repo_root: Path, target_root: Path) -> dict[str, object]:
     extend_workspace_package_path(repo_root)
     from vgo_installer.ledger_service import refresh_install_ledger
+    from vgo_verify.bootstrap_doctor_runtime import collect_host_runtime
 
     try:
         payload = refresh_install_ledger(target_root)
     except SystemExit as exc:
         raise CliError(str(exc)) from exc
+    payload['host_runtime'] = collect_host_runtime(target_root)
     return payload

--- a/apps/vgo-cli/src/vgo_cli/mcp_provision.py
+++ b/apps/vgo-cli/src/vgo_cli/mcp_provision.py
@@ -23,6 +23,45 @@ SCRIPTED_SERVER_INSTALLS = {
 }
 
 
+def load_active_servers(target_root: Path) -> dict[str, dict[str, Any]]:
+    active_path = target_root / "mcp" / "servers.active.json"
+    if not active_path.exists():
+        return {}
+    try:
+        payload = json.loads(active_path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    servers = payload.get("servers")
+    if not isinstance(servers, dict):
+        return {}
+    return {
+        str(name): dict(config)
+        for name, config in servers.items()
+        if isinstance(config, dict)
+    }
+
+
+def scripted_server_host_visible(target_root: Path, server_name: str) -> bool:
+    return server_name in load_active_servers(target_root)
+
+
+def upgrade_result_with_active_surface(
+    *,
+    target_root: Path,
+    server_name: str,
+    provision_path: str,
+    result: ProvisionResult,
+) -> ProvisionResult:
+    if provision_path != "scripted_cli" or result.status != "local_tool_present":
+        return result
+    if not scripted_server_host_visible(target_root, server_name):
+        return result
+    command_name = SCRIPTED_SERVER_COMMANDS.get(server_name)
+    if command_name and shutil.which(command_name):
+        return ProvisionResult(status="ready", next_step="none")
+    return result
+
+
 @dataclass(frozen=True)
 class ProvisionResult:
     status: str
@@ -49,9 +88,14 @@ class ProvisionExecutor:
             )
         command_name = SCRIPTED_SERVER_COMMANDS.get(server_name)
         if command_name and shutil.which(command_name):
-            return ProvisionResult(
-                status="ready",
-                next_step="none",
+            return upgrade_result_with_active_surface(
+                target_root=target_root,
+                server_name=server_name,
+                provision_path=strategy,
+                result=ProvisionResult(
+                status="local_tool_present",
+                next_step=f"Register {server_name} in the host active MCP surface for {host_id}.",
+                ),
             )
         if not allow_scripted_install:
             return ProvisionResult(
@@ -82,9 +126,14 @@ class ProvisionExecutor:
                 next_step=f"Review the {runner} install output and install {server_name} manually if needed.",
             )
         if command_name and shutil.which(command_name):
-            return ProvisionResult(
-                status="ready",
-                next_step="none",
+            return upgrade_result_with_active_surface(
+                target_root=target_root,
+                server_name=server_name,
+                provision_path=strategy,
+                result=ProvisionResult(
+                status="local_tool_present",
+                next_step=f"Register {server_name} in the host active MCP surface for {host_id}.",
+                ),
             )
         return ProvisionResult(
             status="verification_failed",
@@ -193,6 +242,12 @@ def attempt_server(
         target_root=target_root,
         host_id=host_id,
         allow_scripted_install=allow_scripted_install,
+    )
+    result = upgrade_result_with_active_surface(
+        target_root=target_root,
+        server_name=server_name,
+        provision_path=strategy,
+        result=result,
     )
     return {
         "name": server_name,

--- a/apps/vgo-cli/src/vgo_cli/output.py
+++ b/apps/vgo-cli/src/vgo_cli/output.py
@@ -41,12 +41,17 @@ def print_install_completion_report(
     mcp_receipt: dict[str, object],
 ) -> None:
     follow_up = manual_follow_up_servers(mcp_receipt)
+    host_runtime = install_receipt.get('host_runtime') if isinstance(install_receipt, dict) else {}
+    vibe_host_ready = 'unknown'
+    if isinstance(host_runtime, dict) and 'vibe_host_ready' in host_runtime:
+        vibe_host_ready = bool(host_runtime.get('vibe_host_ready'))
     print('')
     print('MCP auto-provision summary')
     print(f'- host: {host_id}')
     print(f'- profile: {profile}')
     print(f'- target_root: {target_root}')
     print(f'- installed_locally: {mcp_receipt.get("install_state") == "installed_locally"}')
+    print(f'- vibe_host_ready: {vibe_host_ready}')
     print(f'- mcp_auto_provision_attempted: {bool(mcp_receipt.get("mcp_auto_provision_attempted"))}')
     print('- completed_parts: runtime payload installed; post-install gates reconciled; MCP outcomes summarized once at completion')
     for item in mcp_receipt.get('mcp_results') or []:

--- a/apps/vgo-cli/src/vgo_cli/workspace.py
+++ b/apps/vgo-cli/src/vgo_cli/workspace.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 
 def extend_workspace_package_path(repo_root: Path) -> None:
-    for rel in ('packages/contracts/src', 'packages/installer-core/src', 'packages/runtime-core/src'):
+    for rel in (
+        'packages/contracts/src',
+        'packages/installer-core/src',
+        'packages/runtime-core/src',
+        'packages/verification-core/src',
+    ):
         src = repo_root / rel
         if src.is_dir() and str(src) not in sys.path:
             sys.path.insert(0, str(src))

--- a/config/mcp-auto-provision.registry.json
+++ b/config/mcp-auto-provision.registry.json
@@ -9,6 +9,7 @@
   ],
   "allowed_statuses": [
     "ready",
+    "local_tool_present",
     "attempt_failed",
     "host_native_unavailable",
     "missing_credentials",

--- a/docs/plans/2026-04-07-codex-host-ready-and-mcp-truth-separation-execution-plan.md
+++ b/docs/plans/2026-04-07-codex-host-ready-and-mcp-truth-separation-execution-plan.md
@@ -1,0 +1,208 @@
+# Codex Host-Ready And MCP Truth Separation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make install and check surfaces report `$vibe` host readiness separately from MCP readiness, using real Codex host-active surfaces instead of payload-only or PATH-only signals.
+
+**Architecture:** Introduce a single truth model for install/check/bootstrap reporting with two independent axes: base governed runtime host readiness and per-MCP host visibility. Codex-specific host-ready detection should be grounded in `~/.codex` active surfaces, while MCP status should distinguish host registration, host-native pending, local CLI presence, and online readiness without collapsing them into one `ready` bit.
+
+**Tech Stack:** Python installer/reporting code, JSON receipts, Codex host materialization logic, pytest runtime-neutral and unit tests.
+
+---
+
+### Task 1: Freeze the new readiness vocabulary in tests
+
+**Files:**
+- Modify: `tests/runtime_neutral/test_mcp_auto_provision.py`
+- Modify: `tests/runtime_neutral/test_bootstrap_doctor.py`
+- Modify: `tests/unit/test_vgo_cli_commands.py`
+- Modify: `tests/runtime_neutral/test_installed_runtime_scripts.py`
+
+- [ ] **Step 1: Write failing tests for split reporting**
+
+Add assertions that install reporting distinguishes:
+- `installed_locally`
+- `vibe_host_ready`
+- per-MCP readiness
+- `online_ready`
+
+Include a Codex case where local payload exists but host-active-surface evidence is insufficient, and assert that overall wording cannot collapse to generic install-complete language.
+
+- [ ] **Step 2: Run the targeted tests to verify RED**
+
+Run:
+
+```bash
+python3 -m pytest \
+  tests/runtime_neutral/test_mcp_auto_provision.py \
+  tests/runtime_neutral/test_bootstrap_doctor.py \
+  tests/unit/test_vgo_cli_commands.py \
+  tests/runtime_neutral/test_installed_runtime_scripts.py -q
+```
+
+Expected:
+- at least one failure proving the current implementation still treats PATH-only or payload-only signals as sufficient
+
+- [ ] **Step 3: Add fixture coverage for Codex host-active-surface validation**
+
+Model:
+- a real-host-ready Codex target with discoverable `skills/vibe`, `commands`, closure, and active MCP/profile surfaces
+- a payload-only target where receipts exist but host-active-surface evidence is incomplete
+
+### Task 2: Add a Codex host-ready evaluator for `$vibe`
+
+**Files:**
+- Modify: `packages/installer-core/src/vgo_installer/host_closure.py`
+- Modify: `apps/vgo-cli/src/vgo_cli/install_support.py`
+- Modify: `apps/vgo-cli/src/vgo_cli/commands.py`
+- Add or modify: shared helper module near the existing install/report support if needed
+
+- [ ] **Step 1: Write the failing tests for host-ready evaluation**
+
+Encode the rule that `vibe_host_ready=true` for `codex` requires host-visible evidence from the real target root, not just installer receipts or file parity.
+
+- [ ] **Step 2: Run the relevant tests and confirm failure**
+
+Run:
+
+```bash
+python3 -m pytest \
+  tests/runtime_neutral/test_installed_runtime_scripts.py \
+  tests/unit/test_vgo_cli_commands.py -q
+```
+
+Expected:
+- failure proving the current closure/install pipeline cannot yet compute the stricter host-ready state
+
+- [ ] **Step 3: Implement a host-ready evaluator**
+
+The evaluator should:
+- read the normalized host id and target root
+- for `codex`, validate the active skill/command/runtime surfaces used by the real host
+- emit a structured result that downstream reporters can consume
+- avoid conflating specialist wrapper readiness with `$vibe` host readiness
+
+### Task 3: Replace PATH-only MCP `ready` with host-visible MCP readiness states
+
+**Files:**
+- Modify: `apps/vgo-cli/src/vgo_cli/mcp_provision.py`
+- Modify: `apps/vgo-cli/src/vgo_cli/output.py`
+- Modify: `packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py`
+- Modify: `packages/installer-core/src/vgo_installer/materializer.py`
+- Modify: `packages/installer-core/src/vgo_installer/ledger_service.py` if receipt ownership changes
+
+- [ ] **Step 1: Write failing tests for MCP truth separation**
+
+Add cases where:
+- `scrapling` exists on PATH but is not yet host-visible in the relevant active surface
+- `claude-flow` exists on PATH but still requires host registration/activation semantics
+- `github`, `context7`, or `serena` remain pending because host-native registration is unavailable
+
+Require the receipt and doctor/report output to distinguish "tool present" from "host ready".
+
+- [ ] **Step 2: Run the targeted MCP tests and verify RED**
+
+Run:
+
+```bash
+python3 -m pytest \
+  tests/runtime_neutral/test_mcp_auto_provision.py \
+  tests/runtime_neutral/test_bootstrap_doctor.py -q
+```
+
+Expected:
+- failures showing the current `ready` meaning is too broad
+
+- [ ] **Step 3: Implement a stricter MCP state model**
+
+Adjust receipt generation so statuses communicate host truth, for example by separating:
+- host-native pending
+- host-visible ready
+- local tool present but not host-registered
+- attempt failed
+- not attempted
+
+### Task 4: Verify the end-to-end install/check language against a real Codex target
+
+**Files:**
+- Modify as needed based on failing verification
+- Test/verify against: real or simulated Codex target fixtures
+
+- [ ] **Step 1: Run the full targeted verification matrix**
+
+Run:
+
+```bash
+python3 -m pytest \
+  tests/runtime_neutral/test_mcp_auto_provision.py \
+  tests/runtime_neutral/test_bootstrap_doctor.py \
+  tests/unit/test_vgo_cli_commands.py \
+  tests/unit/test_installer_ledger_service.py \
+  tests/runtime_neutral/test_installed_runtime_scripts.py -q
+```
+
+Expected:
+- all tests pass
+
+- [ ] **Step 2: Perform a real-host manual spot check**
+
+On a real Codex root, verify:
+- `$vibe` host-ready is only reported when the active host surface is complete
+- partial MCP state is rendered as partial MCP state
+- no overall wording implies "everything installed" when MCPs still need host follow-up
+
+## Ownership Boundaries
+
+- Install/report pipeline:
+  - `apps/vgo-cli/src/vgo_cli/commands.py`
+  - `apps/vgo-cli/src/vgo_cli/install_support.py`
+  - `apps/vgo-cli/src/vgo_cli/output.py`
+  - `apps/vgo-cli/src/vgo_cli/mcp_provision.py`
+- Host truth surfaces:
+  - `packages/installer-core/src/vgo_installer/host_closure.py`
+  - `packages/installer-core/src/vgo_installer/materializer.py`
+  - `packages/installer-core/src/vgo_installer/ledger_service.py`
+- Verification:
+  - `packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py`
+  - `tests/runtime_neutral/test_mcp_auto_provision.py`
+  - `tests/runtime_neutral/test_bootstrap_doctor.py`
+  - `tests/runtime_neutral/test_installed_runtime_scripts.py`
+  - `tests/unit/test_vgo_cli_commands.py`
+  - `tests/unit/test_installer_ledger_service.py`
+
+## Verification Commands
+
+```bash
+python3 -m pytest \
+  tests/runtime_neutral/test_mcp_auto_provision.py \
+  tests/runtime_neutral/test_bootstrap_doctor.py \
+  tests/unit/test_vgo_cli_commands.py \
+  tests/unit/test_installer_ledger_service.py \
+  tests/runtime_neutral/test_installed_runtime_scripts.py -q
+```
+
+## Delivery Acceptance Plan
+
+- Accept only if the targeted test suite passes.
+- Accept only if `codex` install reporting can separately answer:
+  - is the runtime installed locally?
+  - is `$vibe` host-ready?
+  - which MCPs are actually host-ready?
+  - which MCPs still require follow-up?
+- Accept only if no install/check surface uses wording that suggests full MCP installation when only local CLIs were installed.
+
+## Completion Language Rules
+
+- Do not say "安装完成" without immediately specifying whether that means local payload only or `$vibe` host-ready.
+- Do not say an MCP is ready unless the host-active-surface evidence supports it.
+- Report remaining manual follow-up as a separate section, not as a footnote hidden behind success language.
+
+## Rollback Rules
+
+- If the stricter truth model breaks unrelated host flows, stop and isolate whether the failure is in shared reporting vocabulary or host-specific surface detection.
+- Roll back only the new truth-model code paths, not unrelated install/freshness/runtime changes already present in the worktree.
+
+## Phase Cleanup Expectations
+
+- Leave behind the requirement doc, the execution plan, updated receipts/tests/code, and explicit verification evidence.
+- Do not delete or rewrite unrelated planning docs or dirty worktree files.

--- a/docs/requirements/2026-04-07-codex-host-ready-and-mcp-truth-separation.md
+++ b/docs/requirements/2026-04-07-codex-host-ready-and-mcp-truth-separation.md
@@ -1,0 +1,82 @@
+# Codex Host-Ready And MCP Truth Separation
+
+## Goal
+
+Make the install/check flow tell the truth about two independent outcomes:
+
+- whether `codex` can actually discover and run `$vibe` from the real host root
+- whether each required MCP surface is actually installed and visible in the host's active surface
+
+The installer must stop conflating local payload installation, CLI presence on PATH, and real host readiness.
+
+## Deliverable
+
+- A revised install/check truth model that reports `vibe host-ready` separately from per-MCP readiness.
+- Codex-specific host-active-surface verification proving whether `$vibe` is actually live in `~/.codex`.
+- Updated receipts, final reporting, and verification surfaces that never describe MCP as installed merely because a CLI exists on PATH.
+- Regression tests covering the new reporting contract and Codex host-ready validation.
+
+## Constraints
+
+- Do not revert or overwrite unrelated in-progress work.
+- Preserve the current public host list and current profile mapping behavior.
+- Do not require all MCP surfaces to succeed before allowing a truthful "`$vibe` host-ready" success result.
+- Do not claim host-native MCP registration exists when the installer only has a template, placeholder, or follow-up hint.
+- Keep `codex` anchored to the real host root `~/.codex` unless the operator explicitly chooses isolation.
+
+## Acceptance Criteria
+
+- Install completion output is split into at least these surfaces:
+  - `installed locally`
+  - `vibe host-ready`
+  - `mcp auto-provision attempted`
+  - per-MCP readiness
+  - `online-ready`
+- For `codex`, `vibe host-ready=true` is only allowed when host-visible active surfaces agree that the governed runtime is materially discoverable from the real host root.
+- For `codex`, host-ready validation must check the real host surfaces rather than only payload parity or receipt presence.
+- Scripted MCP entries such as `scrapling` and `claude-flow` are not reported as host-ready merely because their commands exist on PATH; the reported state must reflect host visibility/registration semantics.
+- Host-native MCP entries such as `github`, `context7`, and `serena` must remain clearly reported as pending when the installer cannot complete real host registration.
+- `check` and doctor-style verification surfaces must reuse the same truth model rather than silently translating states back to generic `ready`.
+- Targeted tests fail before the implementation change and pass after it.
+
+## Product Acceptance Criteria
+
+- A user who sees "本体安装完成" can trust that `$vibe` is actually discoverable and usable from the current Codex host.
+- A user who sees an MCP listed as ready can trust that it is actually visible through the host's active surface, not merely present as a local executable.
+- A user can still get a successful base installation when `$vibe` is host-ready but some MCP surfaces remain pending.
+
+## Manual Spot Checks
+
+- Inspect the real Codex host root under `~/.codex` and identify which files constitute the active runtime surface for `$vibe`.
+- Inspect the real Codex MCP active surface and compare it against receipt states for `github`, `context7`, `serena`, `scrapling`, and `claude-flow`.
+- Confirm the final install report wording distinguishes base runtime success from MCP follow-up.
+- Confirm `check` and doctor output preserve the same distinction.
+
+## Completion Language Policy
+
+- Do not use "安装完成" as a single undifferentiated claim.
+- Do not use "MCP ready" unless the state is backed by the host-visible active surface.
+- Report residual manual follow-up separately from verified host-ready runtime status.
+
+## Delivery Truth Contract
+
+- Report the exact files used to compute `vibe host-ready`.
+- Report the exact files or probes used to compute each MCP readiness state.
+- Report the exact targeted test commands used to verify the new contract.
+- If any status remains approximate or advisory, label it directly.
+
+## Non-Goals
+
+- Implementing full host-native registration for every MCP provider.
+- Redesigning unrelated install flows for hosts that do not share the same contradiction.
+- Blocking base installation on every pending MCP surface.
+
+## Autonomy Mode
+
+- Single-session governed execution with targeted verification.
+
+## Inferred Assumptions
+
+- The user wants the installer's success language fixed at the code and receipt layer, not only in assistant-facing prompts.
+- The current `codex` success criterion is "`$vibe` can be directly discovered from the real host root".
+- MCP truthfulness should be improved across shared reporting surfaces even if the immediate pain was observed in `codex`.

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
@@ -79,7 +79,10 @@ def collect_mcp_servers(profile_object: dict[str, Any], servers_template: dict[s
             next_step = "Provision the corresponding Codex plugin in the host runtime."
         elif mode == "stdio":
             command_name = str(server.get("command") or "")
-            if not command_present(command_name):
+            if command_present(command_name):
+                status = "local_tool_present"
+                next_step = "Register the stdio server in the host active MCP surface."
+            else:
                 status = "manual_action_required"
                 next_step = str(server.get("note") or f"Install command '{command_name}' and register the MCP server in the host.")
         mcp_servers.append(
@@ -109,6 +112,118 @@ def collect_mcp_servers_from_receipt(mcp_receipt: dict[str, Any] | None) -> list
             }
         )
     return servers
+
+
+def load_active_mcp_servers(active_mcp_path: Path) -> dict[str, dict[str, Any]]:
+    if not active_mcp_path.exists():
+        return {}
+    try:
+        payload = load_json(active_mcp_path)
+    except Exception:
+        return {}
+    servers = payload.get("servers") if isinstance(payload, dict) else None
+    if not isinstance(servers, dict):
+        return {}
+    return {
+        str(name): dict(config)
+        for name, config in servers.items()
+        if isinstance(config, dict)
+    }
+
+
+def reconcile_mcp_servers_with_active_surface(
+    mcp_servers: list[dict[str, Any]],
+    *,
+    active_mcp_path: Path,
+) -> list[dict[str, Any]]:
+    active_servers = load_active_mcp_servers(active_mcp_path)
+    reconciled: list[dict[str, Any]] = []
+    for server in mcp_servers:
+        next_server = dict(server)
+        name = str(next_server.get("name") or "")
+        status = str(next_server.get("status") or "")
+        active_entry = active_servers.get(name)
+        mode = str(next_server.get("mode") or "")
+        command_name = ""
+        if isinstance(active_entry, dict):
+            command_name = str(active_entry.get("command") or "")
+            if not mode or mode == "unknown":
+                mode = str(active_entry.get("mode") or mode or "unknown")
+                next_server["mode"] = mode
+        if mode == "scripted_cli":
+            mode = "stdio"
+            next_server["mode"] = mode
+        if mode == "stdio" and status == "local_tool_present" and active_entry is not None:
+            if command_name and command_present(command_name):
+                next_server["status"] = "ready"
+                next_server["next_step"] = "none"
+        reconciled.append(next_server)
+    return reconciled
+
+
+def collect_host_runtime(target_root: Path) -> dict[str, Any]:
+    runtime_skill_entry = target_root / "skills" / "vibe" / "SKILL.md"
+    commands_root = target_root / "commands"
+    host_closure_path = target_root / ".vibeskills" / "host-closure.json"
+    settings_path = target_root / "settings.json"
+    host_settings_path = target_root / ".vibeskills" / "host-settings.json"
+    settings_surface_exists = settings_path.exists() or host_settings_path.exists()
+    settings_surface_path = settings_path if settings_path.exists() else host_settings_path
+    settings_surface_kind = (
+        "settings.json"
+        if settings_path.exists()
+        else "host-settings.json"
+        if host_settings_path.exists()
+        else "missing"
+    )
+
+    host_closure_payload: dict[str, Any] = {}
+    host_closure_valid = False
+    if host_closure_path.exists():
+        try:
+            loaded = load_json(host_closure_path)
+        except Exception:
+            loaded = None
+        if isinstance(loaded, dict):
+            host_closure_payload = loaded
+            host_closure_valid = True
+
+    runtime_skill_entry_path = str(runtime_skill_entry.resolve())
+    commands_root_path = str(commands_root.resolve())
+    host_closure_runtime_matches = (
+        host_closure_valid
+        and str(host_closure_payload.get("runtime_skill_entry") or "").strip() == runtime_skill_entry_path
+    )
+    host_closure_commands_match = (
+        host_closure_valid
+        and str(host_closure_payload.get("commands_root") or "").strip() == commands_root_path
+    )
+    host_closure_commands_materialized = bool(host_closure_payload.get("commands_materialized")) if host_closure_valid else False
+    vibe_host_ready = (
+        runtime_skill_entry.exists()
+        and commands_root.exists()
+        and settings_surface_exists
+        and host_closure_valid
+        and host_closure_runtime_matches
+        and host_closure_commands_match
+        and host_closure_commands_materialized
+    )
+    return {
+        "runtime_skill_entry_path": runtime_skill_entry_path,
+        "runtime_skill_entry_exists": runtime_skill_entry.exists(),
+        "commands_root_path": commands_root_path,
+        "commands_root_exists": commands_root.exists(),
+        "host_closure_path": str(host_closure_path),
+        "host_closure_exists": host_closure_path.exists(),
+        "host_closure_valid": host_closure_valid,
+        "host_closure_runtime_matches": host_closure_runtime_matches,
+        "host_closure_commands_match": host_closure_commands_match,
+        "host_closure_commands_materialized": host_closure_commands_materialized,
+        "settings_surface_path": str(settings_surface_path),
+        "settings_surface_exists": settings_surface_exists,
+        "settings_surface_kind": settings_surface_kind,
+        "vibe_host_ready": vibe_host_ready,
+    }
 
 
 def collect_secret_surfaces(secrets_policy: dict[str, Any]) -> list[dict[str, Any]]:
@@ -285,12 +400,14 @@ def build_bootstrap_artifact(
     mcp_servers = collect_mcp_servers_from_receipt(receipt)
     if not mcp_servers:
         mcp_servers = collect_mcp_servers(profile_object, servers_template)
+    mcp_servers = reconcile_mcp_servers_with_active_surface(mcp_servers, active_mcp_path=active_mcp_path)
     install_state = str(receipt.get("install_state") or "unknown")
     auto_provision_attempted = bool(receipt.get("mcp_auto_provision_attempted"))
     secret_surfaces = collect_secret_surfaces(secrets_policy)
     secret_status_by_name = {item["name"]: item["status"] for item in secret_surfaces}
     enhancement_surfaces = collect_enhancement_surfaces(memory_governance)
     integration_surfaces = collect_integration_surfaces(tool_registry, secret_status_by_name)
+    host_runtime = collect_host_runtime(target_root)
     summary = build_summary(
         settings_path=settings_path,
         active_mcp_path=active_mcp_path,
@@ -322,6 +439,7 @@ def build_bootstrap_artifact(
             "vector_diff_model_state": summary["vector_diff_model_state"],
             "vector_diff_model_source": summary["vector_diff_model_source"],
         },
+        "host_runtime": host_runtime,
         "plugins": plugins,
         "external_tools": external_tools,
         "enhancement_surfaces": enhancement_surfaces,

--- a/scripts/bootstrap/one-shot-setup.ps1
+++ b/scripts/bootstrap/one-shot-setup.ps1
@@ -111,6 +111,7 @@ function Write-McpAutoProvisionSummary {
     )
 
     $receiptPath = Join-Path $TargetRoot '.vibeskills\mcp-auto-provision.json'
+    $activePath = Join-Path $TargetRoot 'mcp\servers.active.json'
     Write-Host 'MCP auto-provision summary'
     if (-not (Test-Path -LiteralPath $receiptPath)) {
         Write-Host '- receipt: missing' -ForegroundColor Yellow
@@ -118,14 +119,38 @@ function Write-McpAutoProvisionSummary {
     }
 
     $payload = Get-Content -LiteralPath $receiptPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $activeServers = @{}
+    if (Test-Path -LiteralPath $activePath) {
+        try {
+            $activePayload = Get-Content -LiteralPath $activePath -Raw -Encoding UTF8 | ConvertFrom-Json
+            if ($null -ne $activePayload -and $activePayload.PSObject.Properties.Name -contains 'servers' -and $null -ne $activePayload.servers) {
+                foreach ($serverProp in $activePayload.servers.PSObject.Properties) {
+                    $activeServers[[string]$serverProp.Name] = $serverProp.Value
+                }
+            }
+        } catch {
+        }
+    }
     Write-Host ("- installed_locally: {0}" -f ([string]($payload.install_state -eq 'installed_locally')).ToLowerInvariant())
     Write-Host ("- mcp_auto_provision_attempted: {0}" -f ([string][bool]$payload.mcp_auto_provision_attempted).ToLowerInvariant())
     $manualFollowUp = @()
     foreach ($item in @($payload.mcp_results)) {
         if ($null -eq $item) { continue }
-        Write-Host ("- {0}: status={1} next_step={2}" -f [string]$item.name, [string]$item.status, [string]$item.next_step)
-        if ([string]$item.status -ne 'ready') {
-            $manualFollowUp += [string]$item.name
+        $name = [string]$item.name
+        $status = [string]$item.status
+        $nextStep = [string]$item.next_step
+        if ($status -eq 'local_tool_present' -and $activeServers.ContainsKey($name)) {
+            $activeServer = $activeServers[$name]
+            $mode = if ($null -ne $activeServer -and $activeServer.PSObject.Properties.Name -contains 'mode') { [string]$activeServer.mode } else { '' }
+            $commandName = if ($null -ne $activeServer -and $activeServer.PSObject.Properties.Name -contains 'command') { [string]$activeServer.command } else { '' }
+            if ($mode -eq 'stdio' -and (Test-NonEmptyString -Value $commandName) -and (Get-Command $commandName -ErrorAction SilentlyContinue)) {
+                $status = 'ready'
+                $nextStep = 'none'
+            }
+        }
+        Write-Host ("- {0}: status={1} next_step={2}" -f $name, $status, $nextStep)
+        if ($status -ne 'ready') {
+            $manualFollowUp += $name
         }
     }
     Write-Host ("- manual_follow_up: {0}" -f $(if ($manualFollowUp.Count -gt 0) { $manualFollowUp -join ', ' } else { 'none' }))

--- a/scripts/bootstrap/one-shot-setup.sh
+++ b/scripts/bootstrap/one-shot-setup.sh
@@ -308,24 +308,41 @@ print_mcp_auto_provision_summary() {
   fi
   "${python_bin}" - "${TARGET_ROOT}" <<'PY'
 import json
+import shutil
 import sys
 from pathlib import Path
 
 target_root = Path(sys.argv[1])
 receipt_path = target_root / ".vibeskills" / "mcp-auto-provision.json"
+active_path = target_root / "mcp" / "servers.active.json"
 print("MCP auto-provision summary")
 if not receipt_path.exists():
     print("- receipt: missing")
     sys.exit(0)
 
 payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+try:
+    active_payload = json.loads(active_path.read_text(encoding="utf-8")) if active_path.exists() else {}
+except json.JSONDecodeError:
+    active_payload = {}
+active_servers = active_payload.get("servers") if isinstance(active_payload, dict) else {}
+if not isinstance(active_servers, dict):
+    active_servers = {}
 print(f"- installed_locally: {payload.get('install_state') == 'installed_locally'}")
 print(f"- mcp_auto_provision_attempted: {bool(payload.get('mcp_auto_provision_attempted'))}")
 manual_follow_up = []
 for item in payload.get("mcp_results") or []:
-    print(f"- {item.get('name')}: status={item.get('status')} next_step={item.get('next_step')}")
-    if item.get("status") != "ready":
-        manual_follow_up.append(str(item.get("name")))
+    name = str(item.get("name") or "")
+    status = str(item.get("status") or "")
+    next_step = str(item.get("next_step") or "none")
+    active_entry = active_servers.get(name)
+    if status == "local_tool_present" and isinstance(active_entry, dict):
+        if str(active_entry.get("mode") or "") == "stdio" and shutil.which(str(active_entry.get("command") or "")):
+            status = "ready"
+            next_step = "none"
+    print(f"- {name}: status={status} next_step={next_step}")
+    if status != "ready":
+        manual_follow_up.append(name)
 print(f"- manual_follow_up: {', '.join(manual_follow_up) if manual_follow_up else 'none'}")
 PY
 }

--- a/tests/runtime_neutral/test_bootstrap_doctor.py
+++ b/tests/runtime_neutral/test_bootstrap_doctor.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+import importlib
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -142,7 +143,7 @@ class BootstrapDoctorTests(unittest.TestCase):
                     "mcp_auto_provision_attempted": True,
                     "mcp_results": [
                         {"name": "github", "status": "host_native_unavailable", "next_step": "Register in host UI"},
-                        {"name": "scrapling", "status": "ready", "next_step": "none"},
+                        {"name": "scrapling", "status": "local_tool_present", "next_step": "Register in host UI"},
                     ],
                 }
             )
@@ -160,7 +161,123 @@ class BootstrapDoctorTests(unittest.TestCase):
         self.assertEqual("installed_locally", artifact["install_state"])
         self.assertTrue(artifact["mcp"]["auto_provision_attempted"])
         self.assertEqual("host_native_unavailable", artifact["mcp"]["servers"][0]["status"])
+        self.assertEqual("local_tool_present", artifact["mcp"]["servers"][1]["status"])
         self.assertEqual("manual_actions_pending", artifact["summary"]["readiness_state"])
+
+    def test_bootstrap_doctor_upgrades_stdio_server_to_ready_when_active_surface_and_command_agree(self) -> None:
+        (self.target_root / ".vibeskills").mkdir(parents=True, exist_ok=True)
+        (self.target_root / ".vibeskills" / "mcp-auto-provision.json").write_text(
+            json.dumps(
+                {
+                    "install_state": "installed_locally",
+                    "mcp_auto_provision_attempted": True,
+                    "mcp_results": [
+                        {"name": "scrapling", "status": "local_tool_present", "next_step": "Register in host UI"},
+                    ],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.target_root / "mcp").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp" / "servers.active.json").write_text(
+            json.dumps(
+                {
+                    "profile": "full",
+                    "enabled_servers": ["scrapling"],
+                    "servers": {
+                        "scrapling": {"mode": "stdio", "command": "scrapling", "args": ["mcp"]},
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.target_root / "settings.json").write_text(
+            json.dumps({"vco": {"mcp_profile": "full"}, "env": {"VCO_INTENT_ADVICE_API_KEY": "<pending>"}}) + "\n",
+            encoding="utf-8",
+        )
+
+        runtime_module = importlib.import_module("vgo_verify.bootstrap_doctor_runtime")
+        original_command_present = runtime_module.command_present
+        self.addCleanup(setattr, runtime_module, "command_present", original_command_present)
+        runtime_module.command_present = lambda name: name == "scrapling"
+
+        artifact = self.module.evaluate(self.root, self.target_root)
+
+        self.assertEqual("ready", artifact["mcp"]["servers"][0]["status"])
+
+    def test_bootstrap_doctor_reports_vibe_host_ready_separately_from_install_state(self) -> None:
+        (self.target_root / ".vibeskills").mkdir(parents=True, exist_ok=True)
+        (self.target_root / ".vibeskills" / "mcp-auto-provision.json").write_text(
+            json.dumps(
+                {
+                    "install_state": "installed_locally",
+                    "mcp_auto_provision_attempted": True,
+                    "mcp_results": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.target_root / "skills" / "vibe").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "skills" / "vibe" / "SKILL.md").write_text("---\nname: vibe\n---\n", encoding="utf-8")
+        (self.target_root / "commands").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp" / "servers.active.json").write_text('{"profile":"full"}\n', encoding="utf-8")
+        (self.target_root / "settings.json").write_text(
+            json.dumps({"vco": {"mcp_profile": "full"}, "env": {"VCO_INTENT_ADVICE_API_KEY": "<pending>"}}) + "\n",
+            encoding="utf-8",
+        )
+
+        artifact = self.module.evaluate(self.root, self.target_root)
+
+        self.assertEqual("installed_locally", artifact["install_state"])
+        self.assertIn("host_runtime", artifact)
+        self.assertFalse(artifact["host_runtime"]["vibe_host_ready"])
+
+    def test_bootstrap_doctor_reports_vibe_host_ready_when_runtime_surfaces_and_closure_agree(self) -> None:
+        (self.target_root / ".vibeskills").mkdir(parents=True, exist_ok=True)
+        (self.target_root / ".vibeskills" / "mcp-auto-provision.json").write_text(
+            json.dumps(
+                {
+                    "install_state": "installed_locally",
+                    "mcp_auto_provision_attempted": True,
+                    "mcp_results": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        runtime_skill_entry = self.target_root / "skills" / "vibe" / "SKILL.md"
+        runtime_skill_entry.parent.mkdir(parents=True, exist_ok=True)
+        runtime_skill_entry.write_text("---\nname: vibe\n---\n", encoding="utf-8")
+        commands_root = self.target_root / "commands"
+        commands_root.mkdir(parents=True, exist_ok=True)
+        (self.target_root / ".vibeskills" / "host-closure.json").write_text(
+            json.dumps(
+                {
+                    "host_id": "codex",
+                    "runtime_skill_entry": str(runtime_skill_entry.resolve()),
+                    "commands_root": str(commands_root.resolve()),
+                    "commands_materialized": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.target_root / "mcp").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp" / "servers.active.json").write_text('{"profile":"full"}\n', encoding="utf-8")
+        (self.target_root / "settings.json").write_text(
+            json.dumps({"vco": {"mcp_profile": "full"}, "env": {"VCO_INTENT_ADVICE_API_KEY": "<pending>"}}) + "\n",
+            encoding="utf-8",
+        )
+
+        artifact = self.module.evaluate(self.root, self.target_root)
+
+        self.assertTrue(artifact["host_runtime"]["vibe_host_ready"])
+        self.assertTrue(artifact["host_runtime"]["host_closure_exists"])
+        self.assertTrue(artifact["host_runtime"]["settings_surface_exists"])
 
     def test_malformed_non_dict_mcp_receipt_degrades_to_unknown_state(self) -> None:
         (self.target_root / ".vibeskills").mkdir(parents=True, exist_ok=True)

--- a/tests/runtime_neutral/test_installed_runtime_scripts.py
+++ b/tests/runtime_neutral/test_installed_runtime_scripts.py
@@ -293,6 +293,26 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         for wrapper_path in ledger["specialist_wrapper_paths"]:
             self.assertTrue(Path(wrapper_path).exists(), f"wrapper missing: {wrapper_path}")
 
+    def test_shell_install_reports_vibe_host_ready_in_completion_summary(self) -> None:
+        result = subprocess.run(
+            [
+                "bash",
+                str(REPO_ROOT / "install.sh"),
+                "--host",
+                "codex",
+                "--profile",
+                "full",
+                "--target-root",
+                str(self.target_root),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        self.assertIn("- installed_locally: True", result.stdout)
+        self.assertIn("- vibe_host_ready: True", result.stdout)
+
     def test_shell_install_materializes_vgo_cli_for_installed_wrappers(self) -> None:
         self.install_shell_runtime("codex")
 

--- a/tests/runtime_neutral/test_mcp_auto_provision.py
+++ b/tests/runtime_neutral/test_mcp_auto_provision.py
@@ -48,6 +48,7 @@ class McpAutoProvisionContractTests(unittest.TestCase):
         self.assertEqual(
             [
                 "ready",
+                "local_tool_present",
                 "attempt_failed",
                 "host_native_unavailable",
                 "missing_credentials",
@@ -84,7 +85,7 @@ class McpAutoProvisionContractTests(unittest.TestCase):
         self.assertEqual("attempt_failed", self.module.lookup_server(report, "scrapling")["status"])
         self.assertEqual("final_report_only", self.module.lookup_server(report, "scrapling")["disclosure_mode"])
 
-    def test_scripted_cli_probe_marks_existing_tool_ready(self) -> None:
+    def test_scripted_cli_probe_marks_existing_tool_as_local_only_until_host_visible(self) -> None:
         self.module = load_provision_module()
         executor = self.module.ProvisionExecutor()
         original_which = self.module.shutil.which
@@ -101,7 +102,47 @@ class McpAutoProvisionContractTests(unittest.TestCase):
             allow_scripted_install=True,
         )
 
+        self.assertEqual("local_tool_present", result.status)
+        self.assertIn("host", result.next_step.lower())
+
+    def test_scripted_cli_probe_marks_tool_ready_only_when_active_surface_contains_server(self) -> None:
+        self.module = load_provision_module()
+        executor = self.module.ProvisionExecutor()
+        original_which = self.module.shutil.which
+        self.addCleanup(setattr, self.module.shutil, "which", original_which)
+        self.module.shutil.which = lambda name: f"/mock/bin/{name}" if name == "scrapling" else None
+        active_root = self.target_root / "mcp"
+        active_root.mkdir(parents=True, exist_ok=True)
+        (active_root / "servers.active.json").write_text(
+            json.dumps(
+                {
+                    "profile": "full",
+                    "enabled_servers": ["scrapling"],
+                    "servers": {
+                        "scrapling": {
+                            "mode": "stdio",
+                            "command": "scrapling",
+                            "args": ["mcp"],
+                        }
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = executor.attempt(
+            strategy="scripted_cli",
+            server_name="scrapling",
+            contract={"verify_path": "command_present"},
+            repo_root=REPO_ROOT,
+            target_root=self.target_root,
+            host_id="cursor",
+            allow_scripted_install=True,
+        )
+
         self.assertEqual("ready", result.status)
+        self.assertEqual("none", result.next_step)
 
     def test_not_attempted_status_marks_attempted_false(self) -> None:
         self.module = load_provision_module()
@@ -178,6 +219,45 @@ class McpAutoProvisionContractTests(unittest.TestCase):
         self.assertTrue(report["mcp_auto_provision_attempted"])
         self.assertEqual("ready", self.module.lookup_server(report, "scrapling")["status"])
 
+    def test_provision_required_mcp_upgrades_stdio_server_to_ready_when_active_surface_exists(self) -> None:
+        self.module = load_provision_module()
+        active_root = self.target_root / "mcp"
+        active_root.mkdir(parents=True, exist_ok=True)
+        (active_root / "servers.active.json").write_text(
+            json.dumps(
+                {
+                    "profile": "full",
+                    "enabled_servers": ["scrapling", "claude-flow"],
+                    "servers": {
+                        "scrapling": {"mode": "stdio", "command": "scrapling", "args": ["mcp"]},
+                        "claude-flow": {"mode": "stdio", "command": "claude-flow", "args": ["mcp", "start"]},
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        report = self.module.provision_required_mcp(
+            repo_root=REPO_ROOT,
+            target_root=self.target_root,
+            host_id="cursor",
+            profile="full",
+            allow_scripted_install=True,
+            executor=self.module.FakeExecutor(
+                results={
+                    ("host_native", "github"): self.module.ProvisionResult(status="host_native_unavailable"),
+                    ("host_native", "context7"): self.module.ProvisionResult(status="host_native_unavailable"),
+                    ("host_native", "serena"): self.module.ProvisionResult(status="host_native_unavailable"),
+                    ("scripted_cli", "scrapling"): self.module.ProvisionResult(status="local_tool_present"),
+                    ("scripted_cli", "claude-flow"): self.module.ProvisionResult(status="local_tool_present"),
+                }
+            ),
+        )
+
+        self.assertEqual("ready", self.module.lookup_server(report, "scrapling")["status"])
+        self.assertEqual("ready", self.module.lookup_server(report, "claude-flow")["status"])
+
     def test_install_completion_report_summarizes_mcp_follow_up_once(self) -> None:
         output_module = importlib.import_module("vgo_cli.output")
         report = {
@@ -212,6 +292,42 @@ class McpAutoProvisionContractTests(unittest.TestCase):
         self.assertIn("MCP auto-provision summary", rendered)
         self.assertIn("manual_follow_up", rendered)
         self.assertNotIn("[WARN] github", rendered)
+
+    def test_install_completion_report_surfaces_vibe_host_ready_separately(self) -> None:
+        output_module = importlib.import_module("vgo_cli.output")
+        report = {
+            "install_state": "installed_locally",
+            "mcp_auto_provision_attempted": True,
+            "mcp_results": [
+                {
+                    "name": "github",
+                    "status": "host_native_unavailable",
+                    "provision_path": "host_native",
+                    "next_step": "Register in host UI.",
+                }
+            ],
+        }
+        install_receipt = {
+            "payload_summary": {"installed_skill_count": 1},
+            "host_runtime": {
+                "vibe_host_ready": False,
+            },
+        }
+
+        with io.StringIO() as buffer, redirect_stdout(buffer):
+            output_module.print_install_completion_report(
+                frontend="shell",
+                host_id="codex",
+                profile="full",
+                target_root=self.target_root,
+                install_receipt=install_receipt,
+                mcp_receipt=report,
+            )
+            rendered = buffer.getvalue()
+
+        self.assertIn("- installed_locally: True", rendered)
+        self.assertIn("- vibe_host_ready: False", rendered)
+        self.assertIn("- online_ready:", rendered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- separate `vibe_host_ready` from local install completion and compute it from real host runtime surfaces
- stop treating PATH-only stdio MCP tools as fully ready; require host-visible active MCP surfaces before upgrading to `ready`
- keep one-shot/bootstrap MCP summaries aligned with the same truth model

## What changed
- enrich install receipts with `host_runtime` and reuse bootstrap-doctor host-runtime detection in install reporting
- tighten Codex host-ready evaluation to require runtime entry, commands surface, settings surface, and matching `host-closure.json`
- add `local_tool_present` to the MCP readiness vocabulary and only upgrade stdio MCPs such as `scrapling` / `claude-flow` to `ready` when `mcp/servers.active.json` includes them and the command is actually available
- preserve pending/manual-follow-up semantics for host-native MCPs like `github`, `context7`, and `serena`
- update one-shot shell and PowerShell summaries so they do not lag behind materialized active MCP surfaces
- add governed requirement/plan docs and regression coverage for the split readiness contract

## Verification
```bash
python3 -m pytest tests/runtime_neutral/test_mcp_auto_provision.py tests/runtime_neutral/test_bootstrap_doctor.py tests/unit/test_vgo_cli_commands.py tests/unit/test_installer_ledger_service.py tests/runtime_neutral/test_installed_runtime_scripts.py::InstalledRuntimeScriptsTests::test_shell_install_reports_vibe_host_ready_in_completion_summary -q
```

Result: `34 passed in 2.30s`

Also checked:
- `bash -n scripts/bootstrap/one-shot-setup.sh`
- PowerShell parser validation for `scripts/bootstrap/one-shot-setup.ps1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `vibe_host_ready` indicator to installation completion reports
  * Introduced `local_tool_present` status for MCP servers with available CLI tools but not yet host-visible
  * Enhanced host readiness detection to distinguish between local availability and host visibility

* **Bug Fixes**
  * Corrected MCP stdio server readiness detection logic

* **Documentation**
  * Added specification and execution plan for host readiness separation from MCP auto-provision status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->