### PR TITLE
fix: complete pr130 review fixes and harden vibe upgrade flow

### DIFF
--- a/apps/vgo-cli/src/vgo_cli/upgrade_service.py
+++ b/apps/vgo-cli/src/vgo_cli/upgrade_service.py
@@ -62,8 +62,11 @@ def refresh_upstream_status(
     commit_result = run_subprocess(['git', 'rev-parse', 'FETCH_HEAD'], cwd=repo_root)
     if commit_result.returncode != 0:
         raise CliError(commit_result.stderr.strip() or 'Failed to resolve fetched upstream commit.')
+    remote_commit = commit_result.stdout.strip()
+    if not remote_commit:
+        raise CliError('Failed to resolve fetched upstream commit.')
 
-    release_result = run_subprocess(['git', 'show', 'FETCH_HEAD:config/version-governance.json'], cwd=repo_root)
+    release_result = run_subprocess(['git', 'show', f'{remote_commit}:config/version-governance.json'], cwd=repo_root)
     if release_result.returncode != 0:
         raise CliError(release_result.stderr.strip() or 'Failed to read fetched release metadata.')
     release_payload = json.loads(release_result.stdout or '{}')
@@ -72,7 +75,7 @@ def refresh_upstream_status(
     merged = merge_upgrade_status(
         current_status,
         remote={
-            'remote_latest_commit': commit_result.stdout.strip(),
+            'remote_latest_commit': remote_commit,
             'remote_latest_version': str(release.get('version') or '').strip(),
             'remote_latest_checked_at': None,
         },

--- a/apps/vgo-cli/src/vgo_cli/upgrade_service.py
+++ b/apps/vgo-cli/src/vgo_cli/upgrade_service.py
@@ -43,8 +43,14 @@ def refresh_installed_status(repo_root: Path, target_root: Path, host_id: str) -
     return merged
 
 
-def refresh_upstream_status(repo_root: Path, target_root: Path, current_status: dict[str, object]) -> dict[str, object]:
-    if not is_upstream_cache_stale(current_status):
+def refresh_upstream_status(
+    repo_root: Path,
+    target_root: Path,
+    current_status: dict[str, object],
+    *,
+    force_refresh: bool = False,
+) -> dict[str, object]:
+    if not force_refresh and not is_upstream_cache_stale(current_status):
         return current_status
 
     repo_url = str(current_status.get('repo_remote') or '').strip()
@@ -75,12 +81,13 @@ def refresh_upstream_status(repo_root: Path, target_root: Path, current_status: 
     return merged
 
 
-def reset_repo_to_official_head(repo_root: Path, branch: str) -> None:
+def reset_repo_to_official_head(repo_root: Path, branch: str, target_commit: str | None = None) -> None:
+    target_ref = str(target_commit or '').strip() or 'FETCH_HEAD'
     commands = (
         ['git', 'reset', '--hard', 'HEAD'],
         ['git', 'clean', '-fd'],
-        ['git', 'checkout', '-B', branch, 'FETCH_HEAD'],
-        ['git', 'reset', '--hard', 'FETCH_HEAD'],
+        ['git', 'checkout', '-B', branch, target_ref],
+        ['git', 'reset', '--hard', target_ref],
     )
     for command in commands:
         result = run_subprocess(command, cwd=repo_root)
@@ -184,7 +191,7 @@ def upgrade_runtime(
         )
 
     before = refresh_installed_status(resolved_repo_root, target_root, host_id)
-    status = refresh_upstream_status(resolved_repo_root, target_root, before)
+    status = refresh_upstream_status(resolved_repo_root, target_root, before, force_refresh=True)
     if not bool(status.get('update_available')):
         print(
             'Vibe-Skills already current: '
@@ -193,7 +200,8 @@ def upgrade_runtime(
         return {'changed': False, 'before': before, 'after': status}
 
     branch = str(status.get('repo_default_branch') or 'main').strip() or 'main'
-    reset_repo_to_official_head(resolved_repo_root, branch)
+    target_commit = str(status.get('remote_latest_commit') or '').strip() or None
+    reset_repo_to_official_head(resolved_repo_root, branch, target_commit)
     reinstall_runtime(
         repo_root=resolved_repo_root,
         target_root=target_root,

--- a/tests/unit/test_vgo_cli_upgrade_service.py
+++ b/tests/unit/test_vgo_cli_upgrade_service.py
@@ -324,6 +324,56 @@ def test_upgrade_runtime_forces_fresh_upstream_refresh_before_deciding_update(
     assert result["changed"] is False
 
 
+def test_refresh_upstream_status_reads_release_metadata_from_resolved_commit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    commands: list[list[str]] = []
+
+    def fake_run_subprocess(command: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        assert cwd == repo_root
+        if command[:3] == ["git", "fetch", "--quiet"]:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if command == ["git", "rev-parse", "FETCH_HEAD"]:
+            return subprocess.CompletedProcess(command, 0, stdout="abc123\n", stderr="")
+        if command == ["git", "show", "abc123:config/version-governance.json"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout='{"release":{"version":"3.0.1"}}\n',
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(upgrade_service, "run_subprocess", fake_run_subprocess)
+
+    status = upgrade_service.refresh_upstream_status(
+        repo_root,
+        target_root,
+        {
+            "repo_remote": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+            "repo_default_branch": "main",
+            "installed_version": "3.0.0",
+            "installed_commit": "old",
+        },
+        force_refresh=True,
+    )
+
+    assert status["remote_latest_commit"] == "abc123"
+    assert status["remote_latest_version"] == "3.0.1"
+    assert commands == [
+        ["git", "fetch", "--quiet", "https://github.com/foryourhealth111-pixel/Vibe-Skills.git", "main"],
+        ["git", "rev-parse", "FETCH_HEAD"],
+        ["git", "show", "abc123:config/version-governance.json"],
+    ]
+
+
 def test_upgrade_runtime_propagates_refresh_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
 

--- a/tests/unit/test_vgo_cli_upgrade_service.py
+++ b/tests/unit/test_vgo_cli_upgrade_service.py
@@ -41,7 +41,11 @@ def test_upgrade_runtime_resolves_canonical_git_root_before_refresh(monkeypatch:
         }
 
     monkeypatch.setattr(upgrade_service, "refresh_installed_status", fake_refresh_installed_status)
-    monkeypatch.setattr(upgrade_service, "refresh_upstream_status", lambda repo_root_arg, target_root_arg, status: status)
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_upstream_status",
+        lambda repo_root_arg, target_root_arg, status, **kwargs: status,
+    )
 
     result = upgrade_service.upgrade_runtime(
         repo_root=repo_root,
@@ -84,7 +88,11 @@ def test_upgrade_runtime_noops_when_install_is_already_current(
             "update_available": False,
         },
     )
-    monkeypatch.setattr(upgrade_service, "refresh_upstream_status", lambda repo_root_arg, target_root_arg, status: status)
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_upstream_status",
+        lambda repo_root_arg, target_root_arg, status, **kwargs: status,
+    )
     monkeypatch.setattr(
         upgrade_service,
         "reset_repo_to_official_head",
@@ -191,7 +199,12 @@ def test_upgrade_runtime_refreshes_repo_reinstalls_and_checks_when_update_is_ava
     monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
     monkeypatch.setattr(upgrade_service, "refresh_installed_status", lambda repo_root_arg, target_root_arg, host_id: next(statuses))
 
-    def fake_refresh_upstream(repo_root_arg: Path, target_root_arg: Path, current_status: dict[str, object]) -> dict[str, object]:
+    def fake_refresh_upstream(
+        repo_root_arg: Path,
+        target_root_arg: Path,
+        current_status: dict[str, object],
+        **kwargs: object,
+    ) -> dict[str, object]:
         steps.append("refresh")
         merged = dict(current_status)
         merged.update(
@@ -205,7 +218,11 @@ def test_upgrade_runtime_refreshes_repo_reinstalls_and_checks_when_update_is_ava
         return merged
 
     monkeypatch.setattr(upgrade_service, "refresh_upstream_status", fake_refresh_upstream)
-    monkeypatch.setattr(upgrade_service, "reset_repo_to_official_head", lambda repo_root_arg, branch: steps.append(f"reset:{branch}"))
+    monkeypatch.setattr(
+        upgrade_service,
+        "reset_repo_to_official_head",
+        lambda repo_root_arg, branch, target_commit=None: steps.append(f"reset:{branch}:{target_commit}"),
+    )
     monkeypatch.setattr(upgrade_service, "reinstall_runtime", lambda **kwargs: steps.append("reinstall"))
     monkeypatch.setattr(
         upgrade_service,
@@ -226,10 +243,85 @@ def test_upgrade_runtime_refreshes_repo_reinstalls_and_checks_when_update_is_ava
         skip_runtime_freshness_gate=False,
     )
 
-    assert steps == ["refresh", "reset:main", "reinstall", "check"]
+    assert steps == ["refresh", "reset:main:new", "reinstall", "check"]
     assert result["changed"] is True
     assert result["before"]["installed_version"] == "3.0.0"
     assert result["after"]["installed_version"] == "3.0.1"
+
+
+def test_upgrade_runtime_forces_fresh_upstream_refresh_before_deciding_update(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+
+    monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_installed_status",
+        lambda repo_root_arg, target_root_arg, host_id: {
+            "installed_version": "3.0.0",
+            "installed_commit": "local",
+            "remote_latest_version": "3.0.1",
+            "remote_latest_commit": "stale-remote",
+            "remote_latest_checked_at": "2026-04-10T00:00:00Z",
+            "update_available": True,
+        },
+    )
+
+    recorded: dict[str, object] = {}
+
+    def fake_refresh_upstream(
+        repo_root_arg: Path,
+        target_root_arg: Path,
+        current_status: dict[str, object],
+        *,
+        force_refresh: bool = False,
+    ) -> dict[str, object]:
+        recorded["force_refresh"] = force_refresh
+        return {
+            **current_status,
+            "remote_latest_version": "3.0.0",
+            "remote_latest_commit": "local",
+            "update_available": False,
+        }
+
+    monkeypatch.setattr(upgrade_service, "refresh_upstream_status", fake_refresh_upstream)
+    monkeypatch.setattr(
+        upgrade_service,
+        "reset_repo_to_official_head",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not reset repo")),
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "reinstall_runtime",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("should not reinstall")),
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "run_upgrade_check",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("should not run check")),
+    )
+
+    result = upgrade_service.upgrade_runtime(
+        repo_root=repo_root,
+        target_root=target_root,
+        host_id="codex",
+        profile="full",
+        frontend="shell",
+        install_external=False,
+        strict_offline=False,
+        require_closed_ready=False,
+        allow_external_skill_fallback=False,
+        skip_runtime_freshness_gate=False,
+    )
+
+    assert recorded["force_refresh"] is True
+    assert result["changed"] is False
 
 
 def test_upgrade_runtime_propagates_refresh_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -249,7 +341,7 @@ def test_upgrade_runtime_propagates_refresh_failures(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(
         upgrade_service,
         "refresh_upstream_status",
-        lambda repo_root_arg, target_root_arg, current_status: (_ for _ in ()).throw(upgrade_service.CliError("refresh failed")),
+        lambda repo_root_arg, target_root_arg, current_status, **kwargs: (_ for _ in ()).throw(upgrade_service.CliError("refresh failed")),
     )
 
     with pytest.raises(upgrade_service.CliError, match="refresh failed"):
@@ -286,7 +378,7 @@ def test_upgrade_runtime_propagates_check_failures(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(
         upgrade_service,
         "refresh_upstream_status",
-        lambda repo_root_arg, target_root_arg, current_status: {
+        lambda repo_root_arg, target_root_arg, current_status, **kwargs: {
             **current_status,
             "remote_latest_version": "3.0.1",
             "remote_latest_commit": "new",
@@ -294,7 +386,7 @@ def test_upgrade_runtime_propagates_check_failures(monkeypatch: pytest.MonkeyPat
             "repo_default_branch": "main",
         },
     )
-    monkeypatch.setattr(upgrade_service, "reset_repo_to_official_head", lambda repo_root_arg, branch: None)
+    monkeypatch.setattr(upgrade_service, "reset_repo_to_official_head", lambda repo_root_arg, branch, target_commit=None: None)
     monkeypatch.setattr(upgrade_service, "reinstall_runtime", lambda **kwargs: None)
     monkeypatch.setattr(
         upgrade_service,
@@ -395,4 +487,30 @@ def test_reset_repo_to_official_head_discards_local_changes_before_switch(monkey
         ["git", "clean", "-fd"],
         ["git", "checkout", "-B", "main", "FETCH_HEAD"],
         ["git", "reset", "--hard", "FETCH_HEAD"],
+    ]
+
+
+def test_reset_repo_to_official_head_uses_explicit_target_commit_when_provided(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
+    commands: list[list[str]] = []
+
+    def fake_run_subprocess(command: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        assert cwd == repo_root
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(upgrade_service, "run_subprocess", fake_run_subprocess)
+
+    upgrade_service.reset_repo_to_official_head(repo_root, "main", "abc123")
+
+    assert commands == [
+        ["git", "reset", "--hard", "HEAD"],
+        ["git", "clean", "-fd"],
+        ["git", "checkout", "-B", "main", "abc123"],
+        ["git", "reset", "--hard", "abc123"],
     ]


### PR DESCRIPTION
## Summary
- fix upgrade repo resolution and check-gate regressions on the `pr130-review-fix` branch
- tighten freshness validation and add regression coverage
- force `vgo_cli upgrade` to refresh upstream state before deciding whether an update exists
- reset to the resolved remote commit instead of relying on a stale `FETCH_HEAD`

## Verification
- `pytest tests/unit/test_vgo_cli_upgrade_service.py -q`
- seeded stale `upgrade-status.json` with `update_available=true` and an old `remote_latest_commit`, then ran `python3 -m vgo_cli.main upgrade ...`
- confirmed the command now reports `Vibe-Skills already current` and rewrites `.vibeskills/upgrade-status.json` with `update_available=false` and matching local/remote commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * The upgrade process now always checks upstream for the latest version before upgrading, ensuring fresh data is used regardless of cache state.
  * Upgrades now target the exact upstream commit fetched, preventing misaligned resets during updates.
* **Tests**
  * Added tests verifying forced upstream refresh behavior and correct commit-based release metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->