### PR TITLE
fix: expose vibe-upgrade in discoverable wrapper surfaces

### DIFF
--- a/config/runtime-core-packaging.full.json
+++ b/config/runtime-core-packaging.full.json
@@ -125,7 +125,8 @@
       "vibe",
       "vibe-want",
       "vibe-how",
-      "vibe-do"
+      "vibe-do",
+      "vibe-upgrade"
     ]
   },
   "internal_skill_corpus": {

--- a/config/runtime-core-packaging.json
+++ b/config/runtime-core-packaging.json
@@ -116,7 +116,8 @@
           "vibe",
           "vibe-want",
           "vibe-how",
-          "vibe-do"
+          "vibe-do",
+          "vibe-upgrade"
         ]
       },
       "internal_skill_corpus": {
@@ -219,7 +220,8 @@
           "vibe",
           "vibe-want",
           "vibe-how",
-          "vibe-do"
+          "vibe-do",
+          "vibe-upgrade"
         ]
       },
       "internal_skill_corpus": {

--- a/config/runtime-core-packaging.minimal.json
+++ b/config/runtime-core-packaging.minimal.json
@@ -146,7 +146,8 @@
       "vibe",
       "vibe-want",
       "vibe-how",
-      "vibe-do"
+      "vibe-do",
+      "vibe-upgrade"
     ]
   },
   "internal_skill_corpus": {

--- a/config/vibe-entry-surfaces.json
+++ b/config/vibe-entry-surfaces.json
@@ -25,6 +25,12 @@
       "display_name": "Vibe: Do It",
       "requested_stage_stop": "phase_cleanup",
       "allow_grade_flags": true
+    },
+    {
+      "id": "vibe-upgrade",
+      "display_name": "Vibe: Upgrade",
+      "requested_stage_stop": "phase_cleanup",
+      "allow_grade_flags": false
     }
   ],
   "grade_flags": [

--- a/tests/contract/test_vibe_discoverable_entry_contract.py
+++ b/tests/contract/test_vibe_discoverable_entry_contract.py
@@ -11,19 +11,22 @@ def test_vibe_discoverable_entries_are_shared_and_non_explosive() -> None:
     payload = json.loads((REPO_ROOT / "config" / "vibe-entry-surfaces.json").read_text(encoding="utf-8"))
     entries = {entry["id"]: entry for entry in payload["entries"]}
 
-    assert set(entries) == {"vibe", "vibe-want", "vibe-how", "vibe-do"}
+    assert set(entries) == {"vibe", "vibe-want", "vibe-how", "vibe-do", "vibe-upgrade"}
     assert entries["vibe"]["display_name"] == "Vibe"
     assert entries["vibe-want"]["display_name"] == "Vibe: What Do I Want?"
     assert entries["vibe-how"]["display_name"] == "Vibe: How Do We Do It?"
     assert entries["vibe-do"]["display_name"] == "Vibe: Do It"
+    assert entries["vibe-upgrade"]["display_name"] == "Vibe: Upgrade"
     assert entries["vibe"]["requested_stage_stop"] == "phase_cleanup"
     assert entries["vibe-want"]["requested_stage_stop"] == "requirement_doc"
     assert entries["vibe-how"]["requested_stage_stop"] == "xl_plan"
     assert entries["vibe-do"]["requested_stage_stop"] == "phase_cleanup"
+    assert entries["vibe-upgrade"]["requested_stage_stop"] == "phase_cleanup"
     assert entries["vibe"]["allow_grade_flags"] is True
     assert entries["vibe-want"]["allow_grade_flags"] is False
     assert entries["vibe-how"]["allow_grade_flags"] is True
     assert entries["vibe-do"]["allow_grade_flags"] is True
+    assert entries["vibe-upgrade"]["allow_grade_flags"] is False
     assert payload["grade_flags"] == ["--l", "--xl"]
     assert payload["grade_flag_map"] == {"--l": "L", "--xl": "XL"}
     assert payload["canonical_runtime_skill"] == "vibe"

--- a/tests/integration/test_runtime_core_packaging_roles.py
+++ b/tests/integration/test_runtime_core_packaging_roles.py
@@ -138,13 +138,13 @@ def test_profile_runtime_core_packaging_roles_describe_delivery_model() -> None:
         assert minimal['internal_skill_corpus']['target_relpath'] == 'skills/vibe/bundled/skills'
         assert minimal['public_skill_surface']['mode'] == 'discoverable_wrapper_projection'
         assert minimal['public_skill_surface']['discoverable_entry_surface'] == 'config/vibe-entry-surfaces.json'
-        assert minimal['public_skill_surface']['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
+        assert minimal['public_skill_surface']['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do', 'vibe-upgrade']
     if _supports_surface_split(full):
         assert sorted(full['compatibility_skill_projections']['projected_skill_names']) == CODEX_VIBE_WRAPPER_SKILLS
         assert full['internal_skill_corpus']['entrypoint_filename'] == 'SKILL.runtime-mirror.md'
         assert full['public_skill_surface']['mode'] == 'discoverable_wrapper_projection'
         assert full['public_skill_surface']['discoverable_entry_surface'] == 'config/vibe-entry-surfaces.json'
-        assert full['public_skill_surface']['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
+        assert full['public_skill_surface']['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do', 'vibe-upgrade']
 
 
 def test_profile_runtime_core_packaging_role_sources_match_copy_projection() -> None:

--- a/tests/runtime_neutral/test_claude_preview_scaffold.py
+++ b/tests/runtime_neutral/test_claude_preview_scaffold.py
@@ -57,7 +57,7 @@ def run_package_install(*, host: str, target_root: Path, profile: str = "full") 
 
 
 class ClaudePreviewScaffoldTests(unittest.TestCase):
-    EXPECTED_WRAPPER_SKILLS = ("vibe", "vibe-want", "vibe-how", "vibe-do")
+    EXPECTED_WRAPPER_SKILLS = ("vibe", "vibe-want", "vibe-how", "vibe-do", "vibe-upgrade")
 
     def setUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
@@ -172,7 +172,8 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
         result = subprocess.run(check_cmd, capture_output=True, text=True, check=True)
 
         self.assertIn('[OK] host closure manifest', result.stdout)
-        self.assertIn('[OK] settings.json managed vibeskills node', result.stdout)
+        self.assertIn('[OK] host settings sidecar', result.stdout)
+        self.assertIn('skills-only activation', result.stdout)
         settings = json.loads((self.target_root / 'settings.json').read_text(encoding='utf-8'))
         self.assertEqual(self.existing_settings['env'], settings['env'])
         self.assertEqual(self.existing_settings['model'], settings['model'])

--- a/tests/runtime_neutral/test_cursor_managed_preview.py
+++ b/tests/runtime_neutral/test_cursor_managed_preview.py
@@ -55,6 +55,7 @@ class CursorManagedPreviewTests(unittest.TestCase):
             self.assertTrue((target_root / "skills" / "vibe-want" / "SKILL.md").exists())
             self.assertTrue((target_root / "skills" / "vibe-how" / "SKILL.md").exists())
             self.assertTrue((target_root / "skills" / "vibe-do" / "SKILL.md").exists())
+            self.assertTrue((target_root / "skills" / "vibe-upgrade" / "SKILL.md").exists())
             self.assertFalse((target_root / "settings.json").exists())
             self.assertFalse((target_root / "commands").exists())
 

--- a/tests/runtime_neutral/test_install_profile_differentiation.py
+++ b/tests/runtime_neutral/test_install_profile_differentiation.py
@@ -100,14 +100,18 @@ class InstallProfileDifferentiationTests(unittest.TestCase):
             self.assertEqual("minimal", ledger["profile"])
             self.assertEqual(sorted(MINIMAL_REQUIRED_SKILLS), ledger["payload_summary"]["installed_skill_names"])
             self.assertEqual(["vibe"], ledger["payload_summary"]["public_skill_names"])
-            self.assertEqual(["vibe", "vibe-do", "vibe-how", "vibe-want"], ledger["payload_summary"]["host_visible_entry_names"])
-            self.assertEqual(4, ledger["payload_summary"]["host_visible_entry_count"])
+            self.assertEqual(
+                ["vibe", "vibe-do", "vibe-how", "vibe-upgrade", "vibe-want"],
+                ledger["payload_summary"]["host_visible_entry_names"],
+            )
+            self.assertEqual(5, ledger["payload_summary"]["host_visible_entry_count"])
             # In a fresh temp target, every file should be installer-owned.
             self.assertEqual(count_files(target_root), ledger["payload_summary"]["installed_file_count"])
             self.assertTrue((target_root / "commands" / "vibe.md").exists())
             self.assertTrue((target_root / "commands" / "vibe-want.md").exists())
             self.assertTrue((target_root / "commands" / "vibe-how.md").exists())
             self.assertTrue((target_root / "commands" / "vibe-do.md").exists())
+            self.assertTrue((target_root / "commands" / "vibe-upgrade.md").exists())
 
     def test_full_install_extends_minimal_payload_and_records_larger_summary(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -140,8 +144,11 @@ class InstallProfileDifferentiationTests(unittest.TestCase):
             )
             self.assertEqual(len(FULL_PUBLIC_WRAPPER_SKILLS), full_ledger["payload_summary"]["public_skill_count"])
             self.assertEqual(sorted(FULL_PUBLIC_WRAPPER_SKILLS), full_ledger["payload_summary"]["public_skill_names"])
-            self.assertEqual(["vibe", "vibe-do", "vibe-how", "vibe-want"], full_ledger["payload_summary"]["host_visible_entry_names"])
-            self.assertEqual(4, full_ledger["payload_summary"]["host_visible_entry_count"])
+            self.assertEqual(
+                ["vibe", "vibe-do", "vibe-how", "vibe-upgrade", "vibe-want"],
+                full_ledger["payload_summary"]["host_visible_entry_names"],
+            )
+            self.assertEqual(5, full_ledger["payload_summary"]["host_visible_entry_count"])
             self.assertIn(REPRESENTATIVE_NON_CORE_SKILL, full_ledger["payload_summary"]["installed_skill_names"])
             self.assertGreater(
                 full_ledger["payload_summary"]["installed_file_count"],
@@ -170,14 +177,14 @@ class InstallProfileDifferentiationTests(unittest.TestCase):
                         if candidate.is_dir()
                     }
 
-                    self.assertEqual({"vibe", "vibe-want", "vibe-how", "vibe-do"}, installed_skills)
+                    self.assertEqual({"vibe", "vibe-want", "vibe-how", "vibe-do", "vibe-upgrade"}, installed_skills)
                     self.assertEqual([], ledger["compatibility_roots"])
                     self.assertEqual(
-                        sorted(["vibe", "vibe-do", "vibe-how", "vibe-want"]),
+                        sorted(["vibe", "vibe-do", "vibe-how", "vibe-upgrade", "vibe-want"]),
                         ledger["payload_summary"]["public_skill_names"],
                     )
                     self.assertEqual(
-                        ["vibe", "vibe-do", "vibe-how", "vibe-want"],
+                        ["vibe", "vibe-do", "vibe-how", "vibe-upgrade", "vibe-want"],
                         ledger["payload_summary"]["host_visible_entry_names"],
                     )
 

--- a/tests/runtime_neutral/test_installed_runtime_scripts.py
+++ b/tests/runtime_neutral/test_installed_runtime_scripts.py
@@ -29,6 +29,7 @@ CODEX_COMPATIBILITY_COMMAND_FILES = {
     "vibe-what-do-i-want.md",
     "vibe-how-do-we-do.md",
     "vibe-do-it.md",
+    "vibe-upgrade.md",
 }
 CODEX_WRAPPER_SKILL_NAMES = {
     "vibe",

--- a/tests/runtime_neutral/test_openclaw_runtime_core.py
+++ b/tests/runtime_neutral/test_openclaw_runtime_core.py
@@ -52,7 +52,7 @@ def run_package_install(*, host: str, target_root: Path, profile: str = "full") 
 
 
 class OpenClawRuntimeCoreTests(unittest.TestCase):
-    EXPECTED_WRAPPER_SKILLS = ("vibe", "vibe-want", "vibe-how", "vibe-do")
+    EXPECTED_WRAPPER_SKILLS = ("vibe", "vibe-want", "vibe-how", "vibe-do", "vibe-upgrade")
 
     def test_adapter_registry_exposes_openclaw_preview_runtime_core_lane(self) -> None:
         registry = _load_module("installer_adapter_registry_openclaw", ADAPTER_REGISTRY_MODULE)

--- a/tests/runtime_neutral/test_windsurf_runtime_core.py
+++ b/tests/runtime_neutral/test_windsurf_runtime_core.py
@@ -52,7 +52,7 @@ def run_package_install(*, host: str, target_root: Path, profile: str = "full") 
 
 
 class WindsurfRuntimeCoreTests(unittest.TestCase):
-    EXPECTED_WRAPPER_SKILLS = ("vibe", "vibe-want", "vibe-how", "vibe-do")
+    EXPECTED_WRAPPER_SKILLS = ("vibe", "vibe-want", "vibe-how", "vibe-do", "vibe-upgrade")
 
     def test_adapter_registry_exposes_windsurf_parallel_root(self) -> None:
         registry = _load_module("installer_adapter_registry_windsurf", ADAPTER_REGISTRY_MODULE)

--- a/tests/unit/test_discoverable_entry_surface.py
+++ b/tests/unit/test_discoverable_entry_surface.py
@@ -16,7 +16,7 @@ def test_load_discoverable_entry_surface_reads_shared_wrapper_truth() -> None:
     surface = load_discoverable_entry_surface(ROOT)
 
     assert surface.canonical_runtime_skill == 'vibe'
-    assert surface.projected_skill_names == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
+    assert surface.projected_skill_names == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do', 'vibe-upgrade']
     assert surface.grade_flags == ['--l', '--xl']
     assert surface.grade_flag_map['--l'] == 'L'
     assert surface.grade_flag_map['--xl'] == 'XL'
@@ -24,5 +24,7 @@ def test_load_discoverable_entry_surface_reads_shared_wrapper_truth() -> None:
     assert surface.entry_by_id['vibe-want'].requested_stage_stop == 'requirement_doc'
     assert surface.entry_by_id['vibe-how'].requested_stage_stop == 'xl_plan'
     assert surface.entry_by_id['vibe-do'].requested_stage_stop == 'phase_cleanup'
+    assert surface.entry_by_id['vibe-upgrade'].requested_stage_stop == 'phase_cleanup'
     assert surface.entry_by_id['vibe-want'].allow_grade_flags is False
     assert surface.entry_by_id['vibe-how'].allow_grade_flags is True
+    assert surface.entry_by_id['vibe-upgrade'].allow_grade_flags is False

--- a/tests/unit/test_discoverable_wrappers.py
+++ b/tests/unit/test_discoverable_wrappers.py
@@ -23,12 +23,15 @@ def test_build_wrapper_descriptors_renders_all_discoverable_entries_for_codex() 
         surface=surface,
     )
 
-    assert sorted(rendered) == ['vibe', 'vibe-do', 'vibe-how', 'vibe-want']
+    assert sorted(rendered) == ['vibe', 'vibe-do', 'vibe-how', 'vibe-upgrade', 'vibe-want']
     assert rendered['vibe-how'].relpath.as_posix() == 'commands/vibe-how.md'
+    assert rendered['vibe-upgrade'].relpath.as_posix() == 'commands/vibe-upgrade.md'
     assert 'Vibe: How Do We Do It?' in rendered['vibe-how'].content
+    assert 'Vibe: Upgrade' in rendered['vibe-upgrade'].content
     assert 'Use the `vibe` skill' in rendered['vibe-how'].content
     assert 'Default stop target: `xl_plan`' in rendered['vibe-how'].content
     assert 'Default stop target: `requirement_doc`' in rendered['vibe-want'].content
+    assert 'Public grade flags allowed: no' in rendered['vibe-upgrade'].content
 
 
 def test_build_wrapper_descriptors_renders_skill_wrappers_for_skill_only_hosts() -> None:
@@ -39,9 +42,12 @@ def test_build_wrapper_descriptors_renders_skill_wrappers_for_skill_only_hosts()
         surface=surface,
     )
 
-    assert sorted(rendered) == ['vibe', 'vibe-do', 'vibe-how', 'vibe-want']
+    assert sorted(rendered) == ['vibe', 'vibe-do', 'vibe-how', 'vibe-upgrade', 'vibe-want']
     assert rendered['vibe-how'].relpath.as_posix() == 'skills/vibe-how/SKILL.md'
+    assert rendered['vibe-upgrade'].relpath.as_posix() == 'skills/vibe-upgrade/SKILL.md'
     assert 'name: vibe-how' in rendered['vibe-how'].content
+    assert 'name: vibe-upgrade' in rendered['vibe-upgrade'].content
     assert 'Vibe: How Do We Do It?' in rendered['vibe-how'].content
+    assert 'Vibe: Upgrade' in rendered['vibe-upgrade'].content
     assert 'Default stop target: `xl_plan`' in rendered['vibe-how'].content
     assert '$ARGUMENTS' in rendered['vibe-how'].content

--- a/tests/unit/test_installer_ledger_service.py
+++ b/tests/unit/test_installer_ledger_service.py
@@ -36,7 +36,7 @@ def test_build_install_ledger_tracks_payload_summary(tmp_path) -> None:
     (vibe_root / 'SKILL.md').write_text('# vibe\n', encoding='utf-8')
     (brainstorm_root / 'SKILL.md').write_text('# brainstorming\n', encoding='utf-8')
     (internal_non_core_root / 'SKILL.runtime-mirror.md').write_text('# scikit-learn\n', encoding='utf-8')
-    for name in ('vibe', 'vibe-want', 'vibe-how', 'vibe-do'):
+    for name in ('vibe', 'vibe-want', 'vibe-how', 'vibe-do', 'vibe-upgrade'):
         (wrapper_root / f'{name}.md').write_text(f'# {name}\n', encoding='utf-8')
     settings_path = tmp_path / 'settings.json'
     settings_path.write_text('{}\n', encoding='utf-8')
@@ -53,7 +53,13 @@ def test_build_install_ledger_tracks_payload_summary(tmp_path) -> None:
         runtime_roots={vibe_root, tmp_path / 'skills' / 'vibe' / 'bundled' / 'skills'},
         compatibility_roots={brainstorm_root},
         sidecar_roots={tmp_path / '.vibeskills'},
-        specialist_wrapper_paths=[wrapper_root / 'vibe.md', wrapper_root / 'vibe-want.md', wrapper_root / 'vibe-how.md', wrapper_root / 'vibe-do.md'],
+        specialist_wrapper_paths=[
+            wrapper_root / 'vibe.md',
+            wrapper_root / 'vibe-want.md',
+            wrapper_root / 'vibe-how.md',
+            wrapper_root / 'vibe-do.md',
+            wrapper_root / 'vibe-upgrade.md',
+        ],
         config_rollbacks=[{'path': settings_path, 'created_if_absent': False, 'managed_key': 'vibeskills'}],
         legacy_cleanup_candidates={tmp_path / 'skills' / 'legacy-skill'},
     )
@@ -70,8 +76,8 @@ def test_build_install_ledger_tracks_payload_summary(tmp_path) -> None:
     assert ledger['schema_version'] == 2
     assert ledger['payload_summary']['installed_skill_names'] == ['brainstorming', 'scikit-learn', 'vibe']
     assert ledger['payload_summary']['public_skill_names'] == ['brainstorming', 'vibe']
-    assert ledger['payload_summary']['host_visible_entry_names'] == ['vibe', 'vibe-do', 'vibe-how', 'vibe-want']
-    assert ledger['payload_summary']['host_visible_entry_count'] == 4
+    assert ledger['payload_summary']['host_visible_entry_names'] == ['vibe', 'vibe-do', 'vibe-how', 'vibe-upgrade', 'vibe-want']
+    assert ledger['payload_summary']['host_visible_entry_count'] == 5
     assert ledger['runtime_roots'] == ['skills/vibe', 'skills/vibe/bundled/skills']
     assert ledger['compatibility_roots'] == ['skills/brainstorming']
     assert ledger['sidecar_roots'] == ['.vibeskills']

--- a/tests/unit/test_router_contract_support_descriptor_sources.py
+++ b/tests/unit/test_router_contract_support_descriptor_sources.py
@@ -40,7 +40,7 @@ def _write_runtime_core_packaging(repo_root: Path) -> None:
                     'canonical_entrypoint_relpath': 'skills/vibe',
                     'root_relpath': 'skills',
                     'discoverable_entry_surface': 'config/vibe-entry-surfaces.json',
-                    'projected_skill_names': ['vibe', 'vibe-want', 'vibe-how', 'vibe-do'],
+                    'projected_skill_names': ['vibe', 'vibe-want', 'vibe-how', 'vibe-do', 'vibe-upgrade'],
                 },
                 'internal_skill_corpus': {
                     'target_relpath': 'skills/vibe/bundled/skills',
@@ -103,7 +103,7 @@ def test_resolver_prefers_internal_corpus_descriptor_when_split_semantics_availa
 
     public_surface = module.resolve_public_skill_surface(repo)
     assert public_surface['discoverable_entry_surface'] == 'config/vibe-entry-surfaces.json'
-    assert public_surface['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
+    assert public_surface['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do', 'vibe-upgrade']
 
 
 def test_resolver_uses_installed_internal_corpus_when_repo_internal_descriptor_is_absent(tmp_path: Path) -> None:
@@ -137,7 +137,7 @@ def test_resolver_uses_installed_internal_corpus_when_repo_internal_descriptor_i
 
     public_surface = module.resolve_public_skill_surface(repo)
     assert public_surface['discoverable_entry_surface'] == 'config/vibe-entry-surfaces.json'
-    assert public_surface['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
+    assert public_surface['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do', 'vibe-upgrade']
 
 
 def test_resolver_keeps_legacy_installed_skill_fallback_when_split_semantics_available(tmp_path: Path) -> None:

--- a/tests/unit/test_runtime_packaging_resolver.py
+++ b/tests/unit/test_runtime_packaging_resolver.py
@@ -10,6 +10,7 @@ MODULE_PATH = REPO_ROOT / 'packages' / 'installer-core' / 'src' / 'vgo_installer
 CODEX_VIBE_WRAPPER_SKILLS = [
     'vibe-do-it',
     'vibe-how-do-we-do',
+    'vibe-upgrade',
     'vibe-what-do-i-want',
 ]
 
@@ -41,5 +42,5 @@ def test_runtime_packaging_resolver_loads_profile_projection_from_authoritative_
     assert full['public_skill_surface']['mode'] == 'discoverable_wrapper_projection'
     assert minimal['public_skill_surface']['discoverable_entry_surface'] == 'config/vibe-entry-surfaces.json'
     assert full['public_skill_surface']['discoverable_entry_surface'] == 'config/vibe-entry-surfaces.json'
-    assert minimal['public_skill_surface']['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
-    assert full['public_skill_surface']['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do']
+    assert minimal['public_skill_surface']['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do', 'vibe-upgrade']
+    assert full['public_skill_surface']['projected_skill_names'] == ['vibe', 'vibe-want', 'vibe-how', 'vibe-do', 'vibe-upgrade']


### PR DESCRIPTION
## Summary
- register `vibe-upgrade` in the shared discoverable entry surface
- keep generated runtime-core packaging manifests aligned with the shared entry list
- extend host/runtime tests so Codex and skill-only hosts both verify the new visible wrapper entry
- update claude preview scaffold assertions to match the current skills-only sidecar check output

## Verification
- `python3 -m pytest -q tests/contract/test_vibe_discoverable_entry_contract.py tests/unit/test_discoverable_entry_surface.py tests/unit/test_discoverable_wrappers.py tests/unit/test_runtime_packaging_resolver.py tests/unit/test_router_contract_support_descriptor_sources.py tests/integration/test_runtime_core_packaging_roles.py tests/unit/test_installer_ledger_service.py`
- `python3 -m pytest -q tests/runtime_neutral/test_install_profile_differentiation.py tests/runtime_neutral/test_cursor_managed_preview.py tests/runtime_neutral/test_claude_preview_scaffold.py tests/runtime_neutral/test_openclaw_runtime_core.py tests/runtime_neutral/test_windsurf_runtime_core.py`
- `python3 -m pytest -q tests/runtime_neutral/test_installed_runtime_scripts.py -k 'codex_compatibility_command_shims or codex_wrapper_skill_surface or hyphen_command_shim_surface or wrapper_skill_surface_without_command_files' tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "Vibe: Upgrade" skill, now available as a new addition to the vibe feature family across all runtime profiles, expanding the set of available capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->