### PR TITLE
feat: aggressively route vibe specialist dispatch

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -93,9 +93,9 @@ Use this when the system should still ask the user high-value questions, confirm
 
 That means:
 
-- router-selected specialist skills may appear as bounded recommendations or route truth
+- governed `vibe` runs must surface bounded specialist recommendations and should treat router-selected specialist skills as route truth or executable recommendation candidates
 - runtime-selected skill remains `vibe` for governed entry
-- specialist help is allowed only as bounded native-mode assistance
+- eligible specialist help should auto-promote into bounded native-mode assistance by default
 - specialist help must preserve the specialist skill's own workflow, inputs, outputs, and validation style
 - specialist help must not create a second requirement doc, second plan surface, or second runtime authority
 
@@ -122,7 +122,7 @@ Child-governed lanes must not:
 Specialist dispatch under hierarchy:
 
 - `approved_dispatch`: root-approved specialist usage in the frozen plan
-- `local_suggestion`: child-detected specialist suggestion that stays advisory until root escalation approval
+- `local_suggestion`: residual child-detected specialist suggestion that only remains advisory when blocked, degraded, or explicitly forced to escalate
 
 ## Internal Execution Grades
 
@@ -201,7 +201,7 @@ Execute the approved plan.
 L grade executes planned units serially in the native governed lane.
 XL grade executes waves sequentially and may run only independent units in bounded parallel within a step.
 If subagents are spawned, their prompts must end with `$vibe`.
-If specialist skills are used, execute them as bounded native dispatch units only when root-approved in the frozen plan; otherwise keep them as advisory `local_suggestion` until escalation approval.
+Governed `vibe` runs must emit specialist recommendations; eligible recommendations should auto-promote into bounded native dispatch units, and only blocked, degraded, or forced-escalation cases should remain `local_suggestion`.
 If subagents run in child-governed lanes, they must inherit root-frozen context and must not reopen canonical requirement or plan truth surfaces.
 
 ### 6. `phase_cleanup`

--- a/SKILL.md
+++ b/SKILL.md
@@ -93,9 +93,9 @@ Use this when the system should still ask the user high-value questions, confirm
 
 That means:
 
-- governed `vibe` runs must surface bounded specialist recommendations and should treat router-selected specialist skills as route truth or executable recommendation candidates
+- governed `vibe` runs must surface bounded specialist recommendations and must treat router-selected specialist skills as route truth or executable recommendation candidates
 - runtime-selected skill remains `vibe` for governed entry
-- eligible specialist help should auto-promote into bounded native-mode assistance by default
+- eligible specialist help must auto-promote into bounded native-mode assistance by default
 - specialist help must preserve the specialist skill's own workflow, inputs, outputs, and validation style
 - specialist help must not create a second requirement doc, second plan surface, or second runtime authority
 
@@ -201,7 +201,7 @@ Execute the approved plan.
 L grade executes planned units serially in the native governed lane.
 XL grade executes waves sequentially and may run only independent units in bounded parallel within a step.
 If subagents are spawned, their prompts must end with `$vibe`.
-Governed `vibe` runs must emit specialist recommendations; eligible recommendations should auto-promote into bounded native dispatch units, and only blocked, degraded, or forced-escalation cases should remain `local_suggestion`.
+Governed `vibe` runs must emit specialist recommendations; eligible recommendations must auto-promote into bounded native dispatch units, and only blocked, degraded, or forced-escalation cases should remain `local_suggestion`.
 If subagents run in child-governed lanes, they must inherit root-frozen context and must not reopen canonical requirement or plan truth surfaces.
 
 ### 6. `phase_cleanup`

--- a/config/native-specialist-execution-policy.json
+++ b/config/native-specialist-execution-policy.json
@@ -5,7 +5,7 @@
   "default_adapter_id": "codex",
   "enable_env": "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION",
   "disable_env": "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION",
-  "default_enabled": false,
+  "default_enabled": true,
   "default_timeout_seconds": 600,
   "degrade_contract": {
     "status": "degraded_non_authoritative",

--- a/config/runtime-input-packet-policy.json
+++ b/config/runtime-input-packet-policy.json
@@ -85,16 +85,17 @@
     "field_name": "local_specialist_suggestions",
     "escalation_required": true,
     "approval_owner": "root_vibe",
-    "status": "advisory_until_root_approval",
+    "status": "auto_promote_when_safe_same_round",
     "auto_absorb_gate": {
       "enabled": true,
       "same_round": true,
       "approval_source": "root_vibe_auto_absorb_gate",
       "required_runtime_skill": "vibe",
+      "require_existing_root_dispatch": false,
       "require_known_recommendation": true,
       "require_native_workflow": true,
       "require_native_usage_required": true,
-      "max_auto_absorb_count": 4,
+      "max_auto_absorb_count": 6,
       "disable_env": "VGO_DISABLE_CHILD_SPECIALIST_AUTO_ABSORB",
       "force_escalation_env": "VGO_FORCE_CHILD_SPECIALIST_ESCALATION"
     }
@@ -200,6 +201,27 @@
     "llm_acceleration_advice",
     "heartbeat_advice"
   ],
-  "specialist_recommendation_limit": 4,
+  "required_specialist_recommendation_count": 1,
+  "specialist_recommendation_limit": 6,
+  "fallback_specialists_by_task_type": {
+    "planning": [
+      "writing-plans"
+    ],
+    "debug": [
+      "systematic-debugging"
+    ],
+    "research": [
+      "brainstorming"
+    ],
+    "coding": [
+      "test-driven-development"
+    ],
+    "review": [
+      "requesting-code-review"
+    ],
+    "default": [
+      "writing-plans"
+    ]
+  },
   "bounded_router_task_type_default": "planning"
 }

--- a/config/skill-promotion-policy.json
+++ b/config/skill-promotion-policy.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
-  "updated_at": "2026-04-06",
+  "updated_at": "2026-04-10",
   "promotion_enabled": true,
-  "default_mode": "recall_first",
+  "default_mode": "aggressive_dispatch_first",
   "allow_auto_dispatch_when_non_destructive": true,
   "require_contract_complete": true,
   "destructive_prompt_patterns": {

--- a/docs/superpowers/plans/2026-04-10-vibe-aggressive-specialist-routing.md
+++ b/docs/superpowers/plans/2026-04-10-vibe-aggressive-specialist-routing.md
@@ -1,0 +1,121 @@
+# Vibe Aggressive Specialist Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `vibe` require specialist recommendations on every governed run and aggressively auto-promote safe recommendations into executable specialist dispatch.
+
+**Architecture:** The change is policy-first and runtime-backed. We will update contract docs and runtime policy, then enforce the new behavior in runtime freeze and execute stages with test-first changes around fallback recommendation synthesis, child auto-absorb, and default native specialist execution.
+
+**Tech Stack:** PowerShell runtime scripts, JSON policy files, Python `unittest` runtime-neutral tests
+
+---
+
+## Chunk 1: Test Baseline
+
+### Task 1: Lock the new routing contract in tests
+
+**Files:**
+- Modify: `tests/runtime_neutral/test_skill_promotion_freeze_contract.py`
+- Modify: `tests/runtime_neutral/test_root_child_hierarchy_bridge.py`
+- Modify: `tests/runtime_neutral/test_l_xl_native_execution_topology.py`
+- Modify: `tests/runtime_neutral/test_skill_promotion_destructive_gate.py`
+
+- [ ] **Step 1: Write or update failing assertions for mandatory recommendations**
+
+Add assertions that a governed run always surfaces at least one specialist recommendation and at least one approved dispatch for safe tasks.
+
+- [ ] **Step 2: Add a failing child-lane test for same-round auto-absorb without existing root dispatch**
+
+Use a child-governed run where approved specialist ids do not overlap frozen local suggestions and assert that safe suggestions still auto-promote.
+
+- [ ] **Step 3: Add a failing assertion for native specialist execution default-on**
+
+Update the execution-policy expectation to require default enabled native specialist execution.
+
+- [ ] **Step 4: Run the targeted test subset and confirm failures**
+
+Run: `python -m pytest tests/runtime_neutral/test_skill_promotion_freeze_contract.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_skill_promotion_destructive_gate.py -q`
+
+Expected: failures reflecting the old conservative routing behavior.
+
+## Chunk 2: Policy and Contract Surfaces
+
+### Task 2: Update governed contract text and policy defaults
+
+**Files:**
+- Modify: `SKILL.md`
+- Modify: `protocols/runtime.md`
+- Modify: `protocols/team.md`
+- Modify: `config/runtime-input-packet-policy.json`
+- Modify: `config/skill-promotion-policy.json`
+- Modify: `config/native-specialist-execution-policy.json`
+
+- [ ] **Step 1: Update contract wording to make recommendation mandatory**
+
+State that governed `vibe` must emit specialist recommendations and aggressively auto-promote eligible ones while preserving `vibe` as sole authority.
+
+- [ ] **Step 2: Add aggressive routing policy knobs**
+
+Add minimum recommendation floor and task-type fallback specialist mapping in `runtime-input-packet-policy.json`.
+
+- [ ] **Step 3: Relax child auto-absorb gate policy**
+
+Remove the implicit requirement for existing root-approved dispatch from policy semantics.
+
+- [ ] **Step 4: Enable native specialist execution by default**
+
+Switch the native specialist execution default from opt-in to opt-out.
+
+## Chunk 3: Runtime Implementation
+
+### Task 3: Enforce aggressive routing in freeze and execute stages
+
+**Files:**
+- Modify: `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+- Modify: `scripts/runtime/Invoke-PlanExecute.ps1`
+- Modify: `scripts/runtime/Write-XlPlan.ps1`
+
+- [ ] **Step 1: Implement fallback specialist recommendation synthesis**
+
+Teach runtime freeze to supplement router output with task-type fallback specialists until the minimum recommendation floor is met.
+
+- [ ] **Step 2: Ensure safe fallback recommendations auto-promote in root scope**
+
+Keep promotion metadata intact and verify synthesized recommendations carry complete native contract metadata.
+
+- [ ] **Step 3: Remove existing-root-dispatch requirement from child same-round auto-absorb**
+
+Update effective dispatch resolution so child lanes can auto-approve known safe recommendations even when frozen approved dispatch is empty.
+
+- [ ] **Step 4: Update plan narrative surfaces**
+
+Adjust plan text so generated execution plans describe specialist dispatch as default governed behavior instead of purely advisory help.
+
+## Chunk 4: Verification and Cleanup
+
+### Task 4: Prove the new routing behavior
+
+**Files:**
+- Modify as needed: relevant verification scripts only if contract wording/assertions break
+
+- [ ] **Step 1: Run the targeted test subset until green**
+
+Run: `python -m pytest tests/runtime_neutral/test_skill_promotion_freeze_contract.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_skill_promotion_destructive_gate.py -q`
+
+Expected: PASS
+
+- [ ] **Step 2: Run one broader governed-runtime regression slice**
+
+Run: `python -m pytest tests/runtime_neutral/test_governed_runtime_bridge.py -q`
+
+Expected: PASS
+
+- [ ] **Step 3: Inspect git diff for touched files only**
+
+Run: `git diff -- SKILL.md protocols/runtime.md protocols/team.md config/runtime-input-packet-policy.json config/skill-promotion-policy.json config/native-specialist-execution-policy.json scripts/runtime/Freeze-RuntimeInputPacket.ps1 scripts/runtime/Invoke-PlanExecute.ps1 scripts/runtime/Write-XlPlan.ps1 tests/runtime_neutral/test_skill_promotion_freeze_contract.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_skill_promotion_destructive_gate.py`
+
+Expected: only aggressive specialist routing changes and aligned tests/docs.
+
+- [ ] **Step 4: Summarize verification evidence**
+
+Record which tests passed, which safeguards remain intentionally strict, and any residual routing edge cases not covered by this change.

--- a/docs/superpowers/plans/2026-04-10-vibe-aggressive-specialist-routing.md
+++ b/docs/superpowers/plans/2026-04-10-vibe-aggressive-specialist-routing.md
@@ -73,6 +73,7 @@ Switch the native specialist execution default from opt-in to opt-out.
 **Files:**
 - Modify: `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
 - Modify: `scripts/runtime/Invoke-PlanExecute.ps1`
+- Modify: `scripts/runtime/Write-RequirementDoc.ps1`
 - Modify: `scripts/runtime/Write-XlPlan.ps1`
 
 - [ ] **Step 1: Implement fallback specialist recommendation synthesis**
@@ -112,7 +113,7 @@ Expected: PASS
 
 - [ ] **Step 3: Inspect git diff for touched files only**
 
-Run: `git diff -- SKILL.md protocols/runtime.md protocols/team.md config/runtime-input-packet-policy.json config/skill-promotion-policy.json config/native-specialist-execution-policy.json scripts/runtime/Freeze-RuntimeInputPacket.ps1 scripts/runtime/Invoke-PlanExecute.ps1 scripts/runtime/Write-XlPlan.ps1 tests/runtime_neutral/test_skill_promotion_freeze_contract.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_skill_promotion_destructive_gate.py`
+Run: `git diff -- SKILL.md protocols/runtime.md protocols/team.md config/runtime-input-packet-policy.json config/skill-promotion-policy.json config/native-specialist-execution-policy.json scripts/runtime/Freeze-RuntimeInputPacket.ps1 scripts/runtime/Invoke-PlanExecute.ps1 scripts/runtime/Write-RequirementDoc.ps1 scripts/runtime/Write-XlPlan.ps1 tests/runtime_neutral/test_skill_promotion_freeze_contract.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py tests/runtime_neutral/test_skill_promotion_destructive_gate.py`
 
 Expected: only aggressive specialist routing changes and aligned tests/docs.
 

--- a/docs/superpowers/specs/2026-04-10-vibe-aggressive-specialist-routing-design.md
+++ b/docs/superpowers/specs/2026-04-10-vibe-aggressive-specialist-routing-design.md
@@ -90,7 +90,7 @@ The governed runtime contract should say, in effect:
 
 - `vibe` must attempt specialist routing on every governed run
 - specialist recommendations are mandatory runtime output, not optional metadata
-- eligible recommendations should auto-promote to `approved_dispatch`
+- eligible recommendations must auto-promote to `approved_dispatch`
 - child lanes may auto-absorb bounded specialist help in the same round without waiting for a separately frozen root dispatch entry
 
 This wording should be reflected consistently in:

--- a/docs/superpowers/specs/2026-04-10-vibe-aggressive-specialist-routing-design.md
+++ b/docs/superpowers/specs/2026-04-10-vibe-aggressive-specialist-routing-design.md
@@ -1,0 +1,135 @@
+# Vibe Aggressive Specialist Routing Design
+
+## Goal
+
+Make `vibe` treat specialist routing as a default governed behavior instead of an optional side path. Every governed `vibe` run must surface bounded specialist recommendations, and every eligible recommendation should promote to executable `approved_dispatch` as aggressively as safety allows.
+
+## Problem
+
+The current runtime already has specialist recommendation, promotion, and native execution plumbing, but the policy remains conservative in three places:
+
+1. `Freeze-RuntimeInputPacket.ps1` can produce zero specialist recommendations when canonical router output is sparse.
+2. Child-lane same-round auto-absorb requires an existing root-approved dispatch before promoting local suggestions.
+3. Native specialist execution is disabled by default, so approved specialist dispatch may still degrade instead of executing.
+
+This creates a mismatch between the intended governed routing story and observed behavior. Users expect routing to visibly happen and to materially affect execution, not just appear as advisory metadata.
+
+## Design Principles
+
+1. `vibe` remains the only governed runtime authority.
+2. Specialist routing becomes mandatory behavior inside `vibe`, not a replacement for `vibe`.
+3. Promotion stays aggressive for safe work and conservative only for destructive or incomplete contracts.
+4. The runtime should prefer executing known native specialists instead of carrying recommendations as passive artifacts.
+
+## Proposed Behavior
+
+### 1. Mandatory specialist recommendation floor
+
+Every governed `vibe` run must emit at least one bounded specialist recommendation.
+
+Recommendation sourcing order:
+
+1. Canonical router ranked specialist candidates
+2. Overlay-provided recommended specialists
+3. Router-selected non-`vibe` specialist route truth, if present
+4. A new runtime fallback map keyed by router task type
+
+If the router does not surface a specialist, the runtime will synthesize one from a policy-backed fallback profile. This keeps route authority intact while ensuring that `vibe` never skips specialist routing.
+
+### 2. Root scope defaults to auto-dispatch
+
+In `root_governed` runs, every non-destructive recommendation with a complete native contract should promote directly to `approved_dispatch`.
+
+This is already partially true through skill-promotion metadata. The design formalizes it as required behavior rather than incidental behavior and updates contract text to say that eligible recommendations are expected to auto-promote.
+
+### 3. Child scope uses aggressive same-round auto-absorb
+
+Child-governed lanes should no longer require a pre-existing root-approved dispatch before auto-absorbing local specialist suggestions.
+
+If a child suggestion:
+
+- matches a frozen recommendation,
+- preserves native workflow,
+- requires native usage,
+- stays within bounded write-scope rules,
+- and is not destructive,
+
+then the same-round auto-absorb gate should promote it into effective `approved_dispatch` automatically.
+
+Residual `local_suggestion` state should exist only for blocked, degraded, or explicitly forced-escalation cases.
+
+### 4. Native specialist execution defaults on
+
+`native-specialist-execution-policy.json` should enable native execution by default so auto-approved dispatch has a high-probability execution path instead of degrading by policy default.
+
+Environment flags still remain available to disable execution or force escalation in specific scenarios.
+
+## Policy Changes
+
+### Runtime input packet policy
+
+Add or revise policy semantics so that:
+
+- specialist recommendation generation is required
+- a minimum recommendation floor exists
+- fallback specialists are declared by task type
+- child auto-absorb no longer requires existing root dispatch
+- recommendation and auto-absorb limits are high enough to support aggressive routing
+
+### Skill promotion policy
+
+Keep destructive and incomplete-contract protections intact, but frame the default promotion mode as aggressive auto-dispatch for safe work.
+
+### Native specialist execution policy
+
+Change the default from opt-in to opt-out.
+
+## Contract Updates
+
+The governed runtime contract should say, in effect:
+
+- `vibe` must attempt specialist routing on every governed run
+- specialist recommendations are mandatory runtime output, not optional metadata
+- eligible recommendations should auto-promote to `approved_dispatch`
+- child lanes may auto-absorb bounded specialist help in the same round without waiting for a separately frozen root dispatch entry
+
+This wording should be reflected consistently in:
+
+- `SKILL.md`
+- `protocols/runtime.md`
+- `protocols/team.md`
+- human-readable plan/requirement generation surfaces
+
+## Testing Strategy
+
+Add or update tests to prove:
+
+1. Governed runtime always emits at least one specialist recommendation.
+2. A fallback recommendation appears when router ranking alone would otherwise leave no specialist surfaced.
+3. Root runs auto-promote safe recommendations to `approved_dispatch`.
+4. Child runs can auto-absorb same-round specialist dispatch without existing root-approved dispatch.
+5. Destructive prompts still block promotion.
+6. Native specialist execution is enabled by default for eligible dispatch.
+
+## Risks
+
+### Over-routing
+
+The runtime may surface specialists on tasks that would previously have stayed single-lane. This is intentional, but the fallback recommendation set must stay bounded and generic enough not to distort the task.
+
+### Excessive dispatch fan-out
+
+Aggressive routing can create too many specialist units. The policy should keep a finite cap and rely on execution topology to serialize where needed.
+
+### Governance confusion
+
+If wording is sloppy, aggressive routing could look like a second runtime authority. All contract text must explicitly preserve `vibe` as the sole governor.
+
+## Acceptance Criteria
+
+1. `vibe` governed runs always emit at least one specialist recommendation.
+2. Safe recommendations in root scope default to `approved_dispatch`.
+3. Child same-round auto-absorb can promote safe local suggestions without requiring existing root dispatch.
+4. Native specialist execution is enabled by default.
+5. Destructive prompts still do not auto-promote.
+6. Contract docs and verification surfaces describe routing as aggressive-by-default while preserving single runtime authority.

--- a/protocols/runtime.md
+++ b/protocols/runtime.md
@@ -157,8 +157,8 @@ Rules:
 - later stages must append a matching lineage entry for the same governed run
 - spawned subagent prompts must end with `$vibe`
 - milestone evidence must be written before phase completion
-- governed `vibe` runs must record bounded native specialist recommendations under `vibe` governance and should not leave the recommendation surface empty
-- eligible specialist recommendations should auto-promote into bounded native units; only blocked, degraded, or forced-escalation ideas remain advisory escalation requests
+- governed `vibe` runs must record bounded native specialist recommendations under `vibe` governance and must not leave the recommendation surface empty
+- eligible specialist recommendations must auto-promote into bounded native units; only blocked, degraded, or forced-escalation ideas remain advisory escalation requests
 - approved specialist dispatch must be phase-bound as `pre_execution`, `in_execution`, `post_execution`, or `verification`
 - approved specialist dispatch must carry lane policy, write scope, and review mode so execution remains deterministic and conflict-aware
 - `L` uses explicit serial specialist steps; `XL` may use bounded parallel specialist lanes only when root-approved and write-scope-safe

--- a/protocols/runtime.md
+++ b/protocols/runtime.md
@@ -157,8 +157,8 @@ Rules:
 - later stages must append a matching lineage entry for the same governed run
 - spawned subagent prompts must end with `$vibe`
 - milestone evidence must be written before phase completion
-- if the canonical router surfaces specialist skills, record them as bounded native specialist recommendations under `vibe` governance
-- root-approved specialist dispatch may execute as bounded native units; non-approved specialist ideas remain advisory escalation requests
+- governed `vibe` runs must record bounded native specialist recommendations under `vibe` governance and should not leave the recommendation surface empty
+- eligible specialist recommendations should auto-promote into bounded native units; only blocked, degraded, or forced-escalation ideas remain advisory escalation requests
 - approved specialist dispatch must be phase-bound as `pre_execution`, `in_execution`, `post_execution`, or `verification`
 - approved specialist dispatch must carry lane policy, write scope, and review mode so execution remains deterministic and conflict-aware
 - `L` uses explicit serial specialist steps; `XL` may use bounded parallel specialist lanes only when root-approved and write-scope-safe
@@ -253,9 +253,9 @@ Explicitly forbidden for child-governed lanes:
 
 Specialist dispatch semantics under hierarchy:
 
-- `approved_dispatch`: specialist execution approved by root and recorded in frozen plan
+- `approved_dispatch`: specialist execution approved by root and recorded in frozen plan, including same-round auto-absorb approval for safe child-lane recommendations
 - approved dispatch must include phase binding, lane policy, write scope, and review mode so downstream child lanes do not improvise governance semantics
-- `local_suggestion`: child-surfaced specialist suggestion that remains advisory in the frozen packet until root-governed execution either escalates it or auto-absorbs it through the same-round approval gate
+- `local_suggestion`: residual child-surfaced specialist suggestion that remains advisory only when root-governed execution blocks it, degrades it, or explicit policy forces escalation instead of same-round auto-absorb
 
 ## Artifact Contract
 

--- a/protocols/team.md
+++ b/protocols/team.md
@@ -79,7 +79,7 @@ Child-governed lanes must not:
 - `L` execution is handled in `do.md` as serial native execution; this protocol is not the default L executor.
 - `XL` execution is wave-sequential by dependency.
 - Parallel work in `XL` is step-scoped and bounded to independent units only.
-- Specialist dispatch can be executable as bounded units only when root-approved in the frozen plan.
+- Specialist routing is expected on governed runs, and eligible bounded specialist recommendations should become executable dispatch by default.
 - Specialist dispatch is phase-bound: `pre_execution`, `in_execution`, `post_execution`, `verification`.
 - In `XL`, specialist lanes may join bounded parallel windows only when their write scopes are disjoint and their lane policy allows it.
 
@@ -120,7 +120,7 @@ Within XL execution, a specialist skill is a bounded helper, not a replacement r
 Rules:
 
 - `vibe` keeps final control of stage order, plan authority, and completion claims
-- specialist dispatch should be declared in the frozen plan before execution
+- specialist recommendations should always be surfaced in governed runtime output, and safe bounded recommendations should aggressively promote into effective dispatch
 - each specialist receives a bounded subtask contract plus the frozen requirement context
 - specialist outputs must stay in the native format or workflow expected by that specialist skill
 - each approved specialist also carries phase binding, lane policy, write scope, and review mode
@@ -130,7 +130,7 @@ Rules:
 Hierarchy-specific dispatch semantics:
 
 - `approved_dispatch`: specialist usage approved by root and frozen in plan; child lanes may execute directly
-- `local_suggestion`: child-lane specialist suggestion; advisory until explicit root escalation approval
+- `local_suggestion`: residual child-lane specialist suggestion that remains advisory only after safe same-round auto-promotion has been exhausted or blocked
 
 Escalation rule:
 

--- a/scripts/runtime/Freeze-RuntimeInputPacket.ps1
+++ b/scripts/runtime/Freeze-RuntimeInputPacket.ps1
@@ -658,6 +658,14 @@ function Get-VibeSpecialistRecommendations {
         $seen[$fallbackSkillId] = $true
     }
 
+    if (@($recommendations).Count -lt $requiredRecommendationCount) {
+        throw (
+            "Runtime input policy requires at least {0} specialist recommendation(s), but only {1} could be produced for task type '{2}'. " +
+            "Check fallback_specialists_by_task_type/default and router specialist outputs." `
+                -f $requiredRecommendationCount, @($recommendations).Count, $TaskType
+        )
+    }
+
     return @($recommendations)
 }
 

--- a/scripts/runtime/Freeze-RuntimeInputPacket.ps1
+++ b/scripts/runtime/Freeze-RuntimeInputPacket.ps1
@@ -300,6 +300,46 @@ function Get-VibeSpecialistBindingProfile {
     }
 }
 
+function Get-VibeFallbackSpecialistSkillIds {
+    param(
+        [Parameter(Mandatory)] [string]$TaskType,
+        [Parameter(Mandatory)] [object]$Policy,
+        [AllowEmptyString()] [string]$RouterSelectedSkill = '',
+        [AllowEmptyString()] [string]$RuntimeSelectedSkill = ''
+    )
+
+    $skillIds = @()
+    if (-not [string]::IsNullOrWhiteSpace($RouterSelectedSkill) -and
+        -not [string]::Equals($RouterSelectedSkill, $RuntimeSelectedSkill, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $skillIds += [string]$RouterSelectedSkill
+    }
+
+    $fallbackByTaskType = if ($Policy.PSObject.Properties.Name -contains 'fallback_specialists_by_task_type') {
+        $Policy.fallback_specialists_by_task_type
+    } else {
+        $null
+    }
+    if ($null -eq $fallbackByTaskType) {
+        return @($skillIds | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    }
+
+    foreach ($key in @($TaskType, 'default')) {
+        if ([string]::IsNullOrWhiteSpace([string]$key)) {
+            continue
+        }
+        if (-not ($fallbackByTaskType.PSObject.Properties.Name -contains $key)) {
+            continue
+        }
+        foreach ($skillId in @($fallbackByTaskType.$key)) {
+            if (-not [string]::IsNullOrWhiteSpace([string]$skillId)) {
+                $skillIds += [string]$skillId
+            }
+        }
+    }
+
+    return @($skillIds | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+}
+
 function New-VibeSpecialistRecommendation {
     param(
         [Parameter(Mandatory)] [string]$RepoRoot,
@@ -418,6 +458,7 @@ function Get-VibeSpecialistRecommendations {
         [Parameter(Mandatory)] [string]$Task,
         [Parameter(Mandatory)] [object]$RouteResult,
         [Parameter(Mandatory)] [string]$RuntimeSelectedSkill,
+        [AllowEmptyString()] [string]$RouterSelectedSkill = '',
         [Parameter(Mandatory)] [string]$TaskType,
         [Parameter(Mandatory)] [object]$Policy,
         [AllowNull()] [object]$PromotionPolicy = $null,
@@ -540,6 +581,68 @@ function Get-VibeSpecialistRecommendations {
             -TargetRoot $TargetRoot `
             -HostId $HostId)
         $seen[$skillId] = $true
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($RouterSelectedSkill) -and
+        -not [string]::Equals($RouterSelectedSkill, $RuntimeSelectedSkill, [System.StringComparison]::OrdinalIgnoreCase) -and
+        -not $seen.ContainsKey($RouterSelectedSkill) -and
+        @($recommendations).Count -lt $limit) {
+        $customMetadata = if ($customAdmissionIndex.ContainsKey($RouterSelectedSkill)) { $customAdmissionIndex[$RouterSelectedSkill] } else { $null }
+        $recommendations += (New-VibeSpecialistRecommendation `
+            -RepoRoot $RepoRoot `
+            -Task $Task `
+            -SkillId $RouterSelectedSkill `
+            -Source 'route_selected' `
+            -TaskType $TaskType `
+            -Reason 'canonical router selected a specialist candidate for governed bounded execution' `
+            -PackId $null `
+            -Confidence 0.0 `
+            -Rank (@($recommendations).Count + 1) `
+            -DispatchContract $dispatchContractForRecommendation `
+            -PromotionPolicy $PromotionPolicy `
+            -CustomMetadata $customMetadata `
+            -TargetRoot $TargetRoot `
+            -HostId $HostId)
+        $seen[$RouterSelectedSkill] = $true
+    }
+
+    $requiredRecommendationCount = 1
+    if ($Policy.PSObject.Properties.Name -contains 'required_specialist_recommendation_count' -and $Policy.required_specialist_recommendation_count -ne $null) {
+        $requiredRecommendationCount = [int]$Policy.required_specialist_recommendation_count
+    }
+    foreach ($fallbackSkillId in @(Get-VibeFallbackSpecialistSkillIds `
+            -TaskType $TaskType `
+            -Policy $Policy `
+            -RouterSelectedSkill $RouterSelectedSkill `
+            -RuntimeSelectedSkill $RuntimeSelectedSkill)) {
+        if (@($recommendations).Count -ge $limit) {
+            break
+        }
+        if (@($recommendations).Count -ge $requiredRecommendationCount) {
+            break
+        }
+        if ($seen.ContainsKey($fallbackSkillId)) {
+            continue
+        }
+
+        $customMetadata = if ($customAdmissionIndex.ContainsKey($fallbackSkillId)) { $customAdmissionIndex[$fallbackSkillId] } else { $null }
+        $reason = "policy fallback specialist for task type '{0}'" -f $TaskType
+        $recommendations += (New-VibeSpecialistRecommendation `
+            -RepoRoot $RepoRoot `
+            -Task $Task `
+            -SkillId $fallbackSkillId `
+            -Source ("fallback:{0}" -f $TaskType) `
+            -TaskType $TaskType `
+            -Reason $reason `
+            -PackId $null `
+            -Confidence 0.0 `
+            -Rank (@($recommendations).Count + 1) `
+            -DispatchContract $dispatchContractForRecommendation `
+            -PromotionPolicy $PromotionPolicy `
+            -CustomMetadata $customMetadata `
+            -TargetRoot $TargetRoot `
+            -HostId $HostId)
+        $seen[$fallbackSkillId] = $true
     }
 
     return @($recommendations)
@@ -738,6 +841,7 @@ $specialistRecommendations = @(Get-VibeSpecialistRecommendations `
     -Task $Task `
     -RouteResult $routeResult `
     -RuntimeSelectedSkill $runtimeSelectedSkill `
+    -RouterSelectedSkill $routerSelectedSkill `
     -TaskType $taskType `
     -Policy $policy `
     -PromotionPolicy $runtime.skill_promotion_policy `

--- a/scripts/runtime/Freeze-RuntimeInputPacket.ps1
+++ b/scripts/runtime/Freeze-RuntimeInputPacket.ps1
@@ -470,6 +470,23 @@ function Get-VibeSpecialistRecommendations {
     if ($Policy.PSObject.Properties.Name -contains 'specialist_recommendation_limit' -and $Policy.specialist_recommendation_limit -ne $null) {
         $limit = [int]$Policy.specialist_recommendation_limit
     }
+    $requiredRecommendationCount = 1
+    if ($Policy.PSObject.Properties.Name -contains 'required_specialist_recommendation_count' -and $Policy.required_specialist_recommendation_count -ne $null) {
+        $requiredRecommendationCount = [int]$Policy.required_specialist_recommendation_count
+    }
+    if ($limit -lt 1) {
+        throw ("Runtime input policy 'specialist_recommendation_limit' must be at least 1; actual={0}." -f $limit)
+    }
+    if ($requiredRecommendationCount -lt 1) {
+        throw ("Runtime input policy 'required_specialist_recommendation_count' must be at least 1; actual={0}." -f $requiredRecommendationCount)
+    }
+    if ($requiredRecommendationCount -gt $limit) {
+        throw (
+            "Runtime input policy requires at least {0} specialist recommendation(s), but 'specialist_recommendation_limit' is only {1}. Increase the limit or lower the required recommendation count." `
+                -f $requiredRecommendationCount, $limit
+        )
+    }
+
     $dispatchContract = if ($Policy.PSObject.Properties.Name -contains 'specialist_dispatch_contract' -and $null -ne $Policy.specialist_dispatch_contract) {
         $Policy.specialist_dispatch_contract
     } else {
@@ -606,10 +623,6 @@ function Get-VibeSpecialistRecommendations {
         $seen[$RouterSelectedSkill] = $true
     }
 
-    $requiredRecommendationCount = 1
-    if ($Policy.PSObject.Properties.Name -contains 'required_specialist_recommendation_count' -and $Policy.required_specialist_recommendation_count -ne $null) {
-        $requiredRecommendationCount = [int]$Policy.required_specialist_recommendation_count
-    }
     foreach ($fallbackSkillId in @(Get-VibeFallbackSpecialistSkillIds `
             -TaskType $TaskType `
             -Policy $Policy `

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -452,7 +452,11 @@ function Resolve-VibeEffectiveSpecialistDispatch {
         return [pscustomobject]$result
     }
 
-    if (@($frozenApprovedDispatch).Count -eq 0) {
+    $requireExistingRootDispatch = $false
+    if ($autoAbsorbGate.PSObject.Properties.Name -contains 'require_existing_root_dispatch' -and $null -ne $autoAbsorbGate.require_existing_root_dispatch) {
+        $requireExistingRootDispatch = [bool]$autoAbsorbGate.require_existing_root_dispatch
+    }
+    if ($requireExistingRootDispatch -and @($frozenApprovedDispatch).Count -eq 0) {
         $result.auto_absorb_gate.status = 'requires_existing_root_dispatch'
         return [pscustomobject]$result
     }

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -748,7 +748,7 @@ function New-VibeRuntimeInputPacketProjection {
             escalation_required = [bool]$SpecialistDispatch.escalation_required
             escalation_status = [string]$SpecialistDispatch.escalation_status
             approval_owner = if ($Policy.child_specialist_suggestion_contract.PSObject.Properties.Name -contains 'approval_owner') { [string]$Policy.child_specialist_suggestion_contract.approval_owner } else { 'root_vibe' }
-            status = if ($Policy.child_specialist_suggestion_contract.PSObject.Properties.Name -contains 'status') { [string]$Policy.child_specialist_suggestion_contract.status } else { 'advisory_until_root_approval' }
+            status = if ($Policy.child_specialist_suggestion_contract.PSObject.Properties.Name -contains 'status') { [string]$Policy.child_specialist_suggestion_contract.status } else { 'auto_promote_when_safe_same_round' }
         }
         overlay_decisions = @($OverlayDecisions)
         authority_flags = $AuthorityFlagsProjection

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -217,7 +217,7 @@ if ($runtimeInputPacket) {
         $lines += @(
             '',
             '## Specialist Recommendations',
-            'These are bounded native specialist suggestions carried inside the governed `vibe` runtime. They do not replace runtime authority.'
+            'These are mandatory bounded native specialist recommendations carried inside the governed `vibe` runtime. Eligible recommendations should auto-promote into bounded dispatch while `vibe` remains the only runtime authority.'
         )
         foreach ($recommendation in $specialistRecommendations) {
             $lines += @(

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -217,7 +217,7 @@ if ($runtimeInputPacket) {
         $lines += @(
             '',
             '## Specialist Recommendations',
-            'These are mandatory bounded native specialist recommendations carried inside the governed `vibe` runtime. Eligible recommendations should auto-promote into bounded dispatch while `vibe` remains the only runtime authority.'
+            'These are mandatory bounded native specialist recommendations carried inside the governed `vibe` runtime. Eligible recommendations must auto-promote into bounded dispatch while `vibe` remains the only runtime authority.'
         )
         foreach ($recommendation in $specialistRecommendations) {
             $lines += @(

--- a/scripts/runtime/Write-XlPlan.ps1
+++ b/scripts/runtime/Write-XlPlan.ps1
@@ -166,7 +166,8 @@ if (@($approvedDispatch).Count -gt 0 -or @($localSuggestions).Count -gt 0) {
     $lines += @(
         '',
         '## Specialist Skill Dispatch Plan',
-        '- Specialist dispatch is advisory and bounded; it does not transfer runtime authority away from vibe.',
+        '- Specialist routing is mandatory and bounded inside governed `vibe`; it does not transfer runtime authority away from vibe.',
+        '- Eligible specialist recommendations should auto-promote into `approved_dispatch` by default.',
         '- Each specialist must be invoked through its native workflow, input contract, and validation style.',
         '- Specialist outputs remain subordinate to the frozen requirement and the governed plan.'
     )
@@ -188,7 +189,7 @@ if (@($approvedDispatch).Count -gt 0 -or @($localSuggestions).Count -gt 0) {
         $lines += @(
             '',
             '## Child Specialist Escalation Suggestions',
-            '- These suggestions are advisory only until root-governed approval updates the canonical dispatch surface.'
+            '- These are residual suggestions only after same-round safe auto-promotion; anything still listed here requires explicit escalation.'
         )
         foreach ($recommendation in @($localSuggestions)) {
             $lines += @(

--- a/scripts/runtime/Write-XlPlan.ps1
+++ b/scripts/runtime/Write-XlPlan.ps1
@@ -167,7 +167,7 @@ if (@($approvedDispatch).Count -gt 0 -or @($localSuggestions).Count -gt 0) {
         '',
         '## Specialist Skill Dispatch Plan',
         '- Specialist routing is mandatory and bounded inside governed `vibe`; it does not transfer runtime authority away from vibe.',
-        '- Eligible specialist recommendations should auto-promote into `approved_dispatch` by default.',
+        '- Eligible specialist recommendations must auto-promote into `approved_dispatch` by default.',
         '- Each specialist must be invoked through its native workflow, input contract, and validation style.',
         '- Specialist outputs remain subordinate to the frozen requirement and the governed plan.'
     )

--- a/scripts/verify/vibe-child-specialist-escalation-gate.ps1
+++ b/scripts/verify/vibe-child-specialist-escalation-gate.ps1
@@ -65,13 +65,13 @@ $runtimeEntryPath = Get-VgoRuntimeEntrypointPath -RepoRoot $repoRoot -RuntimeCon
 $results = @()
 
 $policyText = Get-Content -LiteralPath (Join-Path $repoRoot 'config\runtime-input-packet-policy.json') -Raw -Encoding UTF8
-foreach ($token in @('specialist_dispatch', 'local_specialist_suggestions', 'escalation_required', 'advisory_until_root_approval', 'auto_absorb_gate')) {
+foreach ($token in @('specialist_dispatch', 'local_specialist_suggestions', 'escalation_required', 'auto_promote_when_safe_same_round', 'auto_absorb_gate')) {
     Add-Assertion -Results ([ref]$results) -Condition ($policyText.Contains($token)) -Message ("runtime input policy contains specialist escalation token: {0}" -f $token)
 }
 
 $teamText = Get-Content -LiteralPath (Join-Path $repoRoot 'protocols\team.md') -Raw -Encoding UTF8
 $stableDocText = Get-Content -LiteralPath (Join-Path $repoRoot 'docs\root-child-vibe-hierarchy-governance.md') -Raw -Encoding UTF8
-Add-Assertion -Results ([ref]$results) -Condition ($teamText.Contains('advisory until the governed plan chooses to dispatch it')) -Message 'team protocol keeps specialist recommendation advisory-first'
+Add-Assertion -Results ([ref]$results) -Condition ($teamText.Contains('safe bounded recommendations should aggressively promote into effective dispatch')) -Message 'team protocol documents aggressive specialist promotion'
 Add-Assertion -Results ([ref]$results) -Condition ($stableDocText.Contains('same-round auto-approve safe suggestions')) -Message 'stable hierarchy doc documents root-governed same-round absorb path'
 
 $runId = "child-specialist-escalation-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8)
@@ -170,7 +170,7 @@ if ($hasChildSummary) {
     Add-Assertion -Results ([ref]$results) -Condition ($null -ne $specialistDispatch) -Message 'runtime packet exposes specialist dispatch surface'
 
     if ($null -ne $specialistDispatch) {
-        Add-Assertion -Results ([ref]$results) -Condition ([string]$specialistDispatch.status -eq 'advisory_until_root_approval') -Message 'child specialist suggestions remain advisory until root approval'
+        Add-Assertion -Results ([ref]$results) -Condition ([string]$specialistDispatch.status -eq 'auto_promote_when_safe_same_round') -Message 'child specialist policy prefers same-round safe auto-promotion'
         if (@($localSuggestions).Count -gt 0) {
             Add-Assertion -Results ([ref]$results) -Condition ([bool]$specialistDispatch.escalation_required) -Message 'child local specialist suggestions require escalation'
             Add-Assertion -Results ([ref]$results) -Condition ([string]$specialistDispatch.escalation_status -eq 'root_approval_required') -Message 'child local specialist escalation status is root_approval_required'

--- a/scripts/verify/vibe-root-child-hierarchy-gate.ps1
+++ b/scripts/verify/vibe-root-child-hierarchy-gate.ps1
@@ -62,7 +62,7 @@ foreach ($token in @(
     'allow_global_dispatch',
     'allow_completion_claim',
     'specialist_dispatch',
-    'advisory_until_root_approval',
+    'auto_promote_when_safe_same_round',
     'escalation_required',
     'auto_absorb_gate'
 )) {

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -202,6 +202,7 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
                 capture_output=True,
                 text=True,
                 check=True,
+                env={**os.environ, "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "1"},
             )
 
             payload = json.loads(completed.stdout)
@@ -276,6 +277,7 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
                 self.assertIn("## Assumptions", requirement_doc)
                 self.assertIn("## Runtime Input Truth", requirement_doc)
                 self.assertIn("## Specialist Recommendations", requirement_doc)
+                self.assertIn("Eligible recommendations should auto-promote", requirement_doc)
             self.assertEqual("requirements", requirement_doc_path.parent.name)
             self.assertEqual("plans", execution_plan_path.parent.name)
             execution_plan = execution_plan_path.read_text(encoding="utf-8")

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -277,7 +277,7 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
                 self.assertIn("## Assumptions", requirement_doc)
                 self.assertIn("## Runtime Input Truth", requirement_doc)
                 self.assertIn("## Specialist Recommendations", requirement_doc)
-                self.assertIn("Eligible recommendations should auto-promote", requirement_doc)
+                self.assertIn("Eligible recommendations must auto-promote", requirement_doc)
             self.assertEqual("requirements", requirement_doc_path.parent.name)
             self.assertEqual("plans", execution_plan_path.parent.name)
             execution_plan = execution_plan_path.read_text(encoding="utf-8")

--- a/tests/runtime_neutral/test_l_xl_native_execution_topology.py
+++ b/tests/runtime_neutral/test_l_xl_native_execution_topology.py
@@ -36,6 +36,7 @@ def run_runtime(
     *,
     mode: str = "interactive_governed",
     script_relative_path: str = "scripts/runtime/invoke-vibe-runtime.ps1",
+    run_id: str | None = None,
     governance_scope: str = "root",
     root_run_id: str = "",
     parent_run_id: str = "",
@@ -53,7 +54,7 @@ def run_runtime(
         raise unittest.SkipTest("PowerShell executable not available in PATH")
 
     script_path = REPO_ROOT / script_relative_path
-    run_id = "pytest-topology-" + uuid.uuid4().hex[:10]
+    effective_run_id = run_id or ("pytest-topology-" + uuid.uuid4().hex[:10])
     approved = approved_specialist_skill_ids or []
     delegation_envelope_path: Path | None = None
     if (
@@ -66,7 +67,7 @@ def run_runtime(
     ):
         delegation_envelope_path = write_delegation_envelope_fixture(
             artifact_root,
-            child_run_id=run_id,
+            child_run_id=effective_run_id,
             root_run_id=root_run_id,
             parent_run_id=parent_run_id,
             parent_unit_id=parent_unit_id,
@@ -112,7 +113,7 @@ def run_runtime(
             f"-Task '{task}' "
             f"-Mode {mode} "
             f"-GovernanceScope {governance_scope} "
-            f"-RunId '{run_id}' "
+            f"-RunId '{effective_run_id}' "
             f"{root_segment}"
             f"{parent_segment}"
             f"{parent_unit_segment}"
@@ -133,7 +134,7 @@ def run_runtime(
         capture_output=True,
         text=True,
         check=True,
-        env={**os.environ, **(extra_env or {})},
+        env={**os.environ, "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "1", **(extra_env or {})},
     )
     stdout = completed.stdout.strip()
     if stdout in ("", "null"):
@@ -872,13 +873,16 @@ class NativeExecutionTopologyTests(unittest.TestCase):
             if not approved_skill_ids:
                 self.skipTest("Root run did not expose approved specialist dispatch skill ids")
 
+            parent_unit_id = "pytest-child-topology-unit"
+            child_run_id = "pytest-topology-" + uuid.uuid4().hex[:10]
             child_payload = run_runtime(
                 task=composite_task + " Child lane requests extra specialist help beyond approved dispatch.",
                 artifact_root=artifact_root,
+                run_id=child_run_id,
                 governance_scope="child",
                 root_run_id=str(root_summary["run_id"]),
                 parent_run_id=str(root_summary["run_id"]),
-                parent_unit_id="pytest-child-topology-unit",
+                parent_unit_id=parent_unit_id,
                 inherited_requirement_doc_path=Path(root_artifacts["requirement_doc"]),
                 inherited_execution_plan_path=Path(root_artifacts["execution_plan"]),
                 approved_specialist_skill_ids=approved_skill_ids[:1],
@@ -888,7 +892,7 @@ class NativeExecutionTopologyTests(unittest.TestCase):
             child_execution_manifest = load_json(child_summary["artifacts"]["execution_manifest"])
 
             specialist_dispatch = child_runtime_input["specialist_dispatch"]
-            self.assertEqual("advisory_until_root_approval", str(specialist_dispatch["status"]))
+            self.assertEqual("auto_promote_when_safe_same_round", str(specialist_dispatch["status"]))
             frozen_local_ids = {
                 str(entry.get("skill_id", "")).strip()
                 for entry in list(specialist_dispatch.get("local_specialist_suggestions") or [])
@@ -965,13 +969,16 @@ class NativeExecutionTopologyTests(unittest.TestCase):
             if len(approved_skill_ids) < 1:
                 self.skipTest("Root run did not expose approved specialist dispatch skill ids")
 
+            parent_unit_id = "pytest-child-topology-fallback-unit"
+            child_run_id = "pytest-topology-" + uuid.uuid4().hex[:10]
             child_payload = run_runtime(
                 task=composite_task + " Child lane requests extra specialist help beyond approved dispatch.",
                 artifact_root=artifact_root,
+                run_id=child_run_id,
                 governance_scope="child",
                 root_run_id=str(root_summary["run_id"]),
                 parent_run_id=str(root_summary["run_id"]),
-                parent_unit_id="pytest-child-topology-fallback-unit",
+                parent_unit_id=parent_unit_id,
                 inherited_requirement_doc_path=Path(root_artifacts["requirement_doc"]),
                 inherited_execution_plan_path=Path(root_artifacts["execution_plan"]),
                 approved_specialist_skill_ids=approved_skill_ids[:1],
@@ -1023,13 +1030,16 @@ class NativeExecutionTopologyTests(unittest.TestCase):
             if len(approved_skill_ids) < 1:
                 self.skipTest("Root run did not expose approved specialist dispatch skill ids")
 
+            parent_unit_id = "pytest-child-topology-live-native-unit"
+            child_run_id = "pytest-topology-" + uuid.uuid4().hex[:10]
             child_payload = run_runtime(
                 task=composite_task + " Child lane requests extra specialist help beyond approved dispatch.",
                 artifact_root=temp_path,
+                run_id=child_run_id,
                 governance_scope="child",
                 root_run_id=str(root_summary["run_id"]),
                 parent_run_id=str(root_summary["run_id"]),
-                parent_unit_id="pytest-child-topology-live-native-unit",
+                parent_unit_id=parent_unit_id,
                 inherited_requirement_doc_path=Path(root_artifacts["requirement_doc"]),
                 inherited_execution_plan_path=Path(root_artifacts["execution_plan"]),
                 approved_specialist_skill_ids=approved_skill_ids[:1],
@@ -1053,7 +1063,7 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                 {"auto_approved_same_round", "partially_auto_approved_same_round"},
             )
 
-    def test_child_divergent_specialist_request_without_overlap_escalates_without_crashing(self) -> None:
+    def test_child_divergent_specialist_request_without_overlap_auto_promotes_when_safe(self) -> None:
         cases = [
             (
                 "L",
@@ -1077,14 +1087,16 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                         governance_scope="root",
                     )
                     root_summary = root_payload["summary"]
-
+                    parent_unit_id = f"pytest-{expected_grade.lower()}-divergent-child-unit"
+                    child_run_id = "pytest-topology-" + uuid.uuid4().hex[:10]
                     child_payload = run_runtime(
                         task=root_task + " Child lane divergence into a new specialist demand set.",
                         artifact_root=artifact_root,
+                        run_id=child_run_id,
                         governance_scope="child",
                         root_run_id=str(root_summary["run_id"]),
                         parent_run_id=str(root_summary["run_id"]),
-                        parent_unit_id=f"pytest-{expected_grade.lower()}-divergent-child-unit",
+                        parent_unit_id=parent_unit_id,
                         inherited_requirement_doc_path=Path(root_summary["artifacts"]["requirement_doc"]),
                         inherited_execution_plan_path=Path(root_summary["artifacts"]["execution_plan"]),
                         approved_specialist_skill_ids=["totally-non-overlap-skill-id"],
@@ -1101,32 +1113,17 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                     )
 
                     specialist_dispatch = child_runtime_input["specialist_dispatch"]
-                    self.assertEqual([], list(specialist_dispatch["approved_dispatch"]))
-                    self.assertEqual([], list(specialist_dispatch["approved_skill_ids"]))
                     self.assertGreaterEqual(len(list(specialist_dispatch["local_specialist_suggestions"])), 1)
-                    self.assertTrue(bool(specialist_dispatch["escalation_required"]))
-                    self.assertEqual("root_approval_required", str(specialist_dispatch["escalation_status"]))
+                    self.assertEqual("auto_promote_when_safe_same_round", str(specialist_dispatch["status"]))
 
                     specialist_accounting = child_execution_manifest["specialist_accounting"]
-                    self.assertEqual(0, int(specialist_accounting["approved_dispatch_count"]))
-                    self.assertEqual(0, int(specialist_accounting["executed_specialist_unit_count"]))
-                    self.assertEqual(0, int(specialist_accounting["degraded_specialist_unit_count"]))
-                    self.assertEqual(0, int(specialist_accounting["specialist_skill_count"]))
-                    self.assertEqual([], list(specialist_accounting["specialist_dispatch_outcomes"]))
-                    self.assertGreaterEqual(int(specialist_accounting["local_suggestion_count"]), 1)
-                    self.assertTrue(bool(specialist_accounting["escalation_required"]))
-
-                    escalation_request_path = specialist_accounting.get("escalation_request_path")
-                    self.assertTrue(escalation_request_path)
-                    self.assertTrue(Path(escalation_request_path).exists())
-                    escalation_request = load_json(escalation_request_path)
-                    self.assertEqual(
-                        sorted(str(skill_id) for skill_id in escalation_request["requested_specialist_skill_ids"]),
-                        sorted(
-                            str(entry.get("skill_id", "")).strip()
-                            for entry in list(specialist_accounting["local_specialist_suggestions"])
-                            if str(entry.get("skill_id", "")).strip()
-                        ),
+                    self.assertGreaterEqual(int(specialist_accounting["approved_dispatch_count"]), 1)
+                    self.assertGreaterEqual(int(specialist_accounting["specialist_skill_count"]), 1)
+                    self.assertFalse(bool(specialist_accounting["escalation_required"]))
+                    self.assertGreaterEqual(len(list(specialist_accounting["specialist_dispatch_outcomes"])), 1)
+                    self.assertIn(
+                        str(specialist_accounting["auto_absorb_gate"]["status"]),
+                        {"auto_approved_same_round", "partially_auto_approved_same_round"},
                     )
                     self.assertEqual("completed_local_scope", child_execution_manifest["status"])
                     self.assertFalse(bool(child_execution_manifest["authority"]["completion_claim_allowed"]))

--- a/tests/runtime_neutral/test_root_child_hierarchy_bridge.py
+++ b/tests/runtime_neutral/test_root_child_hierarchy_bridge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import tempfile
@@ -56,6 +57,7 @@ def run_governed_runtime(task: str, artifact_root: Path) -> dict[str, object]:
         capture_output=True,
         text=True,
         check=True,
+        env={**os.environ, "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "1"},
     )
     stdout = completed.stdout.strip()
     if stdout in ("", "null"):
@@ -122,6 +124,7 @@ def run_child_runtime(
         capture_output=True,
         text=True,
         check=True,
+        env={**os.environ, "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "1"},
     )
     stdout = completed.stdout.strip()
     if stdout in ("", "null"):
@@ -188,12 +191,14 @@ class RootChildHierarchyBridgeTests(unittest.TestCase):
             "governance_scope",
             "hierarchy_contract",
             "child_specialist_suggestion_contract",
+            "required_specialist_recommendation_count",
+            "fallback_specialists_by_task_type",
             "allow_requirement_freeze",
             "allow_plan_freeze",
             "allow_global_dispatch",
             "allow_completion_claim",
             "specialist_dispatch",
-            "advisory_until_root_approval",
+            "auto_promote_when_safe_same_round",
             "escalation_required",
         ]
         for token in expected_tokens:
@@ -249,7 +254,7 @@ class RootChildHierarchyBridgeTests(unittest.TestCase):
                     artifact_root=artifact_root,
                 )
 
-    def test_child_specialist_suggestions_are_advisory_until_root_approval(self) -> None:
+    def test_child_specialist_policy_prefers_same_round_auto_promotion(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             artifact_root = Path(tempdir)
             root_payload = run_governed_runtime(
@@ -329,13 +334,18 @@ class RootChildHierarchyBridgeTests(unittest.TestCase):
                     with self.subTest(suggestion=str(suggestion.get("skill_id", ""))):
                         self.assertNotIn(str(suggestion.get("skill_id", "")), approved_ids)
 
-            self.assertEqual("advisory_until_root_approval", str(specialist_dispatch.get("status", "")))
+            self.assertEqual("auto_promote_when_safe_same_round", str(specialist_dispatch.get("status", "")))
             self.assertEqual("child", execution_manifest["governance_scope"])
             self.assertFalse(execution_manifest["authority"]["completion_claim_allowed"])
             self.assertEqual("vibe", execution_manifest["route_runtime_alignment"]["runtime_selected_skill"])
             self.assertTrue(bool(execution_manifest["dispatch_integrity"]["proof_passed"]))
             self.assertTrue(bool(execution_manifest["dispatch_integrity"]["local_suggestions_contained"]))
             self.assertTrue(bool(execution_manifest["dispatch_integrity"]["executed_specialists_subset_of_approved_dispatch"]))
+            if local_suggestions:
+                self.assertIn(
+                    str(execution_manifest["specialist_accounting"]["auto_absorb_gate"]["status"]),
+                    {"auto_approved_same_round", "partially_auto_approved_same_round"},
+                )
             self.assertEqual(child_run_id, delegation_validation_receipt["child_run_id"])
             self.assertEqual(str(envelope_path.resolve()), str(Path(delegation_validation_receipt["envelope_path"]).resolve()))
             self.assertTrue(bool(delegation_validation_receipt["write_scope_valid"]))

--- a/tests/runtime_neutral/test_runtime_contract_schema.py
+++ b/tests/runtime_neutral/test_runtime_contract_schema.py
@@ -362,7 +362,7 @@ class RuntimeContractSchemaTests(unittest.TestCase):
                 "}; "
                 "$runtime = [pscustomobject]@{ host_adapter = [pscustomobject]@{ requested_id = 'openclaw'; id = 'openclaw'; status = 'preview'; install_mode = 'scaffold'; check_mode = 'audit'; bootstrap_mode = 'bounded' }; host_closure = [pscustomobject]@{ path = '/tmp/closure.json' } }; "
                 "$dispatch = [pscustomobject]@{ approved_dispatch = @([pscustomobject]@{ skill_id = 'systematic-debugging' }); local_specialist_suggestions = @([pscustomobject]@{ skill_id = 'think-harder' }); escalation_required = $true; escalation_status = 'pending_root_approval' }; "
-                "$policy = [pscustomobject]@{ freeze_before_requirement_doc = $true; child_specialist_suggestion_contract = [pscustomobject]@{ approval_owner = 'root_vibe'; status = 'advisory_until_root_approval' } }; "
+                "$policy = [pscustomobject]@{ freeze_before_requirement_doc = $true; child_specialist_suggestion_contract = [pscustomobject]@{ approval_owner = 'root_vibe'; status = 'auto_promote_when_safe_same_round' } }; "
                 "$packet = New-VibeRuntimeInputPacketProjection "
                 "-RunId 'run-7' "
                 "-Task 'debug task' "

--- a/tests/runtime_neutral/test_skill_promotion_destructive_gate.py
+++ b/tests/runtime_neutral/test_skill_promotion_destructive_gate.py
@@ -163,7 +163,6 @@ class SkillPromotionDestructiveGateTests(unittest.TestCase):
                 ML_PROMPT,
                 temp_path,
                 extra_env={
-                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },

--- a/tests/runtime_neutral/test_skill_promotion_freeze_contract.py
+++ b/tests/runtime_neutral/test_skill_promotion_freeze_contract.py
@@ -196,6 +196,63 @@ class SkillPromotionFreezeContractTests(unittest.TestCase):
                 check=True,
             )
 
+    def test_recommendation_builder_rejects_when_floor_cannot_be_satisfied(self) -> None:
+        shell = resolve_powershell()
+        if shell is None:
+            raise unittest.SkipTest("PowerShell executable not available in PATH")
+
+        get_recommendations_function = extract_get_specialist_recommendations_function()
+        script_body = (
+            "& { "
+            "function Get-VibeCustomAdmissionIndex { param([object]$RouteResult) return @{} } "
+            "function Get-VibeFallbackSpecialistSkillIds { "
+            "param([string]$TaskType, [object]$Policy, [string]$RouterSelectedSkill, [string]$RuntimeSelectedSkill) "
+            "return @() "
+            "} "
+            "function New-VibeSpecialistRecommendation { "
+            "param("
+            "[string]$RepoRoot, [string]$Task, [string]$SkillId, [string]$Source, [string]$TaskType, "
+            "[string]$Reason, [AllowNull()][string]$PackId, [double]$Confidence, [int]$Rank, "
+            "[AllowNull()][object]$DispatchContract, [AllowNull()][object]$PromotionPolicy, "
+            "[AllowNull()][object]$CustomMetadata, [string]$TargetRoot, [string]$HostId"
+            ") "
+            "return [pscustomobject]@{ skill_id = $SkillId; source = $Source; rank = $Rank } "
+            "} "
+            f"{get_recommendations_function} "
+            "$routeResult = [pscustomobject]@{ ranked = @() }; "
+            "$policy = [pscustomobject]@{ "
+            "specialist_recommendation_limit = 2; "
+            "required_specialist_recommendation_count = 1; "
+            "overlay_fields = @(); "
+            "specialist_dispatch_contract = [pscustomobject]@{} "
+            "}; "
+            "Get-VibeSpecialistRecommendations "
+            "-RepoRoot '.' "
+            "-Task 'demo task' "
+            "-RouteResult $routeResult "
+            "-RuntimeSelectedSkill 'vibe' "
+            "-RouterSelectedSkill '' "
+            "-TaskType 'planning' "
+            "-Policy $policy | Out-Null "
+            "}"
+        )
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            subprocess.run(
+                [
+                    shell,
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-Command",
+                    script_body,
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=True,
+            )
+
     def test_eligible_matched_skill_is_approved_and_not_ghosted(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             payload = freeze_runtime_packet(ML_PROMPT, Path(tempdir))

--- a/tests/runtime_neutral/test_skill_promotion_freeze_contract.py
+++ b/tests/runtime_neutral/test_skill_promotion_freeze_contract.py
@@ -114,6 +114,15 @@ def extract_split_specialist_dispatch_function() -> str:
 
 
 class SkillPromotionFreezeContractTests(unittest.TestCase):
+    def test_runtime_input_policy_requires_recommendation_floor_and_fallback_specialists(self) -> None:
+        policy = load_json(REPO_ROOT / "config" / "runtime-input-packet-policy.json")
+
+        self.assertEqual(1, int(policy["required_specialist_recommendation_count"]))
+        fallback_by_task_type = policy["fallback_specialists_by_task_type"]
+        for task_type in ("planning", "debug", "research", "coding", "review", "default"):
+            with self.subTest(task_type=task_type):
+                self.assertGreaterEqual(len(as_list(fallback_by_task_type[task_type])), 1)
+
     def test_eligible_matched_skill_is_approved_and_not_ghosted(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             payload = freeze_runtime_packet(ML_PROMPT, Path(tempdir))

--- a/tests/runtime_neutral/test_skill_promotion_freeze_contract.py
+++ b/tests/runtime_neutral/test_skill_promotion_freeze_contract.py
@@ -113,15 +113,88 @@ def extract_split_specialist_dispatch_function() -> str:
     return match.group(1)
 
 
+def extract_get_specialist_recommendations_function() -> str:
+    content = FREEZE_SCRIPT.read_text(encoding="utf-8")
+    match = re.search(
+        r"(function Get-VibeSpecialistRecommendations \{.*?^\})\s*^function Split-VibeSpecialistDispatch",
+        content,
+        re.DOTALL | re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError("Unable to locate Get-VibeSpecialistRecommendations in Freeze-RuntimeInputPacket.ps1")
+    return match.group(1)
+
+
 class SkillPromotionFreezeContractTests(unittest.TestCase):
     def test_runtime_input_policy_requires_recommendation_floor_and_fallback_specialists(self) -> None:
         policy = load_json(REPO_ROOT / "config" / "runtime-input-packet-policy.json")
 
         self.assertEqual(1, int(policy["required_specialist_recommendation_count"]))
+        self.assertLessEqual(
+            int(policy["required_specialist_recommendation_count"]),
+            int(policy["specialist_recommendation_limit"]),
+        )
         fallback_by_task_type = policy["fallback_specialists_by_task_type"]
         for task_type in ("planning", "debug", "research", "coding", "review", "default"):
             with self.subTest(task_type=task_type):
                 self.assertGreaterEqual(len(as_list(fallback_by_task_type[task_type])), 1)
+
+    def test_recommendation_builder_rejects_floor_above_limit(self) -> None:
+        shell = resolve_powershell()
+        if shell is None:
+            raise unittest.SkipTest("PowerShell executable not available in PATH")
+
+        get_recommendations_function = extract_get_specialist_recommendations_function()
+        script_body = (
+            "& { "
+            "function Get-VibeCustomAdmissionIndex { param([object]$RouteResult) return @{} } "
+            "function Get-VibeFallbackSpecialistSkillIds { "
+            "param([string]$TaskType, [object]$Policy, [string]$RouterSelectedSkill, [string]$RuntimeSelectedSkill) "
+            "return @('fallback-skill') "
+            "} "
+            "function New-VibeSpecialistRecommendation { "
+            "param("
+            "[string]$RepoRoot, [string]$Task, [string]$SkillId, [string]$Source, [string]$TaskType, "
+            "[string]$Reason, [AllowNull()][string]$PackId, [double]$Confidence, [int]$Rank, "
+            "[AllowNull()][object]$DispatchContract, [AllowNull()][object]$PromotionPolicy, "
+            "[AllowNull()][object]$CustomMetadata, [string]$TargetRoot, [string]$HostId"
+            ") "
+            "return [pscustomobject]@{ skill_id = $SkillId; source = $Source; rank = $Rank } "
+            "} "
+            f"{get_recommendations_function} "
+            "$routeResult = [pscustomobject]@{ ranked = @() }; "
+            "$policy = [pscustomobject]@{ "
+            "specialist_recommendation_limit = 1; "
+            "required_specialist_recommendation_count = 2; "
+            "overlay_fields = @(); "
+            "specialist_dispatch_contract = [pscustomobject]@{} "
+            "}; "
+            "Get-VibeSpecialistRecommendations "
+            "-RepoRoot '.' "
+            "-Task 'demo task' "
+            "-RouteResult $routeResult "
+            "-RuntimeSelectedSkill 'vibe' "
+            "-RouterSelectedSkill '' "
+            "-TaskType 'planning' "
+            "-Policy $policy | Out-Null "
+            "}"
+        )
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            subprocess.run(
+                [
+                    shell,
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-Command",
+                    script_body,
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=True,
+            )
 
     def test_eligible_matched_skill_is_approved_and_not_ghosted(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
## Summary
- make governed `vibe` runs always surface specialist recommendations and add task-type fallback specialists when router output is sparse
- aggressively auto-promote safe recommendations into `approved_dispatch`, including same-round child-lane auto-absorb without requiring pre-existing root dispatch
- enable native specialist execution by default and align runtime docs, requirement/plan output text, verification gates, and runtime-neutral tests with the new routing contract

## Test Plan
- [x] `python3 -m pytest tests/runtime_neutral/test_skill_promotion_freeze_contract.py tests/runtime_neutral/test_skill_promotion_destructive_gate.py tests/runtime_neutral/test_root_child_hierarchy_bridge.py -q`
- [x] `python3 -m pytest tests/runtime_neutral/test_l_xl_native_execution_topology.py::NativeExecutionTopologyTests::test_child_auto_absorb_can_fallback_to_root_escalation_when_gate_disabled -q`
- [x] `python3 -m pytest tests/runtime_neutral/test_l_xl_native_execution_topology.py::NativeExecutionTopologyTests::test_child_divergent_specialist_request_without_overlap_auto_promotes_when_safe -q`
- [x] `python3 -m pytest tests/runtime_neutral/test_governed_runtime_bridge.py::GovernedRuntimeBridgeTests::test_invoke_vibe_runtime_produces_six_stage_closure_under_temp_artifact_root -q`
- [x] `python3 -m pytest tests/runtime_neutral/test_l_xl_native_execution_topology.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Specialist recommendations are mandatory for every governed run and auto-promote into bounded dispatch when safe; child suggestions auto-promote same-round unless blocked, degraded, or forced to escalate.
* **Configuration Updates**
  * Default native specialist execution enabled (opt-out); recommendation floor, limits, and auto-absorb thresholds increased; task-type fallback specialists and required recommendation count added.
* **Documentation**
  * Governance specs, protocols, and plans updated to reflect mandatory routing and aggressive promotion.
* **Tests**
  * Test suite extended to validate mandatory recommendations, fallback mapping, floors/limits, auto-promotion, and native-execution defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->