### PR TITLE
Fix PowerShell codex duplicate-surface check

### DIFF
--- a/check.ps1
+++ b/check.ps1
@@ -34,6 +34,69 @@ function Test-CanonicalRepoExecution {
   return (Test-VgoCanonicalRepoExecution -StartPath $RepoRoot)
 }
 
+function Resolve-CodexDuplicateSkillRoot {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  if ([string](Resolve-VgoHostId -HostId $HostId) -ne 'codex') {
+    return $null
+  }
+
+  $leaf = [System.IO.Path]::GetFileName([System.IO.Path]::GetFullPath($TargetRoot)).ToLowerInvariant()
+  if ($leaf -ne '.codex') {
+    return $null
+  }
+
+  $parent = Get-VgoParentPath -Path $TargetRoot
+  if ([string]::IsNullOrWhiteSpace($parent)) {
+    return $null
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $parent '.agents\skills\vibe'))
+}
+
+function Test-VibeSkillDir {
+  param([string]$Root)
+
+  if ([string]::IsNullOrWhiteSpace($Root)) {
+    return $false
+  }
+
+  $skillMd = Join-Path $Root 'SKILL.md'
+  if (-not (Test-Path -LiteralPath $skillMd -PathType Leaf)) {
+    return $false
+  }
+
+  try {
+    return [bool](Select-String -LiteralPath $skillMd -Pattern '^[\s]*name:[\s]*vibe[\s]*$' -CaseSensitive:$false -Quiet)
+  } catch {
+    return $false
+  }
+}
+
+function Check-CodexDuplicateSkillSurface {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  $duplicateRoot = Resolve-CodexDuplicateSkillRoot -TargetRoot $TargetRoot -HostId $HostId
+  if ([string]::IsNullOrWhiteSpace($duplicateRoot) -or -not (Test-Path -LiteralPath $duplicateRoot -PathType Container)) {
+    return
+  }
+
+  if (Test-VibeSkillDir -Root $duplicateRoot) {
+    Write-Host ("[FAIL] duplicate Codex-discovered vibe skill surface -> {0}" -f $duplicateRoot) -ForegroundColor Red
+    Write-Host '[FAIL] Re-run install.ps1 for the default Codex root to quarantine the legacy .agents copy, or move it out of .agents/skills manually.' -ForegroundColor Red
+    $script:fail++
+    return
+  }
+
+  Write-WarnNote -Message ("unexpected directory exists at Codex duplicate-surface path: {0}" -f $duplicateRoot)
+}
+
 function Get-CheckGovernance {
   param([string]$RepoRoot)
 
@@ -129,6 +192,29 @@ function Get-JsonObject {
   }
 }
 
+function ConvertTo-VgoStringArray {
+  param($Value)
+
+  $items = New-Object System.Collections.Generic.List[string]
+  foreach ($item in @($Value)) {
+    if ($null -eq $item) {
+      continue
+    }
+    [void]$items.Add([string]$item)
+  }
+  return ,([string[]]$items.ToArray())
+}
+
+function Get-VgoCollectionCount {
+  param($Value)
+
+  if ($null -eq $Value) {
+    return 0
+  }
+
+  return @($Value).Count
+}
+
 function Check-HostVisibleDiscoverableEntries {
   param(
     [string]$TargetRoot,
@@ -148,11 +234,26 @@ function Check-HostVisibleDiscoverableEntries {
   }
 
   $payloadSummary = if ($ledger.PSObject.Properties.Name -contains 'payload_summary') { $ledger.payload_summary } else { $null }
-  $entryNames = if ($null -ne $payloadSummary -and $payloadSummary.PSObject.Properties.Name -contains 'host_visible_entry_names') { @($payloadSummary.host_visible_entry_names | ForEach-Object { [string]$_ }) } else { @() }
-  $wrapperPaths = if ($ledger.PSObject.Properties.Name -contains 'specialist_wrapper_paths') { @($ledger.specialist_wrapper_paths | ForEach-Object { [string]$_ }) } else { @() }
-  $compatibilityRoots = if ($ledger.PSObject.Properties.Name -contains 'compatibility_roots') { @($ledger.compatibility_roots | ForEach-Object { [string]$_ }) } else { @() }
+  $entryNames = if ($null -ne $payloadSummary -and $payloadSummary.PSObject.Properties.Name -contains 'host_visible_entry_names') {
+    ConvertTo-VgoStringArray -Value $payloadSummary.host_visible_entry_names
+  } else {
+    @()
+  }
+  $wrapperPaths = if ($ledger.PSObject.Properties.Name -contains 'specialist_wrapper_paths') {
+    ConvertTo-VgoStringArray -Value $ledger.specialist_wrapper_paths
+  } else {
+    @()
+  }
+  $compatibilityRoots = if ($ledger.PSObject.Properties.Name -contains 'compatibility_roots') {
+    ConvertTo-VgoStringArray -Value $ledger.compatibility_roots
+  } else {
+    @()
+  }
+  $entryNameCount = Get-VgoCollectionCount -Value $entryNames
+  $wrapperPathCount = Get-VgoCollectionCount -Value $wrapperPaths
+  $compatibilityRootCount = Get-VgoCollectionCount -Value $compatibilityRoots
 
-  if ($entryNames.Count -eq 0 -or ($wrapperPaths.Count -eq 0 -and $compatibilityRoots.Count -eq 0)) {
+  if ($entryNameCount -eq 0 -and ($wrapperPathCount -eq 0 -and $compatibilityRootCount -eq 0)) {
     if ($HostId -in @('codex', 'claude-code', 'cursor', 'windsurf', 'openclaw', 'opencode')) {
       Write-Host '[FAIL] host-visible discoverable entries -> missing wrapper inventory' -ForegroundColor Red
       $script:fail++
@@ -217,8 +318,8 @@ function Check-HostVisibleDiscoverableEntries {
     }
   }
 
-  $wrappersReady = ($wrapperPaths.Count -gt 0 -and $missingPaths.Count -eq 0)
-  $compatibilityReady = ($compatibilityRoots.Count -gt 0 -and $missingCompatibilityRoots.Count -eq 0)
+  $wrappersReady = ($wrapperPathCount -gt 0 -and $missingPaths.Count -eq 0)
+  $compatibilityReady = ($compatibilityRootCount -gt 0 -and $missingCompatibilityRoots.Count -eq 0)
 
   if ($invalidWrapperPaths.Count -gt 0) {
     Write-Host ("[FAIL] host-visible discoverable entries -> {0}" -f $invalidWrapperPaths[0]) -ForegroundColor Red

--- a/check.ps1
+++ b/check.ps1
@@ -44,12 +44,21 @@ function Resolve-CodexDuplicateSkillRoot {
     return $null
   }
 
-  $leaf = [System.IO.Path]::GetFileName([System.IO.Path]::GetFullPath($TargetRoot)).ToLowerInvariant()
+  $normalizedTargetRoot = [System.IO.Path]::GetFullPath($TargetRoot)
+  $rootPath = [System.IO.Path]::GetPathRoot($normalizedTargetRoot)
+  if (-not [string]::IsNullOrWhiteSpace($rootPath) -and $normalizedTargetRoot.Length -gt $rootPath.Length) {
+    $normalizedTargetRoot = $normalizedTargetRoot.TrimEnd(
+      [System.IO.Path]::DirectorySeparatorChar,
+      [System.IO.Path]::AltDirectorySeparatorChar
+    )
+  }
+
+  $leaf = [System.IO.Path]::GetFileName($normalizedTargetRoot).ToLowerInvariant()
   if ($leaf -ne '.codex') {
     return $null
   }
 
-  $parent = Get-VgoParentPath -Path $TargetRoot
+  $parent = Get-VgoParentPath -Path $normalizedTargetRoot
   if ([string]::IsNullOrWhiteSpace($parent)) {
     return $null
   }

--- a/docs/plans/2026-04-09-pr141-codex-duplicate-surface-trailing-slash-execution-plan.md
+++ b/docs/plans/2026-04-09-pr141-codex-duplicate-surface-trailing-slash-execution-plan.md
@@ -1,0 +1,35 @@
+# PR141 Codex Duplicate Surface Trailing Slash Execution Plan
+
+**Goal:** Close the trailing-separator bypass in the PowerShell duplicate-surface guard for Codex installs and prove the fix with a targeted regression test.
+
+**Architecture:** Keep the current duplicate-surface detection flow, but normalize the incoming target root once before deriving the leaf and parent paths used to locate the legacy `.agents/skills/vibe` shadow surface.
+
+**Tech Stack:** PowerShell check script, Python runtime-neutral unittest suite
+
+---
+
+### Task 1: Lock the bypass with a failing regression test
+
+**Files:**
+- Modify: `tests/runtime_neutral/test_installed_runtime_scripts.py`
+
+- [ ] Add a PowerShell runtime-neutral test that installs to the default Codex root, appends a trailing path separator to `-TargetRoot`, seeds a legacy `.agents/skills/vibe/SKILL.md`, and asserts that duplicate-surface detection still fires.
+- [ ] Run the targeted test and confirm it fails against the current branch for the expected reason.
+
+### Task 2: Normalize the duplicate-surface target root
+
+**Files:**
+- Modify: `check.ps1`
+
+- [ ] Normalize `TargetRoot` before deriving both the leaf name and the parent path in `Resolve-CodexDuplicateSkillRoot`.
+- [ ] Keep the rest of the guard behavior unchanged.
+
+### Task 3: Verify and commit
+
+**Files:**
+- Inspect: `check.ps1`
+- Inspect: `tests/runtime_neutral/test_installed_runtime_scripts.py`
+
+- [ ] Run the targeted regression slice, including the existing non-trailing duplicate-surface PowerShell test.
+- [ ] Review the diff for scope control.
+- [ ] Commit the repair on `fix/check-codex-duplicate-surface`.

--- a/docs/requirements/2026-04-09-pr141-codex-duplicate-surface-trailing-slash.md
+++ b/docs/requirements/2026-04-09-pr141-codex-duplicate-surface-trailing-slash.md
@@ -1,0 +1,22 @@
+# PR141 Codex Duplicate Surface Trailing Slash Fix
+
+## Goal
+Repair PR `#141` so the Codex duplicate-surface guard remains authoritative when `check.ps1` receives the default Codex target root with a trailing path separator.
+
+## Problem Statement
+The branch adds `Resolve-CodexDuplicateSkillRoot`, but it derives the target leaf from `GetFileName(GetFullPath($TargetRoot))` without trimming trailing directory separators first. On PowerShell, a default Codex root such as `/tmp/home/.codex/` yields an empty leaf instead of `.codex`, so the duplicate-surface guard returns early and silently misses the legacy `.agents/skills/vibe` collision it was meant to catch.
+
+## Required Outcomes
+1. `check.ps1` must treat `.../.codex` and `.../.codex/` as the same default Codex root when deriving the duplicate-surface probe path.
+2. The duplicate-surface failure must still trigger when a legacy `.agents/skills/vibe/SKILL.md` exists and `-TargetRoot` ends in a path separator.
+3. A regression test must prove the trailing-separator case failed before the fix and passes after it.
+
+## Constraints
+- Keep the fix narrowly scoped to the duplicate-surface guard in `check.ps1`.
+- Do not regress the existing null-inventory repair in this PR.
+- Reuse the existing runtime-neutral PowerShell test surface instead of introducing a second ad hoc verification path.
+
+## Acceptance Criteria
+- A targeted PowerShell runtime-neutral test fails on the current branch when `-TargetRoot` ends with `/`.
+- After the implementation change, that test passes and still reports the duplicate-surface failure.
+- The existing duplicate-surface PowerShell test without a trailing separator remains green.

--- a/tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py
+++ b/tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py
@@ -274,6 +274,58 @@ class DiscoverableWrapperHostVisibilityTests(unittest.TestCase):
 
             self.assertIn("[OK] host-visible discoverable entries", result.stdout)
 
+    def test_powershell_check_treats_null_host_visible_entry_names_as_empty_inventory(self) -> None:
+        if shutil.which("pwsh") is None:
+            self.skipTest("pwsh not available")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir) / "codex-root"
+            subprocess.run(
+                [
+                    "pwsh",
+                    "-NoProfile",
+                    "-File",
+                    str(REPO_ROOT / "install.ps1"),
+                    "-HostId",
+                    "codex",
+                    "-Profile",
+                    "full",
+                    "-TargetRoot",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            ledger_path = target_root / ".vibeskills" / "install-ledger.json"
+            ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+            ledger["payload_summary"]["host_visible_entry_names"] = None
+            ledger["payload_summary"]["host_visible_entry_count"] = None
+            ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    "pwsh",
+                    "-NoProfile",
+                    "-File",
+                    str(REPO_ROOT / "check.ps1"),
+                    "-HostId",
+                    "codex",
+                    "-Profile",
+                    "full",
+                    "-TargetRoot",
+                    str(target_root),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            self.assertIn("[OK] host-visible discoverable entries", result.stdout)
+            self.assertNotIn("PropertyNotFoundException", result.stderr)
+            self.assertNotIn("Check-CodexDuplicateSkillSurface", result.stderr)
+
     def test_powershell_check_rejects_wrapper_inventory_outside_target_root(self) -> None:
         if shutil.which("pwsh") is None:
             self.skipTest("pwsh not available")

--- a/tests/runtime_neutral/test_installed_runtime_scripts.py
+++ b/tests/runtime_neutral/test_installed_runtime_scripts.py
@@ -1007,6 +1007,60 @@ class InstalledRuntimeScriptsTests(unittest.TestCase):
         self.assertNotEqual(0, check_result.returncode)
         self.assertIn("duplicate Codex-discovered vibe skill surface", check_result.stdout)
 
+    def test_powershell_check_fails_when_legacy_agents_duplicate_is_reintroduced_with_trailing_separator(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        home_root = self.root / "home-trailing"
+        target_root = home_root / ".codex"
+        target_root.mkdir(parents=True, exist_ok=True)
+
+        env = os.environ.copy()
+        env["HOME"] = str(home_root)
+
+        install_cmd = [
+            powershell,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(REPO_ROOT / "install.ps1"),
+            "-HostId",
+            "codex",
+            "-Profile",
+            "full",
+            "-TargetRoot",
+            str(target_root),
+        ]
+        subprocess.run(install_cmd, capture_output=True, text=True, check=True, env=env)
+
+        duplicate_root = home_root / ".agents" / "skills" / "vibe"
+        duplicate_root.mkdir(parents=True, exist_ok=True)
+        (duplicate_root / "SKILL.md").write_text(
+            "---\nname: vibe\ndescription: legacy duplicate\n---\n",
+            encoding="utf-8",
+        )
+
+        installed_root = target_root / "skills" / "vibe"
+        check_cmd = [
+            powershell,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(installed_root / "check.ps1"),
+            "-HostId",
+            "codex",
+            "-Profile",
+            "full",
+            "-TargetRoot",
+            str(target_root) + os.sep,
+        ]
+        check_result = subprocess.run(check_cmd, capture_output=True, text=True, env=env)
+        self.assertNotEqual(0, check_result.returncode)
+        self.assertIn("duplicate Codex-discovered vibe skill surface", check_result.stdout)
+
     def test_powershell_install_require_closed_ready_enforces_real_host_closure(self) -> None:
         powershell = resolve_powershell()
         if powershell is None:


### PR DESCRIPTION
## Summary
- restore the missing PowerShell `Check-CodexDuplicateSkillSurface` implementation so `check.ps1` fails correctly when the legacy `.agents/skills/vibe` surface is reintroduced
- make PowerShell host-visible wrapper inventory checks null-safe for older ledgers where `payload_summary.host_visible_entry_names` is absent or `null`
- add a PowerShell regression test that locks the null-ledger compatibility path

## Test Plan
- [x] `pytest -q tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py`
- [x] `pytest -q tests/runtime_neutral/test_installed_runtime_scripts.py -k "powershell_check or duplicate_is_reintroduced or legacy_agents_duplicate"`
- [x] `git diff --check`
- [x] `pwsh -NoProfile -ExecutionPolicy Bypass -File check.ps1 -HostId codex -Profile full -TargetRoot /home/lqf/.codex 2>&1 | rg -n "PropertyNotFoundException|Check-CodexDuplicateSkillSurface|Result:"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and normalization of null/empty ledger fields to avoid validation errors.
  * Strengthened detection of legacy duplicate skill surfaces in Codex installs, including cases with trailing path separators.

* **Tests**
  * Added regression tests validating empty-ledger behavior and detection of legacy duplicate surfaces with trailing separators.

* **Documentation**
  * Added execution plan and requirements documenting the trailing-separator duplicate-surface fix and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->