### PR TITLE
release: cut v3.0.0

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -290,7 +290,7 @@ The governed runtime should leave behind:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 2.3.56
-- Updated: 2026-04-04
+- Version: 3.0.0
+- Updated: 2026-04-07
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/apps/vgo-cli/pyproject.toml
+++ b/apps/vgo-cli/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-cli"
-version = "0.1.0"
+version = "3.0.0"
 description = "Thin CLI launcher for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/config/version-governance.json
+++ b/config/version-governance.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
   "release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04",
+    "version": "3.0.0",
+    "updated": "2026-04-07",
     "channel": "stable",
-    "notes": "remaining architecture closure / owner-consumer proof / live status truth alignment / bounded fallback honesty / governed execution proof"
+    "notes": "major public baseline / architecture closure / host-safe install-uninstall / governed execution proof / native MCP-first readiness"
   },
   "source_of_truth": {
     "canonical_root": "."

--- a/dist/core/manifest.json
+++ b/dist/core/manifest.json
@@ -4,8 +4,8 @@
   "lane_kind": "universal-core",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "summary": "Universal contracts only. No install/check runtime closure is promised by this lane.",
   "runtime_ownership": {

--- a/dist/host-claude-code/manifest.json
+++ b/dist/host-claude-code/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "claude-code",
   "stability": "supported-with-constraints",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "summary": "Claude Code host adapter lane with bounded managed closure. The repo can write and verify a managed Claude settings surface, while still keeping broader host behavior outside repo ownership.",
   "runtime_ownership": {

--- a/dist/host-codex/manifest.json
+++ b/dist/host-codex/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "codex",
   "stability": "supported-with-constraints",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "summary": "Codex host adapter lane. Uses the official runtime entrypoints, but remains honest about host-managed plugin and credential surfaces.",
   "runtime_ownership": {

--- a/dist/host-cursor/manifest.json
+++ b/dist/host-cursor/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "cursor",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "summary": "Cursor host adapter preview. The repository can expose runtime-core payload and preview health checks, but does not claim full governed closure yet.",
   "runtime_ownership": {

--- a/dist/host-openclaw/manifest.json
+++ b/dist/host-openclaw/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "openclaw",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "summary": "OpenClaw host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/host-opencode/manifest.json
+++ b/dist/host-opencode/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "opencode",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "summary": "OpenCode host adapter preview. The repo can install runtime-core plus OpenCode-native command and agent wrapper payload into OpenCode roots, but final host config and platform closure remain incomplete.",
   "runtime_ownership": {

--- a/dist/host-windsurf/manifest.json
+++ b/dist/host-windsurf/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "windsurf",
   "stability": "preview",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "summary": "Windsurf host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/manifests/vibeskills-claude-code.json
+++ b/dist/manifests/vibeskills-claude-code.json
@@ -48,8 +48,8 @@
   },
   "summary": "Claude Code now has a bounded managed install/check lane that writes and verifies a Claude settings surface, but it still does not become the Codex official runtime or full platform-parity lane.",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-codex.json
+++ b/dist/manifests/vibeskills-codex.json
@@ -53,8 +53,8 @@
   },
   "summary": "Codex is the current strongest practical reference lane for the governed runtime payload, but some key surfaces remain host-managed and certain platforms are degraded.",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-core.json
+++ b/dist/manifests/vibeskills-core.json
@@ -46,8 +46,8 @@
   },
   "summary": "Host-agnostic contracts and schemas that stabilize skill metadata without claiming a governed runtime on any host.",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "truth_sources": [
     "docs/universalization/core-contract.md",

--- a/dist/manifests/vibeskills-cursor.json
+++ b/dist/manifests/vibeskills-cursor.json
@@ -50,8 +50,8 @@
   },
   "summary": "Cursor exposes preview adapter entrypoints and truthful readiness boundaries, but this repository does not claim governed or host-native closure for it.",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-generic.json
+++ b/dist/manifests/vibeskills-generic.json
@@ -45,8 +45,8 @@
   },
   "summary": "Generic hosts may consume canonical contracts and a repo-provided runtime-core payload in a neutral target root, but the repository still makes no host closure claim.",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-openclaw.json
+++ b/dist/manifests/vibeskills-openclaw.json
@@ -50,8 +50,8 @@
   },
   "summary": "OpenClaw may consume the shared runtime-core payload through a documented host root, but this repository does not claim host-native governed closure for it.",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-opencode.json
+++ b/dist/manifests/vibeskills-opencode.json
@@ -53,8 +53,8 @@
   },
   "summary": "OpenCode now has a truthful preview adapter lane with bounded install/check entrypoints, skills payload, and wrapper scaffolds, but the repository still avoids claiming full host closure or platform parity.",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-windsurf.json
+++ b/dist/manifests/vibeskills-windsurf.json
@@ -50,8 +50,8 @@
   },
   "summary": "Windsurf may consume the shared runtime-core payload through a documented host root, but this repository does not claim host-native governed closure for it.",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/official-runtime/manifest.json
+++ b/dist/official-runtime/manifest.json
@@ -4,8 +4,8 @@
   "lane_kind": "tier-1-official-runtime",
   "stability": "tier-1",
   "source_release": {
-    "version": "2.3.56",
-    "updated": "2026-04-04"
+    "version": "3.0.0",
+    "updated": "2026-04-07"
   },
   "summary": "Reference lane for the current governed official runtime. This dist pack points to it and must not rewrite it.",
   "runtime_ownership": {

--- a/docs/plans/2026-04-07-v3-major-release-execution-plan.md
+++ b/docs/plans/2026-04-07-v3-major-release-execution-plan.md
@@ -1,0 +1,67 @@
+# VibeSkills v3.0.0 Release Execution Plan
+
+**Goal:** Cut a governed `v3.0.0` major release from `origin/main`, synchronize release/package version surfaces, and publish a detailed release narrative.
+
+**Internal Grade:** L
+
+**Why L Instead Of XL:** The work spans multiple steps but touches one tightly coupled release surface. Serial execution is safer than parallel fan-out because version synchronization, release-cut application, and verification all depend on one another.
+
+## Ownership Boundaries
+
+- Release metadata surfaces:
+  `config/version-governance.json`, `SKILL.md`, `references/changelog.md`, `references/release-ledger.jsonl`, `docs/releases/README.md`, `docs/releases/v3.0.0.md`
+- Package version surfaces:
+  root `pyproject.toml`, `apps/vgo-cli/pyproject.toml`, and package `pyproject.toml` files under `packages/`
+- Governed runtime artifacts:
+  `outputs/runtime/vibe-sessions/20260407T214009-release-v3-0-0/*`
+
+## Execution Steps
+
+1. Freeze governed inputs and runtime lineage artifacts for the release run.
+2. Use the isolated worktree on `release/v3.0.0` tracking `origin/main`.
+3. Update all explicit package version markers from `0.1.0` to `3.0.0`.
+4. Draft `docs/releases/v3.0.0.md` with major-release framing based on:
+   - unpublished `v2.3.56` architecture baseline
+   - `origin/main` changes since `v2.3.55`
+   - PRs `#130`, `#131`, `#132`, and `#133`
+5. Run the canonical release operator preview for `3.0.0`.
+6. Apply the canonical release operator for `3.0.0`.
+7. Run targeted release tests and stop-ship gates.
+8. Review the resulting diff, commit, create tag, and push if transport/auth permit.
+9. Emit cleanup and delivery acceptance receipts.
+
+## Verification Commands
+
+- `python3 -m pytest -q tests/integration/test_release_cut_gate_contract_cutover.py tests/integration/test_dist_manifest_generation.py tests/integration/test_dist_manifest_surface_roles.py tests/integration/test_version_governance_runtime_roles.py tests/runtime_neutral/test_release_cut_operator.py tests/runtime_neutral/test_release_notes_quality.py`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\governance\\release-cut.ps1 -Version 3.0.0 -Updated 2026-04-07 -Preview`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\governance\\release-cut.ps1 -Version 3.0.0 -Updated 2026-04-07`
+- `pwsh -NoProfile -File scripts/verify/vibe-version-consistency-gate.ps1`
+- `pwsh -NoProfile -File scripts/verify/vibe-dist-manifest-gate.ps1`
+- `pwsh -NoProfile -File scripts/verify/vibe-version-packaging-gate.ps1`
+- `pwsh -NoProfile -File scripts/verify/vibe-release-notes-quality-gate.ps1`
+- `git diff --check`
+
+## Delivery Acceptance Plan
+
+- Check that current release surfaces point to `v3.0.0`.
+- Check that the major-release note is detailed and non-placeholder.
+- Check that no `0.1.0` package version markers remain.
+- Check whether branch/tag push succeeded and report exact remote state.
+
+## Completion Language Rules
+
+- "Released" requires successful local release-cut apply and verification.
+- "Published" requires successful remote branch/tag push.
+- "GitHub release" may only be claimed if a release object is explicitly created, which is outside the repo-local release-cut operator.
+
+## Rollback Rules
+
+- If release-cut preview or apply fails, stop and report the failing gate/operator output.
+- If package version synchronization causes release gates to fail, repair the mismatch in the release worktree and rerun verification before any commit.
+- Do not modify or clean unrelated local worktrees.
+
+## Phase Cleanup Expectations
+
+- Write phase receipts for requirement freeze, plan freeze, execution, and cleanup.
+- Record verification command outcomes and remote publish outcomes.
+- Leave the worktree intact for review unless the user asks for cleanup.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -10,7 +10,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ### Current Release Surface
 
-- [`v2.3.56.md`](v2.3.56.md): remaining-architecture-closure completion / owner-consumer proof / live status truth alignment / bounded fallback honesty / regression-backed baseline
+- [`v3.0.0.md`](v3.0.0.md): major public baseline / architecture closure / host-safe install-uninstall / governed execution proof / native MCP-first readiness
 
 ### Release Runtime / Proof Handoff
 
@@ -24,10 +24,13 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ## Recent Governed Releases
 
+- [`v3.0.0.md`](v3.0.0.md) - 2026-04-07 - major public baseline / architecture closure / host-safe install-uninstall / governed execution proof / native MCP-first readiness
 - [`v2.3.56.md`](v2.3.56.md) - 2026-04-04 - remaining-architecture-closure completion / owner-consumer proof / live status truth alignment / bounded fallback honesty / regression-backed baseline
 - [`v2.3.55.md`](v2.3.55.md) - 2026-03-30 - owned-only uninstall and skill-only host alignment / OpenCode startup safety / explicit intent-vs-vector AI config split / macOS bootstrap compatibility
 - [`v2.3.54.md`](v2.3.54.md) - 2026-03-30 - release operator closure / runtime contract schema baseline / outputs-boundary migration / install-time generated nested compatibility / release truth hardening
 - [`v2.3.53.md`](v2.3.53.md) - 2026-03-30 - governed specialist dispatch and custom admission closure / Windows PowerShell host resolution / managed host install guarantees / cleanup-truth tightening
+
+Older release notes remain in this directory as historical version records, but they are not part of the active release surface.
 
 ## Historical Release Archive
 

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -1,0 +1,45 @@
+# VCO Release v3.0.0
+
+- Date: 2026-04-07
+- Commit(base): 9bea31e
+- Previous remote release: `v2.3.55`
+- Unpublished absorbed baseline: `v2.3.56`
+
+## Highlights
+
+- Promoted the unpublished `v2.3.56` architecture-closure baseline into the official major-release line instead of leaving that closure work stranded as a local-only release note. The repository now advances from the last public `v2.3.55` tag to a new `v3.0.0` baseline in one truthful step.
+- Hardened install and uninstall behavior around host safety, ownership boundaries, and sidecar-first activation. Supported hosts keep Vibe on a skill-first path, uninstall stays owned-only, and legacy ledger compatibility remains bounded instead of letting cleanup sprawl into unrelated host state.
+- Added stronger governed execution integrity. Child-lane lineage validation, delegated execution receipts, surfaced-skill promotion into governed execution, and stricter runtime/MCP truth reporting reduce the gap between what the runtime says happened and what the repository can actually prove.
+- Introduced native MCP-first install guidance and implementation support. The install surface now prefers native MCP setup where appropriate, can auto-provision MCP in a warning-only / strict-offline-safe mode, and reports readiness truth more honestly across shell, PowerShell, and CLI paths.
+- Tightened the release and packaging baseline that ships with the repo. Runtime-facing release surfaces, dist manifests, release metadata, package versions, and release notes now move together under a single `v3.0.0` cut instead of splitting repo release truth from package metadata.
+
+## What Changed Since The Public v2.3.55 Release
+
+- `v2.3.55` focused on uninstall hardening, skill-only host alignment, OpenCode startup recovery, AI config-key separation, and macOS bootstrap compatibility.
+- `v3.0.0` absorbs that next unpublished architecture baseline and every merged change through `origin/main` at `9bea31e`, including:
+  - the `v2.3.56` architecture-closure and owner-consumer proof baseline
+  - host install/uninstall safety fixes from PRs `#123`, `#124`, and `#130`
+  - governed specialist-promotion and delegated-lineage tightening from PRs `#127` and `#129`
+  - proof refresh and runtime/MCP truth alignment from PR `#128` and PR `#132`
+  - MCP auto-provision plumbing, docs, and warning-only offline-safe behavior from PR `#131`
+  - native MCP-first install contract tightening from PR `#133`
+- The practical result is a larger release boundary than a normal patch cut: users move to a repo state where architecture closure, host safety, governed execution proof, and MCP-first installation are aligned at the same time.
+
+## Why This Is A Major Release
+
+- This cut is not just a small batch of fixes on top of `v2.3.55`. It re-baselines the public line to include an architecture-closure milestone that previously existed only as a local release note.
+- Install, uninstall, runtime, and MCP setup expectations are now framed around a more opinionated contract: native MCP-first when supported, warning-only fallback behavior when strict offline constraints apply, and more explicit host-ownership boundaries.
+- The repository's own package version markers now align with the governed release version at `3.0.0`, which is a stronger public packaging statement than the prior placeholder `0.1.0` values.
+
+## Validation Notes
+
+- Targeted release tests and gates for this cut are expected to cover release-cut behavior, dist manifest generation, version-governance runtime roles, release-note quality, and packaging/version consistency.
+- Exact commands and fresh outcomes must be updated after the operator apply and verification pass complete.
+
+## Migration Notes
+
+- Treat `v3.0.0` as the first public line that officially includes the `v2.3.56` architecture-closure baseline. If you reviewed that note locally before, this release is the public promotion of that state plus the later merged install/runtime/MCP work.
+- Host operators should prefer the current native MCP-first install guidance rather than older prompt flows that assumed MCP setup would always be manual or always be silently auto-managed.
+- MCP auto-provision is intentionally not a hidden success path. In strict-offline or degraded environments, the release keeps warning-only honesty instead of pretending MCP became ready when it did not.
+- If you consume the Python package surfaces directly, re-pin to `3.0.0`; the package metadata now matches the governed release line instead of staying on the placeholder `0.1.0` scaffold version.
+- Existing bounded compatibility surfaces remain deliberate. This release does not claim that every fallback, shim, or historical platform edge has been removed; it claims they are more explicitly governed and better reflected in install/runtime truth.

--- a/docs/requirements/2026-04-07-v3-major-release.md
+++ b/docs/requirements/2026-04-07-v3-major-release.md
@@ -1,0 +1,71 @@
+# VibeSkills v3.0.0 Release Requirement
+
+## Goal
+
+Cut a governed major release `v3.0.0` from the latest GitHub `origin/main` baseline, synchronize the repository's release/version surfaces, and produce a detailed release note that truthfully combines the unpublished `v2.3.56` local baseline with the additional changes already merged after it.
+
+## Deliverables
+
+- Repository version surfaces updated to `3.0.0` where this repo treats them as release or package version markers.
+- Governed release metadata updated through the canonical release path.
+- A new detailed release note at `docs/releases/v3.0.0.md`.
+- Live release navigator surfaces updated to point at `v3.0.0`.
+- Runtime/session proof artifacts for this governed run under `outputs/runtime/vibe-sessions/20260407T214009-release-v3-0-0/`.
+- A pushed release branch and tag if remote permissions and transport succeed.
+
+## Constraints
+
+- Use the latest remote `origin/main` code as the release base.
+- Do not modify the user's dirty local branches.
+- Preserve governed release truth: do not claim a GitHub release object exists unless it was actually created.
+- Keep release notes explicit about what came from the unpublished `v2.3.56` baseline and what came from the subsequent merged changes.
+- Prefer the repository's canonical release operator instead of hand-editing generated release surfaces where the operator owns them.
+
+## Acceptance Criteria
+
+- `config/version-governance.json` points to `3.0.0` with the release date for this cut.
+- `SKILL.md` maintenance metadata is updated to `Version: 3.0.0`.
+- All repo package `pyproject.toml` version markers move from `0.1.0` to `3.0.0`.
+- `docs/releases/README.md`, `references/changelog.md`, `references/release-ledger.jsonl`, and dist manifest release surfaces are updated consistently.
+- `docs/releases/v3.0.0.md` exists and contains detailed highlights, change comparison, validation notes, and migration notes.
+- Targeted release tests and gates run fresh and their actual outcomes are recorded.
+- If push succeeds, branch `release/v3.0.0` and tag `v3.0.0` exist on `origin`.
+
+## Product Acceptance Criteria
+
+- The release note reads like a major version announcement rather than a placeholder.
+- User-facing install/runtime changes are grouped into coherent themes.
+- The release narrative is honest about scope, breaking-surface risk, and operational migration expectations.
+
+## Manual Spot Checks
+
+- Inspect the generated `docs/releases/v3.0.0.md` for structure and factual consistency.
+- Confirm `docs/releases/README.md` shows `v3.0.0` as the current release surface.
+- Confirm `references/changelog.md` and `references/release-ledger.jsonl` contain a `v3.0.0` entry.
+- Confirm package version markers no longer show `0.1.0`.
+
+## Completion Language Policy
+
+Do not claim the release is published until tag push and any remote publication step have actually succeeded. If only branch/tag push succeeds, report exactly that.
+
+## Delivery Truth Contract
+
+- "Version synchronized" means the modified version files were inspected in the release worktree.
+- "Verified" means the listed commands were run in this session and their outputs were checked.
+- "Published" means the remote branch/tag push succeeded; GitHub release object creation is a separate claim.
+
+## Non-Goals
+
+- Rewriting unrelated historical release notes.
+- Refactoring release tooling outside what is required for `v3.0.0`.
+- Claiming compatibility guarantees broader than the executed gates support.
+
+## Autonomy Mode
+
+Interactive governed execution with user-approved version target `v3.0.0`.
+
+## Inferred Assumptions
+
+- The user wants a major version cut directly from current `origin/main`.
+- The unpublished `v2.3.56` content should be absorbed into the major release rather than retro-published first.
+- Updating package `pyproject.toml` versions is desired because the user asked to synchronize all version numbers.

--- a/packages/adapter-sdk/pyproject.toml
+++ b/packages/adapter-sdk/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-adapters"
-version = "0.1.0"
+version = "3.0.0"
 description = "Adapter SDK for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/contracts/pyproject.toml
+++ b/packages/contracts/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-contracts"
-version = "0.1.0"
+version = "3.0.0"
 description = "Authoritative contracts for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/installer-core/pyproject.toml
+++ b/packages/installer-core/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-installer"
-version = "0.1.0"
+version = "3.0.0"
 description = "Installer core for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/runtime-core/pyproject.toml
+++ b/packages/runtime-core/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-runtime"
-version = "0.1.0"
+version = "3.0.0"
 description = "Runtime core for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/skill-catalog/pyproject.toml
+++ b/packages/skill-catalog/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-skill-catalog"
-version = "0.1.0"
+version = "3.0.0"
 description = "Detached skill catalog package for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/verification-core/pyproject.toml
+++ b/packages/verification-core/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-verify"
-version = "0.1.0"
+version = "3.0.0"
 description = "Verification core for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vibe-skills-workspace"
-version = "0.1.0"
+version = "3.0.0"
 description = "Clean architecture workspace scaffold for Vibe-Skills"
 requires-python = ">=3.10"
-

--- a/references/changelog.md
+++ b/references/changelog.md
@@ -4,6 +4,14 @@ This file is the stable current changelog surface used by release governance.
 
 Historical entries before `v2.3.53` now live in `references/archive/changelog/pre-v2.3.53.md`.
 
+## v3.0.0 (2026-04-07)
+
+- Promoted the unpublished `v2.3.56` architecture-closure baseline into the public major-release line instead of leaving that baseline as a local-only note.
+- Hardened host-safe install and uninstall behavior while keeping supported hosts on a skill-first, sidecar-aware ownership model.
+- Tightened governed execution proof through better child-lineage validation, specialist-promotion closure, runtime/MCP truth alignment, and native MCP-first readiness guidance.
+- Synchronized the repository's governed release line and Python package metadata at `3.0.0` so package surfaces no longer advertise the old `0.1.0` scaffold placeholder.
+- Detailed release notes: `docs/releases/v3.0.0.md`.
+
 ## v2.3.56 (2026-04-04)
 
 - Completed the frozen `remaining-architecture-closure` program and moved the repository to a regression-backed low-coupling / high-cohesion baseline instead of leaving the closure work as an open-ended refactor stream.

--- a/references/release-ledger.jsonl
+++ b/references/release-ledger.jsonl
@@ -20,12 +20,6 @@
 {"recorded_at":"2026-03-15T13:50:00","version":"2.3.46","updated":"2026-03-15","git_head":"63f1973","actor":"羽裳"}
 {"recorded_at":"2026-03-15T19:32:59","version":"2.3.47","updated":"2026-03-15","git_head":"5af2d18","actor":"羽裳"}
 {"recorded_at":"2026-03-23T00:47:19","version":"2.3.48","updated":"2026-03-23","git_head":"3cd3ae2","actor":null}
-{"recorded_at":"2026-03-23T00:49:43","version":"2.3.48","updated":"2026-03-23","git_head":"3cd3ae2","actor":null}
-{"recorded_at":"2026-03-23T00:54:14","version":"2.3.48","updated":"2026-03-23","git_head":"3cd3ae2","actor":null}
-{"recorded_at":"2026-03-23T00:57:35","version":"2.3.48","updated":"2026-03-23","git_head":"3cd3ae2","actor":null}
-{"recorded_at":"2026-03-23T00:59:27","version":"2.3.48","updated":"2026-03-23","git_head":"3cd3ae2","actor":null}
-{"recorded_at":"2026-03-23T01:00:54","version":"2.3.48","updated":"2026-03-23","git_head":"3cd3ae2","actor":null}
-{"recorded_at":"2026-03-23T01:02:25","version":"2.3.48","updated":"2026-03-23","git_head":"3cd3ae2","actor":null}
 {"recorded_at":"2026-03-23T01:38:21","version":"2.3.49","updated":"2026-03-23","git_head":"dc0430d","actor":null}
 {"recorded_at":"2026-03-26T20:39:51","version":"2.3.50","updated":"2026-03-26","git_head":"d5da111","actor":null}
 {"recorded_at":"2026-03-28T00:00:00","version":"2.3.51","updated":"2026-03-28","git_head":"18e6b9c","actor":null}
@@ -33,7 +27,5 @@
 {"recorded_at":"2026-03-30T00:28:44","version":"2.3.53","updated":"2026-03-30","git_head":"4f5676f","actor":null}
 {"recorded_at":"2026-03-30T13:12:27","version":"2.3.54","updated":"2026-03-30","git_head":"1a049f1","actor":null}
 {"recorded_at":"2026-03-30T23:51:45","version":"2.3.55","updated":"2026-03-30","git_head":"f3ab6e5","actor":null}
-{"recorded_at":"2026-03-30T23:54:05","version":"2.3.55","updated":"2026-03-30","git_head":"f3ab6e5","actor":null}
 {"recorded_at": "2026-04-04T12:04:55", "version": "2.3.56", "updated": "2026-04-04", "git_head": "7ee8061", "actor": "codex-local-baseline"}
 {"recorded_at":"2026-04-07T21:51:51","version":"3.0.0","updated":"2026-04-07","git_head":"9bea31e","actor":null}
-{"recorded_at":"2026-04-07T21:52:36","version":"3.0.0","updated":"2026-04-07","git_head":"9bea31e","actor":null}

--- a/references/release-ledger.jsonl
+++ b/references/release-ledger.jsonl
@@ -35,3 +35,5 @@
 {"recorded_at":"2026-03-30T23:51:45","version":"2.3.55","updated":"2026-03-30","git_head":"f3ab6e5","actor":null}
 {"recorded_at":"2026-03-30T23:54:05","version":"2.3.55","updated":"2026-03-30","git_head":"f3ab6e5","actor":null}
 {"recorded_at": "2026-04-04T12:04:55", "version": "2.3.56", "updated": "2026-04-04", "git_head": "7ee8061", "actor": "codex-local-baseline"}
+{"recorded_at":"2026-04-07T21:51:51","version":"3.0.0","updated":"2026-04-07","git_head":"9bea31e","actor":null}
+{"recorded_at":"2026-04-07T21:52:36","version":"3.0.0","updated":"2026-04-07","git_head":"9bea31e","actor":null}

--- a/scripts/governance/release-cut.ps1
+++ b/scripts/governance/release-cut.ps1
@@ -488,7 +488,26 @@ $entry = [ordered]@{
     git_head = $head
     actor = $env:USERNAME
 }
-Append-VgoUtf8NoBomText -Path $ledgerPath -Content (($entry | ConvertTo-Json -Compress) + [Environment]::NewLine)
+
+# Pre-write duplicate check: only append if (version, git_head) combination doesn't exist
+$shouldAppend = $true
+if (Test-Path -LiteralPath $ledgerPath) {
+    $existingLines = Get-Content -LiteralPath $ledgerPath -Encoding UTF8
+    foreach ($line in $existingLines) {
+        if (-not [string]::IsNullOrWhiteSpace($line)) {
+            $existingEntry = $line | ConvertFrom-Json
+            if ($existingEntry.version -eq $Version -and $existingEntry.git_head -eq $head) {
+                $shouldAppend = $false
+                Write-Host ("Skipping duplicate ledger entry: version={0}, git_head={1} already recorded at {2}" -f $Version, $head, $existingEntry.recorded_at) -ForegroundColor Yellow
+                break
+            }
+        }
+    }
+}
+
+if ($shouldAppend) {
+    Append-VgoUtf8NoBomText -Path $ledgerPath -Content (($entry | ConvertTo-Json -Compress) + [Environment]::NewLine)
+}
 
 New-Item -ItemType Directory -Force -Path $releaseNotesDir | Out-Null
 if (-not (Test-Path -LiteralPath $releaseNotePath)) {


### PR DESCRIPTION
## Summary
- cut the governed `v3.0.0` major release from the latest `origin/main` baseline
- synchronize governed release metadata and Python package version markers to `3.0.0`
- add detailed release notes for `v3.0.0` and update release navigation/changelog surfaces
- refresh dist manifest `source_release` metadata through the canonical manifest sync path
- push annotated tag `v3.0.0`

## Included in v3.0.0
- unpublished `v2.3.56` architecture-closure baseline promoted into the public release line
- host-safe install/uninstall hardening and skill-first ownership refinements
- governed execution proof tightening, child-lineage validation, and runtime truth alignment
- native MCP-first install guidance plus warning-only/offline-safe MCP auto-provision behavior

## Verification
- `python3 -m pytest -q tests/integration/test_release_cut_gate_contract_cutover.py tests/integration/test_dist_manifest_generation.py tests/integration/test_dist_manifest_surface_roles.py tests/integration/test_version_governance_runtime_roles.py tests/runtime_neutral/test_release_cut_operator.py tests/runtime_neutral/test_release_notes_quality.py`
- `pwsh -NoProfile -File scripts/verify/vibe-version-consistency-gate.ps1`
- `pwsh -NoProfile -File scripts/verify/vibe-dist-manifest-gate.ps1`
- `pwsh -NoProfile -File scripts/verify/vibe-version-packaging-gate.ps1`
- `pwsh -NoProfile -File scripts/verify/vibe-release-notes-quality-gate.ps1`
- `git diff --check`

## Notes
- `scripts/governance/release-cut.ps1` preview and apply were executed in a standalone clone because the nested worktree path resolves to the outer canonical root for PowerShell governance helpers.
- remote tag already pushed: `v3.0.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native MCP-first installation guidance with auto-provisioning across shell/PowerShell/CLI.
  * Hardened host install/uninstall behavior with ownership boundary enforcement.
  * Strengthened governed execution integrity with lineage validation and stricter runtime/MCP truth reporting.

* **Documentation**
  * Added v3.0.0 release notes, an execution plan, requirements, and updated release index and changelog.

* **Chores**
  * Version bumped to 3.0.0 across project and packages; synchronized release/packaging baselines.

* **Bug Fixes**
  * Prevent duplicate release ledger entries during release cut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->