### PR TITLE
Fix advice runtime compatibility and upgrade checks

### DIFF
--- a/apps/vgo-cli/src/vgo_cli/commands.py
+++ b/apps/vgo-cli/src/vgo_cli/commands.py
@@ -13,7 +13,7 @@ from .hosts import (
     resolve_target_root,
 )
 from .install_support import reconcile_install_postconditions
-from .output import parse_json_output, print_install_banner, print_install_completion_hint, print_install_completion_report
+from .output import parse_json_output, print_install_banner, print_install_completion_hint
 from .process import print_process_output, run_powershell_file, run_subprocess
 from .repo import get_installed_runtime_config
 from .upgrade_service import upgrade_runtime
@@ -122,10 +122,6 @@ def route_command(args: argparse.Namespace) -> int:
     ]
     if args.requested_skill:
         command.extend(['--requested-skill', args.requested_skill])
-    if getattr(args, 'entry_intent_id', None):
-        command.extend(['--entry-intent-id', args.entry_intent_id])
-    if getattr(args, 'requested_grade_floor', None):
-        command.extend(['--requested-grade-floor', args.requested_grade_floor])
     if args.host_id:
         command.extend(['--host-id', args.host_id])
     if args.target_root:

--- a/apps/vgo-cli/src/vgo_cli/main.py
+++ b/apps/vgo-cli/src/vgo_cli/main.py
@@ -54,8 +54,6 @@ def build_parser() -> argparse.ArgumentParser:
     route_parser.add_argument('--grade', default='M', choices=('M', 'L', 'XL'))
     route_parser.add_argument('--task-type', default='planning', choices=('planning', 'coding', 'review', 'debug', 'research'))
     route_parser.add_argument('--requested-skill')
-    route_parser.add_argument('--entry-intent-id')
-    route_parser.add_argument('--requested-grade-floor', choices=('L', 'XL'))
     route_parser.add_argument('--host-id')
     route_parser.add_argument('--target-root')
     route_parser.add_argument('--force-runtime-neutral', action='store_true')

--- a/apps/vgo-cli/src/vgo_cli/upgrade_service.py
+++ b/apps/vgo-cli/src/vgo_cli/upgrade_service.py
@@ -11,8 +11,20 @@ from .hosts import install_mode_for_host
 from .install_support import reconcile_install_postconditions
 from .output import parse_json_output
 from .process import run_powershell_file, run_subprocess
-from .repo import get_local_release_metadata, get_official_self_repo_metadata, get_repo_head_commit
+from .repo import (
+    get_local_release_metadata,
+    get_official_self_repo_metadata,
+    get_repo_head_commit,
+    resolve_canonical_repo_root,
+)
 from .upgrade_state import load_upgrade_status, merge_upgrade_status, save_upgrade_status, is_upstream_cache_stale
+
+
+def resolve_upgrade_repo_root(repo_root: Path) -> Path | None:
+    direct = resolve_canonical_repo_root(repo_root)
+    if direct is not None:
+        return direct
+    return resolve_canonical_repo_root(Path.cwd())
 
 
 def refresh_installed_status(repo_root: Path, target_root: Path, host_id: str) -> dict[str, object]:
@@ -167,8 +179,15 @@ def upgrade_runtime(
     allow_external_skill_fallback: bool,
     skip_runtime_freshness_gate: bool,
 ) -> dict[str, object]:
-    before = refresh_installed_status(repo_root, target_root, host_id)
-    status = refresh_upstream_status(repo_root, target_root, before)
+    resolved_repo_root = resolve_upgrade_repo_root(repo_root)
+    if resolved_repo_root is None:
+        raise CliError(
+            'Upgrade requires a canonical git checkout with config/version-governance.json. '
+            'Run the upgrade from the Vibe-Skills repo, or set your working directory to that checkout before invoking the installed runtime.'
+        )
+
+    before = refresh_installed_status(resolved_repo_root, target_root, host_id)
+    status = refresh_upstream_status(resolved_repo_root, target_root, before)
     if not bool(status.get('update_available')):
         print(
             'Vibe-Skills already current: '
@@ -177,9 +196,9 @@ def upgrade_runtime(
         return {'changed': False, 'before': before, 'after': status}
 
     branch = str(status.get('repo_default_branch') or 'main').strip() or 'main'
-    reset_repo_to_official_head(repo_root, branch)
+    reset_repo_to_official_head(resolved_repo_root, branch)
     reinstall_runtime(
-        repo_root=repo_root,
+        repo_root=resolved_repo_root,
         target_root=target_root,
         host_id=host_id,
         profile=profile,
@@ -191,7 +210,7 @@ def upgrade_runtime(
         skip_runtime_freshness_gate=skip_runtime_freshness_gate,
     )
     check_result = run_upgrade_check(
-        repo_root=repo_root,
+        repo_root=resolved_repo_root,
         target_root=target_root,
         host_id=host_id,
         profile=profile,
@@ -200,7 +219,7 @@ def upgrade_runtime(
     if check_result.returncode != 0:
         raise CliError(check_result.stderr.strip() or check_result.stdout.strip() or 'Upgrade check failed.')
 
-    after = refresh_installed_status(repo_root, target_root, host_id)
+    after = refresh_installed_status(resolved_repo_root, target_root, host_id)
     print(
         'Vibe-Skills upgraded: '
         f"before={before.get('installed_version') or 'unknown'}@{before.get('installed_commit') or 'unknown'} "

--- a/apps/vgo-cli/src/vgo_cli/upgrade_service.py
+++ b/apps/vgo-cli/src/vgo_cli/upgrade_service.py
@@ -21,10 +21,7 @@ from .upgrade_state import load_upgrade_status, merge_upgrade_status, save_upgra
 
 
 def resolve_upgrade_repo_root(repo_root: Path) -> Path | None:
-    direct = resolve_canonical_repo_root(repo_root)
-    if direct is not None:
-        return direct
-    return resolve_canonical_repo_root(Path.cwd())
+    return resolve_canonical_repo_root(repo_root)
 
 
 def refresh_installed_status(repo_root: Path, target_root: Path, host_id: str) -> dict[str, object]:
@@ -183,7 +180,7 @@ def upgrade_runtime(
     if resolved_repo_root is None:
         raise CliError(
             'Upgrade requires a canonical git checkout with config/version-governance.json. '
-            'Run the upgrade from the Vibe-Skills repo, or set your working directory to that checkout before invoking the installed runtime.'
+            'Pass --repo-root pointing at a Vibe-Skills git checkout before invoking the upgrade runtime.'
         )
 
     before = refresh_installed_status(resolved_repo_root, target_root, host_id)

--- a/check.ps1
+++ b/check.ps1
@@ -197,7 +197,15 @@ function Normalize-ComparablePath {
     return $null
   }
 
-  return [System.IO.Path]::GetFullPath($Path).TrimEnd([char[]]@('\','/')).ToLowerInvariant()
+  try {
+    $fullPath = [System.IO.Path]::GetFullPath($Path).TrimEnd([char[]]@('\','/'))
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+      return $fullPath.ToLowerInvariant()
+    }
+    return $fullPath
+  } catch {
+    return $null
+  }
 }
 
 function ConvertTo-IntCheckValue {

--- a/check.ps1
+++ b/check.ps1
@@ -197,15 +197,7 @@ function Normalize-ComparablePath {
     return $null
   }
 
-  try {
-    $fullPath = [System.IO.Path]::GetFullPath($Path).TrimEnd([char[]]@('\','/'))
-    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
-      return $fullPath.ToLowerInvariant()
-    }
-    return $fullPath
-  } catch {
-    return $null
-  }
+  return [System.IO.Path]::GetFullPath($Path).TrimEnd([char[]]@('\','/')).ToLowerInvariant()
 }
 
 function ConvertTo-IntCheckValue {
@@ -363,10 +355,15 @@ function Test-ReceiptTargetFreshness {
   } else {
     Format-OptionalValue -Value $receiptVersionCheck.raw
   }
+  $expectedVersionFailureDetail = if ($expectedReceiptContractVersionCheck.valid) {
+    [string]$expectedReceiptContractVersion
+  } else {
+    Format-OptionalValue -Value $expectedReceiptContractVersionCheck.raw
+  }
   Check-Condition `
     -Label 'vibe runtime freshness receipt version' `
-    -Condition ($receiptVersionCheck.valid -and $receiptVersionCheck.value -ge $expectedReceiptContractVersion) `
-    -FailureDetail $receiptVersionFailureDetail
+    -Condition ($expectedReceiptContractVersionCheck.valid -and $receiptVersionCheck.valid -and $receiptVersionCheck.value -ge $expectedReceiptContractVersion) `
+    -FailureDetail ("receipt={0}; expected={1}" -f $receiptVersionFailureDetail, $expectedVersionFailureDetail)
 
   Check-Condition -Label 'vibe runtime freshness receipt target_root' -Condition ($receiptTargetRoot -eq $expectedTargetRoot) -FailureDetail (Format-OptionalValue -Value ([string]$receipt.target_root))
   Check-Condition -Label 'vibe runtime freshness receipt installed_root' -Condition ($receiptInstalledRoot -eq $expectedInstalledRoot) -FailureDetail (Format-OptionalValue -Value ([string]$receipt.installed_root))

--- a/check.ps1
+++ b/check.ps1
@@ -197,7 +197,27 @@ function Normalize-ComparablePath {
     return $null
   }
 
-  return [System.IO.Path]::GetFullPath($Path).TrimEnd([char[]]@('\\','/')).ToLowerInvariant()
+  return [System.IO.Path]::GetFullPath($Path).TrimEnd([char[]]@('\','/')).ToLowerInvariant()
+}
+
+function ConvertTo-IntCheckValue {
+  param(
+    [object]$Value,
+    [int]$Default = 0
+  )
+
+  $raw = if ($null -eq $Value) { $null } else { [string]$Value }
+  $parsed = $Default
+  $valid = $false
+  if (-not [string]::IsNullOrWhiteSpace($raw)) {
+    $valid = [int]::TryParse($raw, [ref]$parsed)
+  }
+
+  return [pscustomobject]@{
+    raw = $raw
+    value = $parsed
+    valid = $valid
+  }
 }
 
 function Format-OptionalValue {
@@ -319,9 +339,26 @@ function Test-ReceiptTargetFreshness {
   $receiptGateResult = if ($receipt.PSObject.Properties.Name -contains 'gate_result') { [string]$receipt.gate_result } else { $null }
   Check-Condition -Label 'vibe runtime freshness receipt gate_result' -Condition ($receiptGateResult -eq 'PASS') -FailureDetail (Format-OptionalValue -Value $receiptGateResult)
 
-  $receiptVersionValue = if ($receipt.PSObject.Properties.Name -contains 'receipt_version') { [int]$receipt.receipt_version } else { 0 }
-  $expectedReceiptContractVersion = if ($RuntimeConfig.PSObject.Properties.Name -contains 'receipt_contract_version') { [int]$RuntimeConfig.receipt_contract_version } else { 1 }
-  Check-Condition -Label 'vibe runtime freshness receipt version' -Condition ($receiptVersionValue -ge $expectedReceiptContractVersion) -FailureDetail ([string]$receiptVersionValue)
+  $receiptVersionCheck = if ($receipt.PSObject.Properties.Name -contains 'receipt_version') {
+    ConvertTo-IntCheckValue -Value $receipt.receipt_version
+  } else {
+    ConvertTo-IntCheckValue
+  }
+  $expectedReceiptContractVersionCheck = if ($RuntimeConfig.PSObject.Properties.Name -contains 'receipt_contract_version') {
+    ConvertTo-IntCheckValue -Value $RuntimeConfig.receipt_contract_version -Default 1
+  } else {
+    ConvertTo-IntCheckValue -Value 1 -Default 1
+  }
+  $expectedReceiptContractVersion = $expectedReceiptContractVersionCheck.value
+  $receiptVersionFailureDetail = if ($receiptVersionCheck.valid) {
+    [string]$receiptVersionCheck.value
+  } else {
+    Format-OptionalValue -Value $receiptVersionCheck.raw
+  }
+  Check-Condition `
+    -Label 'vibe runtime freshness receipt version' `
+    -Condition ($receiptVersionCheck.valid -and $receiptVersionCheck.value -ge $expectedReceiptContractVersion) `
+    -FailureDetail $receiptVersionFailureDetail
 
   Check-Condition -Label 'vibe runtime freshness receipt target_root' -Condition ($receiptTargetRoot -eq $expectedTargetRoot) -FailureDetail (Format-OptionalValue -Value ([string]$receipt.target_root))
   Check-Condition -Label 'vibe runtime freshness receipt installed_root' -Condition ($receiptInstalledRoot -eq $expectedInstalledRoot) -FailureDetail (Format-OptionalValue -Value ([string]$receipt.installed_root))

--- a/check.ps1
+++ b/check.ps1
@@ -34,78 +34,6 @@ function Test-CanonicalRepoExecution {
   return (Test-VgoCanonicalRepoExecution -StartPath $RepoRoot)
 }
 
-function Resolve-CodexDuplicateSkillRoot {
-  param(
-    [string]$TargetRoot,
-    [string]$HostId
-  )
-
-  if ([string](Resolve-VgoHostId -HostId $HostId) -ne 'codex') {
-    return $null
-  }
-
-  $normalizedTargetRoot = [System.IO.Path]::GetFullPath($TargetRoot)
-  $rootPath = [System.IO.Path]::GetPathRoot($normalizedTargetRoot)
-  if (-not [string]::IsNullOrWhiteSpace($rootPath) -and $normalizedTargetRoot.Length -gt $rootPath.Length) {
-    $normalizedTargetRoot = $normalizedTargetRoot.TrimEnd(
-      [System.IO.Path]::DirectorySeparatorChar,
-      [System.IO.Path]::AltDirectorySeparatorChar
-    )
-  }
-
-  $leaf = [System.IO.Path]::GetFileName($normalizedTargetRoot).ToLowerInvariant()
-  if ($leaf -ne '.codex') {
-    return $null
-  }
-
-  $parent = Get-VgoParentPath -Path $normalizedTargetRoot
-  if ([string]::IsNullOrWhiteSpace($parent)) {
-    return $null
-  }
-
-  return [System.IO.Path]::GetFullPath((Join-Path $parent '.agents\skills\vibe'))
-}
-
-function Test-VibeSkillDir {
-  param([string]$Root)
-
-  if ([string]::IsNullOrWhiteSpace($Root)) {
-    return $false
-  }
-
-  $skillMd = Join-Path $Root 'SKILL.md'
-  if (-not (Test-Path -LiteralPath $skillMd -PathType Leaf)) {
-    return $false
-  }
-
-  try {
-    return [bool](Select-String -LiteralPath $skillMd -Pattern '^[\s]*name:[\s]*vibe[\s]*$' -CaseSensitive:$false -Quiet)
-  } catch {
-    return $false
-  }
-}
-
-function Check-CodexDuplicateSkillSurface {
-  param(
-    [string]$TargetRoot,
-    [string]$HostId
-  )
-
-  $duplicateRoot = Resolve-CodexDuplicateSkillRoot -TargetRoot $TargetRoot -HostId $HostId
-  if ([string]::IsNullOrWhiteSpace($duplicateRoot) -or -not (Test-Path -LiteralPath $duplicateRoot -PathType Container)) {
-    return
-  }
-
-  if (Test-VibeSkillDir -Root $duplicateRoot) {
-    Write-Host ("[FAIL] duplicate Codex-discovered vibe skill surface -> {0}" -f $duplicateRoot) -ForegroundColor Red
-    Write-Host '[FAIL] Re-run install.ps1 for the default Codex root to quarantine the legacy .agents copy, or move it out of .agents/skills manually.' -ForegroundColor Red
-    $script:fail++
-    return
-  }
-
-  Write-WarnNote -Message ("unexpected directory exists at Codex duplicate-surface path: {0}" -f $duplicateRoot)
-}
-
 function Get-CheckGovernance {
   param([string]$RepoRoot)
 
@@ -159,6 +87,67 @@ function Get-InstalledRuntimeConfig {
   return [pscustomobject]$merged
 }
 
+function Get-InstalledRuntimeTargetRelpath {
+  param([psobject]$RuntimeConfig)
+
+  $targetRel = if ($null -ne $RuntimeConfig -and $RuntimeConfig.PSObject.Properties.Name -contains 'target_relpath') {
+    [string]$RuntimeConfig.target_relpath
+  } else {
+    ''
+  }
+  if ([string]::IsNullOrWhiteSpace($targetRel)) {
+    return 'skills/vibe'
+  }
+  return $targetRel
+}
+
+function Resolve-CheckTargetContext {
+  param(
+    [Parameter(Mandatory)] [string]$InputRoot,
+    [psobject]$RuntimeConfig
+  )
+
+  $targetRel = Get-InstalledRuntimeTargetRelpath -RuntimeConfig $RuntimeConfig
+  $normalizedInputRoot = [System.IO.Path]::GetFullPath($InputRoot)
+  $segments = @($targetRel -split '[\\/]+' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+  $installedGovernancePath = Join-Path $normalizedInputRoot 'config\version-governance.json'
+  $skillDescriptorPath = Join-Path $normalizedInputRoot 'SKILL.md'
+
+  if ($segments.Count -gt 0 -and (Test-Path -LiteralPath $installedGovernancePath) -and (Test-Path -LiteralPath $skillDescriptorPath)) {
+    $hostCandidate = $normalizedInputRoot
+    $matched = $true
+    for ($index = $segments.Count - 1; $index -ge 0; $index--) {
+      $leaf = Split-Path -Leaf $hostCandidate
+      if ([string]::IsNullOrWhiteSpace($leaf) -or $leaf.ToLowerInvariant() -ne ([string]$segments[$index]).ToLowerInvariant()) {
+        $matched = $false
+        break
+      }
+      $parent = Split-Path -Parent $hostCandidate
+      if ([string]::IsNullOrWhiteSpace($parent) -or $parent -eq $hostCandidate) {
+        $matched = $false
+        break
+      }
+      $hostCandidate = [System.IO.Path]::GetFullPath($parent)
+    }
+
+    if ($matched) {
+      return [pscustomobject]@{
+        target_root = $hostCandidate
+        installed_root = $normalizedInputRoot
+        target_relpath = $targetRel
+        input_kind = 'installed_root'
+      }
+    }
+  }
+
+  return [pscustomobject]@{
+    target_root = $normalizedInputRoot
+    installed_root = [System.IO.Path]::GetFullPath((Join-Path $normalizedInputRoot $targetRel))
+    target_relpath = $targetRel
+    input_kind = 'host_root'
+  }
+}
+
 function Check-Condition {
   param(
     [string]$Label,
@@ -201,153 +190,6 @@ function Get-JsonObject {
   }
 }
 
-function ConvertTo-VgoStringArray {
-  param($Value)
-
-  $items = New-Object System.Collections.Generic.List[string]
-  foreach ($item in @($Value)) {
-    if ($null -eq $item) {
-      continue
-    }
-    [void]$items.Add([string]$item)
-  }
-  return ,([string[]]$items.ToArray())
-}
-
-function Get-VgoCollectionCount {
-  param($Value)
-
-  if ($null -eq $Value) {
-    return 0
-  }
-
-  return @($Value).Count
-}
-
-function Check-HostVisibleDiscoverableEntries {
-  param(
-    [string]$TargetRoot,
-    [string]$HostId
-  )
-
-  $ledgerPath = Join-Path $TargetRoot '.vibeskills\install-ledger.json'
-  if (-not (Test-Path -LiteralPath $ledgerPath -PathType Leaf)) {
-    Write-Host "[FAIL] host-visible discoverable entries -> $ledgerPath" -ForegroundColor Red
-    $script:fail++
-    return
-  }
-
-  $ledger = Get-JsonObject -Path $ledgerPath -Label 'install ledger'
-  if ($null -eq $ledger) {
-    return
-  }
-
-  $payloadSummary = if ($ledger.PSObject.Properties.Name -contains 'payload_summary') { $ledger.payload_summary } else { $null }
-  $entryNames = if ($null -ne $payloadSummary -and $payloadSummary.PSObject.Properties.Name -contains 'host_visible_entry_names') {
-    ConvertTo-VgoStringArray -Value $payloadSummary.host_visible_entry_names
-  } else {
-    @()
-  }
-  $wrapperPaths = if ($ledger.PSObject.Properties.Name -contains 'specialist_wrapper_paths') {
-    ConvertTo-VgoStringArray -Value $ledger.specialist_wrapper_paths
-  } else {
-    @()
-  }
-  $compatibilityRoots = if ($ledger.PSObject.Properties.Name -contains 'compatibility_roots') {
-    ConvertTo-VgoStringArray -Value $ledger.compatibility_roots
-  } else {
-    @()
-  }
-  $entryNameCount = Get-VgoCollectionCount -Value $entryNames
-  $wrapperPathCount = Get-VgoCollectionCount -Value $wrapperPaths
-  $compatibilityRootCount = Get-VgoCollectionCount -Value $compatibilityRoots
-
-  if ($entryNameCount -eq 0 -and ($wrapperPathCount -eq 0 -and $compatibilityRootCount -eq 0)) {
-    if ($HostId -in @('codex', 'claude-code', 'cursor', 'windsurf', 'openclaw', 'opencode')) {
-      Write-Host '[FAIL] host-visible discoverable entries -> missing wrapper inventory' -ForegroundColor Red
-      $script:fail++
-    } else {
-      Write-WarnNote -Message ("host-visible discoverable entries -> no wrapper inventory recorded for host '{0}'" -f $HostId)
-    }
-    return
-  }
-
-  $missingPaths = New-Object System.Collections.Generic.List[string]
-  $invalidWrapperPaths = New-Object System.Collections.Generic.List[string]
-  $missingCompatibilityRoots = New-Object System.Collections.Generic.List[string]
-  $invalidCompatibilityRoots = New-Object System.Collections.Generic.List[string]
-  $targetRootFull = Normalize-ComparablePath -Path $TargetRoot
-  foreach ($wrapperPath in $wrapperPaths) {
-    $candidatePath = $wrapperPath
-    if (-not [System.IO.Path]::IsPathRooted($candidatePath)) {
-      $candidatePath = Join-Path $TargetRoot $candidatePath
-    }
-    try {
-      $wrapperFull = Normalize-ComparablePath -Path $candidatePath
-    } catch {
-      $missingPaths.Add($wrapperPath)
-      continue
-    }
-    $underTarget = $false
-    if ($null -ne $wrapperFull -and $null -ne $targetRootFull) {
-      $underTarget = $wrapperFull.Equals($targetRootFull, [System.StringComparison]::OrdinalIgnoreCase) -or `
-        $wrapperFull.StartsWith($targetRootFull + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase)
-    }
-    if (-not $underTarget) {
-      $invalidWrapperPaths.Add($wrapperPath)
-      continue
-    }
-    if (-not (Test-Path -LiteralPath $candidatePath -PathType Leaf)) {
-      $missingPaths.Add($wrapperPath)
-    }
-  }
-
-  foreach ($compatibilityRoot in $compatibilityRoots) {
-    $candidateRoot = $compatibilityRoot
-    if (-not [System.IO.Path]::IsPathRooted($candidateRoot)) {
-      $candidateRoot = Join-Path $TargetRoot $candidateRoot
-    }
-    try {
-      $rootFull = Normalize-ComparablePath -Path $candidateRoot
-    } catch {
-      $missingCompatibilityRoots.Add($compatibilityRoot)
-      continue
-    }
-    $underTarget = $false
-    if ($null -ne $rootFull -and $null -ne $targetRootFull) {
-      $underTarget = $rootFull.Equals($targetRootFull, [System.StringComparison]::OrdinalIgnoreCase) -or `
-        $rootFull.StartsWith($targetRootFull + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase)
-    }
-    if (-not $underTarget) {
-      $invalidCompatibilityRoots.Add($compatibilityRoot)
-      continue
-    }
-    if (-not (Test-Path -LiteralPath $candidateRoot -PathType Container) -or -not (Test-Path -LiteralPath (Join-Path $candidateRoot 'SKILL.md') -PathType Leaf)) {
-      $missingCompatibilityRoots.Add($compatibilityRoot)
-    }
-  }
-
-  $wrappersReady = ($wrapperPathCount -gt 0 -and $missingPaths.Count -eq 0)
-  $compatibilityReady = ($compatibilityRootCount -gt 0 -and $missingCompatibilityRoots.Count -eq 0)
-
-  if ($invalidWrapperPaths.Count -gt 0) {
-    Write-Host ("[FAIL] host-visible discoverable entries -> {0}" -f $invalidWrapperPaths[0]) -ForegroundColor Red
-    $script:fail++
-  } elseif ($invalidCompatibilityRoots.Count -gt 0) {
-    Write-Host ("[FAIL] host-visible discoverable entries -> {0}" -f $invalidCompatibilityRoots[0]) -ForegroundColor Red
-    $script:fail++
-  } elseif ($wrappersReady -or $compatibilityReady) {
-    Write-Host '[OK] host-visible discoverable entries'
-    $script:pass++
-  } elseif ($missingPaths.Count -gt 0) {
-    Write-Host ("[FAIL] host-visible discoverable entries -> {0}" -f $missingPaths[0]) -ForegroundColor Red
-    $script:fail++
-  } else {
-    Write-Host ("[FAIL] host-visible discoverable entries -> {0}" -f $missingCompatibilityRoots[0]) -ForegroundColor Red
-    $script:fail++
-  }
-}
-
 function Normalize-ComparablePath {
   param([string]$Path)
 
@@ -355,32 +197,90 @@ function Normalize-ComparablePath {
     return $null
   }
 
-  $expanded = $Path
-  if (-not [System.IO.Path]::IsPathRooted($expanded)) {
-    $expanded = Join-Path (Get-Location).ProviderPath $expanded
-  }
-  $full = [System.IO.Path]::GetFullPath($expanded)
-  return $full.TrimEnd([System.IO.Path]::DirectorySeparatorChar).ToLowerInvariant()
+  return [System.IO.Path]::GetFullPath($Path).TrimEnd([char[]]@('\\','/')).ToLowerInvariant()
 }
 
 function Format-OptionalValue {
   param([string]$Value)
+
   if ([string]::IsNullOrWhiteSpace($Value)) {
     return '<missing>'
   }
+
   return $Value
+}
+
+function Resolve-CodexDuplicateSkillRoot {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  if ([string]$HostId -ne 'codex') {
+    return $null
+  }
+
+  $leaf = (Split-Path -Path $TargetRoot -Leaf).ToLowerInvariant()
+  if ($leaf -ne '.codex') {
+    return $null
+  }
+
+  $parent = Get-VgoParentPath -Path $TargetRoot
+  if ([string]::IsNullOrWhiteSpace($parent)) {
+    return $null
+  }
+
+  return (Join-Path $parent '.agents\skills\vibe')
+}
+
+function Test-VibeSkillDirectory {
+  param([string]$Path)
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return $false
+  }
+
+  $skillMd = Join-Path $Path 'SKILL.md'
+  if (-not (Test-Path -LiteralPath $skillMd)) {
+    return $false
+  }
+
+  $lines = Get-Content -LiteralPath $skillMd -TotalCount 20 -Encoding UTF8
+  return [bool](@($lines | Where-Object { $_ -match '^\s*name:\s*vibe\s*$' }).Count -gt 0)
+}
+
+function Check-CodexDuplicateSkillSurface {
+  param(
+    [string]$TargetRoot,
+    [string]$HostId
+  )
+
+  $duplicateRoot = Resolve-CodexDuplicateSkillRoot -TargetRoot $TargetRoot -HostId $HostId
+  if ([string]::IsNullOrWhiteSpace($duplicateRoot) -or -not (Test-Path -LiteralPath $duplicateRoot -PathType Container)) {
+    return
+  }
+
+  if (Test-VibeSkillDirectory -Path $duplicateRoot) {
+    Write-Host ("[FAIL] duplicate Codex-discovered vibe skill surface -> {0}" -f $duplicateRoot) -ForegroundColor Red
+    Write-Host '[FAIL] Re-run install.ps1 for the default Codex root to quarantine the legacy .agents copy, or move it out of .agents/skills manually.' -ForegroundColor Red
+    $script:fail++
+    return
+  }
+
+  Write-WarnNote -Message ("unexpected directory exists at Codex duplicate-surface path: {0}" -f $duplicateRoot)
 }
 
 function Test-ReceiptTargetFreshness {
   param(
     [string]$TargetRoot,
-    [pscustomobject]$RuntimeConfig
+    [psobject]$RuntimeConfig
   )
 
   $receiptRel = [string]$RuntimeConfig.receipt_relpath
   if ([string]::IsNullOrWhiteSpace($receiptRel)) {
     return
   }
+
   $receiptPath = Join-Path $TargetRoot $receiptRel
   if (-not (Test-Path -LiteralPath $receiptPath)) {
     return
@@ -390,14 +290,9 @@ function Test-ReceiptTargetFreshness {
   if ([string]::IsNullOrWhiteSpace($targetRel)) {
     $targetRel = 'skills/vibe'
   }
-  $installedRoot = Join-Path $TargetRoot $targetRel
-  $installedGovernancePath = Join-Path $installedRoot 'config\version-governance.json'
-  if (-not (Test-Path -LiteralPath $installedGovernancePath)) {
-    return
-  }
 
-  $receipt = Get-JsonObject -Path $receiptPath -Label 'runtime freshness receipt'
-  if ($null -eq $receipt) {
+  $installedGovernancePath = Join-Path $TargetRoot (Join-Path $targetRel 'config\version-governance.json')
+  if (-not (Test-Path -LiteralPath $installedGovernancePath)) {
     return
   }
 
@@ -406,45 +301,8 @@ function Test-ReceiptTargetFreshness {
     return
   }
 
-  $receiptVersion = if ($receipt.PSObject.Properties.Name -contains 'receipt_version') { [int]$receipt.receipt_version } else { 0 }
-  $expectedVersion = if ($RuntimeConfig.PSObject.Properties.Name -contains 'receipt_contract_version') { [int]$RuntimeConfig.receipt_contract_version } else { 1 }
-  Check-Condition -Label 'vibe runtime freshness receipt version' -Condition ($receiptVersion -ge $expectedVersion) -FailureDetail ("receipt_version={0}" -f $receiptVersion)
-
-  $receiptGate = if ($receipt.PSObject.Properties.Name -contains 'gate_result') { [string]$receipt.gate_result } else { '' }
-  Check-Condition -Label 'vibe runtime freshness receipt gate_result' -Condition ($receiptGate -eq 'PASS') -FailureDetail ("gate_result={0}" -f (Format-OptionalValue -Value $receiptGate))
-
-  $normalizedTargetRoot = Normalize-ComparablePath -Path $TargetRoot
-  $receiptTargetRoot = if ($receipt.PSObject.Properties.Name -contains 'target_root') { Normalize-ComparablePath -Path ([string]$receipt.target_root) } else { $null }
-  $normalizedInstalledRoot = Normalize-ComparablePath -Path $installedRoot
-  $receiptInstalledRoot = if ($receipt.PSObject.Properties.Name -contains 'installed_root') { Normalize-ComparablePath -Path ([string]$receipt.installed_root) } else { $null }
-
-  Check-Condition -Label 'vibe runtime freshness receipt target_root' -Condition ($receiptTargetRoot -eq $normalizedTargetRoot) -FailureDetail ("target_root={0}" -f (Format-OptionalValue -Value $receiptTargetRoot))
-  Check-Condition -Label 'vibe runtime freshness receipt installed_root' -Condition ($receiptInstalledRoot -eq $normalizedInstalledRoot) -FailureDetail ("installed_root={0}" -f (Format-OptionalValue -Value $receiptInstalledRoot))
-
-  $installedRelease = if ($installedGovernance.PSObject.Properties.Name -contains 'release') { $installedGovernance.release } else { $null }
-  if ($null -eq $installedRelease) {
-    return
-  }
-
-  $installedVersion = if ($installedRelease.PSObject.Properties.Name -contains 'version') { [string]$installedRelease.version } else { $null }
-  $installedUpdated = if ($installedRelease.PSObject.Properties.Name -contains 'updated') { [string]$installedRelease.updated } else { $null }
-
-  $receiptRelease = if ($receipt.PSObject.Properties.Name -contains 'release') { $receipt.release } else { $null }
-  $receiptReleaseVersion = if ($null -ne $receiptRelease -and $receiptRelease.PSObject.Properties.Name -contains 'version') { [string]$receiptRelease.version } else { $null }
-  $receiptReleaseUpdated = if ($null -ne $receiptRelease -and $receiptRelease.PSObject.Properties.Name -contains 'updated') { [string]$receiptRelease.updated } else { $null }
-
-  Check-Condition -Label 'vibe runtime freshness receipt release.version' -Condition ($receiptReleaseVersion -eq $installedVersion) -FailureDetail ("release.version={0}" -f (Format-OptionalValue -Value $receiptReleaseVersion))
-  Check-Condition -Label 'vibe runtime freshness receipt release.updated' -Condition ($receiptReleaseUpdated -eq $installedUpdated) -FailureDetail ("release.updated={0}" -f (Format-OptionalValue -Value $receiptReleaseUpdated))
-}
-
-function Show-InstalledRuntimeUpgradeHint {
-  param(
-    [psobject]$Governance,
-    [string]$TargetRoot,
-    [pscustomobject]$RuntimeConfig
-  )
-
-  if ($null -eq $Governance -or -not ($Governance.PSObject.Properties.Name -contains 'release') -or $null -eq $Governance.release) {
+  $receipt = Get-JsonObject -Path $receiptPath -Label 'runtime freshness receipt'
+  if ($null -eq $receipt) {
     return
   }
 
@@ -452,6 +310,54 @@ function Show-InstalledRuntimeUpgradeHint {
   if ([string]::IsNullOrWhiteSpace($targetRel)) {
     $targetRel = 'skills/vibe'
   }
+
+  $expectedTargetRoot = Normalize-ComparablePath -Path $TargetRoot
+  $expectedInstalledRoot = Normalize-ComparablePath -Path (Join-Path $TargetRoot $targetRel)
+  $receiptTargetRoot = Normalize-ComparablePath -Path ([string]$receipt.target_root)
+  $receiptInstalledRoot = Normalize-ComparablePath -Path ([string]$receipt.installed_root)
+
+  $receiptGateResult = if ($receipt.PSObject.Properties.Name -contains 'gate_result') { [string]$receipt.gate_result } else { $null }
+  Check-Condition -Label 'vibe runtime freshness receipt gate_result' -Condition ($receiptGateResult -eq 'PASS') -FailureDetail (Format-OptionalValue -Value $receiptGateResult)
+
+  $receiptVersionValue = if ($receipt.PSObject.Properties.Name -contains 'receipt_version') { [int]$receipt.receipt_version } else { 0 }
+  $expectedReceiptContractVersion = if ($RuntimeConfig.PSObject.Properties.Name -contains 'receipt_contract_version') { [int]$RuntimeConfig.receipt_contract_version } else { 1 }
+  Check-Condition -Label 'vibe runtime freshness receipt version' -Condition ($receiptVersionValue -ge $expectedReceiptContractVersion) -FailureDetail ([string]$receiptVersionValue)
+
+  Check-Condition -Label 'vibe runtime freshness receipt target_root' -Condition ($receiptTargetRoot -eq $expectedTargetRoot) -FailureDetail (Format-OptionalValue -Value ([string]$receipt.target_root))
+  Check-Condition -Label 'vibe runtime freshness receipt installed_root' -Condition ($receiptInstalledRoot -eq $expectedInstalledRoot) -FailureDetail (Format-OptionalValue -Value ([string]$receipt.installed_root))
+
+  $installedRelease = if ($installedGovernance.PSObject.Properties.Name -contains 'release') { $installedGovernance.release } else { $null }
+  $installedVersion = if ($null -ne $installedRelease -and $installedRelease.PSObject.Properties.Name -contains 'version') { [string]$installedRelease.version } else { $null }
+  $installedUpdated = if ($null -ne $installedRelease -and $installedRelease.PSObject.Properties.Name -contains 'updated') { [string]$installedRelease.updated } else { $null }
+  $receiptRelease = if ($receipt.PSObject.Properties.Name -contains 'release') { $receipt.release } else { $null }
+  $receiptVersion = if ($null -ne $receiptRelease -and $receiptRelease.PSObject.Properties.Name -contains 'version') { [string]$receiptRelease.version } else { $null }
+  $receiptUpdated = if ($null -ne $receiptRelease -and $receiptRelease.PSObject.Properties.Name -contains 'updated') { [string]$receiptRelease.updated } else { $null }
+
+  if (-not [string]::IsNullOrWhiteSpace($installedVersion)) {
+    Check-Condition -Label 'vibe runtime freshness receipt release.version' -Condition ($receiptVersion -eq $installedVersion) -FailureDetail (Format-OptionalValue -Value $receiptVersion)
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($installedUpdated)) {
+    Check-Condition -Label 'vibe runtime freshness receipt release.updated' -Condition ($receiptUpdated -eq $installedUpdated) -FailureDetail (Format-OptionalValue -Value $receiptUpdated)
+  }
+}
+
+function Show-InstalledRuntimeUpgradeHint {
+  param(
+    [psobject]$Governance,
+    [string]$TargetRoot,
+    [psobject]$RuntimeConfig
+  )
+
+  if ($null -eq $Governance -or $null -eq $RuntimeConfig) {
+    return
+  }
+
+  $targetRel = [string]$RuntimeConfig.target_relpath
+  if ([string]::IsNullOrWhiteSpace($targetRel)) {
+    $targetRel = 'skills/vibe'
+  }
+
   $installedGovernancePath = Join-Path $TargetRoot (Join-Path $targetRel 'config\version-governance.json')
   if (-not (Test-Path -LiteralPath $installedGovernancePath)) {
     return
@@ -706,7 +612,6 @@ function Invoke-AdapterSpecificChecks {
       }
     }
   }
-  Check-HostVisibleDiscoverableEntries -TargetRoot $TargetRoot -HostId ([string]$Adapter.id)
 
   Check-Path -Label "upstream lock" -Path (Join-Path $TargetRoot 'config\upstream-lock.json')
   $installedRuntimeGovernancePath = Join-Path $TargetRoot (Join-Path $startupRuntimeTargetRel 'config\version-governance.json')
@@ -795,7 +700,7 @@ function Invoke-AdapterSpecificChecks {
 
   if ([string]$Adapter.id -eq 'codex' -and [string]$Adapter.check_mode -eq 'governed' -and $Profile -eq 'full') {
     foreach ($name in @('vibe-what-do-i-want', 'vibe-how-do-we-do', 'vibe-do-it')) {
-      Check-Path -Label "skill/$name" -Path (Join-Path $TargetRoot "skills\$name\SKILL.md")
+      Check-Path -Label "skill/$name" -Path (Resolve-SkillDescriptorPath -SkillName $name)
     }
   }
 
@@ -813,6 +718,9 @@ function Invoke-AdapterSpecificChecks {
 
   if ([string]$Adapter.id -eq 'codex' -and [string]$Adapter.check_mode -eq 'governed') {
     $codexCommandNames = @('vibe', 'vibe-what-do-i-want', 'vibe-how-do-we-do', 'vibe-do-it')
+    if ($env:OS -ne 'Windows_NT') {
+      $codexCommandNames = @('vibe', 'vibe:what-do-i-want', 'vibe:how-do-we-do', 'vibe:do-it')
+    }
     foreach ($name in $codexCommandNames) {
       Check-Path -Label "codex command/$name" -Path (Join-Path (Join-Path $TargetRoot 'commands') "$name.md") -Required:$false
     }
@@ -820,19 +728,20 @@ function Invoke-AdapterSpecificChecks {
 }
 
 Write-Host "=== VCO Adapter Health Check ===" -ForegroundColor Cyan
+$startupGovernance = Get-CheckGovernance -RepoRoot $RepoRoot
+$startupRuntimeConfig = Get-InstalledRuntimeConfig -Governance $startupGovernance
+$targetContext = Resolve-CheckTargetContext -InputRoot $TargetRoot -RuntimeConfig $startupRuntimeConfig
+$TargetRoot = [string]$targetContext.target_root
+Assert-VgoTargetRootMatchesHostIntent -TargetRoot $TargetRoot -HostId $HostId
+$startupRuntimeTargetRel = [string]$targetContext.target_relpath
+
 Write-Host "Host: $HostId"
 Write-Host "Mode: $($Adapter.check_mode)"
 Write-Host "Target: $TargetRoot"
 Write-Host "SkipRuntimeFreshnessGate: $SkipRuntimeFreshnessGate"
 Write-Host "Deep: $Deep"
-$startupGovernance = Get-CheckGovernance -RepoRoot $RepoRoot
-$startupRuntimeConfig = Get-InstalledRuntimeConfig -Governance $startupGovernance
-$startupRuntimeTargetRel = [string]$startupRuntimeConfig.target_relpath
-if ([string]::IsNullOrWhiteSpace($startupRuntimeTargetRel)) {
-  $startupRuntimeTargetRel = 'skills/vibe'
-}
 
-$runtimeSkillRoot = Join-Path $TargetRoot $startupRuntimeTargetRel
+$runtimeSkillRoot = [string]$targetContext.installed_root
 $runtimeNestedSkillRoot = Join-Path $runtimeSkillRoot 'bundled\skills\vibe'
 $runtimeNestedSkillRootExists = Test-Path -LiteralPath $runtimeNestedSkillRoot
 $nestedBundledPresencePolicy = 'optional'

--- a/check.sh
+++ b/check.sh
@@ -955,7 +955,6 @@ if [[ "${DEEP}" == "true" ]]; then
       fi
     else
       echo "[FAIL] vibe bootstrap doctor gate"
-      WARN=$((WARN+1))
       FAIL=$((FAIL+1))
     fi
   fi

--- a/check.sh
+++ b/check.sh
@@ -293,6 +293,50 @@ info_note() {
   echo "[INFO] ${message}"
 }
 
+resolve_check_target_context() {
+  local input_root="${1:-}"
+  local target_rel="${2:-skills/vibe}"
+  local rel_norm="${target_rel//\\//}"
+  local installed_governance="${input_root}/config/version-governance.json"
+  local skill_descriptor="${input_root}/SKILL.md"
+
+  if [[ -f "${installed_governance}" && -f "${skill_descriptor}" ]]; then
+    local current="${input_root}"
+    local ok="true"
+    local part leaf parent
+    local rel_parts=()
+    IFS='/' read -r -a rel_parts <<< "${rel_norm}"
+    for (( idx=${#rel_parts[@]}-1; idx>=0; idx-- )); do
+      part="${rel_parts[$idx]}"
+      [[ -n "${part}" ]] || continue
+      leaf="$(basename "${current}")"
+      if [[ "$(printf '%s' "${leaf}" | tr '[:upper:]' '[:lower:]')" != "$(printf '%s' "${part}" | tr '[:upper:]' '[:lower:]')" ]]; then
+        ok="false"
+        break
+      fi
+      parent="$(dirname "${current}")"
+      if [[ -z "${parent}" || "${parent}" == "${current}" ]]; then
+        ok="false"
+        break
+      fi
+      current="${parent}"
+    done
+
+    if [[ "${ok}" == "true" ]]; then
+      printf 'target_root=%s\n' "${current}"
+      printf 'installed_root=%s\n' "${input_root}"
+      printf 'target_relpath=%s\n' "${target_rel}"
+      printf 'input_kind=installed_root\n'
+      return 0
+    fi
+  fi
+
+  printf 'target_root=%s\n' "${input_root}"
+  printf 'installed_root=%s\n' "${input_root}/${rel_norm}"
+  printf 'target_relpath=%s\n' "${target_rel}"
+  printf 'input_kind=host_root\n'
+}
+
 normalize_path() {
   local value="${1:-}"
   if [[ -z "$value" ]]; then
@@ -413,110 +457,6 @@ json_query_scalar_from_file() {
   json_query_lines_from_file "$json_path" "$expr" | head -n 1
 }
 
-check_host_visible_discoverable_entries() {
-  local ledger_path="${TARGET_ROOT}/.vibeskills/install-ledger.json"
-  if [[ ! -f "${ledger_path}" ]]; then
-    echo "[FAIL] host-visible discoverable entries -> ${ledger_path}"
-    FAIL=$((FAIL+1))
-    return
-  fi
-
-  local entry_names=()
-  local wrapper_paths=()
-  local compatibility_roots=()
-  local line=""
-  while IFS= read -r line; do
-    entry_names+=("${line}")
-  done < <(json_query_lines_from_file "${ledger_path}" 'payload_summary.host_visible_entry_names' 2>/dev/null || true)
-  while IFS= read -r line; do
-    wrapper_paths+=("${line}")
-  done < <(json_query_lines_from_file "${ledger_path}" 'specialist_wrapper_paths' 2>/dev/null || true)
-  while IFS= read -r line; do
-    compatibility_roots+=("${line}")
-  done < <(json_query_lines_from_file "${ledger_path}" 'compatibility_roots' 2>/dev/null || true)
-
-  if [[ ${#entry_names[@]} -eq 0 || ( ${#wrapper_paths[@]} -eq 0 && ${#compatibility_roots[@]} -eq 0 ) ]]; then
-    if [[ "${HOST_ID}" == "codex" || "${HOST_ID}" == "claude-code" || "${HOST_ID}" == "cursor" || "${HOST_ID}" == "windsurf" || "${HOST_ID}" == "openclaw" || "${HOST_ID}" == "opencode" ]]; then
-      echo "[FAIL] host-visible discoverable entries -> missing wrapper inventory"
-      FAIL=$((FAIL+1))
-    else
-      echo "[WARN] host-visible discoverable entries -> no wrapper inventory recorded for host '${HOST_ID}'"
-      WARN=$((WARN+1))
-    fi
-    return
-  fi
-
-  local missing_paths=()
-  local invalid_wrapper_paths=()
-  local missing_compatibility_roots=()
-  local invalid_compatibility_roots=()
-  local normalized_target_root
-  normalized_target_root="$(normalize_path "${TARGET_ROOT}")"
-  local path=""
-  for path in "${wrapper_paths[@]}"; do
-    local candidate_path="${path}"
-    local normalized_path=""
-    if [[ "${candidate_path}" != /* ]]; then
-      candidate_path="${TARGET_ROOT}/${candidate_path}"
-    fi
-    normalized_path="$(normalize_path "${candidate_path}")"
-    case "${normalized_path}" in
-      "${normalized_target_root}"|"${normalized_target_root}/"*) ;;
-      *)
-        invalid_wrapper_paths+=("${path}")
-        continue
-        ;;
-    esac
-    [[ -f "${candidate_path}" ]] || missing_paths+=("${path}")
-  done
-
-  local compatibility_root=""
-  for compatibility_root in "${compatibility_roots[@]}"; do
-    local candidate_root="${compatibility_root}"
-    local normalized_root=""
-    if [[ "${candidate_root}" != /* ]]; then
-      candidate_root="${TARGET_ROOT}/${candidate_root}"
-    fi
-    normalized_root="$(normalize_path "${candidate_root}")"
-    case "${normalized_root}" in
-      "${normalized_target_root}"|"${normalized_target_root}/"*) ;;
-      *)
-        invalid_compatibility_roots+=("${compatibility_root}")
-        continue
-        ;;
-    esac
-    if [[ ! -d "${candidate_root}" || ! -f "${candidate_root}/SKILL.md" ]]; then
-      missing_compatibility_roots+=("${compatibility_root}")
-    fi
-  done
-
-  local wrappers_ready="false"
-  local compatibility_ready="false"
-  if [[ ${#wrapper_paths[@]} -gt 0 && ${#missing_paths[@]} -eq 0 ]]; then
-    wrappers_ready="true"
-  fi
-  if [[ ${#compatibility_roots[@]} -gt 0 && ${#missing_compatibility_roots[@]} -eq 0 ]]; then
-    compatibility_ready="true"
-  fi
-
-  if [[ ${#invalid_wrapper_paths[@]} -gt 0 ]]; then
-    echo "[FAIL] host-visible discoverable entries -> ${invalid_wrapper_paths[0]}"
-    FAIL=$((FAIL+1))
-  elif [[ ${#invalid_compatibility_roots[@]} -gt 0 ]]; then
-    echo "[FAIL] host-visible discoverable entries -> ${invalid_compatibility_roots[0]}"
-    FAIL=$((FAIL+1))
-  elif [[ "${wrappers_ready}" == "true" || "${compatibility_ready}" == "true" ]]; then
-    echo "[OK] host-visible discoverable entries"
-    PASS=$((PASS+1))
-  elif [[ ${#missing_paths[@]} -gt 0 ]]; then
-    echo "[FAIL] host-visible discoverable entries -> ${missing_paths[0]}"
-    FAIL=$((FAIL+1))
-  else
-    echo "[FAIL] host-visible discoverable entries -> ${missing_compatibility_roots[0]}"
-    FAIL=$((FAIL+1))
-  fi
-}
-
 pick_python() {
   pick_supported_python
 }
@@ -535,7 +475,7 @@ run_runtime_neutral_freshness_gate() {
   if ! python_bin="$(pick_python)"; then
     return 127
   fi
-  "${python_bin}" "${gate_path}" --target-root "${TARGET_ROOT}" --write-receipt
+  "${python_bin}" "${gate_path}" --target-root "${TARGET_ROOT}"
 }
 
 run_runtime_neutral_coherence_gate() {
@@ -681,159 +621,174 @@ show_installed_runtime_upgrade_hint() {
   installed_version="$(json_query_scalar_from_file "$installed_governance" 'release.version' 2>/dev/null || true)"
   installed_updated="$(json_query_scalar_from_file "$installed_governance" 'release.updated' 2>/dev/null || true)"
 
-  if [[ -n "$repo_version" && -n "$installed_version" && "$repo_version" != "$installed_version" ]] ||
-     [[ -n "$repo_updated" && -n "$installed_updated" && "$repo_updated" != "$installed_updated" ]]; then
-    info_note "installed runtime release differs from this repo; re-run install before treating freshness drift as a receipt-only issue"
+  if [[ -n "$repo_version" && "$repo_version" != "$installed_version" ]] || [[ -n "$repo_updated" && "$repo_updated" != "$installed_updated" ]]; then
+    warn_note "installed runtime release differs from canonical repo release (installed=${installed_version:-<missing>}/${installed_updated:-<missing>}, repo=${repo_version:-<missing>}/${repo_updated:-<missing>}). Re-run install.sh or one-shot-setup.sh for TARGET_ROOT=${TARGET_ROOT} before treating freshness failures as receipt-only issues."
   fi
 }
 
 run_runtime_freshness_gate() {
   if [[ "$SKIP_RUNTIME_FRESHNESS_GATE" == "true" ]]; then
-    echo "[WARN] runtime freshness gate skipped by request"
-    WARN=$((WARN+1))
-    validate_runtime_receipt
+    warn_note 'runtime freshness gate skipped by request.'
     return
   fi
 
   if ! canonical_repo_available "${SCRIPT_DIR}"; then
-    echo "[WARN] runtime freshness gate skipped because this check.sh is not running from a canonical repo checkout"
-    WARN=$((WARN+1))
-    validate_runtime_receipt
+    warn_note 'runtime freshness gate skipped: run canonical repo check.sh to execute freshness verification.'
     return
   fi
 
-  if pick_powershell >/dev/null 2>&1; then
-    local gate_script="${SCRIPT_DIR}/scripts/verify/vibe-installed-runtime-freshness-gate.ps1"
-    if [[ -f "$gate_script" ]]; then
-      if run_powershell_file "$gate_script" -TargetRoot "${TARGET_ROOT}" -WriteReceipt; then
-        echo "[OK] vibe installed runtime freshness gate"
-        PASS=$((PASS+1))
-      else
-        echo "[FAIL] vibe installed runtime freshness gate"
-        FAIL=$((FAIL+1))
-      fi
-      validate_runtime_receipt
-      return
+  local governance_path="${SCRIPT_DIR}/config/version-governance.json"
+  local gate_rel='scripts/verify/vibe-installed-runtime-freshness-gate.ps1'
+  if [[ -f "$governance_path" ]]; then
+    local configured_gate
+    configured_gate="$(json_query_scalar_from_file "$governance_path" 'runtime.installed_runtime.post_install_gate' 2>/dev/null || true)"
+    if [[ -n "$configured_gate" ]]; then
+      gate_rel="$configured_gate"
     fi
+  fi
+
+  local gate_path="${SCRIPT_DIR}/${gate_rel}"
+  if [[ ! -f "$gate_path" ]]; then
+    echo "[FAIL] vibe runtime freshness gate script -> $gate_path"
+    FAIL=$((FAIL+1))
+    return
   fi
 
   if run_runtime_neutral_freshness_gate; then
-    echo "[OK] vibe installed runtime freshness gate (runtime-neutral)"
+    echo "[OK] vibe installed runtime freshness gate"
     PASS=$((PASS+1))
+  elif [[ $? -eq 127 ]]; then
+    if ! pick_powershell >/dev/null 2>&1; then
+      warn_note 'runtime freshness gate skipped: neither Python runtime-neutral gate nor a PowerShell fallback is available.'
+      return
+    fi
+    if run_powershell_file "$gate_path" -TargetRoot "$TARGET_ROOT"; then
+      echo "[OK] vibe installed runtime freshness gate"
+      PASS=$((PASS+1))
+    else
+      echo "[FAIL] vibe installed runtime freshness gate"
+      FAIL=$((FAIL+1))
+    fi
   else
     echo "[FAIL] vibe installed runtime freshness gate"
     FAIL=$((FAIL+1))
-  fi
-  validate_runtime_receipt
-}
-
-run_runtime_bom_frontmatter_gate() {
-  if ! canonical_repo_available "${SCRIPT_DIR}"; then
-    echo "[WARN] runtime BOM/frontmatter gate skipped because this check.sh is not running from a canonical repo checkout"
-    WARN=$((WARN+1))
-    return
-  fi
-
-  if pick_powershell >/dev/null 2>&1; then
-    local gate_script="${SCRIPT_DIR}/scripts/verify/vibe-bom-frontmatter-gate.ps1"
-    if [[ -f "$gate_script" ]]; then
-      if run_powershell_file "$gate_script" -TargetRoot "${TARGET_ROOT}"; then
-        echo "[OK] vibe runtime BOM/frontmatter gate"
-        PASS=$((PASS+1))
-      else
-        echo "[FAIL] vibe runtime BOM/frontmatter gate"
-        FAIL=$((FAIL+1))
-      fi
-      return
-    fi
-  fi
-
-  if run_runtime_neutral_bootstrap_doctor; then
-    echo "[OK] vibe runtime BOM/frontmatter gate (runtime-neutral bootstrap doctor)"
-    PASS=$((PASS+1))
-  else
-    echo "[WARN] vibe runtime BOM/frontmatter gate skipped (PowerShell gate unavailable in this shell)"
-    WARN=$((WARN+1))
   fi
 }
 
 run_runtime_coherence_gate() {
   if ! canonical_repo_available "${SCRIPT_DIR}"; then
-    echo "[WARN] runtime coherence gate skipped because this check.sh is not running from a canonical repo checkout"
-    WARN=$((WARN+1))
+    warn_note 'runtime coherence gate skipped: run canonical repo check.sh to execute coherence verification.'
     return
   fi
 
-  if pick_powershell >/dev/null 2>&1; then
-    local gate_script="${SCRIPT_DIR}/scripts/verify/vibe-release-install-runtime-coherence-gate.ps1"
-    if [[ -f "$gate_script" ]]; then
-      if run_powershell_file "$gate_script" -TargetRoot "${TARGET_ROOT}"; then
-        echo "[OK] vibe release/install/runtime coherence gate"
-        PASS=$((PASS+1))
-      else
-        echo "[FAIL] vibe release/install/runtime coherence gate"
-        FAIL=$((FAIL+1))
-      fi
-      return
+  local governance_path="${SCRIPT_DIR}/config/version-governance.json"
+  local gate_rel='scripts/verify/vibe-release-install-runtime-coherence-gate.ps1'
+  if [[ -f "$governance_path" ]]; then
+    local configured_gate
+    configured_gate="$(json_query_scalar_from_file "$governance_path" 'runtime.installed_runtime.coherence_gate' 2>/dev/null || true)"
+    if [[ -n "$configured_gate" ]]; then
+      gate_rel="$configured_gate"
     fi
   fi
 
+  local gate_path="${SCRIPT_DIR}/${gate_rel}"
+  if [[ ! -f "$gate_path" ]]; then
+    echo "[FAIL] vibe runtime coherence gate script -> $gate_path"
+    FAIL=$((FAIL+1))
+    return
+  fi
+
   if run_runtime_neutral_coherence_gate; then
-    echo "[OK] vibe release/install/runtime coherence gate (runtime-neutral)"
+    echo "[OK] vibe release/install/runtime coherence gate"
     PASS=$((PASS+1))
+  elif [[ $? -eq 127 ]]; then
+    if ! pick_powershell >/dev/null 2>&1; then
+      warn_note 'runtime coherence gate skipped: neither Python runtime-neutral gate nor a PowerShell fallback is available.'
+      return
+    fi
+    if run_powershell_file "$gate_path" -TargetRoot "$TARGET_ROOT"; then
+      echo "[OK] vibe release/install/runtime coherence gate"
+      PASS=$((PASS+1))
+    else
+      echo "[FAIL] vibe release/install/runtime coherence gate"
+      FAIL=$((FAIL+1))
+    fi
   else
-    echo "[WARN] vibe release/install/runtime coherence gate skipped (PowerShell gate unavailable in this shell)"
-    WARN=$((WARN+1))
+    echo "[FAIL] vibe release/install/runtime coherence gate"
+    FAIL=$((FAIL+1))
   fi
 }
 
-ADAPTER_CHECK_MODE="$(adapter_query 'check_mode')"
-startup_runtime_target_rel='skills/vibe'
+ADAPTER_CHECK_MODE="$(adapter_query check_mode)"
+
+echo "=== VCO Adapter Health Check ==="
+echo "Host: ${HOST_ID}"
+echo "Mode: ${ADAPTER_CHECK_MODE}"
+echo "Target: ${TARGET_ROOT}"
+echo "SkipRuntimeFreshnessGate: ${SKIP_RUNTIME_FRESHNESS_GATE}"
+echo "Deep: ${DEEP}"
+
+runtime_target_rel="skills/vibe"
 repo_governance_path="${SCRIPT_DIR}/config/version-governance.json"
 if [[ -f "$repo_governance_path" ]]; then
   configured_runtime_target_rel="$(json_query_scalar_from_file "$repo_governance_path" 'runtime.installed_runtime.target_relpath' 2>/dev/null || true)"
   if [[ -n "$configured_runtime_target_rel" ]]; then
-    startup_runtime_target_rel="$configured_runtime_target_rel"
-  fi
-fi
-runtime_skill_root="${TARGET_ROOT}/${startup_runtime_target_rel}"
-runtime_nested_skill_root="${runtime_skill_root}/bundled/skills/vibe"
-runtime_nested_skill_presence_policy='optional'
-runtime_nested_skill_required='false'
-if [[ -f "$repo_governance_path" ]]; then
-  topology_required="$(json_query_scalar_from_file "$repo_governance_path" 'mirror_topology.targets.1.required' 2>/dev/null || true)"
-  topology_presence_policy="$(json_query_scalar_from_file "$repo_governance_path" 'mirror_topology.targets.1.presence_policy' 2>/dev/null || true)"
-  if [[ -n "$topology_presence_policy" ]]; then
-    runtime_nested_skill_presence_policy="$topology_presence_policy"
-  fi
-  if [[ "$topology_required" == 'true' || "$runtime_nested_skill_presence_policy" == 'required' ]]; then
-    runtime_nested_skill_required='true'
+    runtime_target_rel="$configured_runtime_target_rel"
   fi
 fi
 
-if [[ "$ADAPTER_CHECK_MODE" == 'governed' ]]; then
+resolved_target_root="${TARGET_ROOT}"
+resolved_installed_root="${TARGET_ROOT}/${runtime_target_rel}"
+while IFS='=' read -r key value; do
+  case "${key}" in
+    target_root) resolved_target_root="${value}" ;;
+    installed_root) resolved_installed_root="${value}" ;;
+    target_relpath) runtime_target_rel="${value}" ;;
+  esac
+done < <(resolve_check_target_context "${TARGET_ROOT}" "${runtime_target_rel}")
+
+TARGET_ROOT="${resolved_target_root}"
+assert_target_root_matches_host_intent "${TARGET_ROOT}" "${HOST_ID}"
+
+runtime_skill_root="${resolved_installed_root}"
+runtime_nested_skill_root="${runtime_skill_root}/bundled/skills/vibe"
+
+if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   check_path "settings.json" "${TARGET_ROOT}/settings.json"
 fi
-if [[ "$ADAPTER_CHECK_MODE" == 'preview-guidance' ]]; then
-  if [[ "$HOST_ID" == 'opencode' ]]; then
-    echo "[INFO] opencode preview now runs as skills-only activation; the real opencode.json stays untouched and sidecar state is verified"
+if [[ "${ADAPTER_CHECK_MODE}" == "preview-guidance" ]]; then
+  if [[ "${HOST_ID}" == "opencode" ]]; then
+    info_note "opencode preview now runs as skills-only activation; the real opencode.json stays untouched and sidecar state is verified"
+  elif [[ "${HOST_ID}" == "claude-code" ]]; then
+    info_note "claude-code preview now verifies sidecar state plus a managed settings.json surface"
   else
-    echo "[INFO] ${HOST_ID} preview now runs as skills-only activation; host-native config files stay untouched and sidecar state is verified"
+    info_note "${HOST_ID} preview now runs as skills-only activation; host-native config files stay untouched and sidecar state is verified"
   fi
 fi
-if [[ "$ADAPTER_CHECK_MODE" == 'runtime-core' ]]; then
-  echo "[INFO] ${HOST_ID} runtime-core now verifies skill-native activation and sidecar state only; host-native workflow/config files are intentionally absent"
+if [[ "${ADAPTER_CHECK_MODE}" == "runtime-core" ]]; then
+  info_note "${HOST_ID} runtime-core now verifies skill-native activation and sidecar state only; host-native workflow/config files are intentionally absent"
 fi
-if [[ "$HOST_ID" == 'claude-code' || "$HOST_ID" == 'cursor' || "$HOST_ID" == 'windsurf' || "$HOST_ID" == 'openclaw' || "$HOST_ID" == 'opencode' ]]; then
+if [[ "${HOST_ID}" == "claude-code" || "${HOST_ID}" == "cursor" || "${HOST_ID}" == "windsurf" || "${HOST_ID}" == "openclaw" || "${HOST_ID}" == "opencode" ]]; then
   check_path "host settings sidecar" "${TARGET_ROOT}/.vibeskills/host-settings.json"
 fi
-host_closure_path="${TARGET_ROOT}/.vibeskills/host-closure.json"
-check_path "host closure manifest" "$host_closure_path"
-if [[ -f "$host_closure_path" ]]; then
-  closure_state="$(json_query_scalar_from_file "$host_closure_path" 'host_closure_state' 2>/dev/null || true)"
-  if [[ -n "$closure_state" ]]; then
-    if [[ "$closure_state" == 'closed_ready' ]]; then
-      check_condition "host closure state" true
+if [[ "${HOST_ID}" == "claude-code" ]]; then
+  check_path "settings.json" "${TARGET_ROOT}/settings.json"
+  managed_host_id="$(json_query_scalar_from_file "${TARGET_ROOT}/settings.json" 'vibeskills.host_id' 2>/dev/null || true)"
+  if [[ "${managed_host_id}" == "claude-code" ]]; then
+    echo "[OK] settings.json managed vibeskills node"
+    PASS=$((PASS+1))
+  else
+    echo "[FAIL] settings.json managed vibeskills node"
+    FAIL=$((FAIL+1))
+  fi
+fi
+check_path "host closure manifest" "${TARGET_ROOT}/.vibeskills/host-closure.json"
+if [[ -f "${TARGET_ROOT}/.vibeskills/host-closure.json" ]]; then
+  closure_state="$(json_query_scalar_from_file "${TARGET_ROOT}/.vibeskills/host-closure.json" 'host_closure_state' 2>/dev/null || true)"
+  if [[ -n "${closure_state}" ]]; then
+    if [[ "${closure_state}" == "closed_ready" ]]; then
+      echo "[OK] host closure state -> ${closure_state}"
+      PASS=$((PASS+1))
     else
       warn_note "host closure state -> ${closure_state}"
     fi
@@ -843,13 +798,12 @@ if [[ -f "$host_closure_path" ]]; then
     check_path "specialist wrapper launcher" "${wrapper_launcher}"
   fi
 fi
-check_host_visible_discoverable_entries
 if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   check_path "plugins manifest" "${TARGET_ROOT}/config/plugins-manifest.codex.json"
 fi
 check_codex_duplicate_skill_surface
 check_path "upstream lock" "${TARGET_ROOT}/config/upstream-lock.json"
-check_path "vibe version governance config" "${runtime_skill_root}/config/version-governance.json"
+check_path "vibe version governance config" "${TARGET_ROOT}/${runtime_target_rel}/config/version-governance.json"
 installed_runtime_governance="${runtime_skill_root}/config/version-governance.json"
 runtime_release_ledger_required="true"
 if [[ -f "${installed_runtime_governance}" ]]; then
@@ -929,11 +883,15 @@ if [[ "${PROFILE}" == "full" ]]; then
 fi
 if [[ "${HOST_ID}" == "codex" && "${ADAPTER_CHECK_MODE}" == "governed" && "${PROFILE}" == "full" ]]; then
   for n in vibe-what-do-i-want vibe-how-do-we-do vibe-do-it; do
-    check_path "skill/${n}" "${TARGET_ROOT}/skills/${n}/SKILL.md"
+    check_path "skill/${n}" "$(resolve_skill_descriptor_path "${n}")"
   done
 fi
 if [[ "${HOST_ID}" == "codex" && "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   codex_command_names=(vibe vibe-what-do-i-want vibe-how-do-we-do vibe-do-it)
+  codex_kernel="$(uname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+  if [[ "${codex_kernel}" != mingw* && "${codex_kernel}" != msys* && "${codex_kernel}" != cygwin* ]]; then
+    codex_command_names=("vibe" "vibe:what-do-i-want" "vibe:how-do-we-do" "vibe:do-it")
+  fi
   for n in "${codex_command_names[@]}"; do
     check_path "codex command/${n}" "${TARGET_ROOT}/commands/${n}.md" false
   done
@@ -973,39 +931,35 @@ else
 fi
 
 if [[ "${DEEP}" == "true" ]]; then
-  if [[ "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
-    bootstrap_doctor_gate="${SCRIPT_DIR}/scripts/verify/vibe-bootstrap-doctor-gate.ps1"
-    if [[ -f "${bootstrap_doctor_gate}" ]] && pick_powershell >/dev/null 2>&1; then
-      if run_powershell_file "${bootstrap_doctor_gate}" -TargetRoot "${TARGET_ROOT}" -WriteArtifacts; then
+  if [[ "${ADAPTER_CHECK_MODE}" != "governed" ]]; then
+    echo "[WARN] deep doctor skipped for adapter mode '${ADAPTER_CHECK_MODE}'"
+    WARN=$((WARN+1))
+  else
+    doctor_path="${SCRIPT_DIR}/scripts/verify/vibe-bootstrap-doctor-gate.ps1"
+    if [[ ! -f "${doctor_path}" ]]; then
+      echo "[FAIL] vibe bootstrap doctor gate -> ${doctor_path}"
+      FAIL=$((FAIL+1))
+    elif run_runtime_neutral_bootstrap_doctor; then
+      echo "[OK] vibe bootstrap doctor gate"
+      PASS=$((PASS+1))
+    elif [[ $? -eq 127 ]]; then
+      if ! pick_powershell >/dev/null 2>&1; then
+        echo "[WARN] vibe bootstrap doctor gate skipped because neither the Python runtime-neutral doctor nor a PowerShell host is available in this shell environment."
+        WARN=$((WARN+1))
+      elif run_powershell_file "${doctor_path}" -TargetRoot "${TARGET_ROOT}" -WriteArtifacts; then
         echo "[OK] vibe bootstrap doctor gate"
         PASS=$((PASS+1))
       else
         echo "[FAIL] vibe bootstrap doctor gate"
         FAIL=$((FAIL+1))
       fi
-    elif run_runtime_neutral_bootstrap_doctor; then
-      echo "[OK] vibe bootstrap doctor gate (runtime-neutral)"
-      PASS=$((PASS+1))
     else
-      echo "[WARN] vibe bootstrap doctor gate skipped (PowerShell gate unavailable in this shell)"
+      echo "[FAIL] vibe bootstrap doctor gate"
       WARN=$((WARN+1))
+      FAIL=$((FAIL+1))
     fi
-  else
-    echo "[WARN] deep doctor skipped for adapter mode '${ADAPTER_CHECK_MODE}'"
-    WARN=$((WARN+1))
   fi
 fi
 
-echo "=== VCO Adapter Health Check ==="
-echo "Host: ${HOST_ID}"
-echo "Mode: ${ADAPTER_CHECK_MODE}"
-echo "Target: ${TARGET_ROOT}"
-echo "SkipRuntimeFreshnessGate: ${SKIP_RUNTIME_FRESHNESS_GATE}"
-echo "Deep: ${DEEP}"
-
-if [[ $FAIL -gt 0 ]]; then
-  echo "Result: ${PASS} passed, ${FAIL} failed, ${WARN} warnings"
-  exit 1
-fi
-
 echo "Result: ${PASS} passed, ${FAIL} failed, ${WARN} warnings"
+[[ ${FAIL} -eq 0 ]]

--- a/packages/verification-core/src/vgo_verify/router_ai_connectivity_probe.py
+++ b/packages/verification-core/src/vgo_verify/router_ai_connectivity_probe.py
@@ -41,6 +41,7 @@ def attempt_info_lines(label: str, attempts: list[dict[str, Any]] | None) -> lis
 
 
 def next_step_for_advice(status: str, advice: dict[str, Any]) -> str | None:
+    provider_type = str(advice.get("provider_type") or "").strip().lower()
     if status == "disabled_by_policy":
         return "Enable llm acceleration policy (`enabled=true`, `mode` not `off`) before checking advice connectivity."
     if status == "prefix_required":
@@ -57,7 +58,9 @@ def next_step_for_advice(status: str, advice: dict[str, Any]) -> str | None:
     if status == "provider_unreachable":
         return "Check base_url reachability, DNS, network egress, and provider timeout."
     if status == "provider_rejected_request":
-        return "Verify API key validity, model id, and endpoint compatibility (`/responses` or `/chat/completions`)."
+        if provider_type in {"anthropic", "anthropic-compatible"}:
+            return "Verify API key validity, model id, and Anthropic-compatible endpoint compatibility (`/v1/messages`)."
+        return "Verify API key validity, model id, and endpoint compatibility (`/responses`, `/chat/completions`, or `/v1/messages` when using Anthropic-compatible gateways)."
     if status == "parse_error":
         return "Inspect response body in JSON artifact and align provider output format expectations."
     return None

--- a/packages/verification-core/src/vgo_verify/router_ai_probe_advice.py
+++ b/packages/verification-core/src/vgo_verify/router_ai_probe_advice.py
@@ -8,6 +8,8 @@ from .router_ai_probe_support import (
     INTENT_ADVICE_MODEL_ENV,
     ProbeContext,
     TransportFn,
+    anthropic_messages_base_url,
+    extract_anthropic_message_text,
     extract_chat_completion_text,
     extract_openai_response_output_text,
     non_empty,
@@ -128,6 +130,8 @@ def classify_advice_probe_result(attempts: list[dict[str, Any]]) -> tuple[str, s
                     text = extract_openai_response_output_text(payload)
                 elif attempt["endpoint_kind"] in {"chat_completions", "chat_completions_plain"}:
                     text = extract_chat_completion_text(payload)
+                elif attempt["endpoint_kind"] == "anthropic_messages":
+                    text = extract_anthropic_message_text(payload)
 
                 if text:
                     parsed = parse_json_text(text)
@@ -265,6 +269,52 @@ def probe_advice_connectivity(
             "endpoint_used": "mock_fixture",
         }
 
+    timeout_ms = int(provider_cfg.get("timeout_ms", 12000) or 12000)
+
+    if provider_type_normalized in {"anthropic", "anthropic-compatible"}:
+        headers = {
+            "x-api-key": api_key,
+            "anthropic-version": str(provider_cfg.get("anthropic_version") or "2023-06-01"),
+            "Content-Type": "application/json",
+        }
+        base_v1 = anthropic_messages_base_url(str(base_url))
+        anthropic_payload = {
+            "model": model,
+            "max_tokens": 32,
+            "temperature": 0.0,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": 'Return JSON object {"ok": true} only.'}],
+                }
+            ],
+            "system": "Reply with a JSON object only. Do not wrap it in markdown.",
+        }
+        attempts = [
+            request_attempt(
+                transport,
+                purpose="advice",
+                endpoint_kind="anthropic_messages",
+                url=f"{base_v1}/messages",
+                headers=headers,
+                payload=anthropic_payload,
+                timeout_ms=timeout_ms,
+            )
+        ]
+        status, endpoint_used, compact_attempts = classify_advice_probe_result(attempts)
+        result = {
+            "status": status,
+            "provider_type": provider_type,
+            "model": model,
+            "base_url": base_url,
+            "credential_env": credential_env,
+            "credential_state": "configured",
+            "attempts": compact_attempts,
+        }
+        if endpoint_used:
+            result["endpoint_used"] = endpoint_used
+        return result
+
     if provider_type_normalized not in {"openai", "openai-compatible"}:
         return {
             "status": "provider_rejected_request",
@@ -277,7 +327,6 @@ def probe_advice_connectivity(
             "reason": "unsupported_provider_type",
         }
 
-    timeout_ms = int(provider_cfg.get("timeout_ms", 12000) or 12000)
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
@@ -361,6 +410,39 @@ def probe_advice_connectivity(
         ),
     ]
     status, endpoint_used, compact_attempts = classify_advice_probe_result(attempts)
+    normalized_base_url = str(base_url).strip().lower()
+    should_try_anthropic_fallback = (
+        status != "ok"
+        and normalized_base_url not in {"", "https://api.openai.com/v1", "https://api.openai.com"}
+        and "openai.com" not in normalized_base_url
+    )
+    if should_try_anthropic_fallback:
+        anthropic_attempt = request_attempt(
+            transport,
+            purpose="advice",
+            endpoint_kind="anthropic_messages",
+            url=f"{anthropic_messages_base_url(str(base_url))}/messages",
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": str(provider_cfg.get("anthropic_version") or "2023-06-01"),
+                "Content-Type": "application/json",
+            },
+            payload={
+                "model": model,
+                "max_tokens": 32,
+                "temperature": 0.0,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": 'Return JSON object {"ok": true} only.'}],
+                    }
+                ],
+                "system": "Reply with a JSON object only. Do not wrap it in markdown.",
+            },
+            timeout_ms=timeout_ms,
+        )
+        attempts.append(anthropic_attempt)
+        status, endpoint_used, compact_attempts = classify_advice_probe_result(attempts)
     result = {
         "status": status,
         "provider_type": provider_type,

--- a/packages/verification-core/src/vgo_verify/router_ai_probe_support.py
+++ b/packages/verification-core/src/vgo_verify/router_ai_probe_support.py
@@ -94,6 +94,10 @@ def openai_v1_base_url(base_url: str) -> str:
     return f"{trimmed}/v1"
 
 
+def anthropic_messages_base_url(base_url: str) -> str:
+    return openai_v1_base_url(base_url)
+
+
 def parse_json_text(text: str | None) -> Any:
     if not text:
         return None
@@ -148,6 +152,25 @@ def extract_chat_completion_text(payload: dict[str, Any]) -> str | None:
     if isinstance(content, str) and content.strip():
         return content.strip()
     return None
+
+
+def extract_anthropic_message_text(payload: dict[str, Any]) -> str | None:
+    content = payload.get("content")
+    if not isinstance(content, list):
+        return None
+
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "text":
+            continue
+        text = block.get("text")
+        if isinstance(text, str) and text.strip():
+            parts.append(text.strip())
+    if not parts:
+        return None
+    return "\n".join(parts).strip()
 
 
 def extract_vectors(payload: dict[str, Any]) -> list[list[Any]]:

--- a/scripts/router/modules/01-openai-responses.ps1
+++ b/scripts/router/modules/01-openai-responses.ps1
@@ -31,6 +31,15 @@ function Get-OpenAiV1BaseUrl {
     return ("{0}/v1" -f $trim)
 }
 
+function Get-AnthropicMessagesBaseUrl {
+    param(
+        [string]$Override,
+        [string[]]$EnvCandidates = @("VCO_INTENT_ADVICE_BASE_URL")
+    )
+
+    return (Get-OpenAiV1BaseUrl -Override $Override -EnvCandidates $EnvCandidates)
+}
+
 function Get-OpenAiApiKey {
     param([string]$EnvName = "VCO_INTENT_ADVICE_API_KEY")
     if ($EnvName) {
@@ -65,6 +74,16 @@ function Get-OpenAiEmbeddingsEndpoint {
     )
     $base = Get-OpenAiV1BaseUrl -Override $BaseUrl -EnvCandidates $BaseUrlEnvCandidates
     return ("{0}/embeddings" -f $base)
+}
+
+function Get-AnthropicMessagesEndpoint {
+    param(
+        [string]$BaseUrl,
+        [string[]]$BaseUrlEnvCandidates = @("VCO_INTENT_ADVICE_BASE_URL")
+    )
+
+    $base = Get-AnthropicMessagesBaseUrl -Override $BaseUrl -EnvCandidates $BaseUrlEnvCandidates
+    return ("{0}/messages" -f $base)
 }
 
 function Get-OpenAiResponseOutputText {
@@ -148,6 +167,29 @@ function Get-OpenAiChatCompletionOutputText {
     } catch { }
 
     return $null
+}
+
+function Get-AnthropicMessageOutputText {
+    param([object]$Response)
+
+    if (-not $Response) { return $null }
+
+    try {
+        $content = @($Response.content)
+        if ($content.Count -eq 0) { return $null }
+
+        $parts = @()
+        foreach ($block in $content) {
+            if (-not $block) { continue }
+            if ($block.type -ne "text") { continue }
+            if ($block.text) { $parts += [string]$block.text }
+        }
+
+        if ($parts.Count -eq 0) { return $null }
+        return ($parts -join "`n").Trim()
+    } catch {
+        return $null
+    }
 }
 
 function Get-OpenAiEmbeddingsOutputVectors {
@@ -463,6 +505,99 @@ function Invoke-OpenAiEmbeddingsCreate {
             status_code = $status
             latency_ms = [int]$sw.ElapsedMilliseconds
             vectors = @()
+            response = $null
+            error = $message
+        }
+    }
+}
+
+function Invoke-AnthropicMessagesCreate {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Model,
+        [Parameter(Mandatory = $true)]
+        [object[]]$Messages,
+        [string]$System = "",
+        [int]$MaxTokens = 800,
+        [double]$Temperature = 0.2,
+        [double]$TopP = 1.0,
+        [int]$TimeoutMs = 2500,
+        [string]$ApiKey,
+        [string]$ApiKeyEnv = "VCO_INTENT_ADVICE_API_KEY",
+        [string]$BaseUrl,
+        [string[]]$BaseUrlEnvCandidates = @("VCO_INTENT_ADVICE_BASE_URL"),
+        [string]$AnthropicVersion = "2023-06-01"
+    )
+
+    $resolvedApiKey = if ($ApiKey) { $ApiKey } else { Get-OpenAiApiKey -EnvName $ApiKeyEnv }
+    if (-not $resolvedApiKey) {
+        return [pscustomobject]@{
+            ok = $false
+            abstained = $true
+            reason = "missing_intent_advice_api_key"
+            status_code = $null
+            latency_ms = 0
+            output_text = $null
+            response = $null
+            error = $null
+        }
+    }
+
+    $endpoint = Get-AnthropicMessagesEndpoint -BaseUrl $BaseUrl -BaseUrlEnvCandidates $BaseUrlEnvCandidates
+    $timeoutSec = [Math]::Max(1, [int][Math]::Ceiling([double]$TimeoutMs / 1000.0))
+
+    $body = [ordered]@{
+        model = $Model
+        max_tokens = [int]$MaxTokens
+        temperature = [double]$Temperature
+        messages = @($Messages)
+    }
+    if ($TopP -gt 0.0) {
+        $body.top_p = [double]$TopP
+    }
+    if ($System) {
+        $body.system = [string]$System
+    }
+
+    $json = ($body | ConvertTo-Json -Depth 20 -Compress)
+    $headers = @{
+        "x-api-key" = [string]$resolvedApiKey
+        "anthropic-version" = if ($AnthropicVersion) { [string]$AnthropicVersion } else { "2023-06-01" }
+        "Content-Type" = "application/json"
+    }
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        $resp = Invoke-RestMethod -Uri $endpoint -Method Post -Headers $headers -Body $json -TimeoutSec $timeoutSec
+        $sw.Stop()
+        $outputText = Get-AnthropicMessageOutputText -Response $resp
+        return [pscustomobject]@{
+            ok = $true
+            abstained = $false
+            reason = "ok"
+            status_code = 200
+            latency_ms = [int]$sw.ElapsedMilliseconds
+            output_text = $outputText
+            response = $resp
+            error = $null
+        }
+    } catch {
+        $sw.Stop()
+        $message = $_.Exception.Message
+        $status = $null
+        try {
+            if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+                $status = [int]$_.Exception.Response.StatusCode
+            }
+        } catch { }
+
+        return [pscustomobject]@{
+            ok = $false
+            abstained = $true
+            reason = "anthropic_http_error"
+            status_code = $status
+            latency_ms = [int]$sw.ElapsedMilliseconds
+            output_text = $null
             response = $null
             error = $message
         }

--- a/scripts/router/modules/48-llm-acceleration-overlay.ps1
+++ b/scripts/router/modules/48-llm-acceleration-overlay.ps1
@@ -1,4 +1,4 @@
-# LLM Acceleration Overlay (GPT‑5.2 via OpenAI Responses API)
+# LLM Acceleration Overlay (structured advice via compatible provider APIs)
 #
 # Goals:
 # - Only runs when user explicitly invokes /vibe or $vibe (prefix_detected).
@@ -24,7 +24,7 @@ function Get-LlmAccelerationPolicyDefaults {
             max_confidence_for_llm = 0.55
         }
         provider = [pscustomobject]@{
-            type = "openai" # openai|mock
+            type = "openai" # openai|openai-compatible|anthropic|anthropic-compatible|mock
             model = ""
             model_env = "VCO_INTENT_ADVICE_MODEL"
             base_url = ""
@@ -1107,6 +1107,182 @@ function New-LlmDiffDigestInputText {
     return ($text -join "`n")
 }
 
+function Get-LlmAdviceProviderTypeNormalized {
+    param([object]$PolicyResolved)
+
+    $providerType = if ($PolicyResolved -and $PolicyResolved.provider -and $PolicyResolved.provider.type) { [string]$PolicyResolved.provider.type } else { "openai" }
+    return $providerType.Trim().ToLowerInvariant()
+}
+
+function Get-LlmAdviceProviderApiKeyEnvName {
+    param([object]$PolicyResolved)
+
+    if ($PolicyResolved -and $PolicyResolved.provider -and $PolicyResolved.provider.api_key_env) {
+        return [string]$PolicyResolved.provider.api_key_env
+    }
+    return "VCO_INTENT_ADVICE_API_KEY"
+}
+
+function Test-LlmAdviceProviderIsOpenAiFamily {
+    param([string]$ProviderType)
+    return @("openai", "openai-compatible") -contains ([string]$ProviderType).Trim().ToLowerInvariant()
+}
+
+function Test-LlmAdviceProviderIsAnthropicFamily {
+    param([string]$ProviderType)
+    return @("anthropic", "anthropic-compatible") -contains ([string]$ProviderType).Trim().ToLowerInvariant()
+}
+
+function Test-LlmAdviceProviderRequiresRemoteCredential {
+    param([string]$ProviderType)
+    $normalized = ([string]$ProviderType).Trim().ToLowerInvariant()
+    if ($normalized -eq "mock") { return $false }
+    return (Test-LlmAdviceProviderIsOpenAiFamily -ProviderType $normalized) -or (Test-LlmAdviceProviderIsAnthropicFamily -ProviderType $normalized)
+}
+
+function Test-LlmAdviceShouldTryAnthropicFallback {
+    param(
+        [string]$ProviderType,
+        [string]$BaseUrl
+    )
+
+    if (-not (Test-LlmAdviceProviderIsOpenAiFamily -ProviderType $ProviderType)) { return $false }
+    if (-not $BaseUrl) { return $false }
+
+    $normalizedBaseUrl = ([string]$BaseUrl).Trim().ToLowerInvariant()
+    if (-not $normalizedBaseUrl) { return $false }
+    if ($normalizedBaseUrl -eq "https://api.openai.com" -or $normalizedBaseUrl -eq "https://api.openai.com/v1") { return $false }
+    if ($normalizedBaseUrl -match "openai\.com") { return $false }
+    return $true
+}
+
+function Invoke-LlmStructuredJsonProvider {
+    param(
+        [object]$PolicyResolved,
+        [string]$Model,
+        [string]$BaseUrl,
+        [int]$TimeoutMs,
+        [int]$MaxOutputTokens,
+        [double]$Temperature,
+        [double]$TopP,
+        [bool]$Store,
+        [object]$ResponsesInputItems,
+        [object]$ResponsesTextFormat,
+        [object[]]$ChatMessages,
+        [object]$ChatResponseFormat,
+        [object[]]$AnthropicMessages,
+        [string]$SystemInstructions
+    )
+
+    $providerType = Get-LlmAdviceProviderTypeNormalized -PolicyResolved $PolicyResolved
+    $adviceApiKeyEnv = Get-LlmAdviceProviderApiKeyEnvName -PolicyResolved $PolicyResolved
+    $adviceBaseUrlEnvCandidates = if ($PolicyResolved.provider.base_url_env_candidates) { @($PolicyResolved.provider.base_url_env_candidates) } else { @("VCO_INTENT_ADVICE_BASE_URL") }
+    $timeoutMsSafe = [Math]::Max(500, [int]$TimeoutMs)
+    $anthropicVersion = if ($PolicyResolved.provider.anthropic_version) { [string]$PolicyResolved.provider.anthropic_version } else { "2023-06-01" }
+
+    $invokeAnthropic = {
+        $r = Invoke-AnthropicMessagesCreate `
+            -Model $Model `
+            -BaseUrl $BaseUrl `
+            -ApiKeyEnv $adviceApiKeyEnv `
+            -BaseUrlEnvCandidates $adviceBaseUrlEnvCandidates `
+            -Messages $AnthropicMessages `
+            -System $SystemInstructions `
+            -MaxTokens $MaxOutputTokens `
+            -Temperature $Temperature `
+            -TopP $TopP `
+            -TimeoutMs $timeoutMsSafe `
+            -AnthropicVersion $anthropicVersion
+        $r | Add-Member -NotePropertyName api -NotePropertyValue "anthropic_messages" -Force
+        return $r
+    }
+
+    if (Test-LlmAdviceProviderIsAnthropicFamily -ProviderType $providerType) {
+        return (& $invokeAnthropic)
+    }
+
+    if (-not (Test-LlmAdviceProviderIsOpenAiFamily -ProviderType $providerType)) {
+        return [pscustomobject]@{
+            ok = $false
+            abstained = $true
+            reason = "unsupported_provider"
+            api = "none"
+            latency_ms = 0
+            output_text = $null
+            error = $null
+        }
+    }
+
+    $preferChat = $false
+    if ($BaseUrl -and ($BaseUrl -notmatch "openai\.com")) {
+        $preferChat = $true
+    }
+
+    $invokeResponses = {
+        $r = Invoke-OpenAiResponsesCreate `
+            -Model $Model `
+            -BaseUrl $BaseUrl `
+            -ApiKeyEnv $adviceApiKeyEnv `
+            -BaseUrlEnvCandidates $adviceBaseUrlEnvCandidates `
+            -InputItems $ResponsesInputItems `
+            -TextFormat $ResponsesTextFormat `
+            -Instructions $SystemInstructions `
+            -MaxOutputTokens $MaxOutputTokens `
+            -Temperature $Temperature `
+            -TopP $TopP `
+            -TimeoutMs $timeoutMsSafe `
+            -Store:([bool]$Store)
+        $r | Add-Member -NotePropertyName api -NotePropertyValue "responses" -Force
+        return $r
+    }
+
+    $invokeChat = {
+        $r = Invoke-OpenAiChatCompletionsCreate `
+            -Model $Model `
+            -BaseUrl $BaseUrl `
+            -ApiKeyEnv $adviceApiKeyEnv `
+            -BaseUrlEnvCandidates $adviceBaseUrlEnvCandidates `
+            -Messages $ChatMessages `
+            -ResponseFormat $ChatResponseFormat `
+            -MaxTokens $MaxOutputTokens `
+            -Temperature $Temperature `
+            -TopP $TopP `
+            -TimeoutMs $timeoutMsSafe
+        $r | Add-Member -NotePropertyName api -NotePropertyValue "chat_completions" -Force
+        return $r
+    }
+
+    $primary = $null
+    $fallback = $null
+
+    if ($preferChat) {
+        $primary = & $invokeChat
+        if ([bool]$primary.ok -and (-not [bool]$primary.abstained) -and $primary.output_text) { return $primary }
+        if ([string]$primary.reason -eq "missing_intent_advice_api_key") { return $primary }
+
+        $fallback = & $invokeResponses
+        if ([bool]$fallback.ok -and (-not [bool]$fallback.abstained) -and $fallback.output_text) { return $fallback }
+        if ([string]$fallback.reason -eq "missing_intent_advice_api_key") { return $fallback }
+    } else {
+        $primary = & $invokeResponses
+        if ([bool]$primary.ok -and (-not [bool]$primary.abstained) -and $primary.output_text) { return $primary }
+        if ([string]$primary.reason -eq "missing_intent_advice_api_key") { return $primary }
+
+        $fallback = & $invokeChat
+        if ([bool]$fallback.ok -and (-not [bool]$fallback.abstained) -and $fallback.output_text) { return $fallback }
+        if ([string]$fallback.reason -eq "missing_intent_advice_api_key") { return $fallback }
+    }
+
+    if (Test-LlmAdviceShouldTryAnthropicFallback -ProviderType $providerType -BaseUrl $BaseUrl) {
+        $anthropic = & $invokeAnthropic
+        if ([bool]$anthropic.ok -and (-not [bool]$anthropic.abstained) -and $anthropic.output_text) { return $anthropic }
+        return $anthropic
+    }
+
+    if ($fallback) { return $fallback }
+    return $primary
+}
+
 function Invoke-LlmDiffDigestProvider {
     param(
         [object]$PolicyResolved,
@@ -1115,23 +1291,10 @@ function Invoke-LlmDiffDigestProvider {
         [int]$MaxDigestChars
     )
 
-    $providerType = if ($PolicyResolved -and $PolicyResolved.provider -and $PolicyResolved.provider.type) { [string]$PolicyResolved.provider.type } else { "openai" }
-    if ($providerType -ne "openai") {
-        return [pscustomobject]@{
-            ok = $false
-            abstained = $true
-            reason = "unsupported_provider"
-            api = "none"
-            latency_ms = 0
-            digest = $null
-            error = $null
-        }
-    }
+    $providerType = Get-LlmAdviceProviderTypeNormalized -PolicyResolved $PolicyResolved
+    $adviceApiKeyEnv = Get-LlmAdviceProviderApiKeyEnvName -PolicyResolved $PolicyResolved
 
-    $adviceApiKeyEnv = if ($PolicyResolved.provider.api_key_env) { [string]$PolicyResolved.provider.api_key_env } else { "VCO_INTENT_ADVICE_API_KEY" }
-    $adviceBaseUrlEnvCandidates = if ($PolicyResolved.provider.base_url_env_candidates) { @($PolicyResolved.provider.base_url_env_candidates) } else { @("VCO_INTENT_ADVICE_BASE_URL") }
-
-    if (-not (Get-OpenAiApiKey -EnvName $adviceApiKeyEnv)) {
+    if ((Test-LlmAdviceProviderRequiresRemoteCredential -ProviderType $providerType) -and (-not (Get-OpenAiApiKey -EnvName $adviceApiKeyEnv))) {
         return [pscustomobject]@{
             ok = $false
             abstained = $true
@@ -1188,11 +1351,6 @@ function Invoke-LlmDiffDigestProvider {
 
     $instructions = "Return ONLY JSON that matches the JSON Schema. No markdown. No extra keys."
 
-    $baseUrl = if ($PolicyResolved.provider.base_url) { [string]$PolicyResolved.provider.base_url } else { "" }
-    $adviceApiKeyEnv = if ($PolicyResolved.provider.api_key_env) { [string]$PolicyResolved.provider.api_key_env } else { "VCO_INTENT_ADVICE_API_KEY" }
-    $adviceBaseUrlEnvCandidates = if ($PolicyResolved.provider.base_url_env_candidates) { @($PolicyResolved.provider.base_url_env_candidates) } else { @("VCO_INTENT_ADVICE_BASE_URL") }
-    $timeoutMsSafe = [Math]::Max(500, [int]$timeoutMs)
-
     $chatResponseFormat = [ordered]@{
         type = "json_schema"
         json_schema = [ordered]@{
@@ -1206,58 +1364,34 @@ function Invoke-LlmDiffDigestProvider {
         [ordered]@{ role = "system"; content = $instructions },
         [ordered]@{ role = "user"; content = $InputText }
     )
-
-    $preferChat = $false
-    if ($baseUrl -and ($baseUrl -notmatch "openai\.com")) { $preferChat = $true }
-
-    $invokeResponses = {
-        $r = Invoke-OpenAiResponsesCreate `
-            -Model $model `
-            -BaseUrl $baseUrl `
-            -ApiKeyEnv $adviceApiKeyEnv `
-            -BaseUrlEnvCandidates $adviceBaseUrlEnvCandidates `
-            -InputItems $input `
-            -TextFormat $textFormat `
-            -Instructions $instructions `
-            -MaxOutputTokens $maxTokens `
-            -Temperature $temperature `
-            -TopP ([double]$PolicyResolved.provider.top_p) `
-            -TimeoutMs $timeoutMsSafe `
-            -Store:([bool]$PolicyResolved.provider.store)
-        $r | Add-Member -NotePropertyName api -NotePropertyValue "responses" -Force
-        return $r
-    }
-
-    $invokeChat = {
-        $r = Invoke-OpenAiChatCompletionsCreate `
-            -Model $model `
-            -BaseUrl $baseUrl `
-            -ApiKeyEnv $adviceApiKeyEnv `
-            -BaseUrlEnvCandidates $adviceBaseUrlEnvCandidates `
-            -Messages $chatMessages `
-            -ResponseFormat $chatResponseFormat `
-            -MaxTokens $maxTokens `
-            -Temperature $temperature `
-            -TopP ([double]$PolicyResolved.provider.top_p) `
-            -TimeoutMs $timeoutMsSafe
-        $r | Add-Member -NotePropertyName api -NotePropertyValue "chat_completions" -Force
-        return $r
-    }
-
-    $providerResult = $null
-    if ($preferChat) {
-        $providerResult = & $invokeChat
-        if (-not ([bool]$providerResult.ok -and (-not [bool]$providerResult.abstained) -and $providerResult.output_text)) {
-            $providerResult = & $invokeResponses
+    $baseUrl = if ($PolicyResolved.provider.base_url) { [string]$PolicyResolved.provider.base_url } else { "" }
+    $anthropicMessages = @(
+        [ordered]@{
+            role = "user"
+            content = @(
+                [ordered]@{
+                    type = "text"
+                    text = $InputText
+                }
+            )
         }
-    } else {
-        $providerResult = & $invokeResponses
-        if (-not ([bool]$providerResult.ok -and (-not [bool]$providerResult.abstained) -and $providerResult.output_text)) {
-            if ([string]$providerResult.reason -ne "missing_intent_advice_api_key") {
-                $providerResult = & $invokeChat
-            }
-        }
-    }
+    )
+
+    $providerResult = Invoke-LlmStructuredJsonProvider `
+        -PolicyResolved $PolicyResolved `
+        -Model $model `
+        -BaseUrl $baseUrl `
+        -TimeoutMs $timeoutMs `
+        -MaxOutputTokens $maxTokens `
+        -Temperature $temperature `
+        -TopP ([double]$PolicyResolved.provider.top_p) `
+        -Store ([bool]$PolicyResolved.provider.store) `
+        -ResponsesInputItems $input `
+        -ResponsesTextFormat $textFormat `
+        -ChatMessages $chatMessages `
+        -ChatResponseFormat $chatResponseFormat `
+        -AnthropicMessages $anthropicMessages `
+        -SystemInstructions $instructions
 
     if (-not $providerResult -or -not [bool]$providerResult.ok -or [bool]$providerResult.abstained -or (-not $providerResult.output_text)) {
         $reason = if ($providerResult -and $providerResult.reason) { [string]$providerResult.reason } else { "provider_abstained" }
@@ -1372,18 +1506,7 @@ function Invoke-LlmConfirmQuestionBoosterProvider {
         [int]$MaxQuestions
     )
 
-    $providerType = if ($PolicyResolved -and $PolicyResolved.provider -and $PolicyResolved.provider.type) { [string]$PolicyResolved.provider.type } else { "openai" }
-    if ($providerType -ne "openai") {
-        return [pscustomobject]@{
-            ok = $false
-            abstained = $true
-            reason = "provider_not_openai"
-            api = "none"
-            latency_ms = 0
-            confirm_questions = @()
-            error = $null
-        }
-    }
+    $providerType = Get-LlmAdviceProviderTypeNormalized -PolicyResolved $PolicyResolved
 
     $cfg = $null
     try { $cfg = $PolicyResolved.enhancements.confirm_question_booster } catch { }
@@ -1420,11 +1543,6 @@ function Invoke-LlmConfirmQuestionBoosterProvider {
 
     $instructions = "Return ONLY JSON that matches the JSON Schema. No markdown. No extra keys."
 
-    $model = [string]$PolicyResolved.provider.model
-    $baseUrl = if ($PolicyResolved.provider.base_url) { [string]$PolicyResolved.provider.base_url } else { "" }
-    $adviceApiKeyEnv = if ($PolicyResolved.provider.api_key_env) { [string]$PolicyResolved.provider.api_key_env } else { "VCO_INTENT_ADVICE_API_KEY" }
-    $adviceBaseUrlEnvCandidates = if ($PolicyResolved.provider.base_url_env_candidates) { @($PolicyResolved.provider.base_url_env_candidates) } else { @("VCO_INTENT_ADVICE_BASE_URL") }
-
     $chatResponseFormat = [ordered]@{
         type = "json_schema"
         json_schema = [ordered]@{
@@ -1438,60 +1556,34 @@ function Invoke-LlmConfirmQuestionBoosterProvider {
         [ordered]@{ role = "system"; content = $instructions },
         [ordered]@{ role = "user"; content = $InputText }
     )
-
-    $preferChat = $false
-    if ($baseUrl -and ($baseUrl -notmatch "openai\\.com")) {
-        $preferChat = $true
-    }
-
-    $invokeResponses = {
-        $r = Invoke-OpenAiResponsesCreate `
-            -Model $model `
-            -BaseUrl $baseUrl `
-            -ApiKeyEnv $adviceApiKeyEnv `
-            -BaseUrlEnvCandidates $adviceBaseUrlEnvCandidates `
-            -InputItems $input `
-            -TextFormat $textFormat `
-            -Instructions $instructions `
-            -MaxOutputTokens $maxTokens `
-            -Temperature $temperature `
-            -TopP ([double]$PolicyResolved.provider.top_p) `
-            -TimeoutMs $timeoutMsSafe `
-            -Store:([bool]$PolicyResolved.provider.store)
-        $r | Add-Member -NotePropertyName api -NotePropertyValue "responses" -Force
-        return $r
-    }
-
-    $invokeChat = {
-        $r = Invoke-OpenAiChatCompletionsCreate `
-            -Model $model `
-            -BaseUrl $baseUrl `
-            -ApiKeyEnv $adviceApiKeyEnv `
-            -BaseUrlEnvCandidates $adviceBaseUrlEnvCandidates `
-            -Messages $chatMessages `
-            -ResponseFormat $chatResponseFormat `
-            -MaxTokens $maxTokens `
-            -Temperature $temperature `
-            -TopP ([double]$PolicyResolved.provider.top_p) `
-            -TimeoutMs $timeoutMsSafe
-        $r | Add-Member -NotePropertyName api -NotePropertyValue "chat_completions" -Force
-        return $r
-    }
-
-    $providerResult = $null
-    if ($preferChat) {
-        $providerResult = & $invokeChat
-        if (-not ([bool]$providerResult.ok -and (-not [bool]$providerResult.abstained) -and $providerResult.output_text)) {
-            $providerResult = & $invokeResponses
+    $baseUrl = if ($PolicyResolved.provider.base_url) { [string]$PolicyResolved.provider.base_url } else { "" }
+    $anthropicMessages = @(
+        [ordered]@{
+            role = "user"
+            content = @(
+                [ordered]@{
+                    type = "text"
+                    text = $InputText
+                }
+            )
         }
-    } else {
-        $providerResult = & $invokeResponses
-        if (-not ([bool]$providerResult.ok -and (-not [bool]$providerResult.abstained) -and $providerResult.output_text)) {
-            if ([string]$providerResult.reason -ne "missing_intent_advice_api_key") {
-                $providerResult = & $invokeChat
-            }
-        }
-    }
+    )
+
+    $providerResult = Invoke-LlmStructuredJsonProvider `
+        -PolicyResolved $PolicyResolved `
+        -Model ([string]$PolicyResolved.provider.model) `
+        -BaseUrl $baseUrl `
+        -TimeoutMs $timeoutMsSafe `
+        -MaxOutputTokens $maxTokens `
+        -Temperature $temperature `
+        -TopP ([double]$PolicyResolved.provider.top_p) `
+        -Store ([bool]$PolicyResolved.provider.store) `
+        -ResponsesInputItems $input `
+        -ResponsesTextFormat $textFormat `
+        -ChatMessages $chatMessages `
+        -ChatResponseFormat $chatResponseFormat `
+        -AnthropicMessages $anthropicMessages `
+        -SystemInstructions $instructions
 
     if (-not $providerResult -or -not [bool]$providerResult.ok -or [bool]$providerResult.abstained -or (-not $providerResult.output_text)) {
         $reason = if ($providerResult -and $providerResult.reason) { [string]$providerResult.reason } else { "provider_abstained" }
@@ -1551,12 +1643,15 @@ function New-LlmAccelerationProviderPolicyOverride {
             type = if ($prov.type) { [string]$prov.type } else { "openai" }
             model = if ($prov.model) { [string]$prov.model } else { "" }
             base_url = if ($prov.base_url) { [string]$prov.base_url } else { "" }
+            anthropic_version = if ($prov.anthropic_version) { [string]$prov.anthropic_version } else { "" }
             timeout_ms = [Math]::Max(500, [int]$TimeoutMs)
             max_output_tokens = [Math]::Max(200, [int]$MaxOutputTokens)
             temperature = [Math]::Max(0.0, [Math]::Min(1.0, [double]$Temperature))
             top_p = if ($prov.top_p -ne $null) { [double]$prov.top_p } else { 1.0 }
             store = if ($prov.store -ne $null) { [bool]$prov.store } else { $false }
             mock_response_path = if ($prov.mock_response_path) { [string]$prov.mock_response_path } else { "" }
+            api_key_env = if ($prov.api_key_env) { [string]$prov.api_key_env } else { "VCO_INTENT_ADVICE_API_KEY" }
+            base_url_env_candidates = if ($prov.base_url_env_candidates) { @($prov.base_url_env_candidates) } else { @("VCO_INTENT_ADVICE_BASE_URL") }
         }
     }
 }
@@ -1619,8 +1714,8 @@ function Invoke-LlmAccelerationProviderCommittee {
         [string]$InputText
     )
 
-    $providerType = if ($PolicyResolved -and $PolicyResolved.provider -and $PolicyResolved.provider.type) { [string]$PolicyResolved.provider.type } else { "openai" }
-    if ($providerType -ne "openai") {
+    $providerType = Get-LlmAdviceProviderTypeNormalized -PolicyResolved $PolicyResolved
+    if (-not ((Test-LlmAdviceProviderIsOpenAiFamily -ProviderType $providerType) -or (Test-LlmAdviceProviderIsAnthropicFamily -ProviderType $providerType))) {
         return (Invoke-LlmAccelerationProvider -PolicyResolved $PolicyResolved -RepoRoot $RepoRoot -InputText $InputText)
     }
 
@@ -1737,7 +1832,7 @@ function Invoke-LlmAccelerationProviderCommittee {
 	        [string]$InputText
 	    )
 
-	    $providerType = if ($PolicyResolved -and $PolicyResolved.provider -and $PolicyResolved.provider.type) { [string]$PolicyResolved.provider.type } else { "openai" }
+	    $providerType = Get-LlmAdviceProviderTypeNormalized -PolicyResolved $PolicyResolved
 
 	    if ($providerType -eq "mock") {
         $mockRel = if ($PolicyResolved.provider.mock_response_path) { [string]$PolicyResolved.provider.mock_response_path } else { "" }
@@ -1798,7 +1893,6 @@ function Invoke-LlmAccelerationProviderCommittee {
 	    $instructions = "Return ONLY JSON that matches the JSON Schema. No markdown. No extra keys."
 
 	    $model = [string]$PolicyResolved.provider.model
-	    $baseUrl = if ($PolicyResolved.provider.base_url) { [string]$PolicyResolved.provider.base_url } else { "" }
 	    $timeoutMs = [int]$PolicyResolved.provider.timeout_ms
 
 	    $chatResponseFormat = [ordered]@{
@@ -1814,66 +1908,34 @@ function Invoke-LlmAccelerationProviderCommittee {
 	        [ordered]@{ role = "system"; content = $instructions },
 	        [ordered]@{ role = "user"; content = $InputText }
 	    )
+        $baseUrl = if ($PolicyResolved.provider.base_url) { [string]$PolicyResolved.provider.base_url } else { "" }
+        $anthropicMessages = @(
+            [ordered]@{
+                role = "user"
+                content = @(
+                    [ordered]@{
+                        type = "text"
+                        text = $InputText
+                    }
+                )
+            }
+        )
 
-	    $adviceApiKeyEnv = if ($PolicyResolved.provider.api_key_env) { [string]$PolicyResolved.provider.api_key_env } else { "VCO_INTENT_ADVICE_API_KEY" }
-	    $adviceBaseUrlEnvCandidates = if ($PolicyResolved.provider.base_url_env_candidates) { @($PolicyResolved.provider.base_url_env_candidates) } else { @("VCO_INTENT_ADVICE_BASE_URL") }
-	    $preferChat = $false
-	    if ($baseUrl -and ($baseUrl -notmatch "openai\.com")) {
-	        # For most OpenAI-compatible gateways, /chat/completions is the safest baseline.
-	        $preferChat = $true
-	    }
-
-	    $invokeResponses = {
-	        $r = Invoke-OpenAiResponsesCreate `
-	            -Model $model `
-	            -BaseUrl $baseUrl `
-	            -ApiKeyEnv $adviceApiKeyEnv `
-	            -BaseUrlEnvCandidates $adviceBaseUrlEnvCandidates `
-	            -InputItems $input `
-	            -TextFormat $textFormat `
-	            -Instructions $instructions `
-	            -MaxOutputTokens ([int]$PolicyResolved.provider.max_output_tokens) `
-	            -Temperature ([double]$PolicyResolved.provider.temperature) `
-	            -TopP ([double]$PolicyResolved.provider.top_p) `
-	            -TimeoutMs $timeoutMs `
-	            -Store:([bool]$PolicyResolved.provider.store)
-	        $r | Add-Member -NotePropertyName api -NotePropertyValue "responses" -Force
-	        return $r
-	    }
-
-	    $invokeChat = {
-	        $r = Invoke-OpenAiChatCompletionsCreate `
-	            -Model $model `
-	            -BaseUrl $baseUrl `
-	            -ApiKeyEnv $adviceApiKeyEnv `
-	            -BaseUrlEnvCandidates $adviceBaseUrlEnvCandidates `
-	            -Messages $chatMessages `
-	            -ResponseFormat $chatResponseFormat `
-	            -MaxTokens ([int]$PolicyResolved.provider.max_output_tokens) `
-	            -Temperature ([double]$PolicyResolved.provider.temperature) `
-	            -TopP ([double]$PolicyResolved.provider.top_p) `
-	            -TimeoutMs $timeoutMs
-	        $r | Add-Member -NotePropertyName api -NotePropertyValue "chat_completions" -Force
-	        return $r
-	    }
-
-	    $primary = $null
-	    $fallback = $null
-
-	    if ($preferChat) {
-	        $primary = & $invokeChat
-	        if ([bool]$primary.ok -and (-not [bool]$primary.abstained) -and $primary.output_text) { return $primary }
-	        $fallback = & $invokeResponses
-	        if ([bool]$fallback.ok -and (-not [bool]$fallback.abstained) -and $fallback.output_text) { return $fallback }
-	        return $primary
-	    }
-
-	    $primary = & $invokeResponses
-	    if ([bool]$primary.ok -and (-not [bool]$primary.abstained) -and $primary.output_text) { return $primary }
-	    if ([string]$primary.reason -eq "missing_intent_advice_api_key") { return $primary }
-	    $fallback = & $invokeChat
-	    if ([bool]$fallback.ok -and (-not [bool]$fallback.abstained) -and $fallback.output_text) { return $fallback }
-	    return $primary
+        return (Invoke-LlmStructuredJsonProvider `
+            -PolicyResolved $PolicyResolved `
+            -Model $model `
+            -BaseUrl $baseUrl `
+            -TimeoutMs $timeoutMs `
+            -MaxOutputTokens ([int]$PolicyResolved.provider.max_output_tokens) `
+            -Temperature ([double]$PolicyResolved.provider.temperature) `
+            -TopP ([double]$PolicyResolved.provider.top_p) `
+            -Store ([bool]$PolicyResolved.provider.store) `
+            -ResponsesInputItems $input `
+            -ResponsesTextFormat $textFormat `
+            -ChatMessages $chatMessages `
+            -ChatResponseFormat $chatResponseFormat `
+            -AnthropicMessages $anthropicMessages `
+            -SystemInstructions $instructions)
 	}
 
 function Get-DeterministicSampleValueForLlm {
@@ -1939,11 +2001,11 @@ function Get-LlmAccelerationAdvice {
     $topK = [Math]::Max(1, [int]$trigger.top_k)
 
     if ([bool]$trigger.active) {
-        $providerType = [string]$policyResolved.provider.type
+        $providerType = Get-LlmAdviceProviderTypeNormalized -PolicyResolved $policyResolved
         $providerInvokable = $true
 
-        $adviceApiKeyEnv = if ($policyResolved.provider.api_key_env) { [string]$policyResolved.provider.api_key_env } else { "VCO_INTENT_ADVICE_API_KEY" }
-        if ($providerType -eq "openai" -and (-not (Get-OpenAiApiKey -EnvName $adviceApiKeyEnv))) {
+        $adviceApiKeyEnv = Get-LlmAdviceProviderApiKeyEnvName -PolicyResolved $policyResolved
+        if ((Test-LlmAdviceProviderRequiresRemoteCredential -ProviderType $providerType) -and (-not (Get-OpenAiApiKey -EnvName $adviceApiKeyEnv))) {
             $providerInvokable = $false
             $providerSummary = [pscustomobject]@{
                 type = [string]$policyResolved.provider.type

--- a/tests/integration/test_check_shell_bootstrap_doctor_counting.py
+++ b/tests/integration/test_check_shell_bootstrap_doctor_counting.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class CheckShellBootstrapDoctorCountingTests(unittest.TestCase):
+    def test_bootstrap_doctor_plain_fail_branch_only_increments_fail(self) -> None:
+        content = (REPO_ROOT / "check.sh").read_text(encoding="utf-8")
+        self.assertIn(
+            '    else\n'
+            '      echo "[FAIL] vibe bootstrap doctor gate"\n'
+            '      FAIL=$((FAIL+1))\n'
+            '    fi',
+            content,
+        )
+        self.assertNotIn(
+            '    else\n'
+            '      echo "[FAIL] vibe bootstrap doctor gate"\n'
+            '      WARN=$((WARN+1))\n'
+            '      FAIL=$((FAIL+1))\n'
+            '    fi',
+            content,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime_neutral/test_check_installed_runtime_root.py
+++ b/tests/runtime_neutral/test_check_installed_runtime_root.py
@@ -106,7 +106,8 @@ class CheckInstalledRuntimeRootTests(unittest.TestCase):
             )
 
         self.assertEqual(0, result.returncode, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
-        self.assertNotIn("skills\\vibe\\skills\\vibe", result.stdout)
+        normalized_stdout = result.stdout.replace("\\", "/")
+        self.assertNotIn("skills/vibe/skills/vibe", normalized_stdout)
 
     def test_check_ps1_reports_invalid_receipt_version_without_crashing(self) -> None:
         powershell = resolve_powershell()

--- a/tests/runtime_neutral/test_check_installed_runtime_root.py
+++ b/tests/runtime_neutral/test_check_installed_runtime_root.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 import tempfile
@@ -106,6 +107,62 @@ class CheckInstalledRuntimeRootTests(unittest.TestCase):
 
         self.assertEqual(0, result.returncode, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
         self.assertNotIn("skills\\vibe\\skills\\vibe", result.stdout)
+
+    def test_check_ps1_reports_invalid_receipt_version_without_crashing(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir) / ".codex"
+            install_minimal_codex_runtime(target_root)
+            installed_root = target_root / "skills" / "vibe"
+            installed_governance = json.loads(
+                (installed_root / "config" / "version-governance.json").read_text(encoding="utf-8-sig")
+            )
+            release = installed_governance.get("release") or {}
+            receipt_path = installed_root / "outputs" / "runtime-freshness-receipt.json"
+            receipt_path.parent.mkdir(parents=True, exist_ok=True)
+            receipt_path.write_text(
+                json.dumps(
+                    {
+                        "gate_result": "PASS",
+                        "receipt_version": "abc",
+                        "target_root": str(target_root),
+                        "installed_root": str(installed_root),
+                        "release": {
+                            "version": str(release.get("version") or ""),
+                            "updated": str(release.get("updated") or ""),
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    powershell,
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(REPO_ROOT / "check.ps1"),
+                    "-HostId",
+                    "codex",
+                    "-Profile",
+                    "minimal",
+                    "-TargetRoot",
+                    str(target_root),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("[FAIL] vibe runtime freshness receipt version", result.stdout)
+        self.assertNotIn("Cannot convert value", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/runtime_neutral/test_check_installed_runtime_root.py
+++ b/tests/runtime_neutral/test_check_installed_runtime_root.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def resolve_powershell() -> str | None:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("pwsh.exe"),
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files\PowerShell\7-preview\pwsh.exe",
+        shutil.which("powershell"),
+        shutil.which("powershell.exe"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
+def install_minimal_codex_runtime(target_root: Path) -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            str(REPO_ROOT / "install.sh"),
+            "--host",
+            "codex",
+            "--profile",
+            "minimal",
+            "--skip-runtime-freshness-gate",
+            "--target-root",
+            str(target_root),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"install failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+
+
+class CheckInstalledRuntimeRootTests(unittest.TestCase):
+    def test_check_sh_accepts_installed_runtime_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir) / ".codex"
+            install_minimal_codex_runtime(target_root)
+            installed_root = target_root / "skills" / "vibe"
+
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(REPO_ROOT / "check.sh"),
+                    "--host",
+                    "codex",
+                    "--profile",
+                    "minimal",
+                    "--skip-runtime-freshness-gate",
+                    "--target-root",
+                    str(installed_root),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(0, result.returncode, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        self.assertNotIn("skills/vibe/skills/vibe", result.stdout)
+
+    def test_check_ps1_accepts_installed_runtime_root(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir) / ".codex"
+            install_minimal_codex_runtime(target_root)
+            installed_root = target_root / "skills" / "vibe"
+
+            result = subprocess.run(
+                [
+                    powershell,
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(REPO_ROOT / "check.ps1"),
+                    "-HostId",
+                    "codex",
+                    "-Profile",
+                    "minimal",
+                    "-SkipRuntimeFreshnessGate",
+                    "-TargetRoot",
+                    str(installed_root),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(0, result.returncode, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        self.assertNotIn("skills\\vibe\\skills\\vibe", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime_neutral/test_check_installed_runtime_root.py
+++ b/tests/runtime_neutral/test_check_installed_runtime_root.py
@@ -91,7 +91,7 @@ class CheckInstalledRuntimeRootTests(unittest.TestCase):
                     "-ExecutionPolicy",
                     "Bypass",
                     "-File",
-                    str(REPO_ROOT / "check.ps1"),
+                    str(installed_root / "check.ps1"),
                     "-HostId",
                     "codex",
                     "-Profile",
@@ -147,7 +147,7 @@ class CheckInstalledRuntimeRootTests(unittest.TestCase):
                     "-ExecutionPolicy",
                     "Bypass",
                     "-File",
-                    str(REPO_ROOT / "check.ps1"),
+                    str(installed_root / "check.ps1"),
                     "-HostId",
                     "codex",
                     "-Profile",
@@ -163,6 +163,64 @@ class CheckInstalledRuntimeRootTests(unittest.TestCase):
         self.assertNotEqual(0, result.returncode)
         self.assertIn("[FAIL] vibe runtime freshness receipt version", result.stdout)
         self.assertNotIn("Cannot convert value", result.stderr)
+
+    def test_check_ps1_fails_closed_when_expected_receipt_contract_version_is_invalid(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir) / ".codex"
+            install_minimal_codex_runtime(target_root)
+            installed_root = target_root / "skills" / "vibe"
+            governance_path = installed_root / "config" / "version-governance.json"
+            installed_governance = json.loads(governance_path.read_text(encoding="utf-8-sig"))
+            installed_governance["runtime"]["installed_runtime"]["receipt_contract_version"] = "abc"
+            governance_path.write_text(json.dumps(installed_governance) + "\n", encoding="utf-8")
+
+            release = installed_governance.get("release") or {}
+            receipt_path = installed_root / "outputs" / "runtime-freshness-receipt.json"
+            receipt_path.parent.mkdir(parents=True, exist_ok=True)
+            receipt_path.write_text(
+                json.dumps(
+                    {
+                        "gate_result": "PASS",
+                        "receipt_version": 2,
+                        "target_root": str(target_root),
+                        "installed_root": str(installed_root),
+                        "release": {
+                            "version": str(release.get("version") or ""),
+                            "updated": str(release.get("updated") or ""),
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    powershell,
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(installed_root / "check.ps1"),
+                    "-HostId",
+                    "codex",
+                    "-Profile",
+                    "minimal",
+                    "-TargetRoot",
+                    str(target_root),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("[FAIL] vibe runtime freshness receipt version", result.stdout)
+        self.assertIn("expected=", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/runtime_neutral/test_llm_acceleration_overlay_provider_paths.py
+++ b/tests/runtime_neutral/test_llm_acceleration_overlay_provider_paths.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CORE_UTILS = REPO_ROOT / "scripts" / "router" / "modules" / "00-core-utils.ps1"
+OPENAI_RESPONSES = REPO_ROOT / "scripts" / "router" / "modules" / "01-openai-responses.ps1"
+OVERLAY_MODULE = REPO_ROOT / "scripts" / "router" / "modules" / "48-llm-acceleration-overlay.ps1"
+MAIN_FIXTURE_PATH = REPO_ROOT / "scripts" / "verify" / "fixtures" / "llm-acceleration.mock.json"
+MAIN_FIXTURE_TEXT = MAIN_FIXTURE_PATH.read_text(encoding="utf-8")
+
+
+def resolve_powershell() -> str | None:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("pwsh.exe"),
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files\PowerShell\7-preview\pwsh.exe",
+        shutil.which("powershell"),
+        shutil.which("powershell.exe"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
+class LlmAccelerationOverlayProviderPathTests(unittest.TestCase):
+    maxDiff = None
+
+    def run_powershell_json(self, lines: list[str]) -> dict[str, object]:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            script_path = Path(tempdir) / "probe-provider-paths.ps1"
+            script_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            result = subprocess.run(
+                [
+                    powershell,
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(script_path),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(0, result.returncode, msg=result.stdout + result.stderr)
+        stdout = result.stdout.strip()
+        self.assertTrue(stdout, msg=result.stderr)
+        return json.loads(stdout.splitlines()[-1])
+
+    def base_script(self) -> list[str]:
+        return [
+            "$ErrorActionPreference = 'Stop'",
+            f"$repoRoot = '{REPO_ROOT.as_posix()}'",
+            f". '{CORE_UTILS.as_posix()}'",
+            f". '{OPENAI_RESPONSES.as_posix()}'",
+            f". '{OVERLAY_MODULE.as_posix()}'",
+            "[Environment]::SetEnvironmentVariable('TEST_ADVICE_KEY', 'sk-test-provider-paths')",
+            "$policy = Get-LlmAccelerationPolicyDefaults",
+            "$policy.provider.model = 'claude-test'",
+            "$policy.provider.api_key_env = 'TEST_ADVICE_KEY'",
+            "$policy.provider.timeout_ms = 1200",
+            "$policy.provider.max_output_tokens = 600",
+            "$policy.provider.temperature = 0.0",
+            "$policy.provider.store = $false",
+        ]
+
+    def test_anthropic_compatible_main_provider_uses_messages_api(self) -> None:
+        payload = self.run_powershell_json(
+            self.base_script()
+            + [
+                "$policy.provider.type = 'anthropic-compatible'",
+                "$policy.provider.base_url = 'https://anthropic-gateway.example'",
+                "function Invoke-OpenAiResponsesCreate { throw 'responses should not be called for anthropic-compatible provider' }",
+                "function Invoke-OpenAiChatCompletionsCreate { throw 'chat_completions should not be called for anthropic-compatible provider' }",
+                "function Invoke-AnthropicMessagesCreate {",
+                "    param(",
+                "        [string]$Model,",
+                "        [object[]]$Messages,",
+                "        [string]$System,",
+                "        [int]$MaxTokens,",
+                "        [double]$Temperature,",
+                "        [double]$TopP,",
+                "        [int]$TimeoutMs,",
+                "        [string]$ApiKey,",
+                "        [string]$ApiKeyEnv,",
+                "        [string]$BaseUrl,",
+                "        [string[]]$BaseUrlEnvCandidates,",
+                "        [string]$AnthropicVersion",
+                "    )",
+                "    return [pscustomobject]@{",
+                "        ok = $true",
+                "        abstained = $false",
+                "        reason = 'ok'",
+                "        status_code = 200",
+                "        latency_ms = 17",
+                "        output_text = @'",
+                MAIN_FIXTURE_TEXT,
+                "'@",
+                "        response = $null",
+                "        error = $null",
+                "    }",
+                "}",
+                "$result = Invoke-LlmAccelerationProvider -PolicyResolved (Get-LlmAccelerationPolicy -Policy $policy) -RepoRoot $repoRoot -InputText 'route this request'",
+                "[pscustomobject]@{",
+                "    ok = [bool]$result.ok",
+                "    abstained = [bool]$result.abstained",
+                "    reason = [string]$result.reason",
+                "    api = [string]$result.api",
+                "} | ConvertTo-Json -Compress",
+            ]
+        )
+
+        self.assertTrue(payload["ok"])
+        self.assertFalse(payload["abstained"])
+        self.assertEqual("ok", payload["reason"])
+        self.assertEqual("anthropic_messages", payload["api"])
+
+    def test_custom_gateway_openai_provider_can_fallback_to_anthropic_messages(self) -> None:
+        payload = self.run_powershell_json(
+            self.base_script()
+            + [
+                "$policy.provider.type = 'openai'",
+                "$policy.provider.base_url = 'https://anthropic-gateway.example'",
+                "$script:attempts = @()",
+                "function Invoke-OpenAiResponsesCreate {",
+                "    $script:attempts += 'responses'",
+                "    return [pscustomobject]@{ ok = $false; abstained = $true; reason = 'openai_http_error'; status_code = 503; latency_ms = 9; output_text = $null; response = $null; error = '503' }",
+                "}",
+                "function Invoke-OpenAiChatCompletionsCreate {",
+                "    $script:attempts += 'chat_completions'",
+                "    return [pscustomobject]@{ ok = $false; abstained = $true; reason = 'openai_http_error'; status_code = 503; latency_ms = 11; output_text = $null; response = $null; error = '503' }",
+                "}",
+                "function Invoke-AnthropicMessagesCreate {",
+                "    $script:attempts += 'anthropic_messages'",
+                "    return [pscustomobject]@{",
+                "        ok = $true",
+                "        abstained = $false",
+                "        reason = 'ok'",
+                "        status_code = 200",
+                "        latency_ms = 23",
+                "        output_text = @'",
+                MAIN_FIXTURE_TEXT,
+                "'@",
+                "        response = $null",
+                "        error = $null",
+                "    }",
+                "}",
+                "$result = Invoke-LlmAccelerationProvider -PolicyResolved (Get-LlmAccelerationPolicy -Policy $policy) -RepoRoot $repoRoot -InputText 'route this request'",
+                "[pscustomobject]@{",
+                "    ok = [bool]$result.ok",
+                "    abstained = [bool]$result.abstained",
+                "    api = [string]$result.api",
+                "    attempts = @($script:attempts)",
+                "} | ConvertTo-Json -Depth 8 -Compress",
+            ]
+        )
+
+        self.assertTrue(payload["ok"])
+        self.assertFalse(payload["abstained"])
+        self.assertEqual("anthropic_messages", payload["api"])
+        self.assertEqual(["chat_completions", "responses", "anthropic_messages"], payload["attempts"])
+
+    def test_anthropic_compatible_diff_digest_provider_uses_messages_api(self) -> None:
+        payload = self.run_powershell_json(
+            self.base_script()
+            + [
+                "$policy.provider.type = 'anthropic-compatible'",
+                "$policy.provider.base_url = 'https://anthropic-gateway.example'",
+                "function Invoke-OpenAiResponsesCreate { throw 'responses should not be called for anthropic-compatible digest provider' }",
+                "function Invoke-OpenAiChatCompletionsCreate { throw 'chat_completions should not be called for anthropic-compatible digest provider' }",
+                "function Invoke-AnthropicMessagesCreate {",
+                "    return [pscustomobject]@{",
+                "        ok = $true",
+                "        abstained = $false",
+                "        reason = 'ok'",
+                "        status_code = 200",
+                "        latency_ms = 19",
+                "        output_text = '{\"digest\":\"tight summary\"}'",
+                "        response = $null",
+                "        error = $null",
+                "    }",
+                "}",
+                "$result = Invoke-LlmDiffDigestProvider -PolicyResolved (Get-LlmAccelerationPolicy -Policy $policy) -RepoRoot $repoRoot -InputText 'summarize the diff' -MaxDigestChars 120",
+                "[pscustomobject]@{",
+                "    ok = [bool]$result.ok",
+                "    abstained = [bool]$result.abstained",
+                "    reason = [string]$result.reason",
+                "    api = [string]$result.api",
+                "    digest = [string]$result.digest",
+                "} | ConvertTo-Json -Compress",
+            ]
+        )
+
+        self.assertTrue(payload["ok"])
+        self.assertFalse(payload["abstained"])
+        self.assertEqual("ok", payload["reason"])
+        self.assertEqual("anthropic_messages", payload["api"])
+        self.assertEqual("tight summary", payload["digest"])
+
+    def test_anthropic_compatible_confirm_booster_uses_messages_api(self) -> None:
+        payload = self.run_powershell_json(
+            self.base_script()
+            + [
+                "$policy.provider.type = 'anthropic-compatible'",
+                "$policy.provider.base_url = 'https://anthropic-gateway.example'",
+                "function Invoke-OpenAiResponsesCreate { throw 'responses should not be called for anthropic-compatible confirm booster' }",
+                "function Invoke-OpenAiChatCompletionsCreate { throw 'chat_completions should not be called for anthropic-compatible confirm booster' }",
+                "function Invoke-AnthropicMessagesCreate {",
+                "    return [pscustomobject]@{",
+                "        ok = $true",
+                "        abstained = $false",
+                "        reason = 'ok'",
+                "        status_code = 200",
+                "        latency_ms = 21",
+                "        output_text = '{\"confirm_questions\":[\"What repo should I touch?\",\"What output do you expect?\"]}'",
+                "        response = $null",
+                "        error = $null",
+                "    }",
+                "}",
+                "$result = Invoke-LlmConfirmQuestionBoosterProvider -PolicyResolved (Get-LlmAccelerationPolicy -Policy $policy) -RepoRoot $repoRoot -InputText 'improve confirm questions' -MaxQuestions 3",
+                "[pscustomobject]@{",
+                "    ok = [bool]$result.ok",
+                "    abstained = [bool]$result.abstained",
+                "    reason = [string]$result.reason",
+                "    api = [string]$result.api",
+                "    confirm_questions = @($result.confirm_questions)",
+                "} | ConvertTo-Json -Depth 8 -Compress",
+            ]
+        )
+
+        self.assertTrue(payload["ok"])
+        self.assertFalse(payload["abstained"])
+        self.assertEqual("ok", payload["reason"])
+        self.assertEqual("anthropic_messages", payload["api"])
+        self.assertEqual(
+            ["What repo should I touch?", "What output do you expect?"],
+            payload["confirm_questions"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime_neutral/test_router_ai_connectivity_probe.py
+++ b/tests/runtime_neutral/test_router_ai_connectivity_probe.py
@@ -238,6 +238,88 @@ class RouterAiConnectivityProbeTests(unittest.TestCase):
             [attempt["endpoint_kind"] for attempt in artifact["advice"]["attempts"]],
         )
 
+    def test_anthropic_compatible_messages_probe_is_classified_ok(self) -> None:
+        policy = self._policy()
+        policy["provider"]["type"] = "anthropic-compatible"
+        policy["provider"]["base_url"] = "https://anthropic-gateway.example"
+        self._write_policy(policy)
+        self._write_settings({"VCO_INTENT_ADVICE_API_KEY": "sk-test"})
+
+        seen_requests: list[dict] = []
+
+        def transport(req: dict) -> dict:
+            seen_requests.append(req)
+            self.assertEqual("anthropic_messages", req["endpoint_kind"])
+            self.assertTrue(req["url"].endswith("/v1/messages"))
+            self.assertEqual("2023-06-01", req["headers"]["anthropic-version"])
+            return {
+                "ok": True,
+                "status_code": 200,
+                "error_kind": None,
+                "error": None,
+                "body_text": '{"content":[{"type":"text","text":"{\\"ok\\":true}"}]}',
+                "json": {"content": [{"type": "text", "text": '{"ok":true}'}]},
+                "latency_ms": 6,
+            }
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            artifact = self.module.evaluate(
+                self.root,
+                self.target_root,
+                probe_context=self.module.ProbeContext(prefix_detected=True),
+                transport=transport,
+            )
+
+        self.assertEqual("ok", artifact["summary"]["advice_status"])
+        self.assertEqual("anthropic_messages", artifact["advice"]["endpoint_used"])
+        self.assertEqual(["anthropic_messages"], [attempt["endpoint_kind"] for attempt in artifact["advice"]["attempts"]])
+        self.assertEqual(1, len(seen_requests))
+
+    def test_openai_typed_custom_gateway_can_fallback_to_anthropic_messages(self) -> None:
+        policy = self._policy()
+        policy["provider"]["type"] = "openai"
+        policy["provider"]["base_url"] = "https://anthropic-gateway.example"
+        self._write_policy(policy)
+        self._write_settings({"VCO_INTENT_ADVICE_API_KEY": "sk-test"})
+
+        def transport(req: dict) -> dict:
+            if req["endpoint_kind"] in {"responses", "chat_completions", "chat_completions_plain"}:
+                return {
+                    "ok": False,
+                    "status_code": 404,
+                    "error_kind": "http",
+                    "error": "unsupported endpoint",
+                    "body_text": '{"error":"not found"}',
+                    "json": {"error": "not found"},
+                    "latency_ms": 3,
+                }
+            if req["endpoint_kind"] == "anthropic_messages":
+                return {
+                    "ok": True,
+                    "status_code": 200,
+                    "error_kind": None,
+                    "error": None,
+                    "body_text": '{"content":[{"type":"text","text":"{\\"ok\\":true}"}]}',
+                    "json": {"content": [{"type": "text", "text": '{"ok":true}'}]},
+                    "latency_ms": 4,
+                }
+            raise AssertionError(f"unexpected endpoint_kind: {req['endpoint_kind']}")
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            artifact = self.module.evaluate(
+                self.root,
+                self.target_root,
+                probe_context=self.module.ProbeContext(prefix_detected=True),
+                transport=transport,
+            )
+
+        self.assertEqual("ok", artifact["summary"]["advice_status"])
+        self.assertEqual("anthropic_messages", artifact["advice"]["endpoint_used"])
+        self.assertEqual(
+            ["responses", "chat_completions", "chat_completions_plain", "anthropic_messages"],
+            [attempt["endpoint_kind"] for attempt in artifact["advice"]["attempts"]],
+        )
+
     def test_parse_error_is_classified(self) -> None:
         self._write_settings({"VCO_INTENT_ADVICE_API_KEY": "sk-test"})
 

--- a/tests/unit/test_vgo_cli_commands.py
+++ b/tests/unit/test_vgo_cli_commands.py
@@ -10,16 +10,13 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLI_SRC = REPO_ROOT / 'apps' / 'vgo-cli' / 'src'
-RUNTIME_SRC = REPO_ROOT / 'packages' / 'runtime-core' / 'src'
-for src in (CLI_SRC, RUNTIME_SRC):
-    if str(src) not in sys.path:
-        sys.path.insert(0, str(src))
+if str(CLI_SRC) not in sys.path:
+    sys.path.insert(0, str(CLI_SRC))
 
 from vgo_cli.commands import install_command, route_command, runtime_command, upgrade_command, verify_command
 from vgo_cli.errors import CliError
 from vgo_cli.main import build_parser
 from vgo_cli.output import parse_json_output, print_install_completion_hint, print_json_payload
-from vgo_runtime import router_bridge
 
 
 def test_parse_json_output_returns_payload() -> None:
@@ -71,9 +68,7 @@ def test_route_command_delegates_to_runtime_core_bridge(monkeypatch: pytest.Monk
         prompt='route this',
         grade='XL',
         task_type='debug',
-        requested_skill='vibe-how',
-        entry_intent_id='vibe-how',
-        requested_grade_floor='XL',
+        requested_skill='vibe',
         host_id='codex',
         target_root='/tmp/codex',
         force_runtime_neutral=True,
@@ -85,125 +80,12 @@ def test_route_command_delegates_to_runtime_core_bridge(monkeypatch: pytest.Monk
         '--prompt', 'route this',
         '--grade', 'XL',
         '--task-type', 'debug',
-        '--requested-skill', 'vibe-how',
-        '--entry-intent-id', 'vibe-how',
-        '--requested-grade-floor', 'XL',
+        '--requested-skill', 'vibe',
         '--host-id', 'codex',
         '--target-root', '/tmp/codex',
         '--force-runtime-neutral',
     ]
     assert recorded['printed_stdout'] == '{"ok": true}\n'
-
-
-def test_router_bridge_forwards_discoverable_flags_to_powershell_router(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    recorded: dict[str, object] = {}
-
-    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        recorded['command'] = list(command)
-        recorded['cwd'] = kwargs['cwd']
-        return subprocess.CompletedProcess(args=list(command), returncode=0, stdout='{"ok": true}\n', stderr='')
-
-    monkeypatch.setattr(router_bridge, 'resolve_repo_root', lambda _: tmp_path)
-    monkeypatch.setattr(router_bridge.subprocess, 'run', fake_run)
-
-    payload = router_bridge.invoke_canonical_router(
-        argparse.Namespace(
-            prompt='route this',
-            grade='XL',
-            task_type='debug',
-            requested_skill='vibe-how',
-            entry_intent_id='vibe-how',
-            requested_grade_floor='XL',
-            host_id='codex',
-            target_root='/tmp/codex',
-        ),
-        'pwsh',
-    )
-
-    assert payload == {'ok': True}
-    assert recorded['cwd'] == tmp_path
-    assert recorded['command'] == [
-        'pwsh',
-        '-NoLogo',
-        '-NoProfile',
-        '-ExecutionPolicy',
-        'Bypass',
-        '-File',
-        str(tmp_path / 'scripts' / 'router' / 'resolve-pack-route.ps1'),
-        '-Prompt',
-        'route this',
-        '-Grade',
-        'XL',
-        '-TaskType',
-        'debug',
-        '-RequestedSkill',
-        'vibe-how',
-        '-EntryIntentId',
-        'vibe-how',
-        '-RequestedGradeFloor',
-        'XL',
-        '-HostId',
-        'codex',
-        '-TargetRoot',
-        '/tmp/codex',
-    ]
-
-
-def test_router_bridge_runtime_neutral_fallback_passes_discoverable_flags(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    recorded: dict[str, object] = {}
-
-    def fake_route_prompt(**kwargs: object) -> dict[str, object]:
-        recorded.update(kwargs)
-        return {'ok': True}
-
-    monkeypatch.setattr(router_bridge, 'resolve_powershell_host', lambda: None)
-    monkeypatch.setattr(router_bridge, 'resolve_repo_root', lambda _: tmp_path)
-    monkeypatch.setattr(router_bridge, 'route_prompt', fake_route_prompt)
-
-    assert (
-        router_bridge.main(
-            [
-                '--prompt',
-                'route this',
-                '--grade',
-                'XL',
-                '--task-type',
-                'debug',
-                '--requested-skill',
-                'vibe-how',
-                '--entry-intent-id',
-                'vibe-how',
-                '--requested-grade-floor',
-                'XL',
-                '--host-id',
-                'codex',
-                '--target-root',
-                '/tmp/codex',
-                '--force-runtime-neutral',
-            ]
-        )
-        == 0
-    )
-
-    assert recorded == {
-        'prompt': 'route this',
-        'grade': 'XL',
-        'task_type': 'debug',
-        'requested_skill': 'vibe-how',
-        'entry_intent_id': 'vibe-how',
-        'requested_grade_floor': 'XL',
-        'target_root': '/tmp/codex',
-        'host_id': 'codex',
-        'repo_root': tmp_path,
-    }
-    assert capsys.readouterr().out == '{\n  "ok": true\n}\n'
 
 
 
@@ -280,6 +162,53 @@ def test_runtime_command_uses_runtime_contract_for_powershell_dispatch(monkeypat
     assert recorded['shell_script'] == 'check.sh'
     assert recorded['powershell_script'] == 'scripts/runtime/custom-runtime-entrypoint.ps1'
     assert recorded['rest'] == ['--task', 'smoke']
+
+
+def test_upgrade_command_delegates_to_upgrade_service(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import vgo_cli.commands as cli_commands
+
+    recorded: dict[str, object] = {}
+
+    monkeypatch.setattr(cli_commands, 'normalize_host_id', lambda host: host)
+    monkeypatch.setattr(cli_commands, 'resolve_target_root', lambda host_id, target_root: Path(target_root or tmp_path / 'target').resolve())
+    monkeypatch.setattr(
+        cli_commands,
+        'assert_target_root_matches_host_intent',
+        lambda target_root, host_id: recorded.setdefault('intent_checked', (target_root, host_id)),
+    )
+
+    def fake_upgrade_runtime(**kwargs: object) -> dict[str, object]:
+        recorded['kwargs'] = kwargs
+        return {'changed': False}
+
+    monkeypatch.setattr(cli_commands, 'upgrade_runtime', fake_upgrade_runtime)
+
+    args = argparse.Namespace(
+        repo_root=str(tmp_path / 'repo'),
+        host='codex',
+        target_root=str(tmp_path / 'target'),
+        profile='full',
+        frontend='shell',
+        install_external=False,
+        strict_offline=False,
+        require_closed_ready=False,
+        allow_external_skill_fallback=False,
+        skip_runtime_freshness_gate=False,
+    )
+
+    assert upgrade_command(args) == 0
+    assert recorded['kwargs']['repo_root'] == (tmp_path / 'repo').resolve()
+    assert recorded['kwargs']['target_root'] == (tmp_path / 'target').resolve()
+    assert recorded['kwargs']['host_id'] == 'codex'
+
+
+def test_build_parser_includes_upgrade_subcommand() -> None:
+    parser = build_parser()
+    args = parser.parse_args(['upgrade', '--repo-root', '/tmp/repo'])
+
+    assert args.command == 'upgrade'
+    assert args.handler is upgrade_command
+    assert args.frontend == 'shell'
 
 
 def test_install_command_skips_external_dependency_install_when_strict_offline(
@@ -360,57 +289,3 @@ def test_install_command_skips_external_dependency_install_when_strict_offline(
     assert install_command(args) == 0
     assert 'external_called' not in recorded
     assert recorded['reconcile']['strict_offline'] is True
-
-
-def test_build_parser_exposes_upgrade_subcommand() -> None:
-    parser = build_parser()
-
-    args = parser.parse_args(
-        [
-            'upgrade',
-            '--repo-root',
-            'repo-root',
-            '--host',
-            'codex',
-        ]
-    )
-
-    assert args.command == 'upgrade'
-    assert args.host == 'codex'
-    assert args.handler is upgrade_command
-
-
-def test_upgrade_command_delegates_to_upgrade_service(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    import vgo_cli.commands as cli_commands
-
-    recorded: dict[str, object] = {}
-    resolved_target_root = tmp_path / 'resolved-target'
-
-    def fake_upgrade_runtime(**kwargs: object) -> dict[str, object]:
-        recorded.update(kwargs)
-        return {'changed': False}
-
-    monkeypatch.setattr(cli_commands, 'resolve_target_root', lambda host_id, target_root: resolved_target_root)
-    monkeypatch.setattr(cli_commands, 'assert_target_root_matches_host_intent', lambda target_root, host_id: None)
-    monkeypatch.setattr(cli_commands, 'upgrade_runtime', fake_upgrade_runtime)
-
-    args = argparse.Namespace(
-        repo_root=str(tmp_path),
-        frontend='shell',
-        profile='full',
-        host='codex',
-        target_root='',
-        install_external=False,
-        strict_offline=False,
-        require_closed_ready=False,
-        allow_external_skill_fallback=False,
-        skip_runtime_freshness_gate=False,
-    )
-
-    assert upgrade_command(args) == 0
-    assert recorded['repo_root'] == tmp_path.resolve()
-    assert recorded['target_root'] == resolved_target_root
-    assert recorded['host_id'] == 'codex'
-    assert recorded['profile'] == 'full'
-    assert recorded['frontend'] == 'shell'
-    assert resolved_target_root.is_dir()

--- a/tests/unit/test_vgo_cli_upgrade_service.py
+++ b/tests/unit/test_vgo_cli_upgrade_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 import subprocess
 import sys
@@ -8,39 +9,46 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-CLI_SRC = REPO_ROOT / 'apps' / 'vgo-cli' / 'src'
+CLI_SRC = REPO_ROOT / "apps" / "vgo-cli" / "src"
 if str(CLI_SRC) not in sys.path:
     sys.path.insert(0, str(CLI_SRC))
 
-from vgo_cli.errors import CliError
-from vgo_cli.upgrade_service import reinstall_runtime, reset_repo_to_official_head, upgrade_runtime
 
+def test_upgrade_runtime_resolves_canonical_git_root_before_refresh(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
 
-def test_upgrade_runtime_noops_when_install_is_already_current(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    repo_root = tmp_path / 'repo'
-    target_root = tmp_path / 'target'
+    repo_root = tmp_path / "installed-runtime" / "skills" / "vibe"
+    repo_root.mkdir(parents=True)
+    target_root = tmp_path / ".codex"
+    target_root.mkdir()
+    canonical_root = tmp_path / "repo"
+    canonical_root.mkdir()
 
-    monkeypatch.setattr(
-        'vgo_cli.upgrade_service.refresh_installed_status',
-        lambda repo_root, target_root, host_id: {
-            'installed_version': '3.0.1',
-            'installed_commit': 'same',
-            'remote_latest_version': '3.0.1',
-            'remote_latest_commit': 'same',
-            'update_available': False,
-        },
-    )
-    monkeypatch.setattr('vgo_cli.upgrade_service.refresh_upstream_status', lambda repo_root, target_root, current_status: current_status)
-    monkeypatch.setattr('vgo_cli.upgrade_service.reset_repo_to_official_head', lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError('should not reset repo')))
-    monkeypatch.setattr('vgo_cli.upgrade_service.reinstall_runtime', lambda **kwargs: (_ for _ in ()).throw(AssertionError('should not reinstall')))
-    monkeypatch.setattr('vgo_cli.upgrade_service.run_upgrade_check', lambda **kwargs: (_ for _ in ()).throw(AssertionError('should not run check')))
+    recorded: dict[str, Path] = {}
 
-    result = upgrade_runtime(
+    monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: canonical_root)
+
+    def fake_refresh_installed_status(repo_root_arg: Path, target_root_arg: Path, host_id: str) -> dict[str, object]:
+        recorded["repo_root"] = repo_root_arg
+        recorded["target_root"] = target_root_arg
+        recorded["host_id"] = Path(host_id)
+        return {
+            "installed_version": "3.0.1",
+            "installed_commit": "same",
+            "remote_latest_version": "3.0.1",
+            "remote_latest_commit": "same",
+            "update_available": False,
+        }
+
+    monkeypatch.setattr(upgrade_service, "refresh_installed_status", fake_refresh_installed_status)
+    monkeypatch.setattr(upgrade_service, "refresh_upstream_status", lambda repo_root_arg, target_root_arg, status: status)
+
+    result = upgrade_service.upgrade_runtime(
         repo_root=repo_root,
         target_root=target_root,
-        host_id='codex',
-        profile='full',
-        frontend='shell',
+        host_id="codex",
+        profile="full",
+        frontend="shell",
         install_external=False,
         strict_offline=False,
         require_closed_ready=False,
@@ -48,209 +56,55 @@ def test_upgrade_runtime_noops_when_install_is_already_current(monkeypatch: pyte
         skip_runtime_freshness_gate=False,
     )
 
-    assert result['changed'] is False
-    assert 'already current' in capsys.readouterr().out.lower()
+    assert result["changed"] is False
+    assert recorded["repo_root"] == canonical_root
+    assert recorded["target_root"] == target_root
 
 
-def test_upgrade_runtime_refreshes_repo_reinstalls_and_checks_when_update_is_available(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    repo_root = tmp_path / 'repo'
-    target_root = tmp_path / 'target'
-    steps: list[str] = []
-    statuses = iter(
-        [
-            {
-                'installed_version': '3.0.0',
-                'installed_commit': 'old',
-                'repo_default_branch': 'main',
-            },
-            {
-                'installed_version': '3.0.1',
-                'installed_commit': 'new',
-                'remote_latest_version': '3.0.1',
-                'remote_latest_commit': 'new',
-                'update_available': False,
-            },
-        ]
-    )
+def test_upgrade_runtime_raises_clear_error_when_no_canonical_git_repo_exists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
 
-    monkeypatch.setattr('vgo_cli.upgrade_service.refresh_installed_status', lambda repo_root, target_root, host_id: next(statuses))
+    repo_root = tmp_path / "installed-runtime" / "skills" / "vibe"
+    repo_root.mkdir(parents=True)
+    target_root = tmp_path / ".codex"
+    target_root.mkdir()
 
-    def fake_refresh_upstream(repo_root: Path, target_root: Path, current_status: dict[str, object]) -> dict[str, object]:
-        steps.append('refresh')
-        merged = dict(current_status)
-        merged.update(
-            {
-                'remote_latest_version': '3.0.1',
-                'remote_latest_commit': 'new',
-                'update_available': True,
-                'repo_default_branch': 'main',
-            }
-        )
-        return merged
+    monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: None)
 
-    monkeypatch.setattr('vgo_cli.upgrade_service.refresh_upstream_status', fake_refresh_upstream)
-    monkeypatch.setattr('vgo_cli.upgrade_service.reset_repo_to_official_head', lambda repo_root, branch: steps.append(f'reset:{branch}'))
-    monkeypatch.setattr('vgo_cli.upgrade_service.reinstall_runtime', lambda **kwargs: steps.append('reinstall'))
-    monkeypatch.setattr(
-        'vgo_cli.upgrade_service.run_upgrade_check',
-        lambda **kwargs: (steps.append('check') or subprocess.CompletedProcess(args=['check'], returncode=0, stdout='', stderr='')),
-    )
-
-    result = upgrade_runtime(
-        repo_root=repo_root,
-        target_root=target_root,
-        host_id='codex',
-        profile='full',
-        frontend='shell',
-        install_external=False,
-        strict_offline=False,
-        require_closed_ready=False,
-        allow_external_skill_fallback=False,
-        skip_runtime_freshness_gate=False,
-    )
-
-    assert steps == ['refresh', 'reset:main', 'reinstall', 'check']
-    assert result['changed'] is True
-    assert result['before']['installed_version'] == '3.0.0'
-    assert result['after']['installed_version'] == '3.0.1'
-
-
-def test_upgrade_runtime_propagates_refresh_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    repo_root = tmp_path / 'repo'
-    target_root = tmp_path / 'target'
-
-    monkeypatch.setattr(
-        'vgo_cli.upgrade_service.refresh_installed_status',
-        lambda repo_root, target_root, host_id: {'installed_version': '3.0.0', 'installed_commit': 'old'},
-    )
-    monkeypatch.setattr(
-        'vgo_cli.upgrade_service.refresh_upstream_status',
-        lambda repo_root, target_root, current_status: (_ for _ in ()).throw(CliError('refresh failed')),
-    )
-
-    with pytest.raises(CliError, match='refresh failed'):
-        upgrade_runtime(
+    with pytest.raises(upgrade_service.CliError, match="canonical git checkout"):
+        upgrade_service.upgrade_runtime(
             repo_root=repo_root,
             target_root=target_root,
-            host_id='codex',
-            profile='full',
-            frontend='shell',
+            host_id="codex",
+            profile="full",
+            frontend="shell",
             install_external=False,
             strict_offline=False,
             require_closed_ready=False,
             allow_external_skill_fallback=False,
             skip_runtime_freshness_gate=False,
         )
-
-
-def test_upgrade_runtime_propagates_check_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    repo_root = tmp_path / 'repo'
-    target_root = tmp_path / 'target'
-    statuses = iter(
-        [
-            {'installed_version': '3.0.0', 'installed_commit': 'old', 'repo_default_branch': 'main'},
-            {'installed_version': '3.0.1', 'installed_commit': 'new'},
-        ]
-    )
-
-    monkeypatch.setattr('vgo_cli.upgrade_service.refresh_installed_status', lambda repo_root, target_root, host_id: next(statuses))
-    monkeypatch.setattr(
-        'vgo_cli.upgrade_service.refresh_upstream_status',
-        lambda repo_root, target_root, current_status: {
-            **current_status,
-            'remote_latest_version': '3.0.1',
-            'remote_latest_commit': 'new',
-            'update_available': True,
-            'repo_default_branch': 'main',
-        },
-    )
-    monkeypatch.setattr('vgo_cli.upgrade_service.reset_repo_to_official_head', lambda repo_root, branch: None)
-    monkeypatch.setattr('vgo_cli.upgrade_service.reinstall_runtime', lambda **kwargs: None)
-    monkeypatch.setattr(
-        'vgo_cli.upgrade_service.run_upgrade_check',
-        lambda **kwargs: (_ for _ in ()).throw(CliError('check failed')),
-    )
-
-    with pytest.raises(CliError, match='check failed'):
-        upgrade_runtime(
-            repo_root=repo_root,
-            target_root=target_root,
-            host_id='codex',
-            profile='full',
-            frontend='shell',
-            install_external=False,
-            strict_offline=False,
-            require_closed_ready=False,
-            allow_external_skill_fallback=False,
-            skip_runtime_freshness_gate=False,
-        )
-
-
-def test_reinstall_runtime_propagates_strict_offline_to_optional_external_installs(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    repo_root = tmp_path / 'repo'
-    target_root = tmp_path / 'target'
-    recorded: dict[str, object] = {}
-
-    monkeypatch.setattr('vgo_cli.upgrade_service.install_mode_for_host', lambda host_id: 'governed')
-    monkeypatch.setattr(
-        'vgo_cli.upgrade_service.run_installer_core',
-        lambda repo_root, command: subprocess.CompletedProcess(
-            args=command,
-            returncode=0,
-            stdout='{"install_mode":"governed","external_fallback_used":[]}\n',
-            stderr='',
-        ),
-    )
-    monkeypatch.setattr('vgo_cli.upgrade_service.parse_json_output', lambda result: {'install_mode': 'governed', 'external_fallback_used': []})
-
-    def fake_maybe_install_external_dependencies(repo_root: Path, install_mode: str, *, strict_offline: bool = False) -> None:
-        recorded['repo_root'] = repo_root
-        recorded['install_mode'] = install_mode
-        recorded['strict_offline'] = strict_offline
-
-    monkeypatch.setattr('vgo_cli.upgrade_service.maybe_install_external_dependencies', fake_maybe_install_external_dependencies)
-    monkeypatch.setattr('vgo_cli.upgrade_service.reconcile_install_postconditions', lambda *args, **kwargs: None)
-
-    reinstall_runtime(
-        repo_root=repo_root,
-        target_root=target_root,
-        host_id='codex',
-        profile='full',
-        frontend='shell',
-        install_external=True,
-        strict_offline=True,
-        require_closed_ready=False,
-        allow_external_skill_fallback=False,
-        skip_runtime_freshness_gate=False,
-    )
-
-    assert recorded == {
-        'repo_root': repo_root,
-        'install_mode': 'governed',
-        'strict_offline': True,
-    }
 
 
 def test_reset_repo_to_official_head_discards_local_changes_before_switch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    repo_root = tmp_path / 'repo'
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "repo"
     repo_root.mkdir(parents=True)
     commands: list[list[str]] = []
 
     def fake_run_subprocess(command: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
         commands.append(command)
         assert cwd == repo_root
-        return subprocess.CompletedProcess(command, 0, stdout='', stderr='')
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
 
-    monkeypatch.setattr('vgo_cli.upgrade_service.run_subprocess', fake_run_subprocess)
+    monkeypatch.setattr(upgrade_service, "run_subprocess", fake_run_subprocess)
 
-    reset_repo_to_official_head(repo_root, 'main')
+    upgrade_service.reset_repo_to_official_head(repo_root, "main")
 
     assert commands == [
-        ['git', 'reset', '--hard', 'HEAD'],
-        ['git', 'clean', '-fd'],
-        ['git', 'checkout', '-B', 'main', 'FETCH_HEAD'],
-        ['git', 'reset', '--hard', 'FETCH_HEAD'],
+        ["git", "reset", "--hard", "HEAD"],
+        ["git", "clean", "-fd"],
+        ["git", "checkout", "-B", "main", "FETCH_HEAD"],
+        ["git", "reset", "--hard", "FETCH_HEAD"],
     ]

--- a/tests/unit/test_vgo_cli_upgrade_service.py
+++ b/tests/unit/test_vgo_cli_upgrade_service.py
@@ -24,14 +24,14 @@ def test_upgrade_runtime_resolves_canonical_git_root_before_refresh(monkeypatch:
     canonical_root = tmp_path / "repo"
     canonical_root.mkdir()
 
-    recorded: dict[str, Path] = {}
+    recorded: dict[str, object] = {}
 
     monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: canonical_root)
 
     def fake_refresh_installed_status(repo_root_arg: Path, target_root_arg: Path, host_id: str) -> dict[str, object]:
         recorded["repo_root"] = repo_root_arg
         recorded["target_root"] = target_root_arg
-        recorded["host_id"] = Path(host_id)
+        recorded["host_id"] = host_id
         return {
             "installed_version": "3.0.1",
             "installed_commit": "same",
@@ -59,6 +59,25 @@ def test_upgrade_runtime_resolves_canonical_git_root_before_refresh(monkeypatch:
     assert result["changed"] is False
     assert recorded["repo_root"] == canonical_root
     assert recorded["target_root"] == target_root
+    assert recorded["host_id"] == "codex"
+
+
+def test_resolve_upgrade_repo_root_does_not_fall_back_to_unrelated_cwd_repo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "installed-runtime" / "skills" / "vibe"
+    repo_root.mkdir(parents=True)
+
+    unrelated_repo = tmp_path / "other-repo"
+    (unrelated_repo / ".git").mkdir(parents=True)
+    (unrelated_repo / "config").mkdir(parents=True)
+    (unrelated_repo / "config" / "version-governance.json").write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.chdir(unrelated_repo)
+
+    assert upgrade_service.resolve_upgrade_repo_root(repo_root) is None
 
 
 def test_upgrade_runtime_raises_clear_error_when_no_canonical_git_repo_exists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/test_vgo_cli_upgrade_service.py
+++ b/tests/unit/test_vgo_cli_upgrade_service.py
@@ -62,6 +62,62 @@ def test_upgrade_runtime_resolves_canonical_git_root_before_refresh(monkeypatch:
     assert recorded["host_id"] == "codex"
 
 
+def test_upgrade_runtime_noops_when_install_is_already_current(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+
+    monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_installed_status",
+        lambda repo_root_arg, target_root_arg, host_id: {
+            "installed_version": "3.0.1",
+            "installed_commit": "same",
+            "remote_latest_version": "3.0.1",
+            "remote_latest_commit": "same",
+            "update_available": False,
+        },
+    )
+    monkeypatch.setattr(upgrade_service, "refresh_upstream_status", lambda repo_root_arg, target_root_arg, status: status)
+    monkeypatch.setattr(
+        upgrade_service,
+        "reset_repo_to_official_head",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not reset repo")),
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "reinstall_runtime",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("should not reinstall")),
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "run_upgrade_check",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("should not run check")),
+    )
+
+    result = upgrade_service.upgrade_runtime(
+        repo_root=repo_root,
+        target_root=target_root,
+        host_id="codex",
+        profile="full",
+        frontend="shell",
+        install_external=False,
+        strict_offline=False,
+        require_closed_ready=False,
+        allow_external_skill_fallback=False,
+        skip_runtime_freshness_gate=False,
+    )
+
+    assert result["changed"] is False
+    assert "already current" in capsys.readouterr().out.lower()
+
+
 def test_resolve_upgrade_repo_root_does_not_fall_back_to_unrelated_cwd_repo(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -103,6 +159,219 @@ def test_upgrade_runtime_raises_clear_error_when_no_canonical_git_repo_exists(mo
             allow_external_skill_fallback=False,
             skip_runtime_freshness_gate=False,
         )
+
+
+def test_upgrade_runtime_refreshes_repo_reinstalls_and_checks_when_update_is_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    steps: list[str] = []
+    statuses = iter(
+        [
+            {
+                "installed_version": "3.0.0",
+                "installed_commit": "old",
+                "repo_default_branch": "main",
+            },
+            {
+                "installed_version": "3.0.1",
+                "installed_commit": "new",
+                "remote_latest_version": "3.0.1",
+                "remote_latest_commit": "new",
+                "update_available": False,
+            },
+        ]
+    )
+
+    monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
+    monkeypatch.setattr(upgrade_service, "refresh_installed_status", lambda repo_root_arg, target_root_arg, host_id: next(statuses))
+
+    def fake_refresh_upstream(repo_root_arg: Path, target_root_arg: Path, current_status: dict[str, object]) -> dict[str, object]:
+        steps.append("refresh")
+        merged = dict(current_status)
+        merged.update(
+            {
+                "remote_latest_version": "3.0.1",
+                "remote_latest_commit": "new",
+                "update_available": True,
+                "repo_default_branch": "main",
+            }
+        )
+        return merged
+
+    monkeypatch.setattr(upgrade_service, "refresh_upstream_status", fake_refresh_upstream)
+    monkeypatch.setattr(upgrade_service, "reset_repo_to_official_head", lambda repo_root_arg, branch: steps.append(f"reset:{branch}"))
+    monkeypatch.setattr(upgrade_service, "reinstall_runtime", lambda **kwargs: steps.append("reinstall"))
+    monkeypatch.setattr(
+        upgrade_service,
+        "run_upgrade_check",
+        lambda **kwargs: (steps.append("check") or subprocess.CompletedProcess(args=["check"], returncode=0, stdout="", stderr="")),
+    )
+
+    result = upgrade_service.upgrade_runtime(
+        repo_root=repo_root,
+        target_root=target_root,
+        host_id="codex",
+        profile="full",
+        frontend="shell",
+        install_external=False,
+        strict_offline=False,
+        require_closed_ready=False,
+        allow_external_skill_fallback=False,
+        skip_runtime_freshness_gate=False,
+    )
+
+    assert steps == ["refresh", "reset:main", "reinstall", "check"]
+    assert result["changed"] is True
+    assert result["before"]["installed_version"] == "3.0.0"
+    assert result["after"]["installed_version"] == "3.0.1"
+
+
+def test_upgrade_runtime_propagates_refresh_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+
+    monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_installed_status",
+        lambda repo_root_arg, target_root_arg, host_id: {"installed_version": "3.0.0", "installed_commit": "old"},
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_upstream_status",
+        lambda repo_root_arg, target_root_arg, current_status: (_ for _ in ()).throw(upgrade_service.CliError("refresh failed")),
+    )
+
+    with pytest.raises(upgrade_service.CliError, match="refresh failed"):
+        upgrade_service.upgrade_runtime(
+            repo_root=repo_root,
+            target_root=target_root,
+            host_id="codex",
+            profile="full",
+            frontend="shell",
+            install_external=False,
+            strict_offline=False,
+            require_closed_ready=False,
+            allow_external_skill_fallback=False,
+            skip_runtime_freshness_gate=False,
+        )
+
+
+def test_upgrade_runtime_propagates_check_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    statuses = iter(
+        [
+            {"installed_version": "3.0.0", "installed_commit": "old", "repo_default_branch": "main"},
+            {"installed_version": "3.0.1", "installed_commit": "new"},
+        ]
+    )
+
+    monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
+    monkeypatch.setattr(upgrade_service, "refresh_installed_status", lambda repo_root_arg, target_root_arg, host_id: next(statuses))
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_upstream_status",
+        lambda repo_root_arg, target_root_arg, current_status: {
+            **current_status,
+            "remote_latest_version": "3.0.1",
+            "remote_latest_commit": "new",
+            "update_available": True,
+            "repo_default_branch": "main",
+        },
+    )
+    monkeypatch.setattr(upgrade_service, "reset_repo_to_official_head", lambda repo_root_arg, branch: None)
+    monkeypatch.setattr(upgrade_service, "reinstall_runtime", lambda **kwargs: None)
+    monkeypatch.setattr(
+        upgrade_service,
+        "run_upgrade_check",
+        lambda **kwargs: (_ for _ in ()).throw(upgrade_service.CliError("check failed")),
+    )
+
+    with pytest.raises(upgrade_service.CliError, match="check failed"):
+        upgrade_service.upgrade_runtime(
+            repo_root=repo_root,
+            target_root=target_root,
+            host_id="codex",
+            profile="full",
+            frontend="shell",
+            install_external=False,
+            strict_offline=False,
+            require_closed_ready=False,
+            allow_external_skill_fallback=False,
+            skip_runtime_freshness_gate=False,
+        )
+
+
+def test_reinstall_runtime_propagates_strict_offline_to_optional_external_installs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    recorded: dict[str, object] = {}
+
+    monkeypatch.setattr(upgrade_service, "install_mode_for_host", lambda host_id: "governed")
+    monkeypatch.setattr(
+        upgrade_service,
+        "run_installer_core",
+        lambda repo_root_arg, command: subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout='{"install_mode":"governed","external_fallback_used":[]}\n',
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "parse_json_output",
+        lambda result: {"install_mode": "governed", "external_fallback_used": []},
+    )
+
+    def fake_maybe_install_external_dependencies(repo_root_arg: Path, install_mode: str, *, strict_offline: bool = False) -> None:
+        recorded["repo_root"] = repo_root_arg
+        recorded["install_mode"] = install_mode
+        recorded["strict_offline"] = strict_offline
+
+    monkeypatch.setattr(upgrade_service, "maybe_install_external_dependencies", fake_maybe_install_external_dependencies)
+    monkeypatch.setattr(upgrade_service, "reconcile_install_postconditions", lambda *args, **kwargs: None)
+
+    upgrade_service.reinstall_runtime(
+        repo_root=repo_root,
+        target_root=target_root,
+        host_id="codex",
+        profile="full",
+        frontend="shell",
+        install_external=True,
+        strict_offline=True,
+        require_closed_ready=False,
+        allow_external_skill_fallback=False,
+        skip_runtime_freshness_gate=False,
+    )
+
+    assert recorded == {
+        "repo_root": repo_root,
+        "install_mode": "governed",
+        "strict_offline": True,
+    }
 
 
 def test_reset_repo_to_official_head_discards_local_changes_before_switch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add upgrade flow support for installed runtimes that are not themselves git repos
- fix `check.ps1` and `check.sh` target-root normalization so installed runtime roots no longer double-append `skills/vibe`
- extend advice probe support to Anthropic-compatible `/v1/messages` and custom gateway fallback behavior
- fix runtime LLM acceleration execution so main advice, diff digest, confirm booster, and committee paths support Anthropic-compatible providers and OpenAI custom gateway fallback
- add regression coverage for upgrade flow, installed-runtime check roots, probe behavior, and runtime overlay provider paths

## Verification
- `pytest -q tests/runtime_neutral/test_router_ai_connectivity_probe.py tests/runtime_neutral/test_llm_acceleration_overlay_gate.py tests/runtime_neutral/test_llm_acceleration_overlay_provider_paths.py`
- `pytest -q tests/unit/test_vgo_cli_commands.py tests/unit/test_vgo_cli_repo.py tests/unit/test_vgo_cli_upgrade_service.py`
- `pytest -q tests/runtime_neutral/test_check_shell_target_root_guard.py tests/runtime_neutral/test_check_installed_runtime_root.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anthropic "messages" support with provider-family routing, fallbacks, and unified invocation paths.
  * Canonical repo-root resolution for upgrade operations.

* **Bug Fixes**
  * Removed deprecated route command flags to simplify CLI.
  * Improved runtime target resolution, path normalization, and receipt validation.
  * Upgrade now fails with a clear error if no canonical repo checkout is found.

* **Tests**
  * Added unit, runtime-neutral, and integration tests covering provider routing, runtime checks, and upgrade behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->