### PR TITLE
fix: fall back to plain chat completions in router advice probe

### DIFF
--- a/packages/verification-core/src/vgo_verify/router_ai_connectivity_probe.py
+++ b/packages/verification-core/src/vgo_verify/router_ai_connectivity_probe.py
@@ -26,6 +26,20 @@ from .router_ai_probe_support import (
 from .router_ai_probe_vector import probe_vector_diff
 
 
+def attempt_info_lines(label: str, attempts: list[dict[str, Any]] | None) -> list[str]:
+    lines: list[str] = []
+    for attempt in attempts or []:
+        endpoint = str(attempt.get("endpoint_kind") or "unknown")
+        status = attempt.get("status_code")
+        outcome = str(attempt.get("outcome") or "unknown")
+        error_kind = str(attempt.get("error_kind") or "none")
+        latency_ms = attempt.get("latency_ms")
+        lines.append(
+            f"[INFO] {label}_attempt endpoint={endpoint} status={status} outcome={outcome} error_kind={error_kind} latency_ms={latency_ms}"
+        )
+    return lines
+
+
 def next_step_for_advice(status: str, advice: dict[str, Any]) -> str | None:
     if status == "disabled_by_policy":
         return "Enable llm acceleration policy (`enabled=true`, `mode` not `off`) before checking advice connectivity."
@@ -178,7 +192,24 @@ def write_artifacts(repo_root: Path, artifact: dict[str, Any], output_directory:
         f"- Provider Type: `{artifact['advice'].get('provider_type')}`",
         f"- Model: `{artifact['advice'].get('model')}`",
         f"- Credential Env: `{artifact['advice'].get('credential_env')}`",
+        f"- Endpoint Used: `{artifact['advice'].get('endpoint_used')}`",
         "",
+    ]
+    advice_attempts = artifact["advice"].get("attempts") or []
+    if advice_attempts:
+        lines += ["### Advice Attempts", ""]
+        for attempt in advice_attempts:
+            lines.append(
+                "- endpoint=`{endpoint}` status=`{status}` outcome=`{outcome}` error_kind=`{error_kind}` latency_ms=`{latency}`".format(
+                    endpoint=attempt.get("endpoint_kind"),
+                    status=attempt.get("status_code"),
+                    outcome=attempt.get("outcome"),
+                    error_kind=attempt.get("error_kind"),
+                    latency=attempt.get("latency_ms"),
+                )
+            )
+        lines.append("")
+    lines += [
         "## Vector Diff Probe",
         "",
         f"- Status: `{artifact['vector_diff'].get('status')}`",
@@ -186,6 +217,20 @@ def write_artifacts(repo_root: Path, artifact: dict[str, Any], output_directory:
         f"- Model: `{artifact['vector_diff'].get('model')}`",
         "",
     ]
+    vector_attempts = artifact["vector_diff"].get("attempts") or []
+    if vector_attempts:
+        lines += ["### Vector Diff Attempts", ""]
+        for attempt in vector_attempts:
+            lines.append(
+                "- endpoint=`{endpoint}` status=`{status}` outcome=`{outcome}` error_kind=`{error_kind}` latency_ms=`{latency}`".format(
+                    endpoint=attempt.get("endpoint_kind"),
+                    status=attempt.get("status_code"),
+                    outcome=attempt.get("outcome"),
+                    error_kind=attempt.get("error_kind"),
+                    latency=attempt.get("latency_ms"),
+                )
+            )
+        lines.append("")
     if artifact["next_steps"]:
         lines += ["## Next Steps", ""]
         for step in artifact["next_steps"]:
@@ -232,6 +277,10 @@ def main(argv: list[str] | None = None) -> int:
     print(f"[INFO] advice_status={artifact['summary']['advice_status']}")
     print(f"[INFO] vector_diff_status={artifact['summary']['vector_diff_status']}")
     print(f"[INFO] gate_result={artifact['summary']['gate_result']}")
+    for line in attempt_info_lines("advice", artifact["advice"].get("attempts")):
+        print(line)
+    for line in attempt_info_lines("vector_diff", artifact["vector_diff"].get("attempts")):
+        print(line)
     for step in artifact["next_steps"]:
         print(f"[NEXT] {step}")
     return 0 if artifact["summary"]["gate_result"] in {"PASS", "WARN"} else 1

--- a/packages/verification-core/src/vgo_verify/router_ai_probe_advice.py
+++ b/packages/verification-core/src/vgo_verify/router_ai_probe_advice.py
@@ -126,7 +126,7 @@ def classify_advice_probe_result(attempts: list[dict[str, Any]]) -> tuple[str, s
                 text = None
                 if attempt["endpoint_kind"] == "responses":
                     text = extract_openai_response_output_text(payload)
-                elif attempt["endpoint_kind"] == "chat_completions":
+                elif attempt["endpoint_kind"] in {"chat_completions", "chat_completions_plain"}:
                     text = extract_chat_completion_text(payload)
 
                 if text:
@@ -316,6 +316,20 @@ def probe_advice_connectivity(
         "top_p": 1.0,
         "stream": False,
     }
+    plain_chat_payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": "Reply with a JSON object only. Do not wrap it in markdown.",
+            },
+            {"role": "user", "content": 'Return JSON object {"ok": true} only.'},
+        ],
+        "max_tokens": 32,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "stream": False,
+    }
 
     attempts = [
         request_attempt(
@@ -334,6 +348,15 @@ def probe_advice_connectivity(
             url=f"{base_v1}/chat/completions",
             headers=headers,
             payload=chat_payload,
+            timeout_ms=timeout_ms,
+        ),
+        request_attempt(
+            transport,
+            purpose="advice",
+            endpoint_kind="chat_completions_plain",
+            url=f"{base_v1}/chat/completions",
+            headers=headers,
+            payload=plain_chat_payload,
             timeout_ms=timeout_ms,
         ),
     ]

--- a/tests/runtime_neutral/test_router_ai_connectivity_probe.py
+++ b/tests/runtime_neutral/test_router_ai_connectivity_probe.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import sys
@@ -184,6 +186,57 @@ class RouterAiConnectivityProbeTests(unittest.TestCase):
             )
 
         self.assertEqual("provider_rejected_request", artifact["summary"]["advice_status"])
+
+    def test_plain_chat_completion_fallback_is_classified_ok(self) -> None:
+        self._write_settings({"VCO_INTENT_ADVICE_API_KEY": "sk-test"})
+
+        def transport(req: dict) -> dict:
+            if req["endpoint_kind"] == "responses":
+                return {
+                    "ok": False,
+                    "status_code": 404,
+                    "error_kind": "http",
+                    "error": "responses unsupported",
+                    "body_text": '{"error":"not found"}',
+                    "json": {"error": "not found"},
+                    "latency_ms": 4,
+                }
+            if req["endpoint_kind"] == "chat_completions":
+                return {
+                    "ok": False,
+                    "status_code": 400,
+                    "error_kind": "http",
+                    "error": "response_format unsupported",
+                    "body_text": '{"error":"bad request"}',
+                    "json": {"error": "bad request"},
+                    "latency_ms": 5,
+                }
+            if req["endpoint_kind"] == "chat_completions_plain":
+                return {
+                    "ok": True,
+                    "status_code": 200,
+                    "error_kind": None,
+                    "error": None,
+                    "body_text": '{"choices":[{"message":{"content":"{\\"ok\\":true}"}}]}',
+                    "json": {"choices": [{"message": {"content": '{"ok":true}'}}]},
+                    "latency_ms": 6,
+                }
+            raise AssertionError(f"unexpected endpoint_kind: {req['endpoint_kind']}")
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            artifact = self.module.evaluate(
+                self.root,
+                self.target_root,
+                probe_context=self.module.ProbeContext(prefix_detected=True),
+                transport=transport,
+            )
+
+        self.assertEqual("ok", artifact["summary"]["advice_status"])
+        self.assertEqual("chat_completions_plain", artifact["advice"]["endpoint_used"])
+        self.assertEqual(
+            ["responses", "chat_completions", "chat_completions_plain"],
+            [attempt["endpoint_kind"] for attempt in artifact["advice"]["attempts"]],
+        )
 
     def test_parse_error_is_classified(self) -> None:
         self._write_settings({"VCO_INTENT_ADVICE_API_KEY": "sk-test"})
@@ -384,6 +437,46 @@ class RouterAiConnectivityProbeTests(unittest.TestCase):
         self.assertEqual(
             registry_before, (self.root / "config" / "router-provider-registry.json").read_text(encoding="utf-8")
         )
+
+    def test_main_prints_attempt_diagnostics(self) -> None:
+        artifact = {
+            "summary": {
+                "advice_status": "provider_rejected_request",
+                "vector_diff_status": "vector_diff_not_configured",
+                "gate_result": "FAIL",
+            },
+            "next_steps": ["Verify API key validity."],
+            "advice": {
+                "attempts": [
+                    {
+                        "endpoint_kind": "responses",
+                        "status_code": 404,
+                        "error_kind": "http",
+                        "latency_ms": 3,
+                        "outcome": "http_error",
+                    },
+                    {
+                        "endpoint_kind": "chat_completions",
+                        "status_code": 400,
+                        "error_kind": "http",
+                        "latency_ms": 4,
+                        "outcome": "http_error",
+                    },
+                ]
+            },
+            "vector_diff": {"attempts": []},
+        }
+
+        with mock.patch.dict(self.module.main.__globals__, {"evaluate": mock.Mock(return_value=artifact)}):
+            stream = io.StringIO()
+            with contextlib.redirect_stdout(stream):
+                exit_code = self.module.main(["--repo-root", str(self.root), "--target-root", str(self.target_root)])
+
+        self.assertEqual(1, exit_code)
+        output = stream.getvalue()
+        self.assertIn("[INFO] advice_status=provider_rejected_request", output)
+        self.assertIn("[INFO] advice_attempt endpoint=responses status=404 outcome=http_error", output)
+        self.assertIn("[INFO] advice_attempt endpoint=chat_completions status=400 outcome=http_error", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a plain `/chat/completions` fallback when `/responses` or structured chat probing is rejected or unparseable
- surface endpoint-level attempt diagnostics in the connectivity gate console and markdown artifact output
- add regression coverage for the fallback path and the new diagnostics output

## Verification
- `python3 -m pytest tests/runtime_neutral/test_router_ai_connectivity_probe.py tests/runtime_neutral/test_bootstrap_doctor.py -q`
- local real-provider verification against `~/.claude` with the connectivity gate returned `advice_status=ok` and `gate_result=PASS`

## Context
This fixes the case where an OpenAI-compatible provider accepts chat completions but does not successfully satisfy the richer responses probe, which previously led to an incorrect hard failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced AI connectivity probe diagnostics with per-attempt endpoint, status code, outcome, error kind, and latency information.
  * Added fallback support for plain chat completions endpoint when standard endpoints are unavailable.

* **Tests**
  * Added tests for plain chat completion fallback behavior and attempt diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->