### PR TITLE
feat: project discoverable vibe wrappers across supported hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If your AI supports skills, VibeSkills works. 340+ skills spanning coding, resea
 <br/><br/>
 
 <kbd>Install</kbd> &nbsp;→&nbsp;
-<kbd>/vibe or $vibe</kbd> &nbsp;→&nbsp;
+<kbd>vibe | vibe-want | vibe-how | vibe-do</kbd> &nbsp;→&nbsp;
 <kbd>Smart Routing</kbd> &nbsp;→&nbsp;
 <kbd>M / L / XL Execution</kbd> &nbsp;→&nbsp;
 <kbd>Governance Verification</kbd> &nbsp;→&nbsp;
@@ -92,7 +92,7 @@ If your AI supports skills, VibeSkills works. 340+ skills spanning coding, resea
 |:---|:---|
 | **VibeSkills / VCO** | This project. VCO = Vibe Code Orchestrator — the runtime engine behind the skills. |
 | **Skill** | A focused capability module (e.g., `tdd-guide`, `code-review`). Think of skills as expert assistants the system calls on demand. |
-| **Governed runtime** | When you invoke `/vibe`, the system follows a structured process — clarify → plan → execute → verify — instead of diving in blindly. Some hosts may show discoverable labels like `Vibe: What Do I Want?` or `Vibe: Do It`, but they still resolve to the same canonical runtime authority. |
+| **Governed runtime** | When you invoke `vibe`, the system follows a structured process — clarify → plan → execute → verify — instead of diving in blindly. The public discoverable wrapper set is `vibe`, `vibe-want`, `vibe-how`, and `vibe-do`; hosts may render them as labels like `Vibe: What Do I Want?`, but they still resolve to the same canonical runtime authority. |
 | **Canonical Router** | The internal logic that decides which skill to activate for your task. Just invoke `/vibe` and let it route automatically. |
 | **M / L / XL grade** | Task complexity level. M = quick focused task, L = multi-step task, XL = large task with parallel work. Automatically selected. Public overrides are limited to `--l` and `--xl`; they are execution preferences, not separate entrypoints. |
 | **Frozen requirement** | Once you confirm the plan, it is "frozen" — the system will not silently change scope mid-task. |
@@ -236,7 +236,7 @@ After selecting the primary skill, the router also automatically determines the 
 
 </div>
 
-> The system automatically selects the level after requirements clarification, before plan execution. Users can still invoke `/vibe` or `$vibe` directly, or select a discoverable host label such as `Vibe`, `Vibe: What Do I Want?`, `Vibe: How Do We Do It?`, or `Vibe: Do It`.
+> The system automatically selects the level after requirements clarification, before plan execution. Public host-visible entry wrappers ship as `vibe`, `vibe-want`, `vibe-how`, and `vibe-do`. Hosts may render them as `Vibe`, `Vibe: What Do I Want?`, `Vibe: How Do We Do It?`, and `Vibe: Do It`, but they still route into the same governed runtime.
 >
 > When the system calls a specialist skill internally (like `tdd-guide` or `code-review`), it is always scoped to a specific phase — they assist without taking over the overall coordination. In XL tasks with multiple agents, worker agents (child lanes) can suggest specialist help, but the coordinator (root) approves it before execution.
 >

--- a/README.zh.md
+++ b/README.zh.md
@@ -64,7 +64,7 @@
 <br/><br/>
 
 <kbd>安装</kbd> &nbsp;→&nbsp;
-<kbd>/vibe 或 $vibe</kbd> &nbsp;→&nbsp;
+<kbd>vibe | vibe-want | vibe-how | vibe-do</kbd> &nbsp;→&nbsp;
 <kbd>智能路由</kbd> &nbsp;→&nbsp;
 <kbd>M / L / XL 执行</kbd> &nbsp;→&nbsp;
 <kbd>治理验证</kbd> &nbsp;→&nbsp;
@@ -92,7 +92,7 @@
 |:---|:---|
 | **VibeSkills / VCO** | 即本项目。VCO = Vibe Code Orchestrator，是驱动所有技能运行的核心引擎。 |
 | **技能（Skill）** | 独立的能力模块，例如 `tdd-guide`（测试驱动）、`code-review`（代码审查）。可理解为系统按需调用的专家助手。 |
-| **受管运行时（Governed runtime）** | 调用 `/vibe` 后，系统会遵循「澄清 → 规划 → 执行 → 验证」的完整流程，而不是盲目直接执行。有些宿主会把它显示成 `Vibe: What Do I Want?`、`Vibe: Do It` 这类可发现入口，但它们仍然回到同一个 canonical runtime authority。 |
+| **受管运行时（Governed runtime）** | 调用 `vibe` 后，系统会遵循「澄清 → 规划 → 执行 → 验证」的完整流程，而不是盲目直接执行。当前公开的可发现 wrapper 集合固定为 `vibe`、`vibe-want`、`vibe-how`、`vibe-do`；宿主可以把它们显示成 `Vibe: What Do I Want?`、`Vibe: Do It` 这类标签，但它们仍然回到同一个 canonical runtime authority。 |
 | **权威路由器（Canonical Router）** | 根据你的任务自动决定调用哪个技能的内部逻辑，无需手动干预，直接调用 `/vibe` 即可。 |
 | **M / L / XL 执行级别** | 任务复杂度等级：M = 快速小任务，L = 多步骤任务，XL = 可并行的大型任务。系统自动选择。公开覆盖只保留 `--l` 和 `--xl`，它们是执行偏好，不是新的入口。 |
 | **冻结需求（Frozen requirement）** | 确认计划后，系统将锁定需求范围，不会在执行过程中偷偷改变方向。 |
@@ -236,7 +236,7 @@ VibeSkills 的路由保证：
 
 </div>
 
-> 系统会在需求澄清之后、计划执行之前，自动选择级别。用户既可以直接调用 `/vibe` 或 `$vibe`，也可以在支持的宿主里点选 `Vibe`、`Vibe: What Do I Want?`、`Vibe: How Do We Do It?`、`Vibe: Do It` 这些可发现入口。
+> 系统会在需求澄清之后、计划执行之前，自动选择级别。当前公开投影出来的宿主入口固定为 `vibe`、`vibe-want`、`vibe-how`、`vibe-do`；支持菜单化展示的宿主可以把它们渲染成 `Vibe`、`Vibe: What Do I Want?`、`Vibe: How Do We Do It?`、`Vibe: Do It`，但底层仍然只进入同一个 governed runtime。
 >
 > 当系统内部调用专项技能（如 `tdd-guide`、`code-review`）时，这些技能始终被限定在特定执行阶段，只起辅助作用，不会抢占整体流程的控制权。在 XL 级别的多代理任务中，子代理可以建议使用某个专项技能，但需由协调者（根代理）批准后才会实际执行。
 >

--- a/adapters/claude-code/host-profile.json
+++ b/adapters/claude-code/host-profile.json
@@ -23,6 +23,8 @@
     "shared_source": "config/vibe-entry-surfaces.json",
     "authority_owner": "vibe",
     "presentational_only": true,
+    "projection_mode": "generated_wrapper_entries",
+    "host_visible_surface": "managed-launchers",
     "notes": "Discoverable Vibe entries are host-facing launch labels only and do not create a second runtime authority."
   },
   "host_managed_surfaces": [

--- a/adapters/codex/host-profile.json
+++ b/adapters/codex/host-profile.json
@@ -19,6 +19,8 @@
     "shared_source": "config/vibe-entry-surfaces.json",
     "authority_owner": "vibe",
     "presentational_only": true,
+    "projection_mode": "generated_wrapper_entries",
+    "host_visible_surface": "commands",
     "notes": "Discoverable Vibe entries are host-facing launch labels only and do not create a second runtime authority."
   },
   "host_managed_surfaces": [

--- a/adapters/cursor/host-profile.json
+++ b/adapters/cursor/host-profile.json
@@ -17,6 +17,8 @@
     "shared_source": "config/vibe-entry-surfaces.json",
     "authority_owner": "vibe",
     "presentational_only": true,
+    "projection_mode": "generated_wrapper_entries",
+    "host_visible_surface": "preview-launchers",
     "notes": "Discoverable Vibe entries are host-facing launch labels only and do not create a second runtime authority."
   },
   "host_managed_surfaces": [

--- a/adapters/index.json
+++ b/adapters/index.json
@@ -20,7 +20,9 @@
       },
       "discoverable_entries": {
         "shared_source": "config/vibe-entry-surfaces.json",
-        "authority_owner": "vibe"
+        "authority_owner": "vibe",
+        "projection_mode": "generated_wrapper_entries",
+        "host_visible_surface": "commands"
       },
       "host_profile": "adapters/codex/host-profile.json",
       "settings_map": "adapters/codex/settings-map.json",
@@ -41,7 +43,9 @@
       },
       "discoverable_entries": {
         "shared_source": "config/vibe-entry-surfaces.json",
-        "authority_owner": "vibe"
+        "authority_owner": "vibe",
+        "projection_mode": "generated_wrapper_entries",
+        "host_visible_surface": "managed-launchers"
       },
       "host_profile": "adapters/claude-code/host-profile.json",
       "settings_map": "adapters/claude-code/settings-map.json",
@@ -62,7 +66,9 @@
       },
       "discoverable_entries": {
         "shared_source": "config/vibe-entry-surfaces.json",
-        "authority_owner": "vibe"
+        "authority_owner": "vibe",
+        "projection_mode": "generated_wrapper_entries",
+        "host_visible_surface": "preview-launchers"
       },
       "host_profile": "adapters/cursor/host-profile.json",
       "settings_map": "adapters/cursor/settings-map.json",
@@ -83,7 +89,9 @@
       },
       "discoverable_entries": {
         "shared_source": "config/vibe-entry-surfaces.json",
-        "authority_owner": "vibe"
+        "authority_owner": "vibe",
+        "projection_mode": "generated_wrapper_entries",
+        "host_visible_surface": "runtime-core-launchers"
       },
       "host_profile": "adapters/windsurf/host-profile.json",
       "settings_map": "adapters/windsurf/settings-map.json",
@@ -104,7 +112,9 @@
       },
       "discoverable_entries": {
         "shared_source": "config/vibe-entry-surfaces.json",
-        "authority_owner": "vibe"
+        "authority_owner": "vibe",
+        "projection_mode": "generated_wrapper_entries",
+        "host_visible_surface": "runtime-core-launchers"
       },
       "host_profile": "adapters/openclaw/host-profile.json",
       "settings_map": "adapters/openclaw/settings-map.json",
@@ -125,7 +135,9 @@
       },
       "discoverable_entries": {
         "shared_source": "config/vibe-entry-surfaces.json",
-        "authority_owner": "vibe"
+        "authority_owner": "vibe",
+        "projection_mode": "generated_wrapper_entries",
+        "host_visible_surface": "commands-and-agents"
       },
       "host_profile": "adapters/opencode/host-profile.json",
       "settings_map": "adapters/opencode/settings-map.json",

--- a/adapters/openclaw/host-profile.json
+++ b/adapters/openclaw/host-profile.json
@@ -18,6 +18,8 @@
     "shared_source": "config/vibe-entry-surfaces.json",
     "authority_owner": "vibe",
     "presentational_only": true,
+    "projection_mode": "generated_wrapper_entries",
+    "host_visible_surface": "runtime-core-launchers",
     "notes": "Discoverable Vibe entries are host-facing launch labels only and do not create a second runtime authority."
   },
   "host_managed_surfaces": [

--- a/adapters/opencode/host-profile.json
+++ b/adapters/opencode/host-profile.json
@@ -21,6 +21,8 @@
     "shared_source": "config/vibe-entry-surfaces.json",
     "authority_owner": "vibe",
     "presentational_only": true,
+    "projection_mode": "generated_wrapper_entries",
+    "host_visible_surface": "commands-and-agents",
     "notes": "Discoverable Vibe entries are host-facing launch labels only and do not create a second runtime authority."
   },
   "host_managed_surfaces": [

--- a/adapters/windsurf/host-profile.json
+++ b/adapters/windsurf/host-profile.json
@@ -18,6 +18,8 @@
     "shared_source": "config/vibe-entry-surfaces.json",
     "authority_owner": "vibe",
     "presentational_only": true,
+    "projection_mode": "generated_wrapper_entries",
+    "host_visible_surface": "runtime-core-launchers",
     "notes": "Discoverable Vibe entries are host-facing launch labels only and do not create a second runtime authority."
   },
   "host_managed_surfaces": [

--- a/check.ps1
+++ b/check.ps1
@@ -129,6 +129,54 @@ function Get-JsonObject {
   }
 }
 
+function Check-HostVisibleDiscoverableEntries {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  $ledgerPath = Join-Path $TargetRoot '.vibeskills\install-ledger.json'
+  if (-not (Test-Path -LiteralPath $ledgerPath -PathType Leaf)) {
+    Write-Host "[FAIL] host-visible discoverable entries -> $ledgerPath" -ForegroundColor Red
+    $script:fail++
+    return
+  }
+
+  $ledger = Get-JsonObject -Path $ledgerPath -Label 'install ledger'
+  if ($null -eq $ledger) {
+    return
+  }
+
+  $payloadSummary = if ($ledger.PSObject.Properties.Name -contains 'payload_summary') { $ledger.payload_summary } else { $null }
+  $entryNames = if ($null -ne $payloadSummary -and $payloadSummary.PSObject.Properties.Name -contains 'host_visible_entry_names') { @($payloadSummary.host_visible_entry_names | ForEach-Object { [string]$_ }) } else { @() }
+  $wrapperPaths = if ($ledger.PSObject.Properties.Name -contains 'specialist_wrapper_paths') { @($ledger.specialist_wrapper_paths | ForEach-Object { [string]$_ }) } else { @() }
+
+  if ($entryNames.Count -eq 0 -or $wrapperPaths.Count -eq 0) {
+    if ($HostId -in @('codex', 'opencode')) {
+      Write-Host '[FAIL] host-visible discoverable entries -> missing wrapper inventory' -ForegroundColor Red
+      $script:fail++
+    } else {
+      Write-WarnNote -Message ("host-visible discoverable entries -> no wrapper inventory recorded for host '{0}'" -f $HostId)
+    }
+    return
+  }
+
+  $missingPaths = New-Object System.Collections.Generic.List[string]
+  foreach ($wrapperPath in $wrapperPaths) {
+    if (-not (Test-Path -LiteralPath $wrapperPath -PathType Leaf)) {
+      $missingPaths.Add($wrapperPath)
+    }
+  }
+
+  if ($missingPaths.Count -eq 0) {
+    Write-Host '[OK] host-visible discoverable entries'
+    $script:pass++
+  } else {
+    Write-Host ("[FAIL] host-visible discoverable entries -> {0}" -f $missingPaths[0]) -ForegroundColor Red
+    $script:fail++
+  }
+}
+
 function Normalize-ComparablePath {
   param([string]$Path)
 
@@ -551,6 +599,7 @@ function Invoke-AdapterSpecificChecks {
       }
     }
   }
+  Check-HostVisibleDiscoverableEntries -TargetRoot $TargetRoot -HostId ([string]$Adapter.id)
 
   Check-Path -Label "upstream lock" -Path (Join-Path $TargetRoot 'config\upstream-lock.json')
   $installedRuntimeGovernancePath = Join-Path $TargetRoot (Join-Path $startupRuntimeTargetRel 'config\version-governance.json')

--- a/check.ps1
+++ b/check.ps1
@@ -162,8 +162,24 @@ function Check-HostVisibleDiscoverableEntries {
   }
 
   $missingPaths = New-Object System.Collections.Generic.List[string]
+  $targetRootFull = Normalize-ComparablePath -Path $TargetRoot
   foreach ($wrapperPath in $wrapperPaths) {
-    if (-not (Test-Path -LiteralPath $wrapperPath -PathType Leaf)) {
+    $candidatePath = $wrapperPath
+    if (-not [System.IO.Path]::IsPathRooted($candidatePath)) {
+      $candidatePath = Join-Path $TargetRoot $candidatePath
+    }
+    try {
+      $wrapperFull = Normalize-ComparablePath -Path $candidatePath
+    } catch {
+      $missingPaths.Add($wrapperPath)
+      continue
+    }
+    $underTarget = $false
+    if ($null -ne $wrapperFull -and $null -ne $targetRootFull) {
+      $underTarget = $wrapperFull.Equals($targetRootFull, [System.StringComparison]::OrdinalIgnoreCase) -or `
+        $wrapperFull.StartsWith($targetRootFull + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase)
+    }
+    if (-not $underTarget -or -not (Test-Path -LiteralPath $candidatePath -PathType Leaf)) {
       $missingPaths.Add($wrapperPath)
     }
   }
@@ -184,7 +200,7 @@ function Normalize-ComparablePath {
     return $null
   }
 
-  return [System.IO.Path]::GetFullPath($Path).TrimEnd([char[]]@('\\','/')).ToLowerInvariant()
+  return [System.IO.Path]::GetFullPath($Path).TrimEnd([char[]]@('\','/')).ToLowerInvariant()
 }
 
 function Format-OptionalValue {

--- a/check.ps1
+++ b/check.ps1
@@ -152,7 +152,7 @@ function Check-HostVisibleDiscoverableEntries {
   $wrapperPaths = if ($ledger.PSObject.Properties.Name -contains 'specialist_wrapper_paths') { @($ledger.specialist_wrapper_paths | ForEach-Object { [string]$_ }) } else { @() }
 
   if ($entryNames.Count -eq 0 -or $wrapperPaths.Count -eq 0) {
-    if ($HostId -in @('codex', 'opencode')) {
+    if ($HostId -in @('codex', 'claude-code', 'cursor', 'windsurf', 'openclaw', 'opencode')) {
       Write-Host '[FAIL] host-visible discoverable entries -> missing wrapper inventory' -ForegroundColor Red
       $script:fail++
     } else {

--- a/check.sh
+++ b/check.sh
@@ -425,7 +425,7 @@ check_host_visible_discoverable_entries() {
   mapfile -t wrapper_paths < <(json_query_lines_from_file "${ledger_path}" 'specialist_wrapper_paths' 2>/dev/null || true)
 
   if [[ ${#entry_names[@]} -eq 0 || ${#wrapper_paths[@]} -eq 0 ]]; then
-    if [[ "${HOST_ID}" == "codex" || "${HOST_ID}" == "opencode" ]]; then
+    if [[ "${HOST_ID}" == "codex" || "${HOST_ID}" == "claude-code" || "${HOST_ID}" == "cursor" || "${HOST_ID}" == "windsurf" || "${HOST_ID}" == "openclaw" || "${HOST_ID}" == "opencode" ]]; then
       echo "[FAIL] host-visible discoverable entries -> missing wrapper inventory"
       FAIL=$((FAIL+1))
     else

--- a/check.sh
+++ b/check.sh
@@ -436,9 +436,24 @@ check_host_visible_discoverable_entries() {
   fi
 
   local missing_paths=()
+  local normalized_target_root
+  normalized_target_root="$(normalize_path "${TARGET_ROOT}")"
   local path=""
   for path in "${wrapper_paths[@]}"; do
-    [[ -f "${path}" ]] || missing_paths+=("${path}")
+    local candidate_path="${path}"
+    local normalized_path=""
+    if [[ "${candidate_path}" != /* ]]; then
+      candidate_path="${TARGET_ROOT}/${candidate_path}"
+    fi
+    normalized_path="$(normalize_path "${candidate_path}")"
+    case "${normalized_path}" in
+      "${normalized_target_root}"|"${normalized_target_root}/"*) ;;
+      *)
+        missing_paths+=("${path}")
+        continue
+        ;;
+    esac
+    [[ -f "${candidate_path}" ]] || missing_paths+=("${path}")
   done
 
   if [[ ${#missing_paths[@]} -eq 0 ]]; then

--- a/check.sh
+++ b/check.sh
@@ -413,6 +413,43 @@ json_query_scalar_from_file() {
   json_query_lines_from_file "$json_path" "$expr" | head -n 1
 }
 
+check_host_visible_discoverable_entries() {
+  local ledger_path="${TARGET_ROOT}/.vibeskills/install-ledger.json"
+  if [[ ! -f "${ledger_path}" ]]; then
+    echo "[FAIL] host-visible discoverable entries -> ${ledger_path}"
+    FAIL=$((FAIL+1))
+    return
+  fi
+
+  mapfile -t entry_names < <(json_query_lines_from_file "${ledger_path}" 'payload_summary.host_visible_entry_names' 2>/dev/null || true)
+  mapfile -t wrapper_paths < <(json_query_lines_from_file "${ledger_path}" 'specialist_wrapper_paths' 2>/dev/null || true)
+
+  if [[ ${#entry_names[@]} -eq 0 || ${#wrapper_paths[@]} -eq 0 ]]; then
+    if [[ "${HOST_ID}" == "codex" || "${HOST_ID}" == "opencode" ]]; then
+      echo "[FAIL] host-visible discoverable entries -> missing wrapper inventory"
+      FAIL=$((FAIL+1))
+    else
+      echo "[WARN] host-visible discoverable entries -> no wrapper inventory recorded for host '${HOST_ID}'"
+      WARN=$((WARN+1))
+    fi
+    return
+  fi
+
+  local missing_paths=()
+  local path=""
+  for path in "${wrapper_paths[@]}"; do
+    [[ -f "${path}" ]] || missing_paths+=("${path}")
+  done
+
+  if [[ ${#missing_paths[@]} -eq 0 ]]; then
+    echo "[OK] host-visible discoverable entries"
+    PASS=$((PASS+1))
+  else
+    echo "[FAIL] host-visible discoverable entries -> ${missing_paths[0]}"
+    FAIL=$((FAIL+1))
+  fi
+}
+
 pick_python() {
   pick_supported_python
 }
@@ -741,6 +778,7 @@ if [[ -f "${TARGET_ROOT}/.vibeskills/host-closure.json" ]]; then
     check_path "specialist wrapper launcher" "${wrapper_launcher}"
   fi
 fi
+check_host_visible_discoverable_entries
 if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   check_path "plugins manifest" "${TARGET_ROOT}/config/plugins-manifest.codex.json"
 fi

--- a/check.sh
+++ b/check.sh
@@ -421,8 +421,15 @@ check_host_visible_discoverable_entries() {
     return
   fi
 
-  mapfile -t entry_names < <(json_query_lines_from_file "${ledger_path}" 'payload_summary.host_visible_entry_names' 2>/dev/null || true)
-  mapfile -t wrapper_paths < <(json_query_lines_from_file "${ledger_path}" 'specialist_wrapper_paths' 2>/dev/null || true)
+  local entry_names=()
+  local wrapper_paths=()
+  local line=""
+  while IFS= read -r line; do
+    entry_names+=("${line}")
+  done < <(json_query_lines_from_file "${ledger_path}" 'payload_summary.host_visible_entry_names' 2>/dev/null || true)
+  while IFS= read -r line; do
+    wrapper_paths+=("${line}")
+  done < <(json_query_lines_from_file "${ledger_path}" 'specialist_wrapper_paths' 2>/dev/null || true)
 
   if [[ ${#entry_names[@]} -eq 0 || ${#wrapper_paths[@]} -eq 0 ]]; then
     if [[ "${HOST_ID}" == "codex" || "${HOST_ID}" == "claude-code" || "${HOST_ID}" == "cursor" || "${HOST_ID}" == "windsurf" || "${HOST_ID}" == "openclaw" || "${HOST_ID}" == "opencode" ]]; then

--- a/config/adapter-registry.json
+++ b/config/adapter-registry.json
@@ -20,7 +20,9 @@
       },
       "discoverable_entries": {
         "shared_source": "config/vibe-entry-surfaces.json",
-        "authority_owner": "vibe"
+        "authority_owner": "vibe",
+        "projection_mode": "generated_wrapper_entries",
+        "host_visible_surface": "commands"
       },
       "host_profile": "adapters/codex/host-profile.json",
       "settings_map": "adapters/codex/settings-map.json",
@@ -41,7 +43,9 @@
       },
       "discoverable_entries": {
         "shared_source": "config/vibe-entry-surfaces.json",
-        "authority_owner": "vibe"
+        "authority_owner": "vibe",
+        "projection_mode": "generated_wrapper_entries",
+        "host_visible_surface": "managed-launchers"
       },
       "host_profile": "adapters/claude-code/host-profile.json",
       "settings_map": "adapters/claude-code/settings-map.json",
@@ -62,7 +66,9 @@
       },
       "discoverable_entries": {
         "shared_source": "config/vibe-entry-surfaces.json",
-        "authority_owner": "vibe"
+        "authority_owner": "vibe",
+        "projection_mode": "generated_wrapper_entries",
+        "host_visible_surface": "preview-launchers"
       },
       "host_profile": "adapters/cursor/host-profile.json",
       "settings_map": "adapters/cursor/settings-map.json",
@@ -83,7 +89,9 @@
       },
       "discoverable_entries": {
         "shared_source": "config/vibe-entry-surfaces.json",
-        "authority_owner": "vibe"
+        "authority_owner": "vibe",
+        "projection_mode": "generated_wrapper_entries",
+        "host_visible_surface": "runtime-core-launchers"
       },
       "host_profile": "adapters/windsurf/host-profile.json",
       "settings_map": "adapters/windsurf/settings-map.json",
@@ -104,7 +112,9 @@
       },
       "discoverable_entries": {
         "shared_source": "config/vibe-entry-surfaces.json",
-        "authority_owner": "vibe"
+        "authority_owner": "vibe",
+        "projection_mode": "generated_wrapper_entries",
+        "host_visible_surface": "runtime-core-launchers"
       },
       "host_profile": "adapters/openclaw/host-profile.json",
       "settings_map": "adapters/openclaw/settings-map.json",
@@ -125,7 +135,9 @@
       },
       "discoverable_entries": {
         "shared_source": "config/vibe-entry-surfaces.json",
-        "authority_owner": "vibe"
+        "authority_owner": "vibe",
+        "projection_mode": "generated_wrapper_entries",
+        "host_visible_surface": "commands-and-agents"
       },
       "host_profile": "adapters/opencode/host-profile.json",
       "settings_map": "adapters/opencode/settings-map.json",

--- a/config/runtime-core-packaging.full.json
+++ b/config/runtime-core-packaging.full.json
@@ -77,9 +77,10 @@
       "public_skill_surface": "Declared public skill projections are the only top-level skills intentionally exposed to host discovery.",
       "internal_skill_corpus": "Full bundled specialist corpus may be materialized under the canonical vibe root and consumed by runtime descriptor resolution without top-level exposure.",
       "compatibility_skill_projections": "Compatibility projections preserve selected direct-entry skill paths only when host or runtime behavior still depends on them.",
-      "public_skill_surface_mode": "canonical_vibe_only",
+      "public_skill_surface_mode": "discoverable_wrapper_projection",
       "internal_skill_corpus_enabled": true,
-      "compatibility_projection_mode": "explicit_projection_only"
+      "compatibility_projection_mode": "explicit_projection_only",
+      "discoverable_entry_surface": "config/vibe-entry-surfaces.json"
     },
     "copy_directories": {
       "active_sources": [
@@ -96,7 +97,8 @@
       "excluded_bundled_skill_names": [
         "vibe"
       ],
-      "public_surface_mode": "canonical_vibe_only",
+      "public_surface_mode": "discoverable_wrapper_projection",
+      "discoverable_entry_surface": "config/vibe-entry-surfaces.json",
       "internal_corpus_target_relpath": "skills/vibe/bundled/skills",
       "compatibility_skill_projections": []
     }
@@ -111,10 +113,14 @@
   "copy_bundled_skills": true,
   "skills_allowlist": [],
   "public_skill_surface": {
-    "mode": "canonical_vibe_only",
+    "mode": "discoverable_wrapper_projection",
     "canonical_vibe_target_relpath": "skills/vibe",
+    "discoverable_entry_surface": "config/vibe-entry-surfaces.json",
     "projected_skill_names": [
-      "vibe"
+      "vibe",
+      "vibe-want",
+      "vibe-how",
+      "vibe-do"
     ]
   },
   "internal_skill_corpus": {

--- a/config/runtime-core-packaging.json
+++ b/config/runtime-core-packaging.json
@@ -77,7 +77,9 @@
     "surface_contracts": {
       "public_skill_surface": "Declared public skill projections are the only top-level skills intentionally exposed to host discovery.",
       "internal_skill_corpus": "Full bundled specialist corpus may be materialized under the canonical vibe root and consumed by runtime descriptor resolution without top-level exposure.",
-      "compatibility_skill_projections": "Compatibility projections preserve selected direct-entry skill paths only when host or runtime behavior still depends on them."
+      "compatibility_skill_projections": "Compatibility projections preserve selected direct-entry skill paths only when host or runtime behavior still depends on them.",
+      "public_skill_surface_mode": "discoverable_wrapper_projection",
+      "discoverable_entry_surface": "config/vibe-entry-surfaces.json"
     }
   },
   "profiles": {
@@ -107,10 +109,14 @@
         "writing-plans"
       ],
       "public_skill_surface": {
-        "mode": "canonical_vibe_only",
+        "mode": "discoverable_wrapper_projection",
         "canonical_vibe_target_relpath": "skills/vibe",
+        "discoverable_entry_surface": "config/vibe-entry-surfaces.json",
         "projected_skill_names": [
-          "vibe"
+          "vibe",
+          "vibe-want",
+          "vibe-how",
+          "vibe-do"
         ]
       },
       "internal_skill_corpus": {
@@ -160,14 +166,16 @@
           "excluded_bundled_skill_names": [
             "vibe"
           ],
-          "public_surface_mode": "canonical_vibe_only",
+          "public_surface_mode": "discoverable_wrapper_projection",
+          "discoverable_entry_surface": "config/vibe-entry-surfaces.json",
           "internal_corpus_target_relpath": "skills/vibe/bundled/skills",
           "compatibility_skill_projections": []
         },
         "surface_contracts": {
-          "public_skill_surface_mode": "canonical_vibe_only",
+          "public_skill_surface_mode": "discoverable_wrapper_projection",
           "internal_skill_corpus_enabled": true,
-          "compatibility_projection_mode": "explicit_projection_only"
+          "compatibility_projection_mode": "explicit_projection_only",
+          "discoverable_entry_surface": "config/vibe-entry-surfaces.json"
         }
       },
       "managed_skill_inventory": {
@@ -204,10 +212,14 @@
       "copy_bundled_skills": true,
       "skills_allowlist": [],
       "public_skill_surface": {
-        "mode": "canonical_vibe_only",
+        "mode": "discoverable_wrapper_projection",
         "canonical_vibe_target_relpath": "skills/vibe",
+        "discoverable_entry_surface": "config/vibe-entry-surfaces.json",
         "projected_skill_names": [
-          "vibe"
+          "vibe",
+          "vibe-want",
+          "vibe-how",
+          "vibe-do"
         ]
       },
       "internal_skill_corpus": {
@@ -244,14 +256,16 @@
           "excluded_bundled_skill_names": [
             "vibe"
           ],
-          "public_surface_mode": "canonical_vibe_only",
+          "public_surface_mode": "discoverable_wrapper_projection",
+          "discoverable_entry_surface": "config/vibe-entry-surfaces.json",
           "internal_corpus_target_relpath": "skills/vibe/bundled/skills",
           "compatibility_skill_projections": []
         },
         "surface_contracts": {
-          "public_skill_surface_mode": "canonical_vibe_only",
+          "public_skill_surface_mode": "discoverable_wrapper_projection",
           "internal_skill_corpus_enabled": true,
-          "compatibility_projection_mode": "explicit_projection_only"
+          "compatibility_projection_mode": "explicit_projection_only",
+          "discoverable_entry_surface": "config/vibe-entry-surfaces.json"
         }
       },
       "managed_skill_inventory": {

--- a/config/runtime-core-packaging.minimal.json
+++ b/config/runtime-core-packaging.minimal.json
@@ -77,9 +77,10 @@
       "public_skill_surface": "Declared public skill projections are the only top-level skills intentionally exposed to host discovery.",
       "internal_skill_corpus": "Full bundled specialist corpus may be materialized under the canonical vibe root and consumed by runtime descriptor resolution without top-level exposure.",
       "compatibility_skill_projections": "Compatibility projections preserve selected direct-entry skill paths only when host or runtime behavior still depends on them.",
-      "public_skill_surface_mode": "canonical_vibe_only",
+      "public_skill_surface_mode": "discoverable_wrapper_projection",
       "internal_skill_corpus_enabled": true,
-      "compatibility_projection_mode": "explicit_projection_only"
+      "compatibility_projection_mode": "explicit_projection_only",
+      "discoverable_entry_surface": "config/vibe-entry-surfaces.json"
     },
     "copy_directories": {
       "active_sources": [
@@ -109,7 +110,8 @@
       "excluded_bundled_skill_names": [
         "vibe"
       ],
-      "public_surface_mode": "canonical_vibe_only",
+      "public_surface_mode": "discoverable_wrapper_projection",
+      "discoverable_entry_surface": "config/vibe-entry-surfaces.json",
       "internal_corpus_target_relpath": "skills/vibe/bundled/skills",
       "compatibility_skill_projections": []
     }
@@ -137,10 +139,14 @@
     "writing-plans"
   ],
   "public_skill_surface": {
-    "mode": "canonical_vibe_only",
+    "mode": "discoverable_wrapper_projection",
     "canonical_vibe_target_relpath": "skills/vibe",
+    "discoverable_entry_surface": "config/vibe-entry-surfaces.json",
     "projected_skill_names": [
-      "vibe"
+      "vibe",
+      "vibe-want",
+      "vibe-how",
+      "vibe-do"
     ]
   },
   "internal_skill_corpus": {

--- a/docs/plans/2026-04-08-pr137-discoverable-wrapper-review-fixes-execution-plan.md
+++ b/docs/plans/2026-04-08-pr137-discoverable-wrapper-review-fixes-execution-plan.md
@@ -1,0 +1,59 @@
+# PR137 Discoverable Wrapper Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Repair PR `#137` so discoverable wrapper projection is real across the six supported hosts, discoverable-entry verification is truthful, and Linux/Windows checks agree on the same inventories.
+
+**Architecture:** Keep the shared discoverable-entry config as the only public-entry truth, then generate host-visible wrappers by host surface type: command wrappers for command-menu hosts and skill wrappers for skill-menu hosts. Split install-ledger inventories so discoverable entries and host bridge launchers stop sharing one ambiguous path list.
+
+**Tech Stack:** Python installer-core, Bash/PowerShell check scripts, JSON install ledger, unittest/pytest runtime-neutral tests
+
+---
+
+### Task 1: Lock the broken contract with failing tests
+
+**Files:**
+- Modify: `tests/unit/test_discoverable_wrappers.py`
+- Modify: `tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py`
+- Modify: `tests/runtime_neutral/test_claude_preview_scaffold.py`
+- Modify: `tests/runtime_neutral/test_windsurf_runtime_core.py`
+- Modify: `tests/runtime_neutral/test_openclaw_runtime_core.py`
+
+- [ ] Add a unit test proving skill-only hosts generate `skills/<entry>/SKILL.md` wrappers from the shared discoverable-entry contract.
+- [ ] Add a runtime-neutral regression test proving that deleting only the specialist bridge launcher does not fail discoverable-entry validation.
+- [ ] Update host install tests so `claude-code`, `windsurf`, and `openclaw` expect discoverable wrapper skills instead of asserting no wrapper surface exists.
+- [ ] Run the targeted tests and confirm they fail against the current branch.
+
+### Task 2: Implement real multi-host wrapper materialization
+
+**Files:**
+- Modify: `packages/installer-core/src/vgo_installer/discoverable_wrappers.py`
+- Modify: `packages/installer-core/src/vgo_installer/materializer.py`
+- Modify: `packages/installer-core/src/vgo_installer/install_runtime.py`
+
+- [ ] Generate wrapper files by host surface type:
+  `commands/*.md` for command-menu hosts and `skills/*/SKILL.md` for skill-menu hosts.
+- [ ] Keep opencode dual command roots intact.
+- [ ] Make installer failure explicit when a declared discoverable-entry surface yields zero materialized wrappers on a supported host.
+
+### Task 3: Split discoverable-entry inventory from bridge-launcher inventory
+
+**Files:**
+- Modify: `packages/installer-core/src/vgo_installer/install_runtime.py`
+- Modify: `packages/installer-core/src/vgo_installer/ledger_service.py`
+- Modify: `check.sh`
+- Modify: `check.ps1`
+
+- [ ] Record discoverable entry wrapper paths separately from host specialist bridge launchers.
+- [ ] Derive `payload_summary.host_visible_entry_names` from discoverable entry inventory only.
+- [ ] Make Bash and PowerShell discoverable-entry checks validate only discoverable entry paths.
+
+### Task 4: Verify and push the repaired PR branch
+
+**Files:**
+- Inspect: touched tests and install ledger output
+
+- [ ] Run targeted unit/runtime-neutral verification for the new wrapper and ledger contracts.
+- [ ] Run a broader regression slice covering codex plus representative skill-only hosts.
+- [ ] Review the final diff for cohesion and cross-platform consistency.
+- [ ] Commit and push the repair to `feat/vibe-discoverable-entry`.

--- a/docs/quick-start.en.md
+++ b/docs/quick-start.en.md
@@ -20,7 +20,14 @@ Go straight to:
 
 The main entry there is not a wall of commands. It is a prompt you can copy into your AI assistant.
 
-If your host already exposes discoverable `vibe` launch surfaces, the common entries are:
+The current public host-visible wrapper set is fixed to these four entries:
+
+- `vibe`
+- `vibe-want`
+- `vibe-how`
+- `vibe-do`
+
+If your host supports menu-style rendering, it will usually display them as:
 
 - `Vibe`
 - `Vibe: What Do I Want?`
@@ -29,10 +36,10 @@ If your host already exposes discoverable `vibe` launch surfaces, the common ent
 
 They still resolve to the same governed `vibe` runtime. The difference is the default stop target:
 
-- `Vibe`: run the full governed flow
-- `Vibe: What Do I Want?`: clarify goals, boundaries, and acceptance criteria first
-- `Vibe: How Do We Do It?`: freeze the requirement and plan
-- `Vibe: Do It`: execute the full governed flow without skipping requirement or plan
+- `vibe` / `Vibe`: run the full governed flow
+- `vibe-want` / `Vibe: What Do I Want?`: clarify goals, boundaries, and acceptance criteria first
+- `vibe-how` / `Vibe: How Do We Do It?`: freeze the requirement and plan
+- `vibe-do` / `Vibe: Do It`: execute the full governed flow without skipping requirement or plan
 
 If you want a heavier execution lane, use only:
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -20,7 +20,14 @@
 
 这里的主入口不是一堆命令，而是一段可以直接复制给 AI 的安装提示词。
 
-如果宿主已经把 `vibe` 暴露成可发现入口，你现在会看到这几种常见入口：
+当前公开投影出来的宿主可见入口固定是这四个 wrapper：
+
+- `vibe`
+- `vibe-want`
+- `vibe-how`
+- `vibe-do`
+
+如果宿主支持菜单化展示，它通常会把它们显示成这几种标签：
 
 - `Vibe`
 - `Vibe: What Do I Want?`
@@ -29,10 +36,10 @@
 
 它们都还是同一个 `vibe` governed runtime，只是默认停靠点不同：
 
-- `Vibe`：走完整受管流程
-- `Vibe: What Do I Want?`：先把目标、边界、验收标准说清楚
-- `Vibe: How Do We Do It?`：冻结 requirement 和 plan
-- `Vibe: Do It`：执行完整流程，但不会跳过 requirement / plan
+- `vibe` / `Vibe`：走完整受管流程
+- `vibe-want` / `Vibe: What Do I Want?`：先把目标、边界、验收标准说清楚
+- `vibe-how` / `Vibe: How Do We Do It?`：冻结 requirement 和 plan
+- `vibe-do` / `Vibe: Do It`：执行完整流程，但不会跳过 requirement / plan
 
 如果你希望提高执行强度，只用：
 

--- a/docs/requirements/2026-04-08-pr137-discoverable-wrapper-review-fixes.md
+++ b/docs/requirements/2026-04-08-pr137-discoverable-wrapper-review-fixes.md
@@ -1,0 +1,29 @@
+# PR137 Discoverable Wrapper Review Fixes
+
+## Goal
+Bring PR `#137` back into a truthful, mergeable state by fixing the two blocking review defects in discoverable wrapper projection and discoverable-entry verification.
+
+## Problem Statement
+The branch currently claims multi-host discoverable `vibe` entry projection, but only `codex` and `opencode` actually materialize host-visible wrappers. The other supported hosts silently install zero discoverable wrappers while metadata and docs still declare generated wrapper entry support.
+
+The branch also mixes two different inventories into one ledger field: host-visible discoverable entries and host specialist bridge launchers. That makes `check.sh` and `check.ps1` misreport missing bridge launchers as missing discoverable entries.
+
+## Required Outcomes
+1. `codex`, `claude-code`, `cursor`, `windsurf`, `openclaw`, and `opencode` must all materialize the shared discoverable `vibe`, `vibe-want`, `vibe-how`, and `vibe-do` entry set into a host-visible install surface.
+2. Skill-only hosts must materialize discoverable entries as generated wrapper skills instead of silently emitting no wrapper inventory.
+3. The installer must fail if a host with a declared discoverable-entry surface produces zero host-visible wrappers.
+4. The install ledger must separate discoverable entry inventory from host specialist bridge launcher inventory.
+5. `check.sh` and `check.ps1` must validate discoverable entries against discoverable-entry inventory only, and must keep bridge-launcher validation separate.
+6. Linux and Windows verification paths must agree on the same truth model.
+
+## Constraints
+- Keep `config/vibe-entry-surfaces.json` as the single source of truth for discoverable entry ids and stage-stop semantics.
+- Do not introduce a second runtime authority beyond canonical `vibe`.
+- Do not regress existing codex/opencode discoverable entry behavior.
+- Do not claim host visibility from docs or metadata unless install/check now prove it.
+
+## Acceptance Criteria
+- Fresh installs for `claude-code`, `cursor`, `windsurf`, and `openclaw` contain generated discoverable wrapper skills for the four public entries.
+- Fresh installs for `codex` and `opencode` still contain the four discoverable wrapper command files.
+- Removing a bridge launcher causes only bridge-launcher validation to fail; discoverable-entry validation remains green if entry wrappers still exist.
+- Targeted unit/runtime-neutral tests cover both the materialization contract and the split inventory contract.

--- a/docs/superpowers/plans/2026-04-08-vibe-multi-host-wrapper-skill-projection.md
+++ b/docs/superpowers/plans/2026-04-08-vibe-multi-host-wrapper-skill-projection.md
@@ -1,0 +1,677 @@
+# Vibe Multi-Host Wrapper Skill Projection Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Materialize `vibe`, `vibe-want`, `vibe-how`, and `vibe-do` as host-visible wrapper entries across supported hosts while preserving one canonical governed runtime authority: `vibe`.
+
+**Architecture:** Keep `config/vibe-entry-surfaces.json` as the single discoverable-entry truth, route all wrapper selections back into canonical `vibe`, and add a shared projection/materialization layer that packaging, installer-core, host adapters, install/check reporting, and docs all consume consistently. Public wrapper visibility must be verified as a host-visible outcome, not inferred from docs, sidecars, or runtime payload presence.
+
+**Tech Stack:** Python installer-core, Python runtime-core, contracts package, shell and PowerShell wrappers, pytest, JSON packaging manifests, host adapter metadata
+
+---
+
+**Spec:** `docs/superpowers/specs/2026-04-08-vibe-multi-host-wrapper-skill-projection-design.md`
+
+## File Structure
+
+### Shared contract and packaging
+- Modify: `config/runtime-core-packaging.json`
+  Responsibility: make base packaging declare discoverable wrapper public-surface semantics.
+- Modify: `config/runtime-core-packaging.full.json`
+  Responsibility: full profile must publicly project all discoverable wrappers while keeping bundled specialist corpus internal.
+- Modify: `config/runtime-core-packaging.minimal.json`
+  Responsibility: minimal profile must publicly project the same wrapper entries without widening internal skill scope.
+- Create: `packages/contracts/src/vgo_contracts/discoverable_entry_surface.py`
+  Responsibility: load and validate `config/vibe-entry-surfaces.json` once for cross-package reuse.
+- Modify: `packages/installer-core/src/vgo_installer/runtime_packaging.py`
+  Responsibility: resolve wrapper-aware public-surface projections from shared contract.
+- Modify: `packages/runtime-core/src/vgo_runtime/router_contract_support.py`
+  Responsibility: expose wrapper-aware public-surface metadata to runtime descriptor resolution.
+
+### Installer materialization and ledger
+- Create: `packages/installer-core/src/vgo_installer/discoverable_wrappers.py`
+  Responsibility: render host-visible wrapper descriptors from shared discoverable-entry metadata.
+- Modify: `packages/installer-core/src/vgo_installer/materializer.py`
+  Responsibility: delegate wrapper file creation to the focused wrapper materializer.
+- Modify: `packages/installer-core/src/vgo_installer/install_runtime.py`
+  Responsibility: call wrapper materialization during install and record wrapper roots/paths in ledger state.
+- Modify: `packages/installer-core/src/vgo_installer/install_plan.py`
+  Responsibility: carry wrapper-aware packaging manifest metadata into install ledger generation.
+- Modify: `packages/installer-core/src/vgo_installer/ledger_service.py`
+  Responsibility: distinguish canonical public skills from host-visible entry surfaces in payload summaries.
+
+### Host adapters and host-visible checks
+- Modify: `config/adapter-registry.json`
+  Responsibility: declare shared discoverable-entry surface plus projection-mode metadata.
+- Modify: `adapters/index.json`
+  Responsibility: keep adapter index aligned with registry-level wrapper projection truth.
+- Modify: `adapters/codex/host-profile.json`
+- Modify: `adapters/claude-code/host-profile.json`
+- Modify: `adapters/cursor/host-profile.json`
+- Modify: `adapters/windsurf/host-profile.json`
+- Modify: `adapters/openclaw/host-profile.json`
+- Modify: `adapters/opencode/host-profile.json`
+  Responsibility: preserve `presentational_only: true` while adding truthful `host-visible projection` metadata.
+- Modify: `check.sh`
+  Responsibility: validate host-visible wrapper entry readiness on Linux/macOS shells.
+- Modify: `check.ps1`
+  Responsibility: validate host-visible wrapper entry readiness on Windows/PowerShell.
+
+### Wrapper source surfaces and docs
+- Modify: `commands/vibe.md`
+  Responsibility: keep canonical wrapper source stable for generated host command variants.
+- Modify: `config/opencode/commands/vibe.md`
+  Responsibility: keep OpenCode canonical wrapper source stable for generated host command variants.
+- Modify: `README.md`
+- Modify: `README.zh.md`
+- Modify: `docs/quick-start.md`
+- Modify: `docs/quick-start.en.md`
+  Responsibility: describe discoverable wrappers as actual shipped host-visible surfaces, not hypothetical labels.
+
+### Tests
+- Modify: `tests/contract/test_vibe_discoverable_entry_contract.py`
+- Modify: `tests/contract/test_adapter_descriptor_contract.py`
+- Modify: `tests/unit/test_adapter_registry_support.py`
+- Modify: `tests/unit/test_runtime_packaging_resolver.py`
+- Modify: `tests/unit/test_router_contract_support_descriptor_sources.py`
+- Modify: `tests/integration/test_runtime_core_packaging_roles.py`
+- Modify: `tests/unit/test_installer_ledger_service.py`
+- Modify: `tests/runtime_neutral/test_install_profile_differentiation.py`
+- Modify: `tests/runtime_neutral/test_installed_runtime_scripts.py`
+- Modify: `tests/runtime_neutral/test_claude_preview_scaffold.py`
+- Modify: `tests/runtime_neutral/test_opencode_preview_parity.py`
+- Modify: `tests/runtime_neutral/test_windsurf_runtime_core.py`
+- Modify: `tests/runtime_neutral/test_openclaw_runtime_core.py`
+- Create: `tests/unit/test_discoverable_entry_surface.py`
+- Create: `tests/unit/test_discoverable_wrappers.py`
+- Create: `tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py`
+
+## Chunk 1: Shared Contract And Packaging Resolution
+
+### Task 1: Lock the wrapper-aware public-surface contract in tests
+
+**Files:**
+- Modify: `tests/contract/test_vibe_discoverable_entry_contract.py`
+- Modify: `tests/unit/test_runtime_packaging_resolver.py`
+- Modify: `tests/integration/test_runtime_core_packaging_roles.py`
+
+- [ ] **Step 1: Extend contract tests to require a wrapper-aware public surface**
+
+Add assertions that packaging resolves:
+
+```python
+assert full["public_skill_surface"]["mode"] == "discoverable_wrapper_projection"
+assert full["public_skill_surface"]["discoverable_entry_surface"] == "config/vibe-entry-surfaces.json"
+assert full["public_skill_surface"]["projected_skill_names"] == ["vibe", "vibe-want", "vibe-how", "vibe-do"]
+assert minimal["public_skill_surface"]["projected_skill_names"] == ["vibe", "vibe-want", "vibe-how", "vibe-do"]
+```
+
+- [ ] **Step 2: Run the packaging tests to verify failure**
+
+Run:
+
+```bash
+pytest \
+  tests/contract/test_vibe_discoverable_entry_contract.py \
+  tests/unit/test_runtime_packaging_resolver.py \
+  tests/integration/test_runtime_core_packaging_roles.py -q
+```
+
+Expected: FAIL because manifests still expose only `["vibe"]`.
+
+- [ ] **Step 3: Update base and profile packaging manifests**
+
+Edit:
+- `config/runtime-core-packaging.json`
+- `config/runtime-core-packaging.full.json`
+- `config/runtime-core-packaging.minimal.json`
+
+Use a wrapper-aware shape like:
+
+```json
+"public_skill_surface": {
+  "mode": "discoverable_wrapper_projection",
+  "canonical_vibe_target_relpath": "skills/vibe",
+  "discoverable_entry_surface": "config/vibe-entry-surfaces.json",
+  "projected_skill_names": ["vibe", "vibe-want", "vibe-how", "vibe-do"]
+}
+```
+
+Keep:
+- `compatibility_skill_projections.projected_skill_names == []`
+- internal corpus under `skills/vibe/bundled/skills`
+
+- [ ] **Step 4: Re-run the packaging tests to verify pass**
+
+Run the same `pytest` command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  config/runtime-core-packaging.json \
+  config/runtime-core-packaging.full.json \
+  config/runtime-core-packaging.minimal.json \
+  tests/contract/test_vibe_discoverable_entry_contract.py \
+  tests/unit/test_runtime_packaging_resolver.py \
+  tests/integration/test_runtime_core_packaging_roles.py
+git commit -m "feat: project discoverable vibe wrappers in packaging manifests"
+```
+
+### Task 2: Centralize discoverable-entry loading so runtime and installer read one truth
+
+**Files:**
+- Create: `packages/contracts/src/vgo_contracts/discoverable_entry_surface.py`
+- Create: `tests/unit/test_discoverable_entry_surface.py`
+- Modify: `packages/installer-core/src/vgo_installer/runtime_packaging.py`
+- Modify: `packages/runtime-core/src/vgo_runtime/router_contract_support.py`
+- Modify: `tests/unit/test_router_contract_support_descriptor_sources.py`
+
+- [ ] **Step 1: Write failing unit tests for the shared discoverable-entry loader**
+
+Create `tests/unit/test_discoverable_entry_surface.py` with coverage for:
+
+```python
+surface = load_discoverable_entry_surface(REPO_ROOT)
+assert surface.canonical_runtime_skill == "vibe"
+assert surface.projected_skill_names == ["vibe", "vibe-want", "vibe-how", "vibe-do"]
+assert surface.grade_flag_map["--xl"] == "XL"
+assert surface.entry_by_id["vibe-want"].allow_grade_flags is False
+```
+
+Update `tests/unit/test_router_contract_support_descriptor_sources.py` to assert router contract support can read wrapper-aware public surface metadata without falling back to hardcoded `skills` assumptions.
+
+- [ ] **Step 2: Run the loader/resolver tests to verify failure**
+
+Run:
+
+```bash
+pytest \
+  tests/unit/test_discoverable_entry_surface.py \
+  tests/unit/test_router_contract_support_descriptor_sources.py -q
+```
+
+Expected: FAIL because the shared loader module does not exist yet.
+
+- [ ] **Step 3: Implement the shared contract helper and use it in resolver code**
+
+Create `packages/contracts/src/vgo_contracts/discoverable_entry_surface.py` with a small typed API such as:
+
+```python
+@dataclass(frozen=True)
+class DiscoverableEntry:
+    id: str
+    display_name: str
+    requested_stage_stop: str
+    allow_grade_flags: bool
+
+def load_discoverable_entry_surface(repo_root: Path) -> DiscoverableEntrySurface: ...
+```
+
+Then:
+- call it from `packages/installer-core/src/vgo_installer/runtime_packaging.py`
+- call it from `packages/runtime-core/src/vgo_runtime/router_contract_support.py`
+- remove any duplicated wrapper-name lists from resolver logic
+
+- [ ] **Step 4: Re-run the loader/resolver tests to verify pass**
+
+Run the same `pytest` command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  packages/contracts/src/vgo_contracts/discoverable_entry_surface.py \
+  packages/installer-core/src/vgo_installer/runtime_packaging.py \
+  packages/runtime-core/src/vgo_runtime/router_contract_support.py \
+  tests/unit/test_discoverable_entry_surface.py \
+  tests/unit/test_router_contract_support_descriptor_sources.py
+git commit -m "refactor: centralize discoverable vibe entry surface loading"
+```
+
+## Chunk 2: Wrapper Materialization And Host Projection
+
+### Task 3: Introduce a focused installer helper that renders host-visible wrapper descriptors
+
+**Files:**
+- Create: `packages/installer-core/src/vgo_installer/discoverable_wrappers.py`
+- Create: `tests/unit/test_discoverable_wrappers.py`
+- Modify: `packages/installer-core/src/vgo_installer/materializer.py`
+- Modify: `packages/installer-core/src/vgo_installer/install_runtime.py`
+
+- [ ] **Step 1: Write failing tests for wrapper rendering and install-time materialization**
+
+Create `tests/unit/test_discoverable_wrappers.py` with cases like:
+
+```python
+rendered = build_wrapper_descriptors(
+    host_id="codex",
+    projected_entries=["vibe", "vibe-want", "vibe-how", "vibe-do"],
+)
+assert sorted(rendered.keys()) == ["vibe", "vibe-do", "vibe-how", "vibe-want"]
+assert "Use the `vibe` skill" in rendered["vibe-how"].content
+assert "Vibe: How Do We Do It?" in rendered["vibe-how"].description
+```
+
+Add an install-time test asserting a temp Codex or OpenCode target root receives wrapper files after installer execution.
+
+- [ ] **Step 2: Run the wrapper tests to verify failure**
+
+Run:
+
+```bash
+pytest \
+  tests/unit/test_discoverable_wrappers.py \
+  tests/runtime_neutral/test_install_profile_differentiation.py -q
+```
+
+Expected: FAIL because no wrapper materializer exists and install payload summary still sees only canonical `vibe`.
+
+- [ ] **Step 3: Implement generated wrapper rendering in a focused helper**
+
+Create `packages/installer-core/src/vgo_installer/discoverable_wrappers.py` with host-focused responsibilities only:
+
+```python
+def render_wrapper_frontmatter(host_id: str, entry: DiscoverableEntry) -> str: ...
+def render_wrapper_body(entry: DiscoverableEntry) -> str: ...
+def materialize_host_visible_wrappers(... ) -> list[Path]: ...
+```
+
+Use existing canonical sources as style references:
+- `commands/vibe.md`
+- `config/opencode/commands/vibe.md`
+
+Then update:
+- `materializer.py` to delegate wrapper generation instead of growing more mixed responsibilities
+- `install_runtime.py` to call the helper and record generated wrapper paths
+
+- [ ] **Step 4: Re-run the wrapper tests to verify pass**
+
+Run the same `pytest` command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  packages/installer-core/src/vgo_installer/discoverable_wrappers.py \
+  packages/installer-core/src/vgo_installer/materializer.py \
+  packages/installer-core/src/vgo_installer/install_runtime.py \
+  tests/unit/test_discoverable_wrappers.py \
+  tests/runtime_neutral/test_install_profile_differentiation.py
+git commit -m "feat: materialize discoverable vibe wrapper entries"
+```
+
+### Task 4: Align adapter metadata with generated wrapper projection truth
+
+**Files:**
+- Modify: `config/adapter-registry.json`
+- Modify: `adapters/index.json`
+- Modify: `adapters/codex/host-profile.json`
+- Modify: `adapters/claude-code/host-profile.json`
+- Modify: `adapters/cursor/host-profile.json`
+- Modify: `adapters/windsurf/host-profile.json`
+- Modify: `adapters/openclaw/host-profile.json`
+- Modify: `adapters/opencode/host-profile.json`
+- Modify: `tests/contract/test_adapter_descriptor_contract.py`
+- Modify: `tests/unit/test_adapter_registry_support.py`
+
+- [ ] **Step 1: Extend adapter tests to require projection metadata**
+
+Keep the existing invariant:
+
+```python
+assert discoverable_entries["presentational_only"] is True
+```
+
+Add new assertions such as:
+
+```python
+assert discoverable_entries["projection_mode"] == "generated_wrapper_entries"
+assert discoverable_entries["shared_source"] == "config/vibe-entry-surfaces.json"
+assert discoverable_entries["authority_owner"] == "vibe"
+assert discoverable_entries["host_visible_surface"]
+```
+
+- [ ] **Step 2: Run adapter contract tests to verify failure**
+
+Run:
+
+```bash
+pytest \
+  tests/contract/test_adapter_descriptor_contract.py \
+  tests/unit/test_adapter_registry_support.py -q
+```
+
+Expected: FAIL because profiles currently stop at `presentational_only` with no host-visible projection metadata.
+
+- [ ] **Step 3: Update adapter registry and host profiles**
+
+Add per-adapter fields that stay truthful and host-specific without owning semantics, for example:
+
+```json
+"discoverable_entries": {
+  "shared_source": "config/vibe-entry-surfaces.json",
+  "authority_owner": "vibe",
+  "presentational_only": true,
+  "projection_mode": "generated_wrapper_entries",
+  "host_visible_surface": "commands"
+}
+```
+
+Use host-appropriate `host_visible_surface` values:
+- Codex: command surface
+- Claude Code: command or managed launcher surface
+- Cursor: preview-guidance command/skill surface
+- Windsurf/OpenClaw: runtime-core wrapper surface
+- OpenCode: command/agent surface
+
+- [ ] **Step 4: Re-run adapter contract tests to verify pass**
+
+Run the same `pytest` command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  config/adapter-registry.json \
+  adapters/index.json \
+  adapters/codex/host-profile.json \
+  adapters/claude-code/host-profile.json \
+  adapters/cursor/host-profile.json \
+  adapters/windsurf/host-profile.json \
+  adapters/openclaw/host-profile.json \
+  adapters/opencode/host-profile.json \
+  tests/contract/test_adapter_descriptor_contract.py \
+  tests/unit/test_adapter_registry_support.py
+git commit -m "docs: declare host-visible wrapper projection metadata"
+```
+
+## Chunk 3: Ledger Truth, Check Surfaces, And Cross-Platform Validation
+
+### Task 5: Separate canonical public skills from host-visible wrapper entries in install ledgers
+
+**Files:**
+- Modify: `packages/installer-core/src/vgo_installer/install_plan.py`
+- Modify: `packages/installer-core/src/vgo_installer/ledger_service.py`
+- Modify: `tests/unit/test_installer_ledger_service.py`
+- Modify: `tests/runtime_neutral/test_install_profile_differentiation.py`
+- Modify: `tests/runtime_neutral/test_installed_runtime_scripts.py`
+
+- [ ] **Step 1: Write failing tests for host-visible entry summary fields**
+
+Extend ledger tests to require fields like:
+
+```python
+assert ledger["payload_summary"]["public_skill_names"] == ["vibe"]
+assert ledger["payload_summary"]["host_visible_entry_names"] == ["vibe", "vibe-do", "vibe-how", "vibe-want"]
+assert ledger["payload_summary"]["host_visible_entry_count"] == 4
+```
+
+Extend runtime-neutral install tests so both `minimal` and `full` installs still report only canonical public top-level skills while also reporting all host-visible wrapper entries.
+
+- [ ] **Step 2: Run the ledger/install summary tests to verify failure**
+
+Run:
+
+```bash
+pytest \
+  tests/unit/test_installer_ledger_service.py \
+  tests/runtime_neutral/test_install_profile_differentiation.py \
+  tests/runtime_neutral/test_installed_runtime_scripts.py -q
+```
+
+Expected: FAIL because `build_payload_summary()` only counts `skills/<name>` directories today.
+
+- [ ] **Step 3: Update ledger summary generation**
+
+Modify `ledger_service.py` so payload summary distinguishes:
+
+```python
+{
+  "public_skill_names": ["vibe"],
+  "public_skill_count": 1,
+  "host_visible_entry_names": ["vibe", "vibe-do", "vibe-how", "vibe-want"],
+  "host_visible_entry_count": 4,
+}
+```
+
+Use wrapper paths recorded during install rather than inferring host-visible readiness from `skills/` directories alone.
+
+- [ ] **Step 4: Re-run the ledger/install summary tests to verify pass**
+
+Run the same `pytest` command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  packages/installer-core/src/vgo_installer/install_plan.py \
+  packages/installer-core/src/vgo_installer/ledger_service.py \
+  tests/unit/test_installer_ledger_service.py \
+  tests/runtime_neutral/test_install_profile_differentiation.py \
+  tests/runtime_neutral/test_installed_runtime_scripts.py
+git commit -m "feat: report host-visible vibe wrapper entries in install ledger"
+```
+
+### Task 6: Make `check.sh` and `check.ps1` validate host-visible wrapper readiness honestly
+
+**Files:**
+- Modify: `check.sh`
+- Modify: `check.ps1`
+- Create: `tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py`
+- Modify: `tests/runtime_neutral/test_claude_preview_scaffold.py`
+- Modify: `tests/runtime_neutral/test_opencode_preview_parity.py`
+- Modify: `tests/runtime_neutral/test_windsurf_runtime_core.py`
+- Modify: `tests/runtime_neutral/test_openclaw_runtime_core.py`
+
+- [ ] **Step 1: Write failing runtime-neutral checks for wrapper visibility**
+
+Create `tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py` with shell and PowerShell coverage:
+
+```python
+result = subprocess.run([... "check.sh", "--host", "codex", "--target-root", str(target_root)], ...)
+assert "host-visible discoverable entries" in result.stdout
+assert "[OK]" in result.stdout
+```
+
+Add a degraded case where wrapper files are removed after install and assert check output contains a failure such as `not host-visible`.
+
+- [ ] **Step 2: Run the check-surface tests to verify failure**
+
+Run:
+
+```bash
+pytest \
+  tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py \
+  tests/runtime_neutral/test_claude_preview_scaffold.py \
+  tests/runtime_neutral/test_opencode_preview_parity.py \
+  tests/runtime_neutral/test_windsurf_runtime_core.py \
+  tests/runtime_neutral/test_openclaw_runtime_core.py -q
+```
+
+Expected: FAIL because current check scripts do not validate wrapper visibility.
+
+- [ ] **Step 3: Update shell and PowerShell check flows**
+
+Teach both scripts to:
+- load install ledger payload summary
+- inspect recorded wrapper paths
+- report a dedicated line for host-visible discoverable entry readiness
+- fail or warn honestly when runtime payload exists but wrappers are missing
+
+Keep platform-specific wrapper behavior equivalent:
+- `check.sh` for Linux/macOS
+- `check.ps1` for Windows/PowerShell
+
+- [ ] **Step 4: Re-run the check-surface tests to verify pass**
+
+Run the same `pytest` command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  check.sh \
+  check.ps1 \
+  tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py \
+  tests/runtime_neutral/test_claude_preview_scaffold.py \
+  tests/runtime_neutral/test_opencode_preview_parity.py \
+  tests/runtime_neutral/test_windsurf_runtime_core.py \
+  tests/runtime_neutral/test_openclaw_runtime_core.py
+git commit -m "feat: verify host-visible vibe wrapper readiness in check flows"
+```
+
+### Task 7: Update user-facing docs so they describe shipped wrapper surfaces truthfully
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.zh.md`
+- Modify: `docs/quick-start.md`
+- Modify: `docs/quick-start.en.md`
+
+- [ ] **Step 1: Add or update doc assertions in existing text-based tests**
+
+If no dedicated doc test already covers the changed wording, extend an existing discoverability-oriented test or add a small integration test that asserts wording like:
+
+```python
+assert "If your host exposes the installed wrapper entries" in quick_start
+assert "host-visible" in quick_start
+```
+
+- [ ] **Step 2: Run the affected docs/discoverability tests to verify failure**
+
+Run:
+
+```bash
+pytest \
+  tests/integration/test_codex_install_prompt_discoverability.py \
+  tests/integration/test_version_governance_runtime_roles.py -q
+```
+
+Expected: FAIL or require wording updates because docs currently overpromise discoverability without install-time host-visible proof.
+
+- [ ] **Step 3: Update docs**
+
+Make docs say the truthful shipped behavior:
+- wrapper entries are installed host-visible surfaces on supported hosts
+- they still resolve to canonical `vibe`
+- `$vibe` textual invocation remains valid but is not the primary discoverable UX
+
+- [ ] **Step 4: Re-run the affected docs/discoverability tests to verify pass**
+
+Run the same `pytest` command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  README.md \
+  README.zh.md \
+  docs/quick-start.md \
+  docs/quick-start.en.md \
+  tests/integration/test_codex_install_prompt_discoverability.py \
+  tests/integration/test_version_governance_runtime_roles.py
+git commit -m "docs: align multi-host wrapper discoverability wording"
+```
+
+## Chunk 4: End-To-End Verification And Delivery Evidence
+
+### Task 8: Run the full wrapper-projection verification matrix before claiming completion
+
+**Files:**
+- Inspect only: working tree, install receipts, generated wrapper files, test logs
+
+- [ ] **Step 1: Run the focused pytest regression matrix**
+
+Run:
+
+```bash
+pytest \
+  tests/contract/test_vibe_discoverable_entry_contract.py \
+  tests/contract/test_adapter_descriptor_contract.py \
+  tests/unit/test_adapter_registry_support.py \
+  tests/unit/test_discoverable_entry_surface.py \
+  tests/unit/test_discoverable_wrappers.py \
+  tests/unit/test_runtime_packaging_resolver.py \
+  tests/unit/test_router_contract_support_descriptor_sources.py \
+  tests/unit/test_installer_ledger_service.py \
+  tests/integration/test_runtime_core_packaging_roles.py \
+  tests/runtime_neutral/test_install_profile_differentiation.py \
+  tests/runtime_neutral/test_installed_runtime_scripts.py \
+  tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py \
+  tests/runtime_neutral/test_claude_preview_scaffold.py \
+  tests/runtime_neutral/test_opencode_preview_parity.py \
+  tests/runtime_neutral/test_windsurf_runtime_core.py \
+  tests/runtime_neutral/test_openclaw_runtime_core.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run shell install/check smoke tests in temp roots**
+
+Run:
+
+```bash
+tmp_root="$(mktemp -d)"
+bash ./install.sh --host codex --profile full --target-root "${tmp_root}/codex"
+bash ./check.sh --host codex --profile full --target-root "${tmp_root}/codex" --deep
+```
+
+Expected:
+- install succeeds
+- check reports host-visible discoverable entries ready
+- generated wrapper files exist under the Codex host-visible command surface
+
+- [ ] **Step 3: Run PowerShell install/check smoke tests in temp roots**
+
+Run:
+
+```bash
+pwsh -NoProfile -File ./install.ps1 -HostId codex -Profile full -TargetRoot "${tmp_root}/codex-ps"
+pwsh -NoProfile -File ./check.ps1 -HostId codex -Profile full -TargetRoot "${tmp_root}/codex-ps" -Deep
+```
+
+Expected:
+- install succeeds
+- check reports host-visible discoverable entries ready
+- wrapper visibility status matches shell lane
+
+- [ ] **Step 4: Inspect git diff and summarize proof artifacts**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected:
+- only planned files changed
+- no stray host-temp artifacts remain
+
+- [ ] **Step 5: Commit final implementation batch**
+
+```bash
+git add .
+git commit -m "feat: project discoverable vibe wrappers across supported hosts"
+```
+
+## Plan Notes
+- Keep `presentational_only: true` in adapter metadata. The wrappers are still presentational launch surfaces, even after they become real host-visible installed entries.
+- Do not widen `compatibility_skill_projections` into semantic truth. Wrapper visibility belongs to `public_skill_surface` plus generated host entry artifacts.
+- Do not solve this by hand-maintaining four semantic copies of runtime command files per host. Use generation or a focused render helper so semantics remain centralized.
+- Do not claim Windows/Linux compatibility until both install/check smoke lanes and the runtime-neutral tests pass.

--- a/docs/superpowers/specs/2026-04-08-vibe-multi-host-wrapper-skill-projection-design.md
+++ b/docs/superpowers/specs/2026-04-08-vibe-multi-host-wrapper-skill-projection-design.md
@@ -1,0 +1,457 @@
+# Vibe Multi-Host Wrapper Skill Projection Design
+
+## Summary
+Define a multi-host discoverable entry architecture that exposes `vibe`, `vibe-want`, `vibe-how`, and `vibe-do` as host-visible wrapper skills while preserving one canonical governed runtime authority: `vibe`.
+
+The core runtime, routing, stage machine, requirement freeze, plan freeze, execution, and cleanup contracts remain singular and canonical. The new work is the projection layer: shared entry metadata must drive packaging, installer materialization, host adapter projection, install/check reporting, and regression tests so that discoverable menu entries are actually materialized on supported hosts instead of existing only in docs and contract files.
+
+This design assumes the target hosts support skill-menu or command-menu discoverability. The problem being solved is not whether hosts can render menus. The problem is making the repo ship those discoverable entries consistently across hosts without forking runtime truth.
+
+## Problem
+The repository already has a shared discoverable-entry contract in `config/vibe-entry-surfaces.json`, and runtime packet handling already understands `entry_intent_id`, `requested_stage_stop`, and grade-floor metadata. But the install surface still exposes only canonical `vibe` because the packaging layer remains locked to `canonical_vibe_only`.
+
+That creates four concrete failures:
+
+1. docs claim that users may see `Vibe`, `Vibe: What Do I Want?`, `Vibe: How Do We Do It?`, and `Vibe: Do It`
+2. host adapters declare discoverable entries as a presentational concept
+3. runtime tests validate the shortcut contract
+4. installed hosts still materialize only the canonical `vibe` launch surface
+
+The result is a cross-layer contract drift: runtime truth exists, docs promise it, but packaging and installation do not project it into host-visible menu entries.
+
+## Goals
+- Materialize four host-visible wrapper entries from one shared contract.
+- Preserve one runtime authority, one stage machine, and one requirement/plan/cleanup truth surface.
+- Keep grade-floor flags orthogonal to stage intent and prohibit stage-grade alias explosion.
+- Make the solution host-generic so `codex`, `claude-code`, `cursor`, `windsurf`, `openclaw`, and `opencode` consume the same discoverable-entry truth.
+- Keep packaging, installer behavior, install reports, and docs aligned with what hosts actually receive.
+- Add explicit verification for Linux and Windows materialization paths.
+
+## Non-Goals
+- No new runtime authority besides `vibe`.
+- No `vibe-want-xl`, `vibe-how-l`, `vibe-do-xl`, or other matrix aliases.
+- No host-specific semantic forks where an adapter decides what a wrapper means.
+- No duplication of requirement generation, planning, execution, or cleanup logic.
+- No assumption that `$vibe xxx` textual subcommands are the primary UX.
+- No attempt to solve host plugin provisioning, provider credentials, or MCP readiness inside this design.
+
+## Existing Constraints
+
+### Canonical Discoverable Contract
+`config/vibe-entry-surfaces.json` is already the correct shared truth for:
+
+- `id`
+- `display_name`
+- `requested_stage_stop`
+- `allow_grade_flags`
+- public grade flags `--l` and `--xl`
+
+The approved ids are fixed:
+
+- `vibe`
+- `vibe-want`
+- `vibe-how`
+- `vibe-do`
+
+### Current Root Cause
+`config/runtime-core-packaging.full.json` and `config/runtime-core-packaging.minimal.json` still define:
+
+- `public_skill_surface.mode = canonical_vibe_only`
+- `public_skill_surface.projected_skill_names = ["vibe"]`
+
+That keeps the public install surface narrower than the discoverable-entry contract.
+
+### Runtime Boundary That Must Not Change
+The canonical runtime remains:
+
+- runtime skill id: `vibe`
+- requirement authority: single governed requirement doc
+- planning authority: single governed plan doc
+- execution authority: canonical plan execution
+- cleanup authority: canonical phase cleanup
+
+Wrappers may only influence entry metadata:
+
+- `entry_intent_id`
+- `requested_stage_stop`
+- `requested_grade_floor`
+
+## Architecture Decision
+Choose a **multiple thin wrapper skills, single canonical runtime** architecture.
+
+Each discoverable entry is a host-visible wrapper surface generated from shared metadata. Each wrapper points back to canonical `vibe` and contributes only bounded launch metadata. Runtime semantics remain centralized in the existing governed runtime.
+
+This gives the user the multi-entry discoverability they want, but keeps architecture quality defensible:
+
+- high cohesion: runtime behavior lives in runtime-core, not in adapters
+- low coupling: hosts project the same contract without owning semantics
+- low regression risk: wrappers do not fork execution logic
+
+## Design Units
+
+### 1. Shared Entry Contract Unit
+**Responsibility:** define the only approved public discoverable entries and their launch semantics.
+
+**Primary file:** `config/vibe-entry-surfaces.json`
+
+**Interface:**
+- input to packaging projection
+- input to host adapter projection
+- input to runtime validation
+- input to install/check reporting
+
+**Rules:**
+- only one canonical runtime skill id: `vibe`
+- only four public entry ids
+- only `--l` and `--xl` as public grade-floor flags
+- `vibe-want` rejects public grade flags
+
+### 2. Public Surface Packaging Unit
+**Responsibility:** describe which discoverable wrappers must be materialized as host-visible public surfaces.
+
+**Primary files:**
+- `config/runtime-core-packaging.json`
+- `config/runtime-core-packaging.full.json`
+- `config/runtime-core-packaging.minimal.json`
+
+**Interface:**
+- consumed by packaging resolvers in installer-core and runtime-core
+- exported into install plan and manifest descriptors
+
+**Required change:**
+- replace `canonical_vibe_only` with a wrapper-aware public surface mode
+- declare wrapper projections from shared contract rather than hardcoded per profile
+
+**Boundary rule:**
+- public surface describes host-visible entry surfaces
+- compatibility projections remain for legacy or host-specific path preservation only
+- internal skill corpus remains private under canonical `vibe`
+
+### 3. Wrapper Projection Resolver Unit
+**Responsibility:** resolve which wrapper skills/commands should exist in a target installation for a given profile and host.
+
+**Primary files:**
+- `packages/installer-core/src/vgo_installer/runtime_packaging.py`
+- `packages/runtime-core/src/vgo_runtime/router_contract_support.py`
+- `packages/installer-core/src/vgo_installer/install_plan.py`
+
+**Interface:**
+- takes packaging config plus discoverable-entry contract
+- returns canonical root, public wrapper names, resolver roots, and projection metadata
+
+**Rules:**
+- wrapper names are derived from shared entry ids, not duplicated in code and config separately
+- canonical `vibe` stays the runtime-selected skill even when wrapper entry is used
+- resolver output must be stable across repo mode and installed-host mode
+
+### 4. Host Materialization Unit
+**Responsibility:** physically materialize host-visible wrapper skill or command descriptors in the installed target root.
+
+**Primary files:**
+- `packages/installer-core/src/vgo_installer/materializer.py`
+- `packages/installer-core/src/vgo_installer/install_runtime.py`
+
+**Interface:**
+- receives resolved public wrapper projection data
+- writes host-visible wrapper files into the host’s command or skill discovery surface
+
+**Rules:**
+- wrappers are generated artifacts, not hand-maintained semantic copies
+- wrappers may vary in shell syntax or frontmatter shape per host, but not in entry semantics
+- generated wrappers must be recorded in the install ledger as host-visible surfaces
+
+### 5. Host Adapter Projection Unit
+**Responsibility:** define how each host renders the same discoverable wrappers into its native menu/discovery surface.
+
+**Primary files:**
+- `config/adapter-registry.json`
+- `adapters/*/host-profile.json`
+- host-specific templates or command descriptors under adapter/config trees
+
+**Host-specific behavior allowed:**
+- path conventions
+- frontmatter/schema differences
+- display formatting differences required by host limitations
+
+**Host-specific behavior forbidden:**
+- inventing extra public entry ids
+- changing stop targets
+- changing grade-flag policy
+- creating separate runtime authorities
+
+### 5A. Per-Host Projection Contract
+The projection mechanism is shared, but the host-visible target differs by adapter.
+
+**Codex**
+- target shape: command-style discoverable entries in the host command surface
+- installed expectation: canonical `vibe` plus wrapper command files for `vibe-want`, `vibe-how`, and `vibe-do`
+- verification focus: files are present in the real Codex host root and visible to the command menu, not only present in repo `commands/`
+
+**Claude Code**
+- target shape: host-visible commands or skill launchers within the managed Claude settings surface
+- installed expectation: wrapper entries are added without replacing the broader host-managed settings space
+- verification focus: wrapper entries are merged into the real Claude host surface and survive bounded settings merging
+
+**Cursor**
+- target shape: preview-guidance discoverable command or skill entries
+- installed expectation: wrappers are exposed as menu-visible launch surfaces without claiming full takeover of Cursor settings
+- verification focus: wrapper projection exists in the real Cursor host root and is reported separately from generic runtime payload
+
+**Windsurf**
+- target shape: runtime-core wrapper descriptors in the Windsurf host-visible launch surface
+- installed expectation: runtime payload and `.vibeskills/*` sidecar remain separate from wrapper discoverability
+- verification focus: wrapper readiness is reported independently from runtime-core sidecar installation
+
+**OpenClaw**
+- target shape: preview runtime-core wrapper descriptors compatible with attach, copy, or bundle style installation
+- installed expectation: wrapper discoverability is visible in the chosen OpenClaw host path, not just in sidecar artifacts
+- verification focus: install/check distinguishes runtime payload presence from wrapper menu visibility
+
+**OpenCode**
+- target shape: command or agent discoverable entries alongside the existing preview-guidance payload
+- installed expectation: wrapper entries live in the host-visible OpenCode discovery surface while real `opencode.json` remains host-managed
+- verification focus: wrapper entries are visible independently of `opencode.json.example`, provider credentials, or plugin state
+
+**Generic adapter**
+- out of scope for discoverable-wrapper completeness
+- rule: generic may remain canonical-`vibe` only unless it grows a stable host-visible menu contract
+
+### 6. Install And Check Reporting Unit
+**Responsibility:** report truthfully whether wrapper entries are installed locally and host-visible.
+
+**Primary files:**
+- `install.sh`
+- `install.ps1`
+- `check.sh`
+- `check.ps1`
+- installer-core reporting paths
+
+**Required reporting split:**
+- `installed locally`
+- `vibe host-ready`
+- `host-visible discoverable entries`
+- `mcp native auto-provision attempted`
+- per-MCP `host-visible readiness`
+- `online-ready`
+
+**Truth rule:**
+- runtime payload existing is not enough
+- wrapper metadata in config is not enough
+- docs mentioning wrappers is not enough
+- host-visible installed wrapper files must exist before the install/check path reports discoverable entries ready
+
+## Wrapper Semantics
+
+### Canonical `vibe`
+- entry id: `vibe`
+- stop target: `phase_cleanup`
+- grade flags allowed: yes
+- semantic meaning: full governed flow
+
+### `vibe-want`
+- entry id: `vibe-want`
+- stop target: `deep_interview`
+- grade flags allowed: no
+- semantic meaning: clarify goal, boundaries, and acceptance criteria
+
+### `vibe-how`
+- entry id: `vibe-how`
+- stop target: `xl_plan`
+- grade flags allowed: yes
+- semantic meaning: freeze requirement and plan without executing later stages
+
+### `vibe-do`
+- entry id: `vibe-do`
+- stop target: `phase_cleanup`
+- grade flags allowed: yes
+- semantic meaning: execute the governed flow, while still preserving requirement and plan stages
+
+## Data Flow
+
+### Launch Flow
+1. User selects a host-visible wrapper entry from a skill or command menu.
+2. The wrapper injects `entry_intent_id`.
+3. The wrapper injects the approved `requested_stage_stop`.
+4. If allowed, the wrapper forwards `--l` or `--xl` as `requested_grade_floor`.
+5. Canonical router/runtime authority still resolves to `vibe`.
+6. Governed runtime executes the same six-stage state machine and stops at the requested stop target.
+
+### Packaging And Installation Flow
+1. Packaging loads shared entry contract.
+2. Packaging resolves public wrapper projection names.
+3. Installer materializes canonical `vibe` plus wrapper descriptors into host-visible surfaces.
+4. Install ledger records wrapper surfaces as generated managed artifacts.
+5. Check flow validates both runtime payload and host-visible wrapper presence.
+
+### Validation Flow
+1. Contract tests validate shared entry truth.
+2. Packaging tests validate wrapper projection resolution.
+3. Installer tests validate wrapper materialization.
+4. Runtime tests validate packet metadata and stop behavior.
+5. Cross-platform tests validate Linux and Windows install/check parity.
+
+## Practical Implementation Strategy
+
+### Phase 1: Contract And Packaging Alignment
+Update packaging manifests so public surfaces are derived from discoverable-entry truth rather than fixed to `["vibe"]`.
+
+Implementation targets:
+- `config/runtime-core-packaging.json`
+- `config/runtime-core-packaging.full.json`
+- `config/runtime-core-packaging.minimal.json`
+- `packages/installer-core/src/vgo_installer/runtime_packaging.py`
+- `packages/runtime-core/src/vgo_runtime/router_contract_support.py`
+
+Deliverable:
+- packaging resolver can enumerate all four approved wrappers from shared contract
+
+### Phase 2: Generated Wrapper Projection
+Introduce a generated-wrapper projection path so each host receives discoverable wrapper descriptors without semantic duplication.
+
+Implementation targets:
+- `packages/installer-core/src/vgo_installer/materializer.py`
+- `packages/installer-core/src/vgo_installer/install_runtime.py`
+- host template locations referenced by adapters
+
+Deliverable:
+- installer writes host-visible wrapper files for `vibe-want`, `vibe-how`, and `vibe-do` in addition to canonical `vibe`
+
+### Phase 3: Adapter-Specific Projection Rules
+Make each supported adapter consume the same discoverable-entry truth and project wrapper files into the host-native discovery surface.
+
+Implementation targets:
+- `config/adapter-registry.json`
+- `adapters/codex/host-profile.json`
+- `adapters/claude-code/host-profile.json`
+- `adapters/cursor/host-profile.json`
+- `adapters/windsurf/host-profile.json`
+- `adapters/openclaw/host-profile.json`
+- `adapters/opencode/host-profile.json`
+
+Deliverable:
+- every adapter reports that discoverable entries are projected from shared wrapper truth, not presentational-only placeholders with no materialization path
+
+### Phase 4: Install, Check, And Report Truthfulness
+Make install/check output explicitly report host-visible discoverable entry readiness and fail or degrade honestly when wrapper materialization is absent.
+
+Implementation targets:
+- `install.sh`
+- `install.ps1`
+- `check.sh`
+- `check.ps1`
+- installer-core reporting functions
+
+Deliverable:
+- install/check can tell the operator whether discoverable wrapper entries are merely configured or actually visible in the host
+
+### Phase 5: Docs And Regression Closure
+Update docs to describe discoverable wrappers as actual shipped surfaces and lock behavior with cross-layer tests.
+
+Implementation targets:
+- `docs/quick-start.md`
+- `docs/quick-start.en.md`
+- install-path docs for affected hosts
+- release notes / PR description
+
+Deliverable:
+- docs, install behavior, and test evidence tell the same story
+
+## Error Handling And Edge Cases
+- If a host adapter cannot materialize a stable host-visible wrapper surface, install/check must report `not host-visible` rather than silently succeeding.
+- If a host has formatting constraints on entry labels, cosmetic display changes are allowed, but ids must remain stable.
+- If a wrapper file is missing after installation, check must mark discoverable-entry readiness as incomplete even if canonical `vibe` exists.
+- If more than one public grade flag is requested, runtime input validation must continue rejecting the invocation.
+- If a wrapper that forbids grade flags receives one, the runtime or launcher must reject it explicitly rather than silently ignoring it.
+- If the canonical `vibe` root exists but wrapper descriptors are stale, installer refresh must replace them atomically enough to avoid partial host-visible drift.
+
+## Testing Strategy
+
+### Contract Tests
+- extend `tests/contract/test_vibe_discoverable_entry_contract.py`
+- extend `tests/contract/test_adapter_descriptor_contract.py`
+
+Assertions:
+- four fixed ids only
+- fixed display names only
+- correct stop targets
+- grade-flag allowance policy
+- adapters consume shared wrapper truth
+
+### Packaging Resolver Tests
+- extend `tests/unit/test_runtime_packaging_resolver.py`
+- extend `tests/integration/test_runtime_core_packaging_roles.py`
+- extend `tests/unit/test_router_contract_support_descriptor_sources.py`
+
+Assertions:
+- public surface projection resolves all four wrapper ids
+- canonical runtime relpath stays `skills/vibe`
+- compatibility projections stay narrow and do not become semantic truth
+
+### Installer Materialization Tests
+- add or extend installer-core tests around generated wrapper files
+- extend `tests/runtime_neutral/test_install_profile_differentiation.py`
+
+Assertions:
+- target root contains host-visible wrapper descriptors
+- wrappers are recorded in ledger state
+- full and minimal profiles behave according to policy
+
+### Runtime Integration Tests
+- preserve and extend:
+  - `tests/integration/test_runtime_packet_execution.py`
+  - `tests/unit/test_vgo_cli_commands.py`
+  - `tests/runtime_neutral/test_l_xl_native_execution_topology.py`
+
+Assertions:
+- wrapper entries still resolve runtime-selected skill to `vibe`
+- stop-stage behavior is truthful
+- `vibe-want` rejects grade flags
+- `vibe-how` and `vibe-do` preserve grade-floor behavior
+
+### Cross-Platform Verification
+Required verification lanes:
+- Linux install/check path
+- Windows install/check path
+
+Evidence target:
+- wrapper entries are not only contract-valid but physically materialized in host-visible surfaces on both platforms
+
+## Cohesion And Coupling Standard
+This design must be implemented so that:
+
+- runtime-core owns runtime behavior
+- installer-core owns materialization
+- adapter metadata owns host-specific projection format
+- docs describe public behavior but never define semantics
+
+Bad implementation patterns to reject:
+
+- host adapters hardcoding stop targets independently
+- duplicated wrapper semantics in multiple command files with no generator or shared source
+- install scripts directly inventing wrapper names not present in shared contract
+- runtime behavior branching by host when the entry semantics are host-neutral
+
+## Rollout Strategy
+Use a staged rollout:
+
+1. land contract and packaging alignment first
+2. land generated wrapper materialization second
+3. land install/check truthfulness third
+4. land docs and release evidence last
+
+This sequencing keeps regression diagnosis easier because each phase narrows the fault domain.
+
+## Acceptance Criteria
+- A fresh install on a supported host materializes host-visible entries for `vibe`, `vibe-want`, `vibe-how`, and `vibe-do`.
+- Selecting any wrapper still routes into canonical `vibe` governed runtime.
+- `vibe-want` stops at `deep_interview` and cannot take `--l` or `--xl`.
+- `vibe-how` stops at `xl_plan` and can carry a grade floor into planning.
+- `vibe-do` executes the full governed path without skipping requirement or plan.
+- Packaging, installer, adapter metadata, docs, and tests all derive from the same shared discoverable-entry contract.
+- Linux and Windows verification prove host-visible wrapper materialization, not just runtime payload presence.
+
+## Open Questions Resolved By This Design
+- Multiple wrapper skills are the correct compatibility shape because they map cleanly into host skill menus.
+- They are still wrappers, not new runtimes.
+- Cross-host support should be implemented once in shared projection logic, not re-invented host by host.
+- `$vibe xxx` textual composition is not the primary public UX and does not need to be the center of this design.

--- a/packages/contracts/src/vgo_contracts/__init__.py
+++ b/packages/contracts/src/vgo_contracts/__init__.py
@@ -7,6 +7,13 @@ from .adapter_registry_support import (
     resolve_adapter_registry_path,
 )
 from .catalog_descriptor import CatalogDescriptor
+from .discoverable_entry_surface import (
+    DISCOVERABLE_ENTRY_SURFACE_RELPATH,
+    DiscoverableEntry,
+    DiscoverableEntrySurface,
+    load_discoverable_entry_surface,
+    resolve_discoverable_entry_surface_path,
+)
 from .governance_runtime_roles import (
     REQUIRED_RUNTIME_MARKER_NOTES,
     RUNTIME_PAYLOAD_ROLE_NOTES,
@@ -60,6 +67,11 @@ __all__ = [
     'resolve_adapter_entry',
     'resolve_adapter_registry_path',
     'CatalogDescriptor',
+    'DISCOVERABLE_ENTRY_SURFACE_RELPATH',
+    'DiscoverableEntry',
+    'DiscoverableEntrySurface',
+    'load_discoverable_entry_surface',
+    'resolve_discoverable_entry_surface_path',
     'REQUIRED_RUNTIME_MARKER_NOTES',
     'RUNTIME_PAYLOAD_ROLE_NOTES',
     'derive_required_runtime_marker_groups',

--- a/packages/contracts/src/vgo_contracts/discoverable_entry_surface.py
+++ b/packages/contracts/src/vgo_contracts/discoverable_entry_surface.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+
+
+DISCOVERABLE_ENTRY_SURFACE_RELPATH = Path('config') / 'vibe-entry-surfaces.json'
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoverableEntry:
+    id: str
+    display_name: str
+    requested_stage_stop: str
+    allow_grade_flags: bool
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoverableEntrySurface:
+    canonical_runtime_skill: str
+    entries: tuple[DiscoverableEntry, ...]
+    grade_flags: list[str]
+    grade_flag_map: dict[str, str]
+    forbid_stage_grade_matrix: bool
+
+    @property
+    def entry_by_id(self) -> dict[str, DiscoverableEntry]:
+        return {entry.id: entry for entry in self.entries}
+
+    @property
+    def projected_skill_names(self) -> list[str]:
+        return [entry.id for entry in self.entries]
+
+
+def resolve_discoverable_entry_surface_path(start_path: str | Path) -> Path:
+    current = Path(start_path).resolve()
+    if current.is_file():
+        current = current.parent
+
+    while True:
+        candidate = current / DISCOVERABLE_ENTRY_SURFACE_RELPATH
+        if candidate.exists():
+            return candidate
+        if current.parent == current:
+            break
+        current = current.parent
+
+    raise RuntimeError(f'VGO discoverable entry surface not found from start path: {start_path}')
+
+
+def load_discoverable_entry_surface(start_path: str | Path) -> DiscoverableEntrySurface:
+    payload = json.loads(resolve_discoverable_entry_surface_path(start_path).read_text(encoding='utf-8-sig'))
+    entries = tuple(
+        DiscoverableEntry(
+            id=str(entry['id']).strip(),
+            display_name=str(entry['display_name']).strip(),
+            requested_stage_stop=str(entry['requested_stage_stop']).strip(),
+            allow_grade_flags=bool(entry['allow_grade_flags']),
+        )
+        for entry in payload.get('entries') or []
+    )
+    return DiscoverableEntrySurface(
+        canonical_runtime_skill=str(payload.get('canonical_runtime_skill') or 'vibe').strip() or 'vibe',
+        entries=entries,
+        grade_flags=[str(flag).strip() for flag in payload.get('grade_flags') or [] if str(flag).strip()],
+        grade_flag_map={
+            str(flag).strip(): str(grade).strip()
+            for flag, grade in (payload.get('grade_flag_map') or {}).items()
+            if str(flag).strip() and str(grade).strip()
+        },
+        forbid_stage_grade_matrix=bool(payload.get('forbid_stage_grade_matrix')),
+    )

--- a/packages/installer-core/src/vgo_installer/discoverable_wrappers.py
+++ b/packages/installer-core/src/vgo_installer/discoverable_wrappers.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from vgo_contracts.discoverable_entry_surface import DiscoverableEntry, DiscoverableEntrySurface
+
+
+@dataclass(frozen=True, slots=True)
+class WrapperDescriptor:
+    entry_id: str
+    relpath: Path
+    content: str
+
+
+def _frontmatter_lines(host_id: str, entry: DiscoverableEntry) -> list[str]:
+    lines = [
+        "---",
+        f"description: Launch {entry.display_name} through the canonical governed Vibe runtime.",
+    ]
+    if host_id == "opencode":
+        lines.append("agent: vibe-plan")
+    lines.append("---")
+    return lines
+
+
+def _body_lines(entry: DiscoverableEntry) -> list[str]:
+    grade_line = "yes" if entry.allow_grade_flags else "no"
+    return [
+        "Use the `vibe` skill and follow its governed runtime contract for this request.",
+        "",
+        f"Wrapper entry: {entry.display_name} (`{entry.id}`)",
+        f"Default stop target: `{entry.requested_stage_stop}`",
+        f"Public grade flags allowed: {grade_line}",
+        "",
+        "Request:",
+        "$ARGUMENTS",
+    ]
+
+
+def build_wrapper_descriptors(host_id: str, surface: DiscoverableEntrySurface) -> dict[str, WrapperDescriptor]:
+    descriptors: dict[str, WrapperDescriptor] = {}
+    for entry in surface.entries:
+        content = "\n".join([*_frontmatter_lines(host_id, entry), "", *_body_lines(entry), ""]) + "\n"
+        descriptors[entry.id] = WrapperDescriptor(
+            entry_id=entry.id,
+            relpath=Path("commands") / f"{entry.id}.md",
+            content=content,
+        )
+    return descriptors
+
+
+def _host_command_surface_relpaths(host_id: str) -> tuple[Path, ...]:
+    normalized = (host_id or "").strip().lower()
+    if normalized == "opencode":
+        return (Path("commands"), Path("command"))
+    if normalized in {"claude-code", "cursor", "windsurf", "openclaw"}:
+        return ()
+    return (Path("commands"),)
+
+
+def materialize_host_visible_wrappers(
+    *,
+    target_root: Path,
+    host_id: str,
+    surface: DiscoverableEntrySurface,
+) -> list[Path]:
+    descriptors = build_wrapper_descriptors(host_id, surface)
+    written: list[Path] = []
+    for rel_root in _host_command_surface_relpaths(host_id):
+        root = target_root / rel_root
+        root.mkdir(parents=True, exist_ok=True)
+        for descriptor in descriptors.values():
+            destination = root / descriptor.relpath.name
+            destination.write_text(descriptor.content, encoding="utf-8")
+            written.append(destination)
+    return written

--- a/packages/installer-core/src/vgo_installer/discoverable_wrappers.py
+++ b/packages/installer-core/src/vgo_installer/discoverable_wrappers.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from vgo_contracts.discoverable_entry_surface import DiscoverableEntry, DiscoverableEntrySurface
+from vgo_contracts.runtime_surface_contract import uses_skill_only_activation
 
 
 @dataclass(frozen=True, slots=True)
@@ -13,11 +14,25 @@ class WrapperDescriptor:
     content: str
 
 
-def _frontmatter_lines(host_id: str, entry: DiscoverableEntry) -> list[str]:
-    lines = [
-        "---",
-        f"description: Launch {entry.display_name} through the canonical governed Vibe runtime.",
-    ]
+def _host_wrapper_relpath(host_id: str, entry: DiscoverableEntry) -> Path:
+    normalized = (host_id or "").strip().lower()
+    if normalized != "opencode" and uses_skill_only_activation(normalized):
+        return Path("skills") / entry.id / "SKILL.md"
+    return Path("commands") / f"{entry.id}.md"
+
+
+def _frontmatter_lines(host_id: str, entry: DiscoverableEntry, *, relpath: Path) -> list[str]:
+    lines = ["---"]
+    if relpath.name == "SKILL.md":
+        lines.extend(
+            [
+                f"name: {entry.id}",
+                "description: >-",
+                f"  Launch {entry.display_name} through the canonical governed Vibe runtime.",
+            ]
+        )
+    else:
+        lines.append(f"description: Launch {entry.display_name} through the canonical governed Vibe runtime.")
     if host_id == "opencode":
         lines.append("agent: vibe-plan")
     lines.append("---")
@@ -41,22 +56,24 @@ def _body_lines(entry: DiscoverableEntry) -> list[str]:
 def build_wrapper_descriptors(host_id: str, surface: DiscoverableEntrySurface) -> dict[str, WrapperDescriptor]:
     descriptors: dict[str, WrapperDescriptor] = {}
     for entry in surface.entries:
-        content = "\n".join([*_frontmatter_lines(host_id, entry), "", *_body_lines(entry), ""]) + "\n"
+        relpath = _host_wrapper_relpath(host_id, entry)
+        content = "\n".join([*_frontmatter_lines(host_id, entry, relpath=relpath), "", *_body_lines(entry), ""]) + "\n"
         descriptors[entry.id] = WrapperDescriptor(
             entry_id=entry.id,
-            relpath=Path("commands") / f"{entry.id}.md",
+            relpath=relpath,
             content=content,
         )
     return descriptors
 
 
-def _host_command_surface_relpaths(host_id: str) -> tuple[Path, ...]:
+def _host_surface_targets(host_id: str, descriptor: WrapperDescriptor) -> tuple[Path, ...]:
     normalized = (host_id or "").strip().lower()
-    if normalized == "opencode":
-        return (Path("commands"), Path("command"))
-    if normalized in {"claude-code", "cursor", "windsurf", "openclaw"}:
-        return ()
-    return (Path("commands"),)
+    if normalized == "opencode" and descriptor.relpath.parts and descriptor.relpath.parts[0] == "commands":
+        return (
+            descriptor.relpath,
+            Path("command") / descriptor.relpath.name,
+        )
+    return (descriptor.relpath,)
 
 
 def materialize_host_visible_wrappers(
@@ -67,11 +84,13 @@ def materialize_host_visible_wrappers(
 ) -> list[Path]:
     descriptors = build_wrapper_descriptors(host_id, surface)
     written: list[Path] = []
-    for rel_root in _host_command_surface_relpaths(host_id):
-        root = target_root / rel_root
-        root.mkdir(parents=True, exist_ok=True)
-        for descriptor in descriptors.values():
-            destination = root / descriptor.relpath.name
+    for descriptor in descriptors.values():
+        for destination_rel in _host_surface_targets(host_id, descriptor):
+            destination = target_root / destination_rel
+            if descriptor.entry_id == "vibe" and destination_rel == Path("skills") / "vibe" / "SKILL.md" and destination.exists():
+                written.append(destination)
+                continue
+            destination.parent.mkdir(parents=True, exist_ok=True)
             destination.write_text(descriptor.content, encoding="utf-8")
             written.append(destination)
     return written

--- a/packages/installer-core/src/vgo_installer/host_closure.py
+++ b/packages/installer-core/src/vgo_installer/host_closure.py
@@ -30,7 +30,7 @@ HOST_BRIDGE_COMMAND_ENV = {
 
 TrackCreatedPath = Callable[[Path | str], None]
 RecordManagedJson = Callable[[Path], None]
-RecordSpecialistWrapper = Callable[[Path], None]
+RecordBridgeLauncher = Callable[[Path], None]
 
 
 def detect_platform_tag() -> str:
@@ -95,7 +95,7 @@ def materialize_host_specialist_wrapper(
     bridge_command: str | None,
     *,
     track_created_path: TrackCreatedPath,
-    record_specialist_wrapper: RecordSpecialistWrapper,
+    record_bridge_launcher: RecordBridgeLauncher,
 ) -> dict[str, Any]:
     tools_root = target_root / ".vibeskills" / "bin"
     tools_root.mkdir(parents=True, exist_ok=True)
@@ -124,7 +124,7 @@ def materialize_host_specialist_wrapper(
         encoding="utf-8",
     )
     _ensure_executable(wrapper_py)
-    record_specialist_wrapper(wrapper_py)
+    record_bridge_launcher(wrapper_py)
 
     platform_tag = detect_platform_tag()
     if platform_tag == "windows":
@@ -167,7 +167,7 @@ def materialize_host_specialist_wrapper(
             encoding="utf-8",
         )
         _ensure_executable(launcher)
-    record_specialist_wrapper(launcher)
+    record_bridge_launcher(launcher)
 
     return {
         "platform": platform_tag,
@@ -326,7 +326,7 @@ def materialize_host_closure(
     *,
     track_created_path: TrackCreatedPath,
     record_managed_json: RecordManagedJson,
-    record_specialist_wrapper: RecordSpecialistWrapper,
+    record_bridge_launcher: RecordBridgeLauncher,
 ) -> tuple[Path, dict[str, Any]]:
     host_id = adapter["id"]
     bridge_command, bridge_source = resolve_bridge_command(host_id)
@@ -335,7 +335,7 @@ def materialize_host_closure(
         host_id,
         bridge_command,
         track_created_path=track_created_path,
-        record_specialist_wrapper=record_specialist_wrapper,
+        record_bridge_launcher=record_bridge_launcher,
     )
     settings_materialized = materialize_host_settings(
         target_root,

--- a/packages/installer-core/src/vgo_installer/install_runtime.py
+++ b/packages/installer-core/src/vgo_installer/install_runtime.py
@@ -39,6 +39,7 @@ from .materializer import (
     install_opencode_guidance_payload,
     install_runtime_core_mode_payload,
     materialize_allowlisted_skills,
+    materialize_host_visible_wrappers,
     materialize_internal_skill_corpus,
     resolve_bundled_skills_root,
     restore_skill_entrypoint_if_needed,
@@ -567,6 +568,15 @@ def main(argv: list[str] | None = None):
         )
     else:
         raise SystemExit(f"Unsupported adapter install mode: {mode}")
+
+    for wrapper_path in materialize_host_visible_wrappers(
+        repo_root=repo_root,
+        target_root=target_root,
+        host_id=adapter["id"],
+        surface=dict(packaging.get("public_skill_surface") or {}),
+    ):
+        track_created_path(wrapper_path)
+        record_specialist_wrapper(wrapper_path)
 
     closure_path, closure = materialize_host_closure(
         target_root,

--- a/packages/installer-core/src/vgo_installer/install_runtime.py
+++ b/packages/installer-core/src/vgo_installer/install_runtime.py
@@ -74,6 +74,7 @@ ledger_state = {
     "merged_files": {},
     "template_generated": set(),
     "specialist_wrapper_paths": [],
+    "bridge_launcher_paths": [],
     "runtime_roots": set(),
     "compatibility_roots": set(),
     "sidecar_roots": set(),
@@ -144,6 +145,15 @@ def record_specialist_wrapper(path: Path) -> None:
         resolved = str(path)
     if resolved not in ledger_state["specialist_wrapper_paths"]:
         ledger_state["specialist_wrapper_paths"].append(resolved)
+
+
+def record_bridge_launcher(path: Path) -> None:
+    try:
+        resolved = str(path.resolve())
+    except FileNotFoundError:
+        resolved = str(path)
+    if resolved not in ledger_state["bridge_launcher_paths"]:
+        ledger_state["bridge_launcher_paths"].append(resolved)
 
 
 def record_runtime_root(path: Path | str) -> None:
@@ -228,6 +238,7 @@ def materialization_state_from_ledger_state() -> MaterializationLedgerState:
         merged_files=dict(ledger_state["merged_files"]),
         generated_from_template_if_absent=set(ledger_state["template_generated"]),
         specialist_wrapper_paths=list(ledger_state["specialist_wrapper_paths"]),
+        bridge_launcher_paths=list(ledger_state["bridge_launcher_paths"]),
         runtime_roots=set(ledger_state["runtime_roots"]),
         compatibility_roots=set(ledger_state["compatibility_roots"]),
         sidecar_roots=set(ledger_state["sidecar_roots"]),
@@ -569,12 +580,19 @@ def main(argv: list[str] | None = None):
     else:
         raise SystemExit(f"Unsupported adapter install mode: {mode}")
 
-    for wrapper_path in materialize_host_visible_wrappers(
+    wrapper_paths = materialize_host_visible_wrappers(
         repo_root=repo_root,
         target_root=target_root,
         host_id=adapter["id"],
         surface=dict(packaging.get("public_skill_surface") or {}),
-    ):
+    )
+    discoverable_entry_surface = str((packaging.get("public_skill_surface") or {}).get("discoverable_entry_surface") or "").strip()
+    if discoverable_entry_surface and adapter.get("discoverable_entries") and not wrapper_paths:
+        raise SystemExit(
+            "Discoverable wrapper projection for "
+            f"'{adapter['id']}' produced no host-visible entries."
+        )
+    for wrapper_path in wrapper_paths:
         track_created_path(wrapper_path)
         record_specialist_wrapper(wrapper_path)
 
@@ -583,7 +601,7 @@ def main(argv: list[str] | None = None):
         adapter,
         track_created_path=track_created_path,
         record_managed_json=record_managed_json,
-        record_specialist_wrapper=record_specialist_wrapper,
+        record_bridge_launcher=record_bridge_launcher,
     )
     record_sidecar_root(target_root / ".vibeskills")
     require_closed_ready_effective = bool(args.require_closed_ready and is_closed_ready_required(adapter))

--- a/packages/installer-core/src/vgo_installer/ledger_service.py
+++ b/packages/installer-core/src/vgo_installer/ledger_service.py
@@ -157,6 +157,16 @@ def build_payload_summary(target_root: Path | str, ledger: dict) -> dict[str, ob
         for name in managed_skill_names
         if not name.startswith('.') and (target_root_path / 'skills' / name).is_dir()
     )
+    host_visible_entry_names = sorted(
+        {
+            candidate.stem
+            for raw_path in ledger.get('specialist_wrapper_paths') or []
+            for candidate in [Path(str(raw_path)).resolve(strict=False)]
+            if candidate.is_file()
+            and candidate.suffix == '.md'
+            and candidate.parent.resolve(strict=False) != (target_root_path / 'skills').resolve(strict=False)
+        }
+    )
     packaging_manifest = ledger.get('packaging_manifest') if isinstance(ledger.get('packaging_manifest'), dict) else {}
     internal_skill_corpus = packaging_manifest.get('internal_skill_corpus') if isinstance(packaging_manifest, dict) else {}
     internal_skill_target = None
@@ -246,6 +256,8 @@ def build_payload_summary(target_root: Path | str, ledger: dict) -> dict[str, ob
         'installed_skill_names': installed_skill_names,
         'public_skill_count': len(public_skill_names),
         'public_skill_names': public_skill_names,
+        'host_visible_entry_count': len(host_visible_entry_names),
+        'host_visible_entry_names': host_visible_entry_names,
         'internal_skill_count': len(internal_skill_names),
         'installed_file_count': len(owned_files),
     }

--- a/packages/installer-core/src/vgo_installer/ledger_service.py
+++ b/packages/installer-core/src/vgo_installer/ledger_service.py
@@ -158,15 +158,6 @@ def build_payload_summary(target_root: Path | str, ledger: dict) -> dict[str, ob
         for name in managed_skill_names
         if not name.startswith('.') and (target_root_path / 'skills' / name).is_dir()
     )
-    host_visible_entry_names: set[str] = set()
-    for raw_path in ledger.get('specialist_wrapper_paths') or []:
-        candidate = Path(str(raw_path)).resolve(strict=False)
-        if not candidate.is_file():
-            continue
-        name = candidate.parent.name if candidate.name == 'SKILL.md' else candidate.stem
-        normalized = _normalize_skill_name(name)
-        if normalized is not None:
-            host_visible_entry_names.add(normalized)
     packaging_manifest = ledger.get('packaging_manifest') if isinstance(ledger.get('packaging_manifest'), dict) else {}
     internal_skill_corpus = packaging_manifest.get('internal_skill_corpus') if isinstance(packaging_manifest, dict) else {}
     internal_skill_target = None
@@ -202,6 +193,16 @@ def build_payload_summary(target_root: Path | str, ledger: dict) -> dict[str, ob
         else:
             candidate = candidate.resolve(strict=False)
         return candidate
+
+    host_visible_entry_names: set[str] = set()
+    for raw_path in ledger.get('specialist_wrapper_paths') or []:
+        candidate = resolve_owned_candidate(str(raw_path))
+        if not is_under_target_root(candidate) or not candidate.is_file():
+            continue
+        name = candidate.parent.name if candidate.name == 'SKILL.md' else candidate.stem
+        normalized = _normalize_skill_name(name)
+        if normalized is not None:
+            host_visible_entry_names.add(normalized)
 
     def collect_owned_tree(path_value: Path | str) -> None:
         candidate = resolve_owned_candidate(path_value)

--- a/packages/installer-core/src/vgo_installer/ledger_service.py
+++ b/packages/installer-core/src/vgo_installer/ledger_service.py
@@ -20,6 +20,7 @@ class MaterializationLedgerState:
     merged_files: dict[str, dict[str, object]] = field(default_factory=dict)
     generated_from_template_if_absent: set[Path | str] = field(default_factory=set)
     specialist_wrapper_paths: list[Path | str] = field(default_factory=list)
+    bridge_launcher_paths: list[Path | str] = field(default_factory=list)
     runtime_roots: set[Path | str] = field(default_factory=set)
     compatibility_roots: set[Path | str] = field(default_factory=set)
     sidecar_roots: set[Path | str] = field(default_factory=set)
@@ -157,16 +158,15 @@ def build_payload_summary(target_root: Path | str, ledger: dict) -> dict[str, ob
         for name in managed_skill_names
         if not name.startswith('.') and (target_root_path / 'skills' / name).is_dir()
     )
-    host_visible_entry_names = sorted(
-        {
-            candidate.stem
-            for raw_path in ledger.get('specialist_wrapper_paths') or []
-            for candidate in [Path(str(raw_path)).resolve(strict=False)]
-            if candidate.is_file()
-            and candidate.suffix == '.md'
-            and candidate.parent.resolve(strict=False) != (target_root_path / 'skills').resolve(strict=False)
-        }
-    )
+    host_visible_entry_names: set[str] = set()
+    for raw_path in ledger.get('specialist_wrapper_paths') or []:
+        candidate = Path(str(raw_path)).resolve(strict=False)
+        if not candidate.is_file():
+            continue
+        name = candidate.parent.name if candidate.name == 'SKILL.md' else candidate.stem
+        normalized = _normalize_skill_name(name)
+        if normalized is not None:
+            host_visible_entry_names.add(normalized)
     packaging_manifest = ledger.get('packaging_manifest') if isinstance(ledger.get('packaging_manifest'), dict) else {}
     internal_skill_corpus = packaging_manifest.get('internal_skill_corpus') if isinstance(packaging_manifest, dict) else {}
     internal_skill_target = None
@@ -195,8 +195,16 @@ def build_payload_summary(target_root: Path | str, ledger: dict) -> dict[str, ob
             return False
         return True
 
+    def resolve_owned_candidate(path_value: Path | str) -> Path:
+        candidate = Path(path_value)
+        if not candidate.is_absolute():
+            candidate = (target_root_path / candidate).resolve(strict=False)
+        else:
+            candidate = candidate.resolve(strict=False)
+        return candidate
+
     def collect_owned_tree(path_value: Path | str) -> None:
-        candidate = Path(path_value).resolve(strict=False)
+        candidate = resolve_owned_candidate(path_value)
         if not is_under_target_root(candidate) or not candidate.is_dir():
             return
         for file_path in candidate.rglob('*'):
@@ -204,7 +212,7 @@ def build_payload_summary(target_root: Path | str, ledger: dict) -> dict[str, ob
                 owned_files.add(str(file_path.resolve(strict=False)))
 
     def collect_owned_file(path_value: Path | str) -> None:
-        candidate = Path(path_value).resolve(strict=False)
+        candidate = resolve_owned_candidate(path_value)
         if not is_under_target_root(candidate) or not candidate.is_file():
             return
         owned_files.add(str(candidate))
@@ -223,7 +231,7 @@ def build_payload_summary(target_root: Path | str, ledger: dict) -> dict[str, ob
         collect_owned_tree(raw_path)
         collect_owned_file(raw_path)
     for raw_path in ledger.get('owned_tree_roots') or []:
-        candidate = Path(str(raw_path)).resolve(strict=False)
+        candidate = resolve_owned_candidate(str(raw_path))
         if candidate == target_root_resolved or candidate == skills_root:
             continue
         if candidate.parent == skills_root and candidate.name not in managed_skill_names:
@@ -257,7 +265,7 @@ def build_payload_summary(target_root: Path | str, ledger: dict) -> dict[str, ob
         'public_skill_count': len(public_skill_names),
         'public_skill_names': public_skill_names,
         'host_visible_entry_count': len(host_visible_entry_names),
-        'host_visible_entry_names': host_visible_entry_names,
+        'host_visible_entry_names': sorted(host_visible_entry_names),
         'internal_skill_count': len(internal_skill_names),
         'installed_file_count': len(owned_files),
     }
@@ -333,6 +341,7 @@ def build_install_ledger(
         'merged_files': _sorted_merged_files(state.merged_files),
         'generated_from_template_if_absent': _sorted_paths(state.generated_from_template_if_absent),
         'specialist_wrapper_paths': _sorted_wrapper_paths(state.specialist_wrapper_paths),
+        'bridge_launcher_paths': _sorted_wrapper_paths(state.bridge_launcher_paths),
         'runtime_roots': runtime_roots,
         'compatibility_roots': compatibility_roots,
         'sidecar_roots': sidecar_roots,

--- a/packages/installer-core/src/vgo_installer/materializer.py
+++ b/packages/installer-core/src/vgo_installer/materializer.py
@@ -23,6 +23,7 @@ from vgo_contracts.mirror_topology_contract import (
 )
 
 from .ledger_service import MaterializationLedgerState
+from .discoverable_wrappers import materialize_host_visible_wrappers as _materialize_host_visible_wrappers
 
 TrackCreatedPath = Callable[[Path | str], None]
 RecordOwnedTreeRoot = Callable[[Path | str], None]
@@ -472,6 +473,26 @@ def ensure_skill_present(
                 break
     if required and resolve_skill_entrypoint(destination) is None:
         missing.add(name)
+
+
+def materialize_host_visible_wrappers(
+    *,
+    repo_root: Path,
+    target_root: Path,
+    host_id: str,
+    surface: dict[str, Any],
+) -> list[Path]:
+    from vgo_contracts.discoverable_entry_surface import load_discoverable_entry_surface
+
+    discoverable_entry_surface = str(surface.get("discoverable_entry_surface") or "").strip()
+    if not discoverable_entry_surface:
+        return []
+    entry_surface = load_discoverable_entry_surface(repo_root)
+    return _materialize_host_visible_wrappers(
+        target_root=target_root,
+        host_id=host_id,
+        surface=entry_surface,
+    )
 
 
 def install_codex_payload(

--- a/packages/installer-core/src/vgo_installer/runtime_packaging.py
+++ b/packages/installer-core/src/vgo_installer/runtime_packaging.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from ._bootstrap import ensure_contracts_src_on_path
+
+ensure_contracts_src_on_path()
+
+from vgo_contracts.discoverable_entry_surface import load_discoverable_entry_surface
+
 try:
     from ._io import load_json
 except ImportError:  # pragma: no cover - standalone module loading in file-based tests
@@ -57,6 +63,14 @@ def _compatibility_projection_names(packaging: dict[str, Any]) -> list[str]:
 
 def public_skill_projection_names(packaging: dict[str, Any]) -> list[str]:
     surface = packaging.get('public_skill_surface') or {}
+    discoverable_surface = str(surface.get('discoverable_entry_surface') or '').strip()
+    if discoverable_surface:
+        repo_root = Path(packaging.get('_repo_root') or '').resolve() if packaging.get('_repo_root') else None
+        if repo_root is not None:
+            try:
+                return load_discoverable_entry_surface(repo_root).projected_skill_names
+            except RuntimeError:
+                pass
     names = surface.get('projected_skill_names') or []
     seen: set[str] = set()
     result: list[str] = []
@@ -94,6 +108,7 @@ def resolve_runtime_core_packaging(repo_root: Path, profile: str) -> dict[str, A
         merged.pop('default_profile', None)
         merged = _deep_merge(merged, profile_overlay)
         merged.setdefault('profile', profile)
+        merged['_repo_root'] = str(repo_root)
         merged.setdefault('bundled_skills_source', 'bundled/skills')
         merged.setdefault('skills_allowlist', [])
         merged.setdefault('public_skill_surface', {})
@@ -106,11 +121,18 @@ def resolve_runtime_core_packaging(repo_root: Path, profile: str) -> dict[str, A
         )
         if not merged.get('skills_allowlist'):
             merged['skills_allowlist'] = _compatibility_projection_names(merged)
+        discoverable_surface = str((merged.get('public_skill_surface') or {}).get('discoverable_entry_surface') or '').strip()
+        if discoverable_surface:
+            try:
+                merged['public_skill_surface']['projected_skill_names'] = load_discoverable_entry_surface(repo_root).projected_skill_names
+            except RuntimeError:
+                pass
         return merged
 
     projection_path = resolve_runtime_core_projection_path(repo_root, profile)
     packaging = load_json(projection_path)
     packaging.setdefault('profile', profile)
+    packaging['_repo_root'] = str(repo_root)
     packaging.setdefault('bundled_skills_source', 'bundled/skills')
     packaging.setdefault('skills_allowlist', [])
     packaging.setdefault('public_skill_surface', {})
@@ -123,4 +145,10 @@ def resolve_runtime_core_packaging(repo_root: Path, profile: str) -> dict[str, A
     )
     if not packaging.get('skills_allowlist'):
         packaging['skills_allowlist'] = _compatibility_projection_names(packaging)
+    discoverable_surface = str((packaging.get('public_skill_surface') or {}).get('discoverable_entry_surface') or '').strip()
+    if discoverable_surface:
+        try:
+            packaging['public_skill_surface']['projected_skill_names'] = load_discoverable_entry_surface(repo_root).projected_skill_names
+        except RuntimeError:
+            pass
     return packaging

--- a/packages/installer-core/src/vgo_installer/runtime_packaging.py
+++ b/packages/installer-core/src/vgo_installer/runtime_packaging.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+import importlib.util
+import sys
 from pathlib import Path
 from typing import Any
 
-from ._bootstrap import ensure_contracts_src_on_path
+try:
+    from ._bootstrap import ensure_contracts_src_on_path
+except ImportError:  # pragma: no cover - standalone module loading in file-based tests
+    bootstrap_path = Path(__file__).with_name('_bootstrap.py')
+    bootstrap_spec = importlib.util.spec_from_file_location('vgo_installer_runtime_packaging_bootstrap', bootstrap_path)
+    if bootstrap_spec is None or bootstrap_spec.loader is None:
+        raise
+    bootstrap_module = importlib.util.module_from_spec(bootstrap_spec)
+    sys.modules.setdefault(bootstrap_spec.name, bootstrap_module)
+    bootstrap_spec.loader.exec_module(bootstrap_module)
+    ensure_contracts_src_on_path = bootstrap_module.ensure_contracts_src_on_path
 
 ensure_contracts_src_on_path()
 
@@ -12,9 +24,6 @@ from vgo_contracts.discoverable_entry_surface import load_discoverable_entry_sur
 try:
     from ._io import load_json
 except ImportError:  # pragma: no cover - standalone module loading in file-based tests
-    import importlib.util
-    import sys
-
     io_path = Path(__file__).with_name('_io.py')
     spec = importlib.util.spec_from_file_location('vgo_installer_runtime_packaging_io', io_path)
     if spec is None or spec.loader is None:

--- a/packages/runtime-core/src/vgo_runtime/router_contract_support.py
+++ b/packages/runtime-core/src/vgo_runtime/router_contract_support.py
@@ -7,6 +7,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+CONTRACTS_SRC = Path(__file__).resolve().parents[4] / "packages" / "contracts" / "src"
+if CONTRACTS_SRC.is_dir() and str(CONTRACTS_SRC) not in os.sys.path:
+    os.sys.path.insert(0, str(CONTRACTS_SRC))
+
+from vgo_contracts.discoverable_entry_surface import load_discoverable_entry_surface
+
 
 @dataclass(frozen=True)
 class RepoContext:
@@ -189,15 +195,28 @@ def resolve_requested_canonical(requested_skill: str | None, alias_map: dict[str
 def resolve_public_skill_surface(repo: RepoContext) -> dict[str, Any]:
     packaging = load_runtime_core_packaging(repo.config_root)
     surface = packaging.get("public_skill_surface") or {}
+    discoverable_entry_surface = str(surface.get("discoverable_entry_surface") or "").strip()
     canonical_relpath = (
         str(surface.get("canonical_entrypoint_relpath") or "").strip()
         or str((packaging.get("canonical_vibe_payload") or {}).get("target_relpath") or "skills/vibe").strip()
         or "skills/vibe"
     )
     root_relpath = str(surface.get("root_relpath") or "skills").strip() or "skills"
+    projected_skill_names = [
+        str(name).strip()
+        for name in surface.get("projected_skill_names") or []
+        if str(name).strip()
+    ]
+    if discoverable_entry_surface:
+        try:
+            projected_skill_names = load_discoverable_entry_surface(repo.repo_root).projected_skill_names
+        except RuntimeError:
+            pass
     return {
         "root_relpath": root_relpath,
         "canonical_entrypoint_relpath": canonical_relpath,
+        "discoverable_entry_surface": discoverable_entry_surface,
+        "projected_skill_names": projected_skill_names,
     }
 
 

--- a/tests/contract/test_adapter_descriptor_contract.py
+++ b/tests/contract/test_adapter_descriptor_contract.py
@@ -53,5 +53,8 @@ def test_host_profiles_expose_discoverable_entries_as_presentational_surface() -
         assert discoverable_entries['shared_source'] == 'config/vibe-entry-surfaces.json'
         assert discoverable_entries['authority_owner'] == 'vibe'
         assert discoverable_entries['presentational_only'] is True
+        assert discoverable_entries['projection_mode'] == 'generated_wrapper_entries'
+        assert isinstance(discoverable_entries['host_visible_surface'], str)
+        assert discoverable_entries['host_visible_surface'].strip()
 
     assert discoverable_profiles, 'expected at least one host profile with discoverable entry surfaces'

--- a/tests/integration/test_runtime_core_packaging_roles.py
+++ b/tests/integration/test_runtime_core_packaging_roles.py
@@ -126,11 +126,15 @@ def test_profile_runtime_core_packaging_roles_describe_delivery_model() -> None:
     if _supports_surface_split(minimal):
         assert minimal['compatibility_skill_projections']['projected_skill_names'] == []
         assert minimal['internal_skill_corpus']['target_relpath'] == 'skills/vibe/bundled/skills'
-        assert minimal['public_skill_surface']['projected_skill_names'] == ['vibe']
+        assert minimal['public_skill_surface']['mode'] == 'discoverable_wrapper_projection'
+        assert minimal['public_skill_surface']['discoverable_entry_surface'] == 'config/vibe-entry-surfaces.json'
+        assert minimal['public_skill_surface']['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
     if _supports_surface_split(full):
         assert full['compatibility_skill_projections']['projected_skill_names'] == []
         assert full['internal_skill_corpus']['entrypoint_filename'] == 'SKILL.runtime-mirror.md'
-        assert full['public_skill_surface']['projected_skill_names'] == ['vibe']
+        assert full['public_skill_surface']['mode'] == 'discoverable_wrapper_projection'
+        assert full['public_skill_surface']['discoverable_entry_surface'] == 'config/vibe-entry-surfaces.json'
+        assert full['public_skill_surface']['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
 
 
 def test_profile_runtime_core_packaging_role_sources_match_copy_projection() -> None:

--- a/tests/runtime_neutral/test_claude_preview_scaffold.py
+++ b/tests/runtime_neutral/test_claude_preview_scaffold.py
@@ -57,6 +57,8 @@ def run_package_install(*, host: str, target_root: Path, profile: str = "full") 
 
 
 class ClaudePreviewScaffoldTests(unittest.TestCase):
+    EXPECTED_WRAPPER_SKILLS = ("vibe", "vibe-want", "vibe-how", "vibe-do")
+
     def setUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
         self.root = Path(self.tempdir.name)
@@ -138,6 +140,8 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
         self.assertEqual(str((self.target_root / 'skills').resolve()), settings['vibeskills']['skills_root'])
         self.assertTrue(closure_path.exists())
         self.assertTrue(host_settings_path.exists())
+        for name in self.EXPECTED_WRAPPER_SKILLS:
+            self.assertTrue((self.target_root / 'skills' / name / 'SKILL.md').exists())
         self.assertFalse((self.target_root / 'commands').exists())
         self.assertEqual('preview-guidance', payload['install_mode'])
         self.assertEqual(str(closure_path), payload['host_closure_path'])
@@ -174,6 +178,9 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
         self.assertEqual(self.existing_settings['model'], settings['model'])
         self.assertEqual('claude-code', settings['vibeskills']['host_id'])
         self.assertTrue((self.target_root / '.vibeskills' / 'host-settings.json').exists())
+        self.assertIn('[OK] host-visible discoverable entries', result.stdout)
+        for name in self.EXPECTED_WRAPPER_SKILLS:
+            self.assertTrue((self.target_root / 'skills' / name / 'SKILL.md').exists())
         self.assertFalse((self.target_root / 'commands').exists())
 
 

--- a/tests/runtime_neutral/test_cursor_managed_preview.py
+++ b/tests/runtime_neutral/test_cursor_managed_preview.py
@@ -52,6 +52,9 @@ class CursorManagedPreviewTests(unittest.TestCase):
             self.assertTrue(closure_path.exists())
             self.assertTrue(host_settings_path.exists())
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
+            self.assertTrue((target_root / "skills" / "vibe-want" / "SKILL.md").exists())
+            self.assertTrue((target_root / "skills" / "vibe-how" / "SKILL.md").exists())
+            self.assertTrue((target_root / "skills" / "vibe-do" / "SKILL.md").exists())
             self.assertFalse((target_root / "settings.json").exists())
             self.assertFalse((target_root / "commands").exists())
 

--- a/tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py
+++ b/tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class DiscoverableWrapperHostVisibilityTests(unittest.TestCase):
+    def test_shell_check_reports_host_visible_discoverable_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir) / "codex-root"
+            subprocess.run(
+                [
+                    "bash",
+                    str(REPO_ROOT / "install.sh"),
+                    "--host",
+                    "codex",
+                    "--profile",
+                    "full",
+                    "--target-root",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(REPO_ROOT / "check.sh"),
+                    "--host",
+                    "codex",
+                    "--profile",
+                    "full",
+                    "--target-root",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            self.assertIn("[OK] host-visible discoverable entries", result.stdout)
+
+    def test_shell_check_fails_when_a_wrapper_entry_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir) / "codex-root"
+            subprocess.run(
+                [
+                    "bash",
+                    str(REPO_ROOT / "install.sh"),
+                    "--host",
+                    "codex",
+                    "--profile",
+                    "full",
+                    "--target-root",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            (target_root / "commands" / "vibe-how.md").unlink()
+
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(REPO_ROOT / "check.sh"),
+                    "--host",
+                    "codex",
+                    "--profile",
+                    "full",
+                    "--target-root",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("[FAIL] host-visible discoverable entries", result.stdout)
+
+    def test_powershell_check_reports_host_visible_discoverable_entries(self) -> None:
+        if shutil.which("pwsh") is None:
+            self.skipTest("pwsh not available")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir) / "codex-root"
+            subprocess.run(
+                [
+                    "pwsh",
+                    "-NoProfile",
+                    "-File",
+                    str(REPO_ROOT / "install.ps1"),
+                    "-HostId",
+                    "codex",
+                    "-Profile",
+                    "full",
+                    "-TargetRoot",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            result = subprocess.run(
+                [
+                    "pwsh",
+                    "-NoProfile",
+                    "-File",
+                    str(REPO_ROOT / "check.ps1"),
+                    "-HostId",
+                    "codex",
+                    "-Profile",
+                    "full",
+                    "-TargetRoot",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            self.assertIn("[OK] host-visible discoverable entries", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py
+++ b/tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py
@@ -12,6 +12,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class DiscoverableWrapperHostVisibilityTests(unittest.TestCase):
+    def _write_external_wrapper_ledger_path(self, target_root: Path, external_wrapper: Path) -> None:
+        ledger_path = target_root / ".vibeskills" / "install-ledger.json"
+        ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+        ledger["specialist_wrapper_paths"] = [str(external_wrapper)]
+        ledger["payload_summary"]["host_visible_entry_names"] = ["vibe"]
+        ledger["payload_summary"]["host_visible_entry_count"] = 1
+        ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
+
     def test_shell_check_reports_host_visible_discoverable_entries(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             target_root = Path(tempdir) / "codex-root"
@@ -68,6 +76,46 @@ class DiscoverableWrapperHostVisibilityTests(unittest.TestCase):
                 check=True,
             )
             (target_root / "commands" / "vibe-how.md").unlink()
+
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(REPO_ROOT / "check.sh"),
+                    "--host",
+                    "codex",
+                    "--profile",
+                    "full",
+                    "--target-root",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("[FAIL] host-visible discoverable entries", result.stdout)
+
+    def test_shell_check_rejects_wrapper_inventory_outside_target_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir, tempfile.TemporaryDirectory() as external_dir:
+            target_root = Path(tempdir) / "codex-root"
+            subprocess.run(
+                [
+                    "bash",
+                    str(REPO_ROOT / "install.sh"),
+                    "--host",
+                    "codex",
+                    "--profile",
+                    "full",
+                    "--target-root",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            external_wrapper = Path(external_dir) / "vibe.md"
+            external_wrapper.write_text("# vibe\n", encoding="utf-8")
+            self._write_external_wrapper_ledger_path(target_root, external_wrapper)
 
             result = subprocess.run(
                 [
@@ -170,6 +218,53 @@ class DiscoverableWrapperHostVisibilityTests(unittest.TestCase):
             )
 
             self.assertIn("[OK] host-visible discoverable entries", result.stdout)
+
+    def test_powershell_check_rejects_wrapper_inventory_outside_target_root(self) -> None:
+        if shutil.which("pwsh") is None:
+            self.skipTest("pwsh not available")
+
+        with tempfile.TemporaryDirectory() as tempdir, tempfile.TemporaryDirectory() as external_dir:
+            target_root = Path(tempdir) / "codex-root"
+            subprocess.run(
+                [
+                    "pwsh",
+                    "-NoProfile",
+                    "-File",
+                    str(REPO_ROOT / "install.ps1"),
+                    "-HostId",
+                    "codex",
+                    "-Profile",
+                    "full",
+                    "-TargetRoot",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            external_wrapper = Path(external_dir) / "vibe.md"
+            external_wrapper.write_text("# vibe\n", encoding="utf-8")
+            self._write_external_wrapper_ledger_path(target_root, external_wrapper)
+
+            result = subprocess.run(
+                [
+                    "pwsh",
+                    "-NoProfile",
+                    "-File",
+                    str(REPO_ROOT / "check.ps1"),
+                    "-HostId",
+                    "codex",
+                    "-Profile",
+                    "full",
+                    "-TargetRoot",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("[FAIL] host-visible discoverable entries", result.stdout)
 
     def test_powershell_check_keeps_discoverable_entry_validation_separate_from_bridge_launcher_validation(self) -> None:
         if shutil.which("pwsh") is None:

--- a/tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py
+++ b/tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+import json
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -86,6 +87,46 @@ class DiscoverableWrapperHostVisibilityTests(unittest.TestCase):
             self.assertNotEqual(0, result.returncode)
             self.assertIn("[FAIL] host-visible discoverable entries", result.stdout)
 
+    def test_shell_check_keeps_discoverable_entry_validation_separate_from_bridge_launcher_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir) / "codex-root"
+            subprocess.run(
+                [
+                    "bash",
+                    str(REPO_ROOT / "install.sh"),
+                    "--host",
+                    "codex",
+                    "--profile",
+                    "full",
+                    "--target-root",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            closure = json.loads((target_root / ".vibeskills" / "host-closure.json").read_text(encoding="utf-8"))
+            Path(closure["specialist_wrapper"]["launcher_path"]).unlink()
+
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(REPO_ROOT / "check.sh"),
+                    "--host",
+                    "codex",
+                    "--profile",
+                    "full",
+                    "--target-root",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("[FAIL] specialist wrapper launcher", result.stdout)
+            self.assertIn("[OK] host-visible discoverable entries", result.stdout)
+
     def test_powershell_check_reports_host_visible_discoverable_entries(self) -> None:
         if shutil.which("pwsh") is None:
             self.skipTest("pwsh not available")
@@ -128,6 +169,53 @@ class DiscoverableWrapperHostVisibilityTests(unittest.TestCase):
                 check=True,
             )
 
+            self.assertIn("[OK] host-visible discoverable entries", result.stdout)
+
+    def test_powershell_check_keeps_discoverable_entry_validation_separate_from_bridge_launcher_validation(self) -> None:
+        if shutil.which("pwsh") is None:
+            self.skipTest("pwsh not available")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir) / "codex-root"
+            subprocess.run(
+                [
+                    "pwsh",
+                    "-NoProfile",
+                    "-File",
+                    str(REPO_ROOT / "install.ps1"),
+                    "-HostId",
+                    "codex",
+                    "-Profile",
+                    "full",
+                    "-TargetRoot",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            closure = json.loads((target_root / ".vibeskills" / "host-closure.json").read_text(encoding="utf-8"))
+            Path(closure["specialist_wrapper"]["launcher_path"]).unlink()
+
+            result = subprocess.run(
+                [
+                    "pwsh",
+                    "-NoProfile",
+                    "-File",
+                    str(REPO_ROOT / "check.ps1"),
+                    "-HostId",
+                    "codex",
+                    "-Profile",
+                    "full",
+                    "-TargetRoot",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("[FAIL] specialist wrapper launcher", result.stdout)
             self.assertIn("[OK] host-visible discoverable entries", result.stdout)
 
 

--- a/tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py
+++ b/tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 import json
 
@@ -12,6 +13,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class DiscoverableWrapperHostVisibilityTests(unittest.TestCase):
+    def _require_bash(self) -> None:
+        if shutil.which("bash") is None:
+            self.skipTest("bash not available")
+
     def _write_external_wrapper_ledger_path(self, target_root: Path, external_wrapper: Path) -> None:
         ledger_path = target_root / ".vibeskills" / "install-ledger.json"
         ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
@@ -20,7 +25,13 @@ class DiscoverableWrapperHostVisibilityTests(unittest.TestCase):
         ledger["payload_summary"]["host_visible_entry_count"] = 1
         ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
 
+    def test_shell_checks_skip_when_bash_is_unavailable(self) -> None:
+        with mock.patch("shutil.which", return_value=None):
+            with self.assertRaises(unittest.SkipTest):
+                self._require_bash()
+
     def test_shell_check_reports_host_visible_discoverable_entries(self) -> None:
+        self._require_bash()
         with tempfile.TemporaryDirectory() as tempdir:
             target_root = Path(tempdir) / "codex-root"
             subprocess.run(
@@ -58,6 +69,7 @@ class DiscoverableWrapperHostVisibilityTests(unittest.TestCase):
             self.assertIn("[OK] host-visible discoverable entries", result.stdout)
 
     def test_shell_check_fails_when_a_wrapper_entry_is_missing(self) -> None:
+        self._require_bash()
         with tempfile.TemporaryDirectory() as tempdir:
             target_root = Path(tempdir) / "codex-root"
             subprocess.run(
@@ -96,6 +108,7 @@ class DiscoverableWrapperHostVisibilityTests(unittest.TestCase):
             self.assertIn("[FAIL] host-visible discoverable entries", result.stdout)
 
     def test_shell_check_rejects_wrapper_inventory_outside_target_root(self) -> None:
+        self._require_bash()
         with tempfile.TemporaryDirectory() as tempdir, tempfile.TemporaryDirectory() as external_dir:
             target_root = Path(tempdir) / "codex-root"
             subprocess.run(
@@ -136,6 +149,7 @@ class DiscoverableWrapperHostVisibilityTests(unittest.TestCase):
             self.assertIn("[FAIL] host-visible discoverable entries", result.stdout)
 
     def test_shell_check_keeps_discoverable_entry_validation_separate_from_bridge_launcher_validation(self) -> None:
+        self._require_bash()
         with tempfile.TemporaryDirectory() as tempdir:
             target_root = Path(tempdir) / "codex-root"
             subprocess.run(

--- a/tests/runtime_neutral/test_install_profile_differentiation.py
+++ b/tests/runtime_neutral/test_install_profile_differentiation.py
@@ -90,6 +90,8 @@ class InstallProfileDifferentiationTests(unittest.TestCase):
             self.assertEqual("minimal", ledger["profile"])
             self.assertEqual(sorted(MINIMAL_REQUIRED_SKILLS), ledger["payload_summary"]["installed_skill_names"])
             self.assertEqual(["vibe"], ledger["payload_summary"]["public_skill_names"])
+            self.assertEqual(["vibe", "vibe-do", "vibe-how", "vibe-want"], ledger["payload_summary"]["host_visible_entry_names"])
+            self.assertEqual(4, ledger["payload_summary"]["host_visible_entry_count"])
             # In a fresh temp target, every file should be installer-owned.
             self.assertEqual(count_files(target_root), ledger["payload_summary"]["installed_file_count"])
             self.assertTrue((target_root / "commands" / "vibe.md").exists())
@@ -128,6 +130,8 @@ class InstallProfileDifferentiationTests(unittest.TestCase):
             )
             self.assertEqual(1, full_ledger["payload_summary"]["public_skill_count"])
             self.assertEqual(["vibe"], full_ledger["payload_summary"]["public_skill_names"])
+            self.assertEqual(["vibe", "vibe-do", "vibe-how", "vibe-want"], full_ledger["payload_summary"]["host_visible_entry_names"])
+            self.assertEqual(4, full_ledger["payload_summary"]["host_visible_entry_count"])
             self.assertIn(REPRESENTATIVE_NON_CORE_SKILL, full_ledger["payload_summary"]["installed_skill_names"])
             self.assertGreater(
                 full_ledger["payload_summary"]["installed_file_count"],

--- a/tests/runtime_neutral/test_install_profile_differentiation.py
+++ b/tests/runtime_neutral/test_install_profile_differentiation.py
@@ -92,6 +92,10 @@ class InstallProfileDifferentiationTests(unittest.TestCase):
             self.assertEqual(["vibe"], ledger["payload_summary"]["public_skill_names"])
             # In a fresh temp target, every file should be installer-owned.
             self.assertEqual(count_files(target_root), ledger["payload_summary"]["installed_file_count"])
+            self.assertTrue((target_root / "commands" / "vibe.md").exists())
+            self.assertTrue((target_root / "commands" / "vibe-want.md").exists())
+            self.assertTrue((target_root / "commands" / "vibe-how.md").exists())
+            self.assertTrue((target_root / "commands" / "vibe-do.md").exists())
 
     def test_full_install_extends_minimal_payload_and_records_larger_summary(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/runtime_neutral/test_openclaw_runtime_core.py
+++ b/tests/runtime_neutral/test_openclaw_runtime_core.py
@@ -52,6 +52,8 @@ def run_package_install(*, host: str, target_root: Path, profile: str = "full") 
 
 
 class OpenClawRuntimeCoreTests(unittest.TestCase):
+    EXPECTED_WRAPPER_SKILLS = ("vibe", "vibe-want", "vibe-how", "vibe-do")
+
     def test_adapter_registry_exposes_openclaw_preview_runtime_core_lane(self) -> None:
         registry = _load_module("installer_adapter_registry_openclaw", ADAPTER_REGISTRY_MODULE)
         payload = registry.resolve_adapter(REPO_ROOT, "openclaw")
@@ -82,6 +84,8 @@ class OpenClawRuntimeCoreTests(unittest.TestCase):
             self.assertIn("host_closure_path", payload)
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
             self.assertTrue((target_root / "skills" / "vibe" / "bundled" / "skills" / "brainstorming" / "SKILL.runtime-mirror.md").exists())
+            for name in self.EXPECTED_WRAPPER_SKILLS:
+                self.assertTrue((target_root / "skills" / name / "SKILL.md").exists())
             self.assertFalse((target_root / "skills" / "brainstorming").exists())
             self.assertTrue((target_root / ".vibeskills" / "host-settings.json").exists())
             self.assertTrue((target_root / ".vibeskills" / "host-closure.json").exists())
@@ -112,6 +116,8 @@ class OpenClawRuntimeCoreTests(unittest.TestCase):
             self.assertIn("Host   : openclaw", install_result.stdout)
             self.assertIn("Mode   : runtime-core", install_result.stdout)
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
+            for name in self.EXPECTED_WRAPPER_SKILLS:
+                self.assertTrue((target_root / "skills" / name / "SKILL.md").exists())
             self.assertTrue((target_root / ".vibeskills" / "host-settings.json").exists())
             self.assertTrue((target_root / ".vibeskills" / "host-closure.json").exists())
             self.assertFalse((target_root / "commands").exists())
@@ -137,6 +143,7 @@ class OpenClawRuntimeCoreTests(unittest.TestCase):
             self.assertIn("Host: openclaw", check_result.stdout)
             self.assertIn("Mode: runtime-core", check_result.stdout)
             self.assertIn("[OK] host closure manifest", check_result.stdout)
+            self.assertIn("[OK] host-visible discoverable entries", check_result.stdout)
             self.assertIn("[OK] npm check skipped for non-governed adapter mode", check_result.stdout)
             self.assertNotIn("[FAIL] settings.json", check_result.stdout)
             self.assertNotIn("[FAIL] config/plugins-manifest.codex.json", check_result.stdout)

--- a/tests/runtime_neutral/test_windsurf_runtime_core.py
+++ b/tests/runtime_neutral/test_windsurf_runtime_core.py
@@ -52,6 +52,8 @@ def run_package_install(*, host: str, target_root: Path, profile: str = "full") 
 
 
 class WindsurfRuntimeCoreTests(unittest.TestCase):
+    EXPECTED_WRAPPER_SKILLS = ("vibe", "vibe-want", "vibe-how", "vibe-do")
+
     def test_adapter_registry_exposes_windsurf_parallel_root(self) -> None:
         registry = _load_module("installer_adapter_registry_windsurf", ADAPTER_REGISTRY_MODULE)
         payload = registry.resolve_adapter(REPO_ROOT, "windsurf")
@@ -70,6 +72,8 @@ class WindsurfRuntimeCoreTests(unittest.TestCase):
             self.assertIn("host_closure_path", payload)
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
             self.assertTrue((target_root / "skills" / "vibe" / "bundled" / "skills" / "brainstorming" / "SKILL.runtime-mirror.md").exists())
+            for name in self.EXPECTED_WRAPPER_SKILLS:
+                self.assertTrue((target_root / "skills" / name / "SKILL.md").exists())
             self.assertFalse((target_root / "skills" / "brainstorming").exists())
             self.assertTrue((target_root / ".vibeskills" / "host-settings.json").exists())
             self.assertTrue((target_root / ".vibeskills" / "host-closure.json").exists())
@@ -100,6 +104,8 @@ class WindsurfRuntimeCoreTests(unittest.TestCase):
             self.assertIn("Host   : windsurf", install_result.stdout)
             self.assertIn("Mode   : runtime-core", install_result.stdout)
             self.assertTrue((target_root / "skills" / "vibe" / "SKILL.md").exists())
+            for name in self.EXPECTED_WRAPPER_SKILLS:
+                self.assertTrue((target_root / "skills" / name / "SKILL.md").exists())
             self.assertTrue((target_root / ".vibeskills" / "host-settings.json").exists())
             self.assertTrue((target_root / ".vibeskills" / "host-closure.json").exists())
             self.assertFalse((target_root / "commands").exists())
@@ -124,6 +130,7 @@ class WindsurfRuntimeCoreTests(unittest.TestCase):
             )
             self.assertIn("Host: windsurf", check_result.stdout)
             self.assertIn("[OK] host closure manifest", check_result.stdout)
+            self.assertIn("[OK] host-visible discoverable entries", check_result.stdout)
             self.assertNotIn("[FAIL] settings.json", check_result.stdout)
             self.assertNotIn("[FAIL] mcp_config.json", check_result.stdout)
 

--- a/tests/unit/test_adapter_registry_support.py
+++ b/tests/unit/test_adapter_registry_support.py
@@ -40,3 +40,5 @@ def test_adapter_registry_exposes_shared_discoverable_vibe_entry_surface() -> No
     for entry in registry['adapters']:
         assert entry['discoverable_entries']['shared_source'] == registry['discoverable_entry_surface']
         assert entry['discoverable_entries']['authority_owner'] == 'vibe'
+        assert entry['discoverable_entries']['projection_mode'] == 'generated_wrapper_entries'
+        assert str(entry['discoverable_entries']['host_visible_surface']).strip()

--- a/tests/unit/test_discoverable_entry_surface.py
+++ b/tests/unit/test_discoverable_entry_surface.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACTS_SRC = ROOT / 'packages' / 'contracts' / 'src'
+if str(CONTRACTS_SRC) not in sys.path:
+    sys.path.insert(0, str(CONTRACTS_SRC))
+
+from vgo_contracts.discoverable_entry_surface import load_discoverable_entry_surface
+
+
+def test_load_discoverable_entry_surface_reads_shared_wrapper_truth() -> None:
+    surface = load_discoverable_entry_surface(ROOT)
+
+    assert surface.canonical_runtime_skill == 'vibe'
+    assert surface.projected_skill_names == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
+    assert surface.grade_flags == ['--l', '--xl']
+    assert surface.grade_flag_map['--l'] == 'L'
+    assert surface.grade_flag_map['--xl'] == 'XL'
+    assert surface.entry_by_id['vibe'].requested_stage_stop == 'phase_cleanup'
+    assert surface.entry_by_id['vibe-want'].requested_stage_stop == 'deep_interview'
+    assert surface.entry_by_id['vibe-how'].requested_stage_stop == 'xl_plan'
+    assert surface.entry_by_id['vibe-do'].requested_stage_stop == 'phase_cleanup'
+    assert surface.entry_by_id['vibe-want'].allow_grade_flags is False
+    assert surface.entry_by_id['vibe-how'].allow_grade_flags is True

--- a/tests/unit/test_discoverable_wrappers.py
+++ b/tests/unit/test_discoverable_wrappers.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACTS_SRC = ROOT / 'packages' / 'contracts' / 'src'
+INSTALLER_SRC = ROOT / 'packages' / 'installer-core' / 'src'
+for src in (CONTRACTS_SRC, INSTALLER_SRC):
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+
+from vgo_contracts.discoverable_entry_surface import load_discoverable_entry_surface
+from vgo_installer.discoverable_wrappers import build_wrapper_descriptors
+
+
+def test_build_wrapper_descriptors_renders_all_discoverable_entries_for_codex() -> None:
+    surface = load_discoverable_entry_surface(ROOT)
+
+    rendered = build_wrapper_descriptors(
+        host_id='codex',
+        surface=surface,
+    )
+
+    assert sorted(rendered) == ['vibe', 'vibe-do', 'vibe-how', 'vibe-want']
+    assert rendered['vibe-how'].relpath.as_posix() == 'commands/vibe-how.md'
+    assert 'Vibe: How Do We Do It?' in rendered['vibe-how'].content
+    assert 'Use the `vibe` skill' in rendered['vibe-how'].content

--- a/tests/unit/test_discoverable_wrappers.py
+++ b/tests/unit/test_discoverable_wrappers.py
@@ -27,3 +27,18 @@ def test_build_wrapper_descriptors_renders_all_discoverable_entries_for_codex() 
     assert rendered['vibe-how'].relpath.as_posix() == 'commands/vibe-how.md'
     assert 'Vibe: How Do We Do It?' in rendered['vibe-how'].content
     assert 'Use the `vibe` skill' in rendered['vibe-how'].content
+
+
+def test_build_wrapper_descriptors_renders_skill_wrappers_for_skill_only_hosts() -> None:
+    surface = load_discoverable_entry_surface(ROOT)
+
+    rendered = build_wrapper_descriptors(
+        host_id='claude-code',
+        surface=surface,
+    )
+
+    assert sorted(rendered) == ['vibe', 'vibe-do', 'vibe-how', 'vibe-want']
+    assert rendered['vibe-how'].relpath.as_posix() == 'skills/vibe-how/SKILL.md'
+    assert 'name: vibe-how' in rendered['vibe-how'].content
+    assert 'Vibe: How Do We Do It?' in rendered['vibe-how'].content
+    assert '$ARGUMENTS' in rendered['vibe-how'].content

--- a/tests/unit/test_installer_ledger_service.py
+++ b/tests/unit/test_installer_ledger_service.py
@@ -27,12 +27,16 @@ def test_build_install_ledger_tracks_payload_summary(tmp_path) -> None:
     vibe_root = tmp_path / 'skills' / 'vibe'
     brainstorm_root = tmp_path / 'skills' / 'brainstorming'
     internal_non_core_root = tmp_path / 'skills' / 'vibe' / 'bundled' / 'skills' / 'scikit-learn'
+    wrapper_root = tmp_path / 'commands'
     vibe_root.mkdir(parents=True)
     brainstorm_root.mkdir(parents=True)
     internal_non_core_root.mkdir(parents=True, exist_ok=True)
+    wrapper_root.mkdir(parents=True, exist_ok=True)
     (vibe_root / 'SKILL.md').write_text('# vibe\n', encoding='utf-8')
     (brainstorm_root / 'SKILL.md').write_text('# brainstorming\n', encoding='utf-8')
     (internal_non_core_root / 'SKILL.runtime-mirror.md').write_text('# scikit-learn\n', encoding='utf-8')
+    for name in ('vibe', 'vibe-want', 'vibe-how', 'vibe-do'):
+        (wrapper_root / f'{name}.md').write_text(f'# {name}\n', encoding='utf-8')
     settings_path = tmp_path / 'settings.json'
     settings_path.write_text('{}\n', encoding='utf-8')
 
@@ -48,6 +52,7 @@ def test_build_install_ledger_tracks_payload_summary(tmp_path) -> None:
         runtime_roots={vibe_root, tmp_path / 'skills' / 'vibe' / 'bundled' / 'skills'},
         compatibility_roots={brainstorm_root},
         sidecar_roots={tmp_path / '.vibeskills'},
+        specialist_wrapper_paths=[wrapper_root / 'vibe.md', wrapper_root / 'vibe-want.md', wrapper_root / 'vibe-how.md', wrapper_root / 'vibe-do.md'],
         config_rollbacks=[{'path': settings_path, 'created_if_absent': False, 'managed_key': 'vibeskills'}],
         legacy_cleanup_candidates={tmp_path / 'skills' / 'legacy-skill'},
     )
@@ -64,6 +69,8 @@ def test_build_install_ledger_tracks_payload_summary(tmp_path) -> None:
     assert ledger['schema_version'] == 2
     assert ledger['payload_summary']['installed_skill_names'] == ['brainstorming', 'scikit-learn', 'vibe']
     assert ledger['payload_summary']['public_skill_names'] == ['brainstorming', 'vibe']
+    assert ledger['payload_summary']['host_visible_entry_names'] == ['vibe', 'vibe-do', 'vibe-how', 'vibe-want']
+    assert ledger['payload_summary']['host_visible_entry_count'] == 4
     assert ledger['runtime_roots'] == ['skills/vibe', 'skills/vibe/bundled/skills']
     assert ledger['compatibility_roots'] == ['skills/brainstorming']
     assert ledger['sidecar_roots'] == ['.vibeskills']

--- a/tests/unit/test_installer_ledger_service.py
+++ b/tests/unit/test_installer_ledger_service.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import sys
+import tempfile
 
 ROOT = Path(__file__).resolve().parents[2]
 CONTRACTS_SRC = ROOT / 'packages' / 'contracts' / 'src'
@@ -172,6 +173,33 @@ def test_payload_summary_counts_mcp_receipt_when_present(tmp_path) -> None:
     refreshed = build_payload_summary(tmp_path, ledger)
 
     assert refreshed['installed_file_count'] == 2
+
+
+def test_build_payload_summary_ignores_wrapper_paths_outside_target_root(tmp_path) -> None:
+    with tempfile.TemporaryDirectory() as external_dir:
+        external_wrapper = Path(external_dir) / 'vibe-how.md'
+        external_wrapper.write_text('# vibe-how\n', encoding='utf-8')
+
+        summary = build_payload_summary(
+            tmp_path,
+            {
+                'managed_skill_names': [],
+                'specialist_wrapper_paths': [str(external_wrapper)],
+                'packaging_manifest': {},
+                'runtime_roots': [],
+                'compatibility_roots': [],
+                'sidecar_roots': [],
+                'owned_tree_roots': [],
+                'created_paths': [],
+                'managed_json_paths': [],
+                'generated_from_template_if_absent': [],
+                'merged_files': [],
+                'config_rollbacks': [],
+            },
+        )
+
+    assert summary['host_visible_entry_names'] == []
+    assert summary['host_visible_entry_count'] == 0
 
 
 def test_sanitize_managed_skill_names_stays_safe_with_v2_owned_root_like_values() -> None:

--- a/tests/unit/test_router_contract_support_descriptor_sources.py
+++ b/tests/unit/test_router_contract_support_descriptor_sources.py
@@ -36,8 +36,11 @@ def _write_runtime_core_packaging(repo_root: Path) -> None:
         json.dumps(
             {
                 'public_skill_surface': {
+                    'mode': 'discoverable_wrapper_projection',
                     'canonical_entrypoint_relpath': 'skills/vibe',
                     'root_relpath': 'skills',
+                    'discoverable_entry_surface': 'config/vibe-entry-surfaces.json',
+                    'projected_skill_names': ['vibe', 'vibe-want', 'vibe-how', 'vibe-do'],
                 },
                 'internal_skill_corpus': {
                     'target_relpath': 'skills/vibe/bundled/skills',
@@ -98,6 +101,10 @@ def test_resolver_prefers_internal_corpus_descriptor_when_split_semantics_availa
     assert descriptor['skill_md_path'] == str(resolved)
     assert descriptor['description'] == 'repo internal corpus'
 
+    public_surface = module.resolve_public_skill_surface(repo)
+    assert public_surface['discoverable_entry_surface'] == 'config/vibe-entry-surfaces.json'
+    assert public_surface['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
+
 
 def test_resolver_uses_installed_internal_corpus_when_repo_internal_descriptor_is_absent(tmp_path: Path) -> None:
     module = _load_module()
@@ -127,6 +134,10 @@ def test_resolver_uses_installed_internal_corpus_when_repo_internal_descriptor_i
     descriptor = module.read_skill_descriptor(repo, 'skill-beta', str(target_root))
     assert descriptor['skill_md_path'] == str(installed_internal)
     assert descriptor['description'] == 'installed internal corpus'
+
+    public_surface = module.resolve_public_skill_surface(repo)
+    assert public_surface['discoverable_entry_surface'] == 'config/vibe-entry-surfaces.json'
+    assert public_surface['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
 
 
 def test_resolver_keeps_legacy_installed_skill_fallback_when_split_semantics_available(tmp_path: Path) -> None:

--- a/tests/unit/test_runtime_packaging_resolver.py
+++ b/tests/unit/test_runtime_packaging_resolver.py
@@ -32,3 +32,9 @@ def test_runtime_packaging_resolver_loads_profile_projection_from_authoritative_
     assert full['payload_roles']['delivery_model']['bundled_skill_mode'] == 'hidden_full_internal_corpus_minus_canonical_vibe'
     assert minimal['compatibility_skill_projections']['projected_skill_names'] == []
     assert full['compatibility_skill_projections']['projected_skill_names'] == []
+    assert minimal['public_skill_surface']['mode'] == 'discoverable_wrapper_projection'
+    assert full['public_skill_surface']['mode'] == 'discoverable_wrapper_projection'
+    assert minimal['public_skill_surface']['discoverable_entry_surface'] == 'config/vibe-entry-surfaces.json'
+    assert full['public_skill_surface']['discoverable_entry_surface'] == 'config/vibe-entry-surfaces.json'
+    assert minimal['public_skill_surface']['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
+    assert full['public_skill_surface']['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']


### PR DESCRIPTION
## Summary
- project the governed `vibe` runtime as host-visible discoverable wrapper entries (`vibe`, `vibe-want`, `vibe-how`, `vibe-do`) while keeping one canonical runtime authority
- centralize discoverable-entry metadata, materialize wrapper surfaces during install, and report host-visible entry inventory in the install ledger and adapter metadata
- harden `check.sh` and `check.ps1` to verify host-visible wrapper readiness, add runtime-neutral coverage, and align public docs with the shipped wrapper surface

## Test Plan
- [x] `pytest tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py -q`
- [x] `pytest tests/runtime_neutral/test_claude_preview_scaffold.py -q`
- [x] `pytest tests/runtime_neutral/test_opencode_preview_parity.py -q`
- [x] `pytest tests/runtime_neutral/test_windsurf_runtime_core.py -q`
- [x] `pytest tests/runtime_neutral/test_openclaw_runtime_core.py -q`
- [x] `pytest tests/contract/test_vibe_discoverable_entry_contract.py tests/unit/test_runtime_packaging_resolver.py tests/integration/test_runtime_core_packaging_roles.py tests/unit/test_discoverable_entry_surface.py tests/unit/test_router_contract_support_descriptor_sources.py tests/unit/test_discoverable_wrappers.py tests/runtime_neutral/test_install_profile_differentiation.py tests/contract/test_adapter_descriptor_contract.py tests/unit/test_adapter_registry_support.py tests/unit/test_installer_ledger_service.py tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py tests/runtime_neutral/test_claude_preview_scaffold.py tests/runtime_neutral/test_opencode_preview_parity.py tests/runtime_neutral/test_windsurf_runtime_core.py tests/runtime_neutral/test_openclaw_runtime_core.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public invocation expanded to four host-visible wrappers: vibe, vibe-want, vibe-how, vibe-do — all route to the same canonical runtime with distinct default stop targets; hosts may render human-friendly labels.

* **Documentation**
  * README, quick-starts, design/plans, and requirements updated to describe the wrapper set, label mappings, and projection model.

* **Configuration**
  * Packaging and adapter metadata updated so public surfaces project the four wrapper entries and expose host-visible projection metadata.

* **Chores / Installer & Validation**
  * Installer materializes host-visible wrapper artifacts, records them in install state, and check scripts validate wrapper entries separately from bridge-launchers.

* **Tests**
  * New and updated unit, integration, and runtime-neutral tests to verify projection, materialization, ledger fields, and cross-platform checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->