### PR TITLE
feat: strengthen document artifact governance

### DIFF
--- a/config/project-delivery-acceptance-contract.json
+++ b/config/project-delivery-acceptance-contract.json
@@ -65,6 +65,7 @@
       "artifact_review_truth",
       "product_acceptance_truth",
       "completion_language_allowed",
+      "artifact_review_coverage",
       "tdd_evidence_coverage",
       "residual_risks",
       "manual_spot_checks"

--- a/config/project-delivery-acceptance-contract.json
+++ b/config/project-delivery-acceptance-contract.json
@@ -1,10 +1,12 @@
 {
-  "contract_id": "vibe-project-delivery-acceptance-v1",
-  "version": 1,
+  "contract_id": "vibe-project-delivery-acceptance-v3",
+  "version": 3,
   "truth_layers": [
     "governance_truth",
     "engineering_verification_truth",
+    "code_task_tdd_evidence_truth",
     "workflow_completion_truth",
+    "artifact_review_truth",
     "product_acceptance_truth"
   ],
   "truth_states": {
@@ -31,6 +33,10 @@
     "not_run": {
       "counts_as_success": false,
       "completion_language_allowed": false
+    },
+    "not_applicable": {
+      "counts_as_success": true,
+      "completion_language_allowed": true
     }
   },
   "forbidden_completion_collapses": [
@@ -54,9 +60,12 @@
     "must_report_fields": [
       "governance_truth",
       "engineering_verification_truth",
+      "code_task_tdd_evidence_truth",
       "workflow_completion_truth",
+      "artifact_review_truth",
       "product_acceptance_truth",
       "completion_language_allowed",
+      "tdd_evidence_coverage",
       "residual_risks",
       "manual_spot_checks"
     ]

--- a/config/python-validation-targets.txt
+++ b/config/python-validation-targets.txt
@@ -7,5 +7,6 @@ tests/runtime_neutral/test_custom_admission_bridge.py
 tests/runtime_neutral/test_docs_readme_encoding.py
 tests/runtime_neutral/test_governed_runtime_bridge.py
 tests/runtime_neutral/test_install_profile_differentiation.py
+tests/runtime_neutral/test_memory_progressive_disclosure.py
 tests/runtime_neutral/test_runtime_contract_goldens.py
 tests/runtime_neutral/test_python_validation_contract.py

--- a/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance.py
+++ b/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance.py
@@ -39,6 +39,94 @@ def write_artifacts(artifact: dict[str, Any], output_directory: Path) -> None:
         lines.append(
             f"- `{layer}`: state=`{info['state']}` success=`{info['success']}` completion_language_allowed=`{info['completion_language_allowed']}`"
         )
+    frozen_sections = artifact.get("frozen_requirement_sections") or {}
+    if frozen_sections.get("artifact_review_requirements"):
+        lines += ["", "## Frozen Artifact Review Requirements", ""]
+        for item in frozen_sections["artifact_review_requirements"]:
+            lines.append(f"- {item}")
+    if frozen_sections.get("code_task_tdd_evidence_requirements"):
+        lines += ["", "## Frozen Code Task TDD Evidence Requirements", ""]
+        for item in frozen_sections["code_task_tdd_evidence_requirements"]:
+            lines.append(f"- {item}")
+    if frozen_sections.get("code_task_tdd_exceptions"):
+        lines += ["", "## Frozen Code Task TDD Exceptions", ""]
+        for item in frozen_sections["code_task_tdd_exceptions"]:
+            lines.append(f"- {item}")
+    if frozen_sections.get("baseline_document_quality_dimensions"):
+        lines += ["", "## Frozen Baseline Document Quality Dimensions", ""]
+        for item in frozen_sections["baseline_document_quality_dimensions"]:
+            lines.append(f"- {item}")
+    if frozen_sections.get("baseline_ui_quality_dimensions"):
+        lines += ["", "## Frozen Baseline UI Quality Dimensions", ""]
+        for item in frozen_sections["baseline_ui_quality_dimensions"]:
+            lines.append(f"- {item}")
+    if frozen_sections.get("task_specific_acceptance_extensions"):
+        lines += ["", "## Frozen Task-Specific Acceptance Extensions", ""]
+        for item in frozen_sections["task_specific_acceptance_extensions"]:
+            lines.append(f"- {item}")
+    if frozen_sections.get("research_augmentation_sources"):
+        lines += ["", "## Frozen Research Augmentation Sources", ""]
+        for item in frozen_sections["research_augmentation_sources"]:
+            lines.append(f"- {item}")
+    coverage = artifact.get("artifact_review_coverage") or {}
+    tdd_coverage = artifact.get("tdd_evidence_coverage") or {}
+    if any(
+        tdd_coverage.get(key)
+        for key in (
+            "covered_code_task_tdd_evidence_requirements",
+            "missing_code_task_tdd_evidence_requirements",
+            "covered_code_task_tdd_exceptions",
+            "missing_code_task_tdd_exceptions",
+            "red_phase_evidence_paths",
+            "green_phase_evidence_paths",
+            "refactor_phase_evidence_paths",
+        )
+    ):
+        lines += ["", "## Code Task TDD Evidence Coverage", ""]
+        for item in tdd_coverage.get("covered_code_task_tdd_evidence_requirements") or []:
+            lines.append(f"- Covered code-task TDD evidence requirement: {item}")
+        for item in tdd_coverage.get("missing_code_task_tdd_evidence_requirements") or []:
+            lines.append(f"- Missing code-task TDD evidence requirement: {item}")
+        for item in tdd_coverage.get("covered_code_task_tdd_exceptions") or []:
+            lines.append(f"- Covered code-task TDD exception: {item}")
+        for item in tdd_coverage.get("missing_code_task_tdd_exceptions") or []:
+            lines.append(f"- Missing code-task TDD exception: {item}")
+        for item in tdd_coverage.get("red_phase_evidence_paths") or []:
+            lines.append(f"- Red-phase evidence: {item}")
+        for item in tdd_coverage.get("green_phase_evidence_paths") or []:
+            lines.append(f"- Green-phase evidence: {item}")
+        for item in tdd_coverage.get("refactor_phase_evidence_paths") or []:
+            lines.append(f"- Refactor-phase evidence: {item}")
+    if any(
+        coverage.get(key)
+        for key in (
+            "covered_baseline_document_quality_dimensions",
+            "missing_baseline_document_quality_dimensions",
+            "covered_baseline_ui_quality_dimensions",
+            "missing_baseline_ui_quality_dimensions",
+            "covered_task_specific_acceptance_extensions",
+            "missing_task_specific_acceptance_extensions",
+            "considered_research_augmentation_sources",
+            "missing_research_augmentation_sources",
+        )
+    ):
+        lines += ["", "## Artifact Review Coverage", ""]
+        for item in coverage.get("covered_baseline_document_quality_dimensions") or []:
+            lines.append(f"- Covered baseline document quality dimension: {item}")
+        for item in coverage.get("missing_baseline_document_quality_dimensions") or []:
+            lines.append(f"- Missing baseline document quality dimension: {item}")
+        for item in coverage.get("covered_baseline_ui_quality_dimensions") or []:
+            lines.append(f"- Covered baseline UI quality dimension: {item}")
+        for item in coverage.get("missing_baseline_ui_quality_dimensions") or []:
+            lines.append(f"- Missing baseline UI quality dimension: {item}")
+        for item in coverage.get("covered_task_specific_acceptance_extensions") or []:
+            lines.append(f"- Covered task-specific acceptance: {item}")
+        for item in coverage.get("missing_task_specific_acceptance_extensions") or []:
+            lines.append(f"- Missing task-specific acceptance: {item}")
+        for item in coverage.get("considered_research_augmentation_sources") or []:
+            lines.append(f"- Considered research source: {item}")
+        for item in coverage.get("missing_research_augmentation_sources") or []:
+            lines.append(f"- Missing research source: {item}")
     if artifact["manual_spot_checks"]:
         lines += ["", "## Manual Spot Checks", ""]
         for item in artifact["manual_spot_checks"]:

--- a/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py
+++ b/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py
@@ -144,28 +144,26 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
                 )
 
         if code_task_tdd_evidence_state == "passing":
-            if code_task_tdd_exceptions:
-                if missing_code_task_tdd_exceptions:
-                    code_task_tdd_evidence_state = "manual_review_required"
-                    code_task_tdd_evidence_notes.append(
-                        "Code-task TDD exception coverage did not close all frozen exceptions."
-                    )
-            else:
-                if missing_code_task_tdd_evidence_requirements:
-                    code_task_tdd_evidence_state = "manual_review_required"
-                    code_task_tdd_evidence_notes.append(
-                        "Code-task TDD evidence did not record coverage for all frozen TDD requirements."
-                    )
-                if not red_phase_evidence_paths:
-                    code_task_tdd_evidence_state = "manual_review_required"
-                    code_task_tdd_evidence_notes.append(
-                        "Code-task TDD evidence did not record failing-first evidence paths."
-                    )
-                if not green_phase_evidence_paths:
-                    code_task_tdd_evidence_state = "manual_review_required"
-                    code_task_tdd_evidence_notes.append(
-                        "Code-task TDD evidence did not record green-phase verification evidence paths."
-                    )
+            if code_task_tdd_exceptions and missing_code_task_tdd_exceptions:
+                code_task_tdd_evidence_state = "manual_review_required"
+                code_task_tdd_evidence_notes.append(
+                    "Code-task TDD exception coverage did not close all frozen exceptions."
+                )
+            if code_task_tdd_evidence_requirements and missing_code_task_tdd_evidence_requirements:
+                code_task_tdd_evidence_state = "manual_review_required"
+                code_task_tdd_evidence_notes.append(
+                    "Code-task TDD evidence did not record coverage for all frozen TDD requirements."
+                )
+            if not red_phase_evidence_paths:
+                code_task_tdd_evidence_state = "manual_review_required"
+                code_task_tdd_evidence_notes.append(
+                    "Code-task TDD evidence did not record failing-first evidence paths."
+                )
+            if not green_phase_evidence_paths:
+                code_task_tdd_evidence_state = "manual_review_required"
+                code_task_tdd_evidence_notes.append(
+                    "Code-task TDD evidence did not record green-phase verification evidence paths."
+                )
 
     tdd_evidence_payload_notes = str(tdd_evidence_payload.get("notes") or "").strip()
     if tdd_evidence_payload_notes:
@@ -392,6 +390,12 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
         residual_risks.append("Required artifact review remains unresolved.")
     if baseline_document_quality_dimensions and artifact_review_state != "passing":
         residual_risks.append("Frozen baseline document quality dimensions remain unresolved.")
+    if baseline_ui_quality_dimensions and artifact_review_state != "passing":
+        residual_risks.append("Frozen baseline UI quality dimensions remain unresolved.")
+    if task_specific_acceptance_extensions and artifact_review_state != "passing":
+        residual_risks.append("Frozen task-specific acceptance extensions remain unresolved.")
+    if research_augmentation_sources and artifact_review_state != "passing":
+        residual_risks.append("Frozen research augmentation sources remain unresolved.")
     if not product_acceptance_criteria:
         residual_risks.append("Product acceptance criteria were not frozen in the requirement doc.")
     if str(cleanup_receipt.get("cleanup_mode") or "") == "cleanup_degraded":

--- a/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py
+++ b/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py
@@ -7,8 +7,13 @@ from .runtime_delivery_acceptance_support import (
     _derive_readiness_state,
     _extract_bullets,
     _manual_spot_checks_from_requirement,
+    _missing_frozen_items,
     _normalize_truth_state,
+    _normalize_string_list,
     _read_text_if_exists,
+    _requirement_optional_bullets,
+    _resolve_artifact_review_payload,
+    _resolve_tdd_evidence_payload,
     _truth_completion_allowed,
     _truth_success,
     load_json,
@@ -38,6 +43,27 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
     manual_spot_checks, manual_section_missing = _manual_spot_checks_from_requirement(requirement_text)
     completion_language_policy = _extract_bullets(requirement_text, "Completion Language Policy")
     delivery_truth_contract = _extract_bullets(requirement_text, "Delivery Truth Contract")
+    artifact_review_requirements = _requirement_optional_bullets(requirement_text, "Artifact Review Requirements")
+    code_task_tdd_evidence_requirements = _requirement_optional_bullets(
+        requirement_text,
+        "Code Task TDD Evidence Requirements",
+    )
+    code_task_tdd_exceptions = _requirement_optional_bullets(requirement_text, "Code Task TDD Exceptions")
+    baseline_document_quality_dimensions = _requirement_optional_bullets(
+        requirement_text,
+        "Baseline Document Quality Dimensions",
+    )
+    baseline_ui_quality_dimensions = _requirement_optional_bullets(requirement_text, "Baseline UI Quality Dimensions")
+    task_specific_acceptance_extensions = _requirement_optional_bullets(
+        requirement_text,
+        "Task-Specific Acceptance Extensions",
+    )
+    research_augmentation_sources = _requirement_optional_bullets(
+        requirement_text,
+        "Research Augmentation Sources",
+    )
+    artifact_review_payload = _resolve_artifact_review_payload(session_root, execute_receipt)
+    tdd_evidence_payload = _resolve_tdd_evidence_payload(session_root, execute_receipt)
 
     governance_truth_state = "passing"
     governance_truth_notes: list[str] = []
@@ -73,6 +99,78 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
         engineering_truth_state = "partial"
         engineering_truth_notes.append("Execution verification completed with failing or timed-out units.")
 
+    code_task_tdd_evidence_state = "not_applicable"
+    code_task_tdd_evidence_notes: list[str] = []
+    code_task_tdd_evidence_evidence = _normalize_string_list(tdd_evidence_payload.get("evidence_paths"))
+    code_task_tdd_evidence_source_path = str(tdd_evidence_payload.get("source_path") or "").strip()
+    if code_task_tdd_evidence_source_path:
+        code_task_tdd_evidence_evidence = [code_task_tdd_evidence_source_path, *code_task_tdd_evidence_evidence]
+    covered_code_task_tdd_evidence_requirements = _normalize_string_list(
+        tdd_evidence_payload.get("covered_code_task_tdd_evidence_requirements")
+    )
+    covered_code_task_tdd_exceptions = _normalize_string_list(
+        tdd_evidence_payload.get("covered_code_task_tdd_exceptions")
+    )
+    red_phase_evidence_paths = _normalize_string_list(tdd_evidence_payload.get("red_phase_evidence_paths"))
+    green_phase_evidence_paths = _normalize_string_list(tdd_evidence_payload.get("green_phase_evidence_paths"))
+    refactor_phase_evidence_paths = _normalize_string_list(tdd_evidence_payload.get("refactor_phase_evidence_paths"))
+    missing_code_task_tdd_evidence_requirements = _missing_frozen_items(
+        code_task_tdd_evidence_requirements,
+        covered_code_task_tdd_evidence_requirements,
+    )
+    missing_code_task_tdd_exceptions = _missing_frozen_items(
+        code_task_tdd_exceptions,
+        covered_code_task_tdd_exceptions,
+    )
+
+    raw_tdd_evidence_state = str(tdd_evidence_payload.get("status") or tdd_evidence_payload.get("state") or "").strip()
+    if code_task_tdd_evidence_requirements or code_task_tdd_exceptions:
+        if not tdd_evidence_payload:
+            code_task_tdd_evidence_state = "manual_review_required"
+            code_task_tdd_evidence_notes.append(
+                "Requirement doc froze code-task TDD evidence requirements but no TDD evidence payload was recorded."
+            )
+        else:
+            code_task_tdd_evidence_state = _normalize_truth_state(raw_tdd_evidence_state)
+            if code_task_tdd_evidence_state in {"", "not_run"}:
+                code_task_tdd_evidence_state = "manual_review_required"
+                code_task_tdd_evidence_notes.append(
+                    "Code-task TDD evidence was required, but the recorded TDD status did not close the review."
+                )
+            elif code_task_tdd_evidence_state == "passing" and not code_task_tdd_evidence_evidence:
+                code_task_tdd_evidence_state = "manual_review_required"
+                code_task_tdd_evidence_notes.append(
+                    "Code-task TDD evidence reported passing, but no evidence paths were recorded."
+                )
+
+        if code_task_tdd_evidence_state == "passing":
+            if code_task_tdd_exceptions:
+                if missing_code_task_tdd_exceptions:
+                    code_task_tdd_evidence_state = "manual_review_required"
+                    code_task_tdd_evidence_notes.append(
+                        "Code-task TDD exception coverage did not close all frozen exceptions."
+                    )
+            else:
+                if missing_code_task_tdd_evidence_requirements:
+                    code_task_tdd_evidence_state = "manual_review_required"
+                    code_task_tdd_evidence_notes.append(
+                        "Code-task TDD evidence did not record coverage for all frozen TDD requirements."
+                    )
+                if not red_phase_evidence_paths:
+                    code_task_tdd_evidence_state = "manual_review_required"
+                    code_task_tdd_evidence_notes.append(
+                        "Code-task TDD evidence did not record failing-first evidence paths."
+                    )
+                if not green_phase_evidence_paths:
+                    code_task_tdd_evidence_state = "manual_review_required"
+                    code_task_tdd_evidence_notes.append(
+                        "Code-task TDD evidence did not record green-phase verification evidence paths."
+                    )
+
+    tdd_evidence_payload_notes = str(tdd_evidence_payload.get("notes") or "").strip()
+    if tdd_evidence_payload_notes:
+        code_task_tdd_evidence_notes.append(tdd_evidence_payload_notes)
+
     workflow_truth_state = "passing"
     workflow_truth_notes: list[str] = []
     if str(cleanup_receipt.get("cleanup_mode") or "") == "cleanup_degraded":
@@ -88,6 +186,100 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
         workflow_truth_state = "failing"
         workflow_truth_notes.append("Workflow did not reach a clean completed state.")
 
+    artifact_review_state = "passing"
+    artifact_review_notes: list[str] = []
+    artifact_review_evidence = _normalize_string_list(artifact_review_payload.get("evidence_paths"))
+    artifact_review_source_path = str(artifact_review_payload.get("source_path") or "").strip()
+    if artifact_review_source_path:
+        artifact_review_evidence = [artifact_review_source_path, *artifact_review_evidence]
+    covered_baseline_document_quality_dimensions = _normalize_string_list(
+        artifact_review_payload.get("covered_baseline_document_quality_dimensions")
+    )
+    covered_baseline_ui_quality_dimensions = _normalize_string_list(
+        artifact_review_payload.get("covered_baseline_ui_quality_dimensions")
+    )
+    covered_task_specific_acceptance_extensions = _normalize_string_list(
+        artifact_review_payload.get("covered_task_specific_acceptance_extensions")
+    )
+    considered_research_augmentation_sources = _normalize_string_list(
+        artifact_review_payload.get("considered_research_augmentation_sources")
+    )
+    missing_task_specific_acceptance_extensions = _missing_frozen_items(
+        task_specific_acceptance_extensions,
+        covered_task_specific_acceptance_extensions,
+    )
+    missing_baseline_document_quality_dimensions = _missing_frozen_items(
+        baseline_document_quality_dimensions,
+        covered_baseline_document_quality_dimensions,
+    )
+    missing_baseline_ui_quality_dimensions = _missing_frozen_items(
+        baseline_ui_quality_dimensions,
+        covered_baseline_ui_quality_dimensions,
+    )
+    missing_research_augmentation_sources = _missing_frozen_items(
+        research_augmentation_sources,
+        considered_research_augmentation_sources,
+    )
+
+    raw_artifact_review_state = str(
+        artifact_review_payload.get("status") or artifact_review_payload.get("state") or ""
+    ).strip()
+    if artifact_review_requirements:
+        if not artifact_review_payload:
+            artifact_review_state = "manual_review_required"
+            artifact_review_notes.append(
+                "Requirement doc froze artifact review requirements but no artifact-review evidence was recorded."
+            )
+        else:
+            artifact_review_state = _normalize_truth_state(raw_artifact_review_state)
+            if artifact_review_state in {"", "not_run"}:
+                artifact_review_state = "manual_review_required"
+                artifact_review_notes.append(
+                    "Artifact review was required, but the recorded artifact-review status did not close the review."
+                )
+            elif artifact_review_state == "passing" and not artifact_review_evidence:
+                artifact_review_state = "manual_review_required"
+                artifact_review_notes.append(
+                    "Artifact review reported passing, but no artifact-review evidence paths were recorded."
+                )
+    elif artifact_review_payload:
+        artifact_review_state = _normalize_truth_state(raw_artifact_review_state)
+        if artifact_review_state in {"", "not_run"} and not artifact_review_evidence:
+            artifact_review_state = "passing"
+        elif artifact_review_state == "passing" and not artifact_review_evidence:
+            artifact_review_state = "manual_review_required"
+            artifact_review_notes.append(
+                "Artifact review reported passing, but no artifact-review evidence paths were recorded."
+            )
+        elif not artifact_review_state:
+            artifact_review_state = "manual_review_required"
+            artifact_review_notes.append("Artifact review payload did not record a normalized status.")
+
+    if artifact_review_state == "passing" and missing_task_specific_acceptance_extensions:
+        artifact_review_state = "manual_review_required"
+        artifact_review_notes.append(
+            "Artifact review did not record coverage for all frozen task-specific acceptance extensions."
+        )
+    if artifact_review_state == "passing" and missing_baseline_document_quality_dimensions:
+        artifact_review_state = "manual_review_required"
+        artifact_review_notes.append(
+            "Artifact review did not record coverage for all frozen baseline document quality dimensions."
+        )
+    if artifact_review_state == "passing" and missing_baseline_ui_quality_dimensions:
+        artifact_review_state = "manual_review_required"
+        artifact_review_notes.append(
+            "Artifact review did not record coverage for all frozen baseline UI quality dimensions."
+        )
+    if artifact_review_state == "passing" and missing_research_augmentation_sources:
+        artifact_review_state = "manual_review_required"
+        artifact_review_notes.append(
+            "Artifact review did not record consideration of all frozen research augmentation sources."
+        )
+
+    artifact_review_payload_notes = str(artifact_review_payload.get("notes") or "").strip()
+    if artifact_review_payload_notes:
+        artifact_review_notes.append(artifact_review_payload_notes)
+
     product_truth_state = "passing"
     product_truth_notes: list[str] = []
     if engineering_truth_state in {"failing", "degraded"}:
@@ -96,6 +288,24 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
     elif engineering_truth_state == "partial":
         product_truth_state = "partial"
         product_truth_notes.append("Product acceptance cannot pass while engineering verification remains partial.")
+    elif code_task_tdd_evidence_state in {"failing", "degraded", "not_run"}:
+        product_truth_state = "failing"
+        product_truth_notes.append("Code-task TDD evidence truth is not strong enough to support product acceptance.")
+    elif code_task_tdd_evidence_state == "partial":
+        product_truth_state = "partial"
+        product_truth_notes.append("Product acceptance cannot pass while code-task TDD evidence remains partial.")
+    elif code_task_tdd_evidence_state == "manual_review_required":
+        product_truth_state = "manual_review_required"
+        product_truth_notes.append("Frozen code-task TDD evidence requirements remain pending.")
+    elif artifact_review_state in {"failing", "degraded", "not_run"}:
+        product_truth_state = "failing"
+        product_truth_notes.append("Required artifact-review truth is not strong enough to support product acceptance.")
+    elif artifact_review_state == "partial":
+        product_truth_state = "partial"
+        product_truth_notes.append("Product acceptance cannot pass while artifact review remains partial.")
+    elif artifact_review_state == "manual_review_required":
+        product_truth_state = "manual_review_required"
+        product_truth_notes.append("Frozen artifact review requirements remain pending.")
     elif not product_acceptance_criteria:
         product_truth_state = "manual_review_required"
         product_truth_notes.append("Requirement doc is missing frozen product acceptance criteria.")
@@ -117,14 +327,24 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
             "evidence": [str(execution_manifest_path)],
             "notes": " ".join(engineering_truth_notes).strip(),
         },
+        "code_task_tdd_evidence_truth": {
+            "state": _normalize_truth_state(code_task_tdd_evidence_state),
+            "evidence": code_task_tdd_evidence_evidence,
+            "notes": " ".join(code_task_tdd_evidence_notes).strip(),
+        },
         "workflow_completion_truth": {
             "state": _normalize_truth_state(workflow_truth_state),
             "evidence": [str(execute_receipt_path), str(cleanup_receipt_path)],
             "notes": " ".join(workflow_truth_notes).strip(),
         },
+        "artifact_review_truth": {
+            "state": _normalize_truth_state(artifact_review_state),
+            "evidence": artifact_review_evidence,
+            "notes": " ".join(artifact_review_notes).strip(),
+        },
         "product_acceptance_truth": {
             "state": _normalize_truth_state(product_truth_state),
-            "evidence": [str(requirement_doc_path)],
+            "evidence": [str(requirement_doc_path), *artifact_review_evidence],
             "notes": " ".join(product_truth_notes).strip(),
         },
     }
@@ -166,6 +386,12 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
         residual_risks.append("Manual spot checks remain pending.")
     if manual_section_missing:
         residual_risks.append("Manual spot check policy was not frozen in the requirement doc.")
+    if (code_task_tdd_evidence_requirements or code_task_tdd_exceptions) and code_task_tdd_evidence_state != "passing":
+        residual_risks.append("Required code-task TDD evidence remains unresolved.")
+    if artifact_review_requirements and artifact_review_state != "passing":
+        residual_risks.append("Required artifact review remains unresolved.")
+    if baseline_document_quality_dimensions and artifact_review_state != "passing":
+        residual_risks.append("Frozen baseline document quality dimensions remain unresolved.")
     if not product_acceptance_criteria:
         residual_risks.append("Product acceptance criteria were not frozen in the requirement doc.")
     if str(cleanup_receipt.get("cleanup_mode") or "") == "cleanup_degraded":
@@ -183,6 +409,10 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
         "forbidden_completion_hit_count": len(forbidden_hits),
         "incomplete_layers": incomplete_layers,
         "manual_spot_check_count": len(manual_spot_checks),
+        "code_task_tdd_evidence_requirement_count": len(code_task_tdd_evidence_requirements),
+        "artifact_review_requirement_count": len(artifact_review_requirements),
+        "baseline_document_quality_dimension_count": len(baseline_document_quality_dimensions),
+        "baseline_ui_quality_dimension_count": len(baseline_ui_quality_dimensions),
     }
 
     return {
@@ -209,11 +439,37 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
             }
             for layer, info in truth_layers.items()
         },
+        "artifact_review_coverage": {
+            "covered_baseline_document_quality_dimensions": covered_baseline_document_quality_dimensions,
+            "missing_baseline_document_quality_dimensions": missing_baseline_document_quality_dimensions,
+            "covered_baseline_ui_quality_dimensions": covered_baseline_ui_quality_dimensions,
+            "missing_baseline_ui_quality_dimensions": missing_baseline_ui_quality_dimensions,
+            "covered_task_specific_acceptance_extensions": covered_task_specific_acceptance_extensions,
+            "missing_task_specific_acceptance_extensions": missing_task_specific_acceptance_extensions,
+            "considered_research_augmentation_sources": considered_research_augmentation_sources,
+            "missing_research_augmentation_sources": missing_research_augmentation_sources,
+        },
+        "tdd_evidence_coverage": {
+            "covered_code_task_tdd_evidence_requirements": covered_code_task_tdd_evidence_requirements,
+            "missing_code_task_tdd_evidence_requirements": missing_code_task_tdd_evidence_requirements,
+            "covered_code_task_tdd_exceptions": covered_code_task_tdd_exceptions,
+            "missing_code_task_tdd_exceptions": missing_code_task_tdd_exceptions,
+            "red_phase_evidence_paths": red_phase_evidence_paths,
+            "green_phase_evidence_paths": green_phase_evidence_paths,
+            "refactor_phase_evidence_paths": refactor_phase_evidence_paths,
+        },
         "frozen_requirement_sections": {
             "product_acceptance_criteria": product_acceptance_criteria,
             "manual_spot_checks": manual_spot_checks,
             "completion_language_policy": completion_language_policy,
             "delivery_truth_contract": delivery_truth_contract,
+            "artifact_review_requirements": artifact_review_requirements,
+            "code_task_tdd_evidence_requirements": code_task_tdd_evidence_requirements,
+            "code_task_tdd_exceptions": code_task_tdd_exceptions,
+            "baseline_document_quality_dimensions": baseline_document_quality_dimensions,
+            "baseline_ui_quality_dimensions": baseline_ui_quality_dimensions,
+            "task_specific_acceptance_extensions": task_specific_acceptance_extensions,
+            "research_augmentation_sources": research_augmentation_sources,
         },
         "execution_context": {
             "governance_scope": str(execution_manifest.get("governance_scope") or ""),
@@ -224,6 +480,10 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
             "failed_unit_count": failed_unit_count,
             "timed_out_unit_count": timed_out_unit_count,
             "execution_plan_contains_delivery_acceptance_plan": "## Delivery Acceptance Plan" in execution_plan_text,
+            "tdd_evidence_source_path": code_task_tdd_evidence_source_path,
+            "code_task_tdd_evidence_state": _normalize_truth_state(code_task_tdd_evidence_state),
+            "artifact_review_source_path": artifact_review_source_path,
+            "artifact_review_state": _normalize_truth_state(artifact_review_state),
         },
         "forbidden_completion_hits": forbidden_hits,
         "manual_spot_checks": manual_spot_checks,

--- a/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_support.py
+++ b/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_support.py
@@ -145,10 +145,20 @@ def _resolve_optional_payload(
 
     explicit_path_value = str(execute_receipt.get(explicit_path_key) or "").strip()
     if explicit_path_value:
+        resolved_session_root = session_root.resolve()
         explicit_path = Path(explicit_path_value)
         if not explicit_path.is_absolute():
-            explicit_path = (session_root / explicit_path).resolve()
-        if explicit_path.exists():
+            explicit_path = (resolved_session_root / explicit_path).resolve()
+        else:
+            explicit_path = explicit_path.resolve()
+
+        path_in_session_scope = True
+        try:
+            explicit_path.relative_to(resolved_session_root)
+        except ValueError:
+            path_in_session_scope = False
+
+        if path_in_session_scope and explicit_path.exists():
             payload = load_json(explicit_path)
             if isinstance(payload, dict):
                 normalized_payload = dict(payload)

--- a/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_support.py
+++ b/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_support.py
@@ -53,6 +53,33 @@ def _extract_bullets(text: str, heading: str) -> list[str]:
     return bullets
 
 
+def _normalize_string_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        items = value
+    elif value is None:
+        items = []
+    else:
+        items = [value]
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _normalize_match_key(value: str) -> str:
+    return " ".join(str(value).split()).strip().lower()
+
+
+def _missing_frozen_items(required_items: list[str], covered_items: list[str]) -> list[str]:
+    covered_keys = {_normalize_match_key(item) for item in _normalize_string_list(covered_items)}
+    missing: list[str] = []
+    for item in _normalize_string_list(required_items):
+        if _normalize_match_key(item) not in covered_keys:
+            missing.append(item)
+    return missing
+
+
+def _requirement_optional_bullets(requirement_text: str, heading: str) -> list[str]:
+    return _normalize_string_list(_extract_bullets(requirement_text, heading))
+
+
 def _manual_spot_checks_from_requirement(requirement_text: str) -> tuple[list[str], bool]:
     raw_items = _extract_bullets(requirement_text, "Manual Spot Checks")
     if not raw_items:
@@ -65,6 +92,78 @@ def _manual_spot_checks_from_requirement(requirement_text: str) -> tuple[list[st
             return [], False
 
     return normalized_items, False
+
+
+def _resolve_artifact_review_payload(session_root: Path, execute_receipt: dict[str, Any]) -> dict[str, Any]:
+    return _resolve_optional_payload(
+        session_root,
+        execute_receipt,
+        inline_key="artifact_review",
+        explicit_path_key="artifact_review_path",
+        sidecar_filename="artifact-review.json",
+        inline_presence_keys=("status", "state", "evidence_paths", "notes"),
+    )
+
+
+def _resolve_tdd_evidence_payload(session_root: Path, execute_receipt: dict[str, Any]) -> dict[str, Any]:
+    return _resolve_optional_payload(
+        session_root,
+        execute_receipt,
+        inline_key="tdd_evidence",
+        explicit_path_key="tdd_evidence_path",
+        sidecar_filename="tdd-evidence.json",
+        inline_presence_keys=(
+            "status",
+            "state",
+            "evidence_paths",
+            "notes",
+            "red_phase_evidence_paths",
+            "green_phase_evidence_paths",
+            "refactor_phase_evidence_paths",
+            "covered_code_task_tdd_evidence_requirements",
+            "covered_code_task_tdd_exceptions",
+        ),
+    )
+
+
+def _resolve_optional_payload(
+    session_root: Path,
+    execute_receipt: dict[str, Any],
+    *,
+    inline_key: str,
+    explicit_path_key: str,
+    sidecar_filename: str,
+    inline_presence_keys: tuple[str, ...],
+) -> dict[str, Any]:
+    inline_payload = execute_receipt.get(inline_key) or {}
+    if isinstance(inline_payload, dict):
+        has_inline_content = any(inline_payload.get(key) for key in inline_presence_keys)
+        if has_inline_content:
+            payload = dict(inline_payload)
+            payload["source_path"] = str(session_root / "phase-execute.json")
+            return payload
+
+    explicit_path_value = str(execute_receipt.get(explicit_path_key) or "").strip()
+    if explicit_path_value:
+        explicit_path = Path(explicit_path_value)
+        if not explicit_path.is_absolute():
+            explicit_path = (session_root / explicit_path).resolve()
+        if explicit_path.exists():
+            payload = load_json(explicit_path)
+            if isinstance(payload, dict):
+                normalized_payload = dict(payload)
+                normalized_payload["source_path"] = str(explicit_path)
+                return normalized_payload
+
+    sidecar_path = session_root / sidecar_filename
+    if sidecar_path.exists():
+        payload = load_json(sidecar_path)
+        if isinstance(payload, dict):
+            normalized_payload = dict(payload)
+            normalized_payload["source_path"] = str(sidecar_path)
+            return normalized_payload
+
+    return {}
 
 
 def _derive_readiness_state(gate_result: str, manual_spot_checks: list[str]) -> str:

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -27,8 +27,7 @@ function Test-VibeTaskNeedsManualSpotChecks {
         [AllowEmptyString()] [string]$Deliverable = ''
     )
 
-    $text = ('{0} {1}' -f $Task, $Deliverable).ToLowerInvariant()
-    return $text -match 'ui|ux|frontend|browser|page|screen|openclaw|cursor|windsurf|codex|用户|界面|交互|可视化|体验'
+    return Test-VibeTaskNeedsUiBaseline -Task $Task -Deliverable $Deliverable
 }
 
 function Test-VibeTaskNeedsDocumentArtifactBaseline {
@@ -51,6 +50,21 @@ function Test-VibeTaskNeedsDocumentArtifactBaseline {
     }
 
     return -not ($text -match $codeImplementationSignals)
+}
+
+function Test-VibeTaskNeedsUiBaseline {
+    param(
+        [Parameter(Mandatory)] [string]$Task,
+        [AllowEmptyString()] [string]$Deliverable = ''
+    )
+
+    if (Test-VibeTaskNeedsDocumentArtifactBaseline -Task $Task -Deliverable $Deliverable) {
+        return $false
+    }
+
+    $text = ('{0} {1}' -f $Task, $Deliverable).ToLowerInvariant()
+    $uiSignals = '(^|\b)(ui|ux|frontend|browser|screen|visual|interaction|responsive|layout|component|page|dashboard|prototype|wireframe)(\b|$)|界面|交互|可视化|体验|前端|网页'
+    return $text -match $uiSignals
 }
 
 function Test-VibeTaskNeedsCodeTaskTddEvidence {
@@ -230,7 +244,7 @@ if (@($baselineDocumentQualityDimensions).Count -eq 0 -and (Test-VibeTaskNeedsDo
 if (@($artifactReviewRequirements).Count -eq 0 -and @($baselineDocumentQualityDimensions).Count -gt 0) {
     $artifactReviewRequirements = Get-VibeDefaultDocumentArtifactReviewRequirements
 }
-if (@($baselineUiQualityDimensions).Count -eq 0 -and (Test-VibeTaskNeedsManualSpotChecks -Task $Task -Deliverable ([string]$intentContract.deliverable))) {
+if (@($baselineUiQualityDimensions).Count -eq 0 -and (Test-VibeTaskNeedsUiBaseline -Task $Task -Deliverable ([string]$intentContract.deliverable))) {
     $baselineUiQualityDimensions = Get-VibeDefaultBaselineUiQualityDimensions
 }
 $runtimeInputPacket = if (-not [string]::IsNullOrWhiteSpace($RuntimeInputPacketPath) -and (Test-Path -LiteralPath $RuntimeInputPacketPath)) {

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -31,6 +31,52 @@ function Test-VibeTaskNeedsManualSpotChecks {
     return $text -match 'ui|ux|frontend|browser|page|screen|openclaw|cursor|windsurf|codex|用户|界面|交互|可视化|体验'
 }
 
+function Test-VibeTaskNeedsDocumentArtifactBaseline {
+    param(
+        [Parameter(Mandatory)] [string]$Task,
+        [AllowEmptyString()] [string]$Deliverable = ''
+    )
+
+    $text = ('{0} {1}' -f $Task, $Deliverable).ToLowerInvariant()
+    $docOnlySignals = 'without changing (application )?code|without code changes|document-only'
+    $documentArtifactSignals = 'readme|documentation|docx|pdf|pptx|headings|spacing|formatting|markdown|slide|slides|presentation|deck|\bdocument\b|\bdocs\b'
+    $codeImplementationSignals = 'failing test|stack trace|debug|bug|fix|refactor|script|function|class|endpoint|api|component|module|backend|frontend|dashboard|page|screen|unit test|integration test|parser|exporter|renderer|pipeline|service|library|cli'
+
+    if ($text -match $docOnlySignals) {
+        return $true
+    }
+
+    if (-not ($text -match $documentArtifactSignals)) {
+        return $false
+    }
+
+    return -not ($text -match $codeImplementationSignals)
+}
+
+function Test-VibeTaskNeedsCodeTaskTddEvidence {
+    param(
+        [Parameter(Mandatory)] [string]$Task,
+        [AllowEmptyString()] [string]$Deliverable = ''
+    )
+
+    $text = ('{0} {1}' -f $Task, $Deliverable).ToLowerInvariant()
+
+    if ((Test-VibeTaskNeedsDocumentArtifactBaseline -Task $Task -Deliverable $Deliverable) -or ($text -match 'image|logo|illustration|diagram')) {
+        return $false
+    }
+
+    return $text -match 'failing test|stack trace|debug|bug|fix|refactor|implement|build|feature|code|script|function|class|endpoint|api|component|module|frontend|backend|dashboard|page|screen|unit test|integration test'
+}
+
+function Get-VibeDefaultCodeTaskTddEvidenceRequirements {
+    return @(
+        'Record failing-first evidence for the changed behavior before implementation or defect correction.',
+        'Record the green rerun that proves the targeted behavior passed after implementation.',
+        'Map the changed behavior to targeted verification evidence; generic suite success alone is insufficient.',
+        'If automated failing-first evidence is not appropriate, freeze and honor an explicit code-task TDD exception instead of silently skipping the requirement.'
+    )
+}
+
 function Get-VibeProductAcceptanceCriteria {
     param(
         [Parameter(Mandatory)] [object]$IntentContract
@@ -73,6 +119,36 @@ function Get-VibeCompletionLanguagePolicy {
     )
 }
 
+function Get-VibeDefaultBaselineUiQualityDimensions {
+    return @(
+        'Structure Completeness',
+        'Interaction Feedback',
+        'State Coverage',
+        'Design System Consistency',
+        'Responsive Stability',
+        'Spec Fidelity'
+    )
+}
+
+function Get-VibeDefaultBaselineDocumentQualityDimensions {
+    return @(
+        'Structure Integrity',
+        'Formatting Consistency',
+        'Content Completeness',
+        'Link and Reference Integrity',
+        'Layout and Asset Stability',
+        'Output Fidelity'
+    )
+}
+
+function Get-VibeDefaultDocumentArtifactReviewRequirements {
+    return @(
+        'Review the touched document artifact directly against each frozen baseline document quality dimension.',
+        'Open, render, or export the touched document artifact at least once and confirm the touched scope remains intact.',
+        'For formatting-only or layout-only work, confirm content fidelity explicitly before full completion wording is allowed.'
+    )
+}
+
 function Get-VibeDeliveryTruthContractLines {
     return @(
         'Governance truth: requirement, plan, execution, and cleanup artifacts remain traceable and authoritative.',
@@ -80,6 +156,26 @@ function Get-VibeDeliveryTruthContractLines {
         'Workflow completion truth: planned units, delegated lanes, and specialist outputs reconcile back into the governed plan.',
         'Product acceptance truth: observable deliverable behavior satisfies frozen acceptance criteria before full completion language is allowed.'
     )
+}
+
+function Get-VibeOptionalFrozenItems {
+    param(
+        [Parameter(Mandatory)] [object]$IntentContract,
+        [Parameter(Mandatory)] [string[]]$PropertyNames
+    )
+
+    $items = @()
+    foreach ($propertyName in @($PropertyNames)) {
+        if ($null -ne $IntentContract -and $IntentContract.PSObject.Properties.Name -contains $propertyName) {
+            foreach ($item in @($IntentContract.$propertyName)) {
+                if (-not [string]::IsNullOrWhiteSpace([string]$item)) {
+                    $items += [string]$item
+                }
+            }
+        }
+    }
+
+    return @($items | Select-Object -Unique)
 }
 
 $runtime = Get-VibeRuntimeContext -ScriptPath $PSCommandPath
@@ -118,6 +214,25 @@ $productAcceptanceCriteria = Get-VibeProductAcceptanceCriteria -IntentContract $
 $manualSpotChecks = Get-VibeManualSpotChecks -Task $Task -IntentContract $intentContract
 $completionLanguagePolicy = Get-VibeCompletionLanguagePolicy
 $deliveryTruthContract = Get-VibeDeliveryTruthContractLines
+$artifactReviewRequirements = Get-VibeOptionalFrozenItems -IntentContract $intentContract -PropertyNames @('artifact_review_requirements', 'artifactReviewRequirements')
+$codeTaskTddEvidenceRequirements = Get-VibeOptionalFrozenItems -IntentContract $intentContract -PropertyNames @('code_task_tdd_evidence_requirements', 'codeTaskTddEvidenceRequirements')
+$codeTaskTddExceptions = Get-VibeOptionalFrozenItems -IntentContract $intentContract -PropertyNames @('code_task_tdd_exceptions', 'codeTaskTddExceptions')
+$taskSpecificAcceptanceExtensions = Get-VibeOptionalFrozenItems -IntentContract $intentContract -PropertyNames @('task_specific_acceptance_extensions', 'taskSpecificAcceptanceExtensions')
+$researchAugmentationSources = Get-VibeOptionalFrozenItems -IntentContract $intentContract -PropertyNames @('research_augmentation_sources', 'researchAugmentationSources')
+$baselineDocumentQualityDimensions = Get-VibeOptionalFrozenItems -IntentContract $intentContract -PropertyNames @('baseline_document_quality_dimensions', 'baselineDocumentQualityDimensions')
+$baselineUiQualityDimensions = Get-VibeOptionalFrozenItems -IntentContract $intentContract -PropertyNames @('baseline_ui_quality_dimensions', 'baselineUiQualityDimensions')
+if (@($codeTaskTddEvidenceRequirements).Count -eq 0 -and (Test-VibeTaskNeedsCodeTaskTddEvidence -Task $Task -Deliverable ([string]$intentContract.deliverable))) {
+    $codeTaskTddEvidenceRequirements = Get-VibeDefaultCodeTaskTddEvidenceRequirements
+}
+if (@($baselineDocumentQualityDimensions).Count -eq 0 -and (Test-VibeTaskNeedsDocumentArtifactBaseline -Task $Task -Deliverable ([string]$intentContract.deliverable))) {
+    $baselineDocumentQualityDimensions = Get-VibeDefaultBaselineDocumentQualityDimensions
+}
+if (@($artifactReviewRequirements).Count -eq 0 -and @($baselineDocumentQualityDimensions).Count -gt 0) {
+    $artifactReviewRequirements = Get-VibeDefaultDocumentArtifactReviewRequirements
+}
+if (@($baselineUiQualityDimensions).Count -eq 0 -and (Test-VibeTaskNeedsManualSpotChecks -Task $Task -Deliverable ([string]$intentContract.deliverable))) {
+    $baselineUiQualityDimensions = Get-VibeDefaultBaselineUiQualityDimensions
+}
 $runtimeInputPacket = if (-not [string]::IsNullOrWhiteSpace($RuntimeInputPacketPath) -and (Test-Path -LiteralPath $RuntimeInputPacketPath)) {
     Get-Content -LiteralPath $RuntimeInputPacketPath -Raw -Encoding UTF8 | ConvertFrom-Json
 } else {
@@ -168,6 +283,69 @@ $lines += @(
     '## Delivery Truth Contract'
 )
 $lines += @($deliveryTruthContract | ForEach-Object { "- $_" })
+$lines += @(
+    '',
+    '## Artifact Review Requirements'
+)
+if (@($artifactReviewRequirements).Count -gt 0) {
+    $lines += @($artifactReviewRequirements | ForEach-Object { "- $_" })
+} else {
+    $lines += 'No additional artifact review requirements were frozen for this run.'
+}
+$lines += @(
+    '',
+    '## Code Task TDD Evidence Requirements'
+)
+if (@($codeTaskTddEvidenceRequirements).Count -gt 0) {
+    $lines += @($codeTaskTddEvidenceRequirements | ForEach-Object { "- $_" })
+} else {
+    $lines += 'No code-task TDD evidence requirements were frozen for this run.'
+}
+$lines += @(
+    '',
+    '## Code Task TDD Exceptions'
+)
+if (@($codeTaskTddExceptions).Count -gt 0) {
+    $lines += @($codeTaskTddExceptions | ForEach-Object { "- $_" })
+} else {
+    $lines += 'No code-task TDD exceptions were frozen for this run.'
+}
+$lines += @(
+    '',
+    '## Baseline Document Quality Dimensions'
+)
+if (@($baselineDocumentQualityDimensions).Count -gt 0) {
+    $lines += @($baselineDocumentQualityDimensions | ForEach-Object { "- $_" })
+} else {
+    $lines += 'No baseline document quality dimensions were frozen for this run.'
+}
+$lines += @(
+    '',
+    '## Baseline UI Quality Dimensions'
+)
+if (@($baselineUiQualityDimensions).Count -gt 0) {
+    $lines += @($baselineUiQualityDimensions | ForEach-Object { "- $_" })
+} else {
+    $lines += 'No baseline UI quality dimensions were frozen for this run.'
+}
+$lines += @(
+    '',
+    '## Task-Specific Acceptance Extensions'
+)
+if (@($taskSpecificAcceptanceExtensions).Count -gt 0) {
+    $lines += @($taskSpecificAcceptanceExtensions | ForEach-Object { "- $_" })
+} else {
+    $lines += 'No additional task-specific acceptance extensions were frozen for this run.'
+}
+$lines += @(
+    '',
+    '## Research Augmentation Sources'
+)
+if (@($researchAugmentationSources).Count -gt 0) {
+    $lines += @($researchAugmentationSources | ForEach-Object { "- $_" })
+} else {
+    $lines += 'No research augmentation sources were frozen for this run.'
+}
 $lines += @(
     '',
     '> Fill the anti-drift fields once here. Downstream governed plan and completion surfaces should reuse them rather than restate them.',
@@ -237,33 +415,13 @@ if ($runtimeInputPacket) {
     }
 }
 
-$hasMemoryItems = $memoryContextPack -and @($memoryContextPack.items).Count -gt 0
-$hasSelectedCapsules = (
-    $memoryContextPack -and
-    $memoryContextPack.PSObject.Properties.Name -contains 'selected_capsules' -and
-    $null -ne $memoryContextPack.selected_capsules -and
-    @($memoryContextPack.selected_capsules).Count -gt 0
-)
-if ($hasMemoryItems -or $hasSelectedCapsules) {
+if ($memoryContextPack -and @($memoryContextPack.items).Count -gt 0) {
     $lines += @(
         '',
         '## Memory Context',
-        'Bounded stage-aware memory context injected into requirement freezing:',
-        ('- Disclosure level: {0}' -f [string]$memoryContextPack.disclosure_level)
+        'Bounded stage-aware memory context injected into requirement freezing:'
     )
-    if ($hasSelectedCapsules) {
-        foreach ($capsule in @($memoryContextPack.selected_capsules)) {
-            $lines += @(
-                ('- Capsule [{0}] {1}' -f [string]$capsule.capsule_id, [string]$capsule.title),
-                ('  Owner: {0}' -f [string]$capsule.owner),
-                ('  Why now: {0}' -f [string]$capsule.why_now),
-                ('  Expansion Ref: {0}' -f [string]$capsule.expansion_ref)
-            )
-            $lines += @($capsule.summary_lines | ForEach-Object { '  Summary: ' + [string]$_ })
-        }
-    } else {
-        $lines += @($memoryContextPack.items | ForEach-Object { "- $_" })
-    }
+    $lines += @($memoryContextPack.items | ForEach-Object { "- $_" })
 }
 
 $childHandoffPath = $null
@@ -303,12 +461,6 @@ $receipt = [pscustomobject]@{
     memory_context_path = if ($memoryContextPack) { $MemoryContextPath } else { $null }
     memory_context_item_count = if ($memoryContextPack) { @($memoryContextPack.items).Count } else { 0 }
     memory_context_estimated_tokens = if ($memoryContextPack) { [int]$memoryContextPack.estimated_tokens } else { 0 }
-    memory_disclosure_level = if ($memoryContextPack -and $memoryContextPack.PSObject.Properties.Name -contains 'disclosure_level') { [string]$memoryContextPack.disclosure_level } else { $null }
-    memory_capsule_count = if (
-        $memoryContextPack -and
-        $memoryContextPack.PSObject.Properties.Name -contains 'selected_capsules' -and
-        $null -ne $memoryContextPack.selected_capsules
-    ) { @($memoryContextPack.selected_capsules).Count } else { 0 }
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 }
 $receiptPath = Join-Path $sessionRoot 'requirement-doc-receipt.json'

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -429,13 +429,33 @@ if ($runtimeInputPacket) {
     }
 }
 
-if ($memoryContextPack -and @($memoryContextPack.items).Count -gt 0) {
+$hasMemoryItems = $memoryContextPack -and @($memoryContextPack.items).Count -gt 0
+$hasSelectedCapsules = (
+    $memoryContextPack -and
+    $memoryContextPack.PSObject.Properties.Name -contains 'selected_capsules' -and
+    $null -ne $memoryContextPack.selected_capsules -and
+    @($memoryContextPack.selected_capsules).Count -gt 0
+)
+if ($hasMemoryItems -or $hasSelectedCapsules) {
     $lines += @(
         '',
         '## Memory Context',
-        'Bounded stage-aware memory context injected into requirement freezing:'
+        'Bounded stage-aware memory context injected into requirement freezing:',
+        ('- Disclosure level: {0}' -f [string]$memoryContextPack.disclosure_level)
     )
-    $lines += @($memoryContextPack.items | ForEach-Object { "- $_" })
+    if ($hasSelectedCapsules) {
+        foreach ($capsule in @($memoryContextPack.selected_capsules)) {
+            $lines += @(
+                ('- Capsule [{0}] {1}' -f [string]$capsule.capsule_id, [string]$capsule.title),
+                ('  Owner: {0}' -f [string]$capsule.owner),
+                ('  Why now: {0}' -f [string]$capsule.why_now),
+                ('  Expansion Ref: {0}' -f [string]$capsule.expansion_ref)
+            )
+            $lines += @($capsule.summary_lines | ForEach-Object { '  Summary: ' + [string]$_ })
+        }
+    } else {
+        $lines += @($memoryContextPack.items | ForEach-Object { "- $_" })
+    }
 }
 
 $childHandoffPath = $null
@@ -475,6 +495,12 @@ $receipt = [pscustomobject]@{
     memory_context_path = if ($memoryContextPack) { $MemoryContextPath } else { $null }
     memory_context_item_count = if ($memoryContextPack) { @($memoryContextPack.items).Count } else { 0 }
     memory_context_estimated_tokens = if ($memoryContextPack) { [int]$memoryContextPack.estimated_tokens } else { 0 }
+    memory_disclosure_level = if ($memoryContextPack -and $memoryContextPack.PSObject.Properties.Name -contains 'disclosure_level') { [string]$memoryContextPack.disclosure_level } else { $null }
+    memory_capsule_count = if (
+        $memoryContextPack -and
+        $memoryContextPack.PSObject.Properties.Name -contains 'selected_capsules' -and
+        $null -ne $memoryContextPack.selected_capsules
+    ) { @($memoryContextPack.selected_capsules).Count } else { 0 }
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 }
 $receiptPath = Join-Path $sessionRoot 'requirement-doc-receipt.json'

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -502,6 +502,15 @@ $receipt = [pscustomobject]@{
         $memoryContextPack.PSObject.Properties.Name -contains 'selected_capsules' -and
         $null -ne $memoryContextPack.selected_capsules
     ) { @($memoryContextPack.selected_capsules).Count } else { 0 }
+    frozen_requirement_sections = [ordered]@{
+        artifact_review_requirements = @($artifactReviewRequirements)
+        code_task_tdd_evidence_requirements = @($codeTaskTddEvidenceRequirements)
+        code_task_tdd_exceptions = @($codeTaskTddExceptions)
+        baseline_document_quality_dimensions = @($baselineDocumentQualityDimensions)
+        baseline_ui_quality_dimensions = @($baselineUiQualityDimensions)
+        task_specific_acceptance_extensions = @($taskSpecificAcceptanceExtensions)
+        research_augmentation_sources = @($researchAugmentationSources)
+    }
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 }
 $receiptPath = Join-Path $sessionRoot 'requirement-doc-receipt.json'

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -39,7 +39,7 @@ function Test-VibeTaskNeedsDocumentArtifactBaseline {
     $text = ('{0} {1}' -f $Task, $Deliverable).ToLowerInvariant()
     $docOnlySignals = 'without changing (application )?code|without code changes|document-only'
     $documentArtifactSignals = 'readme|documentation|docx|pdf|pptx|headings|spacing|formatting|markdown|slide|slides|presentation|deck|\bdocument\b|\bdocs\b'
-    $codeImplementationSignals = 'failing test|stack trace|debug|bug|fix|refactor|script|function|class|endpoint|api|component|module|backend|frontend|dashboard|page|screen|unit test|integration test|parser|exporter|renderer|pipeline|service|library|cli'
+    $codeImplementationSignals = 'failing test|stack trace|debug|bug|fix|refactor|implement|build|develop|production code|source code|unit test|integration test|script|function|class|parser|exporter|renderer|pipeline|service|module|cli'
 
     if ($text -match $docOnlySignals) {
         return $true
@@ -74,12 +74,13 @@ function Test-VibeTaskNeedsCodeTaskTddEvidence {
     )
 
     $text = ('{0} {1}' -f $Task, $Deliverable).ToLowerInvariant()
+    $codeImplementationSignals = 'failing test|stack trace|debug|bug|fix|refactor|implement|build|develop|production code|source code|unit test|integration test|script|function|class|parser|exporter|renderer|pipeline|service|module|cli'
 
     if ((Test-VibeTaskNeedsDocumentArtifactBaseline -Task $Task -Deliverable $Deliverable) -or ($text -match 'image|logo|illustration|diagram')) {
         return $false
     }
 
-    return $text -match 'failing test|stack trace|debug|bug|fix|refactor|implement|build|feature|code|script|function|class|endpoint|api|component|module|frontend|backend|dashboard|page|screen|unit test|integration test'
+    return $text -match $codeImplementationSignals
 }
 
 function Get-VibeDefaultCodeTaskTddEvidenceRequirements {

--- a/scripts/runtime/Write-XlPlan.ps1
+++ b/scripts/runtime/Write-XlPlan.ps1
@@ -150,6 +150,37 @@ $lines += @(
 )
 $lines += @(
     '',
+    '## Artifact Review Strategy',
+    '- If the frozen requirement doc declares `Artifact Review Requirements`, execution must leave behind explicit artifact-review evidence rather than relying on generic completion wording.',
+    '- Artifact review may be recorded inline in `phase-execute.json` or through a dedicated `artifact-review.json` sidecar, but one of those governed surfaces must exist when direct artifact review is required.',
+    '- Product acceptance stays blocked when required artifact review remains missing, partial, degraded, or manual-review-only.',
+    '',
+    '## Code Task TDD Evidence Plan',
+    '- Reuse the frozen `Code Task TDD Evidence Requirements` section from the requirement doc rather than inventing late closeout claims.',
+    '- Reuse the frozen `Code Task TDD Exceptions` section when strict failing-first sequencing is intentionally exempted.',
+    '- Map each frozen requirement or exception to an implementation step, a targeted verification command, and a proof artifact.',
+    '- If strict failing-first sequencing is blocked, execution must record the bounded reason and fallback evidence explicitly.',
+    '',
+    '## Baseline Document Quality Mapping',
+    '- Use the frozen `Baseline Document Quality Dimensions` section in the requirement doc as the authoritative list of document-artifact quality dimensions that artifact review must cover before a document delivery can claim full completion.',
+    '- Track each baseline document dimension through artifact-review annotations so the delivery-acceptance report can show which structure, formatting, completeness, reference integrity, layout stability, and output fidelity expectations were inspected.',
+    '- Treat missing document-dimension coverage as a manual-review-required hit and keep this mapping separate from UI baselines and code-task TDD evidence.',
+    '',
+    '## Baseline UI Quality Mapping',
+    '- Use the frozen `Baseline UI Quality Dimensions` section in the requirement doc as the authoritative list of dimensions that artifact review must cover before a UI delivery can claim full completion.',
+    '- Track each baseline dimension through execution and artifact-review annotations so the delivery-acceptance report can show which structure, interaction, state, consistency, responsiveness, and fidelity expectations were inspected.',
+    '- Treat missing dimension coverage as a manual-review-required hit and include explicit mapping steps or targeted verification units that drive reviewers to capture the evidence the requirement doc established.',
+    '',
+    '## Task-Specific Acceptance Mapping',
+    '- Reuse frozen task-specific acceptance extensions from the requirement doc instead of inventing late closeout criteria.',
+    '- Keep base delivery truth separate from task-specific expectations so each can be inspected independently during review.',
+    '',
+    '## Research Augmentation Plan',
+    '- Preserve any frozen research augmentation sources from the requirement doc so later reviewers can tell which external standards strengthened the brief.',
+    '- Research augmentation may strengthen rough asks, but it must not replace the user-owned requirement surface.'
+)
+$lines += @(
+    '',
     '## Execution Topology Snapshot',
     "- Delegation mode: $([string]$executionTopology.delegation_mode)",
     "- Review mode: $([string]$executionTopology.review_mode)",
@@ -201,33 +232,13 @@ if (@($approvedDispatch).Count -gt 0 -or @($localSuggestions).Count -gt 0) {
         }
     }
 }
-$hasPlanMemoryItems = $planMemoryContext -and @($planMemoryContext.items).Count -gt 0
-$hasPlanCapsules = (
-    $planMemoryContext -and
-    $planMemoryContext.PSObject.Properties.Name -contains 'selected_capsules' -and
-    $null -ne $planMemoryContext.selected_capsules -and
-    @($planMemoryContext.selected_capsules).Count -gt 0
-)
-if ($hasPlanMemoryItems -or $hasPlanCapsules) {
+if ($planMemoryContext -and @($planMemoryContext.items).Count -gt 0) {
     $lines += @(
         '',
         '## Memory Context',
-        'Bounded stage-aware memory context injected into execution planning:',
-        ('- Disclosure level: {0}' -f [string]$planMemoryContext.disclosure_level)
+        'Bounded stage-aware memory context injected into execution planning:'
     )
-    if ($hasPlanCapsules) {
-        foreach ($capsule in @($planMemoryContext.selected_capsules)) {
-            $lines += @(
-                ('- Capsule [{0}] {1}' -f [string]$capsule.capsule_id, [string]$capsule.title),
-                ('  Owner: {0}' -f [string]$capsule.owner),
-                ('  Why now: {0}' -f [string]$capsule.why_now),
-                ('  Expansion Ref: {0}' -f [string]$capsule.expansion_ref)
-            )
-            $lines += @($capsule.summary_lines | ForEach-Object { '  Summary: ' + [string]$_ })
-        }
-    } else {
-        $lines += @($planMemoryContext.items | ForEach-Object { "- $_" })
-    }
+    $lines += @($planMemoryContext.items | ForEach-Object { "- $_" })
 }
 $lines += @(
     '',
@@ -297,12 +308,6 @@ $receipt = [pscustomobject]@{
     inherited_execution_plan_path = if ($isChildScope) { $planPath } else { $null }
     runtime_input_packet_path = $RuntimeInputPacketPath
     plan_memory_context_path = $PlanMemoryContextPath
-    plan_memory_disclosure_level = if ($planMemoryContext -and $planMemoryContext.PSObject.Properties.Name -contains 'disclosure_level') { [string]$planMemoryContext.disclosure_level } else { $null }
-    plan_memory_capsule_count = if (
-        $planMemoryContext -and
-        $planMemoryContext.PSObject.Properties.Name -contains 'selected_capsules' -and
-        $null -ne $planMemoryContext.selected_capsules
-    ) { @($planMemoryContext.selected_capsules).Count } else { 0 }
     execution_topology_path = $executionTopologyPath
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 }

--- a/scripts/runtime/Write-XlPlan.ps1
+++ b/scripts/runtime/Write-XlPlan.ps1
@@ -232,13 +232,33 @@ if (@($approvedDispatch).Count -gt 0 -or @($localSuggestions).Count -gt 0) {
         }
     }
 }
-if ($planMemoryContext -and @($planMemoryContext.items).Count -gt 0) {
+$hasPlanMemoryItems = $planMemoryContext -and @($planMemoryContext.items).Count -gt 0
+$hasPlanCapsules = (
+    $planMemoryContext -and
+    $planMemoryContext.PSObject.Properties.Name -contains 'selected_capsules' -and
+    $null -ne $planMemoryContext.selected_capsules -and
+    @($planMemoryContext.selected_capsules).Count -gt 0
+)
+if ($hasPlanMemoryItems -or $hasPlanCapsules) {
     $lines += @(
         '',
         '## Memory Context',
-        'Bounded stage-aware memory context injected into execution planning:'
+        'Bounded stage-aware memory context injected into execution planning:',
+        ('- Disclosure level: {0}' -f [string]$planMemoryContext.disclosure_level)
     )
-    $lines += @($planMemoryContext.items | ForEach-Object { "- $_" })
+    if ($hasPlanCapsules) {
+        foreach ($capsule in @($planMemoryContext.selected_capsules)) {
+            $lines += @(
+                ('- Capsule [{0}] {1}' -f [string]$capsule.capsule_id, [string]$capsule.title),
+                ('  Owner: {0}' -f [string]$capsule.owner),
+                ('  Why now: {0}' -f [string]$capsule.why_now),
+                ('  Expansion Ref: {0}' -f [string]$capsule.expansion_ref)
+            )
+            $lines += @($capsule.summary_lines | ForEach-Object { '  Summary: ' + [string]$_ })
+        }
+    } else {
+        $lines += @($planMemoryContext.items | ForEach-Object { "- $_" })
+    }
 }
 $lines += @(
     '',
@@ -308,6 +328,12 @@ $receipt = [pscustomobject]@{
     inherited_execution_plan_path = if ($isChildScope) { $planPath } else { $null }
     runtime_input_packet_path = $RuntimeInputPacketPath
     plan_memory_context_path = $PlanMemoryContextPath
+    plan_memory_disclosure_level = if ($planMemoryContext -and $planMemoryContext.PSObject.Properties.Name -contains 'disclosure_level') { [string]$planMemoryContext.disclosure_level } else { $null }
+    plan_memory_capsule_count = if (
+        $planMemoryContext -and
+        $planMemoryContext.PSObject.Properties.Name -contains 'selected_capsules' -and
+        $null -ne $planMemoryContext.selected_capsules
+    ) { @($planMemoryContext.selected_capsules).Count } else { 0 }
     execution_topology_path = $executionTopologyPath
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 }

--- a/templates/plans/governed-execution-plan-template.md
+++ b/templates/plans/governed-execution-plan-template.md
@@ -28,6 +28,28 @@ Prefill from the frozen requirement doc where available. Only diverge with expli
 
 ## Wave Plan
 
+## Delivery Acceptance Plan
+
+## Artifact Review Strategy
+
+## Code Task TDD Evidence Plan
+
+Prefill this section from the frozen requirement doc. Map each frozen requirement or exception to implementation, targeted verification, and proof artifacts. Only diverge with explicit justification.
+
+## Baseline Document Quality Mapping
+
+Prefill this section with how each frozen baseline document quality dimension will map into artifact-review coverage so the governed document rubric documented in the requirement surface is enforced.
+
+## Baseline UI Quality Mapping
+
+Prefill this section with how each frozen baseline UI quality dimension will map into implementation, verification, and artifact-review coverage so the governed UI rubric documented in the requirement surface is enforced.
+
+## Task-Specific Acceptance Mapping
+
+## Research Augmentation Plan
+
+## Completion Language Rules
+
 ## Ownership Boundaries
 
 ## Verification Commands

--- a/templates/requirements/governed-requirement-template.md
+++ b/templates/requirements/governed-requirement-template.md
@@ -10,6 +10,34 @@
 
 ## Acceptance Criteria
 
+## Product Acceptance Criteria
+
+## Manual Spot Checks
+
+## Completion Language Policy
+
+## Delivery Truth Contract
+
+## Artifact Review Requirements
+
+When baseline document quality dimensions are frozen and no explicit artifact review requirements were supplied, freeze direct document-artifact inspection requirements here. Otherwise write: No additional artifact review requirements were frozen for this run.
+
+## Code Task TDD Evidence Requirements
+
+Freeze only when the task changes code or tests. Otherwise write: No code-task TDD evidence requirements were frozen for this run.
+
+## Code Task TDD Exceptions
+
+## Baseline Document Quality Dimensions
+
+Freeze only when the task primarily changes or delivers a document artifact. Otherwise write: No baseline document quality dimensions were frozen for this run.
+
+## Baseline UI Quality Dimensions
+
+## Task-Specific Acceptance Extensions
+
+## Research Augmentation Sources
+
 > Fill the anti-drift fields once here. Downstream governed plan and completion surfaces should reuse them rather than restate them.
 
 ## Primary Objective

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -56,6 +56,7 @@ UI_TASK = "Build a responsive dashboard UI with clear interaction feedback, mean
 DOC_TASK = "Reformat the project README headings and spacing without changing application code."
 DOC_CODE_TASK = "Implement the markdown export pipeline for the docs renderer and add targeted verification for the parser."
 DOC_DECK_TASK = "Build the release deck slides and refine presentation spacing without changing application code."
+DOC_HOST_KEYWORD_TASK = "Refresh codex onboarding documentation for 用户 handoff without changing application code."
 
 
 def resolve_python_command_spec_via_powershell(command_spec: str, path_entries: list[Path]) -> dict[str, object]:
@@ -481,6 +482,9 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertIn("No code-task TDD evidence requirements were frozen for this run.", requirement_doc)
             self.assertIn("## Baseline Document Quality Dimensions", requirement_doc)
             self.assertIn("- Structure Integrity", requirement_doc)
+            self.assertIn("## Manual Spot Checks", requirement_doc)
+            self.assertIn("None required beyond automated verification for this task unless the execution scope expands to a user-visible or interactive flow.", requirement_doc)
+            self.assertNotIn("Open the primary user-facing flow and confirm the main path works from entry to completion.", requirement_doc)
             self.assertIn("- Formatting Consistency", requirement_doc)
             self.assertIn("- Content Completeness", requirement_doc)
             self.assertIn("- Link and Reference Integrity", requirement_doc)
@@ -588,6 +592,66 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertIn("## Baseline Document Quality Dimensions", requirement_doc)
             self.assertIn("- Structure Integrity", requirement_doc)
             self.assertIn("- Output Fidelity", requirement_doc)
+
+    def test_invoke_vibe_runtime_does_not_freeze_ui_baseline_for_non_ui_doc_tasks_with_host_keywords(self) -> None:
+        script_path = REPO_ROOT / "scripts" / "runtime" / "invoke-vibe-runtime.ps1"
+        run_id = "pytest-governed-runtime-doc-host-keywords"
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            command = [
+                shell,
+                "-NoLogo",
+                "-NoProfile",
+                "-Command",
+                (
+                    "& { "
+                    f"$result = & '{script_path}' "
+                    f"-Task '{DOC_HOST_KEYWORD_TASK}' "
+                    "-Mode interactive_governed "
+                    f"-RunId '{run_id}' "
+                    f"-ArtifactRoot '{artifact_root}'; "
+                    "$result | ConvertTo-Json -Depth 20 }"
+                ),
+            ]
+            completed = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+                env={**os.environ, "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "1"},
+            )
+
+            payload = json.loads(completed.stdout)
+            relative_artifacts = payload["summary"].get("artifacts_relative", {})
+            requirement_doc_path = artifact_root / Path(relative_artifacts["requirement_doc"])
+            self.assertTrue(requirement_doc_path.exists())
+
+            requirement_doc = requirement_doc_path.read_text(encoding="utf-8")
+            self.assertIn("## Baseline UI Quality Dimensions", requirement_doc)
+            self.assertIn("No baseline UI quality dimensions were frozen for this run.", requirement_doc)
+            self.assertNotIn("- Structure Completeness", requirement_doc)
+            self.assertIn("## Baseline Document Quality Dimensions", requirement_doc)
+            self.assertIn("- Structure Integrity", requirement_doc)
+            self.assertIn("## Manual Spot Checks", requirement_doc)
+            self.assertIn("None required beyond automated verification for this task unless the execution scope expands to a user-visible or interactive flow.", requirement_doc)
+            self.assertNotIn("Open the primary user-facing flow and confirm the main path works from entry to completion.", requirement_doc)
+
+    def test_project_delivery_readme_lists_all_truth_layers(self) -> None:
+        readme_path = REPO_ROOT / "tests" / "scenarios" / "project_delivery" / "README.md"
+        readme_text = readme_path.read_text(encoding="utf-8")
+
+        self.assertIn("Each scenario must provide six truth-layer states:", readme_text)
+        self.assertIn("- `governance_truth`", readme_text)
+        self.assertIn("- `engineering_verification_truth`", readme_text)
+        self.assertIn("- `code_task_tdd_evidence_truth`", readme_text)
+        self.assertIn("- `workflow_completion_truth`", readme_text)
+        self.assertIn("- `artifact_review_truth`", readme_text)
+        self.assertIn("- `product_acceptance_truth`", readme_text)
 
     def test_write_requirement_doc_preserves_explicit_document_artifact_review_requirements(self) -> None:
         script_path = REPO_ROOT / "scripts" / "runtime" / "Write-RequirementDoc.ps1"

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -52,6 +52,10 @@ def _create_fake_command(directory: Path, name: str) -> Path:
 
 
 SPECIALIST_TASK = "I have a failing test and a stack trace. Help me debug systematically before proposing fixes."
+UI_TASK = "Build a responsive dashboard UI with clear interaction feedback, meaningful states, and desktop/mobile layout coverage."
+DOC_TASK = "Reformat the project README headings and spacing without changing application code."
+DOC_CODE_TASK = "Implement the markdown export pipeline for the docs renderer and add targeted verification for the parser."
+DOC_DECK_TASK = "Build the release deck slides and refine presentation spacing without changing application code."
 
 
 def resolve_python_command_spec_via_powershell(command_spec: str, path_entries: list[Path]) -> dict[str, object]:
@@ -278,10 +282,24 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
                 self.assertIn("## Runtime Input Truth", requirement_doc)
                 self.assertIn("## Specialist Recommendations", requirement_doc)
                 self.assertIn("Eligible recommendations must auto-promote", requirement_doc)
+                self.assertIn("## Artifact Review Requirements", requirement_doc)
+                self.assertIn("## Code Task TDD Evidence Requirements", requirement_doc)
+                self.assertIn("- Record failing-first evidence for the changed behavior before implementation or defect correction.", requirement_doc)
+                self.assertIn("## Code Task TDD Exceptions", requirement_doc)
+                self.assertIn("No code-task TDD exceptions were frozen for this run.", requirement_doc)
+                self.assertIn("## Baseline Document Quality Dimensions", requirement_doc)
+                self.assertIn("No baseline document quality dimensions were frozen for this run.", requirement_doc)
+                self.assertIn("## Baseline UI Quality Dimensions", requirement_doc)
+                self.assertIn("No baseline UI quality dimensions were frozen for this run.", requirement_doc)
+                self.assertIn("## Task-Specific Acceptance Extensions", requirement_doc)
+                self.assertIn("## Research Augmentation Sources", requirement_doc)
             self.assertEqual("requirements", requirement_doc_path.parent.name)
             self.assertEqual("plans", execution_plan_path.parent.name)
             execution_plan = execution_plan_path.read_text(encoding="utf-8")
             self.assertIn("## Specialist Skill Dispatch Plan", execution_plan)
+            self.assertIn("## Code Task TDD Evidence Plan", execution_plan)
+            self.assertIn("## Baseline Document Quality Mapping", execution_plan)
+            self.assertIn("## Baseline UI Quality Mapping", execution_plan)
 
             runtime_input_packet = json.loads(runtime_input_packet_path.read_text(encoding="utf-8"))
             governance_capsule = json.loads(governance_capsule_path.read_text(encoding="utf-8"))
@@ -354,6 +372,307 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
                     self.assertFalse(bool(result["verification_passed"]))
                 else:
                     self.assertEqual("completed", result["status"])
+
+    def test_invoke_vibe_runtime_freezes_default_ui_baseline_dimensions_for_ui_task(self) -> None:
+        script_path = REPO_ROOT / "scripts" / "runtime" / "invoke-vibe-runtime.ps1"
+        run_id = "pytest-governed-runtime-ui"
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            command = [
+                shell,
+                "-NoLogo",
+                "-NoProfile",
+                "-Command",
+                (
+                    "& { "
+                    f"$result = & '{script_path}' "
+                    f"-Task '{UI_TASK}' "
+                    "-Mode interactive_governed "
+                    f"-RunId '{run_id}' "
+                    f"-ArtifactRoot '{artifact_root}'; "
+                    "$result | ConvertTo-Json -Depth 20 }"
+                ),
+            ]
+            completed = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+                env={**os.environ, "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "1"},
+            )
+
+            payload = json.loads(completed.stdout)
+            session_root = Path(payload["session_root"])
+            summary = payload["summary"]
+            relative_artifacts = summary.get("artifacts_relative", {})
+            requirement_doc_path = artifact_root / Path(relative_artifacts["requirement_doc"])
+            self.assertTrue(requirement_doc_path.exists())
+
+            requirement_doc = requirement_doc_path.read_text(encoding="utf-8")
+            self.assertIn("## Baseline UI Quality Dimensions", requirement_doc)
+            self.assertIn("- Structure Completeness", requirement_doc)
+            self.assertIn("- Interaction Feedback", requirement_doc)
+            self.assertIn("- State Coverage", requirement_doc)
+            self.assertIn("- Design System Consistency", requirement_doc)
+            self.assertIn("- Responsive Stability", requirement_doc)
+            self.assertIn("- Spec Fidelity", requirement_doc)
+            self.assertNotIn("No baseline UI quality dimensions were frozen for this run.", requirement_doc)
+            self.assertEqual(run_id, session_root.name)
+
+    def test_invoke_vibe_runtime_freezes_default_document_baseline_dimensions_for_document_task(self) -> None:
+        script_path = REPO_ROOT / "scripts" / "runtime" / "invoke-vibe-runtime.ps1"
+        run_id = "pytest-governed-runtime-doc"
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            command = [
+                shell,
+                "-NoLogo",
+                "-NoProfile",
+                "-Command",
+                (
+                    "& { "
+                    f"$result = & '{script_path}' "
+                    f"-Task '{DOC_TASK}' "
+                    "-Mode interactive_governed "
+                    f"-RunId '{run_id}' "
+                    f"-ArtifactRoot '{artifact_root}'; "
+                    "$result | ConvertTo-Json -Depth 20 }"
+                ),
+            ]
+            completed = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+                env={**os.environ, "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "1"},
+            )
+
+            payload = json.loads(completed.stdout)
+            relative_artifacts = payload["summary"].get("artifacts_relative", {})
+            requirement_doc_path = artifact_root / Path(relative_artifacts["requirement_doc"])
+            self.assertTrue(requirement_doc_path.exists())
+
+            requirement_doc = requirement_doc_path.read_text(encoding="utf-8")
+            self.assertIn("## Artifact Review Requirements", requirement_doc)
+            self.assertIn(
+                "- Review the touched document artifact directly against each frozen baseline document quality dimension.",
+                requirement_doc,
+            )
+            self.assertIn(
+                "- Open, render, or export the touched document artifact at least once and confirm the touched scope remains intact.",
+                requirement_doc,
+            )
+            self.assertIn(
+                "- For formatting-only or layout-only work, confirm content fidelity explicitly before full completion wording is allowed.",
+                requirement_doc,
+            )
+            self.assertNotIn("No additional artifact review requirements were frozen for this run.", requirement_doc)
+            self.assertIn("## Code Task TDD Evidence Requirements", requirement_doc)
+            self.assertIn("No code-task TDD evidence requirements were frozen for this run.", requirement_doc)
+            self.assertIn("## Baseline Document Quality Dimensions", requirement_doc)
+            self.assertIn("- Structure Integrity", requirement_doc)
+            self.assertIn("- Formatting Consistency", requirement_doc)
+            self.assertIn("- Content Completeness", requirement_doc)
+            self.assertIn("- Link and Reference Integrity", requirement_doc)
+            self.assertIn("- Layout and Asset Stability", requirement_doc)
+            self.assertIn("- Output Fidelity", requirement_doc)
+            self.assertNotIn("No baseline document quality dimensions were frozen for this run.", requirement_doc)
+            self.assertIn("## Baseline UI Quality Dimensions", requirement_doc)
+            self.assertIn("No baseline UI quality dimensions were frozen for this run.", requirement_doc)
+
+    def test_invoke_vibe_runtime_keeps_markdown_code_tasks_on_code_tdd_path(self) -> None:
+        script_path = REPO_ROOT / "scripts" / "runtime" / "invoke-vibe-runtime.ps1"
+        run_id = "pytest-governed-runtime-doc-code"
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            command = [
+                shell,
+                "-NoLogo",
+                "-NoProfile",
+                "-Command",
+                (
+                    "& { "
+                    f"$result = & '{script_path}' "
+                    f"-Task '{DOC_CODE_TASK}' "
+                    "-Mode interactive_governed "
+                    f"-RunId '{run_id}' "
+                    f"-ArtifactRoot '{artifact_root}'; "
+                    "$result | ConvertTo-Json -Depth 20 }"
+                ),
+            ]
+            completed = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+                env={**os.environ, "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "1"},
+            )
+
+            payload = json.loads(completed.stdout)
+            relative_artifacts = payload["summary"].get("artifacts_relative", {})
+            requirement_doc_path = artifact_root / Path(relative_artifacts["requirement_doc"])
+            self.assertTrue(requirement_doc_path.exists())
+
+            requirement_doc = requirement_doc_path.read_text(encoding="utf-8")
+            self.assertIn("## Artifact Review Requirements", requirement_doc)
+            self.assertIn("No additional artifact review requirements were frozen for this run.", requirement_doc)
+            self.assertIn("## Code Task TDD Evidence Requirements", requirement_doc)
+            self.assertIn(
+                "- Record failing-first evidence for the changed behavior before implementation or defect correction.",
+                requirement_doc,
+            )
+            self.assertIn("## Baseline Document Quality Dimensions", requirement_doc)
+            self.assertIn("No baseline document quality dimensions were frozen for this run.", requirement_doc)
+
+    def test_invoke_vibe_runtime_treats_presentation_artifact_tasks_as_non_code_document_work(self) -> None:
+        script_path = REPO_ROOT / "scripts" / "runtime" / "invoke-vibe-runtime.ps1"
+        run_id = "pytest-governed-runtime-doc-deck"
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            command = [
+                shell,
+                "-NoLogo",
+                "-NoProfile",
+                "-Command",
+                (
+                    "& { "
+                    f"$result = & '{script_path}' "
+                    f"-Task '{DOC_DECK_TASK}' "
+                    "-Mode interactive_governed "
+                    f"-RunId '{run_id}' "
+                    f"-ArtifactRoot '{artifact_root}'; "
+                    "$result | ConvertTo-Json -Depth 20 }"
+                ),
+            ]
+            completed = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+                env={**os.environ, "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "1"},
+            )
+
+            payload = json.loads(completed.stdout)
+            relative_artifacts = payload["summary"].get("artifacts_relative", {})
+            requirement_doc_path = artifact_root / Path(relative_artifacts["requirement_doc"])
+            self.assertTrue(requirement_doc_path.exists())
+
+            requirement_doc = requirement_doc_path.read_text(encoding="utf-8")
+            self.assertIn("## Artifact Review Requirements", requirement_doc)
+            self.assertIn(
+                "- Review the touched document artifact directly against each frozen baseline document quality dimension.",
+                requirement_doc,
+            )
+            self.assertIn("## Code Task TDD Evidence Requirements", requirement_doc)
+            self.assertIn("No code-task TDD evidence requirements were frozen for this run.", requirement_doc)
+            self.assertIn("## Baseline Document Quality Dimensions", requirement_doc)
+            self.assertIn("- Structure Integrity", requirement_doc)
+            self.assertIn("- Output Fidelity", requirement_doc)
+
+    def test_write_requirement_doc_preserves_explicit_document_artifact_review_requirements(self) -> None:
+        script_path = REPO_ROOT / "scripts" / "runtime" / "Write-RequirementDoc.ps1"
+        run_id = "pytest-requirement-doc-explicit-artifact-review"
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        explicit_requirements = [
+            "Confirm the README heading hierarchy matches the requested structure exactly.",
+            "Confirm spacing changes did not alter link targets or prose content.",
+        ]
+        intent_contract = {
+            "title": "README formatting adjustment",
+            "goal": DOC_TASK,
+            "deliverable": "Updated README formatting only.",
+            "constraints": [
+                "Do not change application code.",
+            ],
+            "acceptance_criteria": [
+                "Requirement document is frozen before execution.",
+            ],
+            "artifact_review_requirements": explicit_requirements,
+            "non_goals": [
+                "Do not widen scope beyond the README formatting task.",
+            ],
+            "autonomy_mode": "interactive_governed",
+            "assumptions": [
+                "The README is the only touched artifact.",
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            intent_contract_path = artifact_root / "intent-contract.json"
+            intent_contract_path.write_text(
+                json.dumps(intent_contract, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            command = [
+                shell,
+                "-NoLogo",
+                "-NoProfile",
+                "-Command",
+                (
+                    "& { "
+                    f"$result = & '{script_path}' "
+                    f"-Task '{DOC_TASK}' "
+                    "-Mode interactive_governed "
+                    f"-RunId '{run_id}' "
+                    f"-IntentContractPath '{intent_contract_path}' "
+                    f"-ArtifactRoot '{artifact_root}'; "
+                    "$result | ConvertTo-Json -Depth 20 }"
+                ),
+            ]
+            completed = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            payload = json.loads(completed.stdout)
+            requirement_doc_path = Path(payload["requirement_doc_path"])
+            self.assertTrue(requirement_doc_path.exists())
+
+            requirement_doc = requirement_doc_path.read_text(encoding="utf-8")
+            self.assertIn("## Artifact Review Requirements", requirement_doc)
+            for item in explicit_requirements:
+                self.assertIn(f"- {item}", requirement_doc)
+            self.assertNotIn(
+                "- Review the touched document artifact directly against each frozen baseline document quality dimension.",
+                requirement_doc,
+            )
+            self.assertNotIn(
+                "- Open, render, or export the touched document artifact at least once and confirm the touched scope remains intact.",
+                requirement_doc,
+            )
+            self.assertNotIn(
+                "- For formatting-only or layout-only work, confirm content fidelity explicitly before full completion wording is allowed.",
+                requirement_doc,
+            )
+            self.assertIn("## Baseline Document Quality Dimensions", requirement_doc)
+            self.assertIn("- Structure Integrity", requirement_doc)
 
     def test_resolve_vgo_python_command_spec_falls_back_to_python3(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -57,6 +57,8 @@ DOC_TASK = "Reformat the project README headings and spacing without changing ap
 DOC_CODE_TASK = "Implement the markdown export pipeline for the docs renderer and add targeted verification for the parser."
 DOC_DECK_TASK = "Build the release deck slides and refine presentation spacing without changing application code."
 DOC_HOST_KEYWORD_TASK = "Refresh codex onboarding documentation for 用户 handoff without changing application code."
+API_DOC_TASK = "Update API documentation for the authentication flow and refresh endpoint examples."
+WIREFRAME_TASK = "Prototype onboarding screen wireframe with desktop and mobile layout coverage."
 
 
 def resolve_python_command_spec_via_powershell(command_spec: str, path_entries: list[Path]) -> dict[str, object]:
@@ -737,6 +739,150 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             )
             self.assertIn("## Baseline Document Quality Dimensions", requirement_doc)
             self.assertIn("- Structure Integrity", requirement_doc)
+
+    def test_write_requirement_doc_treats_api_documentation_tasks_as_document_artifacts(self) -> None:
+        script_path = REPO_ROOT / "scripts" / "runtime" / "Write-RequirementDoc.ps1"
+        run_id = "pytest-requirement-doc-api-documentation"
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        intent_contract = {
+            "title": "API documentation refresh",
+            "goal": API_DOC_TASK,
+            "deliverable": "Updated API documentation only.",
+            "constraints": [
+                "Do not change application code.",
+            ],
+            "acceptance_criteria": [
+                "Requirement document is frozen before execution.",
+            ],
+            "non_goals": [
+                "Do not implement backend or frontend code changes.",
+            ],
+            "autonomy_mode": "interactive_governed",
+            "assumptions": [
+                "Only documentation artifacts change.",
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            intent_contract_path = artifact_root / "intent-contract.json"
+            intent_contract_path.write_text(
+                json.dumps(intent_contract, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            command = [
+                shell,
+                "-NoLogo",
+                "-NoProfile",
+                "-Command",
+                (
+                    "& { "
+                    f"$result = & '{script_path}' "
+                    f"-Task '{API_DOC_TASK}' "
+                    "-Mode interactive_governed "
+                    f"-RunId '{run_id}' "
+                    f"-IntentContractPath '{intent_contract_path}' "
+                    f"-ArtifactRoot '{artifact_root}'; "
+                    "$result | ConvertTo-Json -Depth 20 }"
+                ),
+            ]
+            completed = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            payload = json.loads(completed.stdout)
+            requirement_doc_path = Path(payload["requirement_doc_path"])
+            self.assertTrue(requirement_doc_path.exists())
+
+            requirement_doc = requirement_doc_path.read_text(encoding="utf-8")
+            self.assertIn("## Artifact Review Requirements", requirement_doc)
+            self.assertIn(
+                "- Review the touched document artifact directly against each frozen baseline document quality dimension.",
+                requirement_doc,
+            )
+            self.assertIn("## Code Task TDD Evidence Requirements", requirement_doc)
+            self.assertIn("No code-task TDD evidence requirements were frozen for this run.", requirement_doc)
+            self.assertIn("## Baseline Document Quality Dimensions", requirement_doc)
+            self.assertIn("- Structure Integrity", requirement_doc)
+            self.assertIn("## Baseline UI Quality Dimensions", requirement_doc)
+            self.assertIn("No baseline UI quality dimensions were frozen for this run.", requirement_doc)
+
+    def test_write_requirement_doc_treats_wireframe_tasks_as_visual_artifacts_without_tdd(self) -> None:
+        script_path = REPO_ROOT / "scripts" / "runtime" / "Write-RequirementDoc.ps1"
+        run_id = "pytest-requirement-doc-wireframe"
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        intent_contract = {
+            "title": "Onboarding wireframe prototype",
+            "goal": WIREFRAME_TASK,
+            "deliverable": "Wireframe-only onboarding screen design artifact.",
+            "constraints": [
+                "Do not implement production code in this phase.",
+            ],
+            "acceptance_criteria": [
+                "Requirement document is frozen before execution.",
+            ],
+            "non_goals": [
+                "Do not convert the wireframe into production UI code.",
+            ],
+            "autonomy_mode": "interactive_governed",
+            "assumptions": [
+                "The deliverable is a visual design artifact, not implementation code.",
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            intent_contract_path = artifact_root / "intent-contract.json"
+            intent_contract_path.write_text(
+                json.dumps(intent_contract, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            command = [
+                shell,
+                "-NoLogo",
+                "-NoProfile",
+                "-Command",
+                (
+                    "& { "
+                    f"$result = & '{script_path}' "
+                    f"-Task '{WIREFRAME_TASK}' "
+                    "-Mode interactive_governed "
+                    f"-RunId '{run_id}' "
+                    f"-IntentContractPath '{intent_contract_path}' "
+                    f"-ArtifactRoot '{artifact_root}'; "
+                    "$result | ConvertTo-Json -Depth 20 }"
+                ),
+            ]
+            completed = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            payload = json.loads(completed.stdout)
+            requirement_doc_path = Path(payload["requirement_doc_path"])
+            self.assertTrue(requirement_doc_path.exists())
+
+            requirement_doc = requirement_doc_path.read_text(encoding="utf-8")
+            self.assertIn("## Code Task TDD Evidence Requirements", requirement_doc)
+            self.assertIn("No code-task TDD evidence requirements were frozen for this run.", requirement_doc)
+            self.assertIn("## Baseline Document Quality Dimensions", requirement_doc)
+            self.assertIn("No baseline document quality dimensions were frozen for this run.", requirement_doc)
+            self.assertIn("## Baseline UI Quality Dimensions", requirement_doc)
+            self.assertIn("- Structure Completeness", requirement_doc)
+            self.assertIn("- Responsive Stability", requirement_doc)
 
     def test_resolve_vgo_python_command_spec_falls_back_to_python3(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -800,6 +800,7 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             payload = json.loads(completed.stdout)
             requirement_doc_path = Path(payload["requirement_doc_path"])
             self.assertTrue(requirement_doc_path.exists())
+            requirement_receipt = payload["receipt"]
 
             requirement_doc = requirement_doc_path.read_text(encoding="utf-8")
             self.assertIn("## Artifact Review Requirements", requirement_doc)
@@ -813,6 +814,29 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertIn("- Structure Integrity", requirement_doc)
             self.assertIn("## Baseline UI Quality Dimensions", requirement_doc)
             self.assertIn("No baseline UI quality dimensions were frozen for this run.", requirement_doc)
+            self.assertEqual(
+                {
+                    "artifact_review_requirements": [
+                        "Review the touched document artifact directly against each frozen baseline document quality dimension.",
+                        "Open, render, or export the touched document artifact at least once and confirm the touched scope remains intact.",
+                        "For formatting-only or layout-only work, confirm content fidelity explicitly before full completion wording is allowed.",
+                    ],
+                    "code_task_tdd_evidence_requirements": [],
+                    "code_task_tdd_exceptions": [],
+                    "baseline_document_quality_dimensions": [
+                        "Structure Integrity",
+                        "Formatting Consistency",
+                        "Content Completeness",
+                        "Link and Reference Integrity",
+                        "Layout and Asset Stability",
+                        "Output Fidelity",
+                    ],
+                    "baseline_ui_quality_dimensions": [],
+                    "task_specific_acceptance_extensions": [],
+                    "research_augmentation_sources": [],
+                },
+                requirement_receipt["frozen_requirement_sections"],
+            )
 
     def test_write_requirement_doc_treats_wireframe_tasks_as_visual_artifacts_without_tdd(self) -> None:
         script_path = REPO_ROOT / "scripts" / "runtime" / "Write-RequirementDoc.ps1"

--- a/tests/runtime_neutral/test_governed_templates.py
+++ b/tests/runtime_neutral/test_governed_templates.py
@@ -56,3 +56,13 @@ class GovernedTemplateTests(unittest.TestCase):
         self.assertIn("## Baseline UI Quality Mapping", script_text)
         self.assertIn("## Task-Specific Acceptance Mapping", script_text)
         self.assertIn("## Research Augmentation Plan", script_text)
+
+
+    def test_project_delivery_contract_requires_artifact_and_tdd_coverage_fields(self) -> None:
+        contract = json.loads(
+            (REPO_ROOT / "config" / "project-delivery-acceptance-contract.json").read_text(encoding="utf-8")
+        )
+        must_report_fields = set((contract.get("report_requirements") or {}).get("must_report_fields") or [])
+
+        self.assertIn("artifact_review_coverage", must_report_fields)
+        self.assertIn("tdd_evidence_coverage", must_report_fields)

--- a/tests/runtime_neutral/test_governed_templates.py
+++ b/tests/runtime_neutral/test_governed_templates.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_section_headings(path: Path) -> set[str]:
+    headings: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            headings.add(stripped[3:].strip())
+    return headings
+
+
+class GovernedTemplateTests(unittest.TestCase):
+    def test_requirement_template_covers_policy_sections_and_artifact_fields(self) -> None:
+        policy = json.loads((REPO_ROOT / "config" / "requirement-doc-policy.json").read_text(encoding="utf-8"))
+        headings = _load_section_headings(REPO_ROOT / "templates" / "requirements" / "governed-requirement-template.md")
+
+        for section in policy["required_sections"]:
+            self.assertIn(section, headings)
+
+        self.assertIn("Artifact Review Requirements", headings)
+        self.assertIn("Code Task TDD Evidence Requirements", headings)
+        self.assertIn("Code Task TDD Exceptions", headings)
+        self.assertIn("Baseline Document Quality Dimensions", headings)
+        self.assertIn("Baseline UI Quality Dimensions", headings)
+        self.assertIn("Task-Specific Acceptance Extensions", headings)
+        self.assertIn("Research Augmentation Sources", headings)
+
+    def test_plan_template_covers_policy_sections_and_artifact_planning_fields(self) -> None:
+        policy = json.loads((REPO_ROOT / "config" / "plan-execution-policy.json").read_text(encoding="utf-8"))
+        headings = _load_section_headings(REPO_ROOT / "templates" / "plans" / "governed-execution-plan-template.md")
+
+        for section in policy["required_plan_sections"]:
+            self.assertIn(section, headings)
+
+        self.assertIn("Artifact Review Strategy", headings)
+        self.assertIn("Code Task TDD Evidence Plan", headings)
+        self.assertIn("Baseline Document Quality Mapping", headings)
+        self.assertIn("Baseline UI Quality Mapping", headings)
+        self.assertIn("Task-Specific Acceptance Mapping", headings)
+        self.assertIn("Research Augmentation Plan", headings)
+
+    def test_write_xl_plan_script_emits_artifact_planning_sections(self) -> None:
+        script_text = (REPO_ROOT / "scripts" / "runtime" / "Write-XlPlan.ps1").read_text(encoding="utf-8")
+
+        self.assertIn("## Artifact Review Strategy", script_text)
+        self.assertIn("## Code Task TDD Evidence Plan", script_text)
+        self.assertIn("## Baseline Document Quality Mapping", script_text)
+        self.assertIn("## Baseline UI Quality Mapping", script_text)
+        self.assertIn("## Task-Specific Acceptance Mapping", script_text)
+        self.assertIn("## Research Augmentation Plan", script_text)

--- a/tests/runtime_neutral/test_python_validation_contract.py
+++ b/tests/runtime_neutral/test_python_validation_contract.py
@@ -20,6 +20,7 @@ EXPECTED_PYTHON_VALIDATION_TARGETS = [
     "tests/runtime_neutral/test_docs_readme_encoding.py",
     "tests/runtime_neutral/test_governed_runtime_bridge.py",
     "tests/runtime_neutral/test_install_profile_differentiation.py",
+    "tests/runtime_neutral/test_memory_progressive_disclosure.py",
     "tests/runtime_neutral/test_runtime_contract_goldens.py",
     "tests/runtime_neutral/test_python_validation_contract.py",
 ]

--- a/tests/runtime_neutral/test_runtime_delivery_acceptance.py
+++ b/tests/runtime_neutral/test_runtime_delivery_acceptance.py
@@ -14,6 +14,7 @@ if SPEC is None or SPEC.loader is None:
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 evaluate = MODULE.evaluate
+write_artifacts = MODULE.write_artifacts
 
 
 def write_json(path: Path, payload: dict[str, object]) -> None:
@@ -34,6 +35,17 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
         failed_unit_count: int = 0,
         manual_spot_checks: list[str] | None = None,
         include_product_criteria: bool = True,
+        artifact_review_requirements: list[str] | None = None,
+        code_task_tdd_evidence_requirements: list[str] | None = None,
+        code_task_tdd_exceptions: list[str] | None = None,
+        baseline_document_quality_dimensions: list[str] | None = None,
+        baseline_ui_quality_dimensions: list[str] | None = None,
+        task_specific_acceptance_extensions: list[str] | None = None,
+        research_augmentation_sources: list[str] | None = None,
+        phase_execute_artifact_review: dict[str, object] | None = None,
+        phase_execute_tdd_evidence: dict[str, object] | None = None,
+        sidecar_artifact_review: dict[str, object] | None = None,
+        sidecar_tdd_evidence: dict[str, object] | None = None,
         governance_scope: str = "root",
         completion_claim_allowed: bool = True,
         cleanup_mode: str = "bounded_cleanup_executed",
@@ -80,6 +92,48 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
             "- Governance truth remains distinct from product acceptance truth.",
             "",
         ]
+        if artifact_review_requirements:
+            requirement_lines += [
+                "## Artifact Review Requirements",
+                *[f"- {item}" for item in artifact_review_requirements],
+                "",
+            ]
+        if code_task_tdd_evidence_requirements:
+            requirement_lines += [
+                "## Code Task TDD Evidence Requirements",
+                *[f"- {item}" for item in code_task_tdd_evidence_requirements],
+                "",
+            ]
+        if code_task_tdd_exceptions:
+            requirement_lines += [
+                "## Code Task TDD Exceptions",
+                *[f"- {item}" for item in code_task_tdd_exceptions],
+                "",
+            ]
+        if baseline_document_quality_dimensions:
+            requirement_lines += [
+                "## Baseline Document Quality Dimensions",
+                *[f"- {item}" for item in baseline_document_quality_dimensions],
+                "",
+            ]
+        if baseline_ui_quality_dimensions:
+            requirement_lines += [
+                "## Baseline UI Quality Dimensions",
+                *[f"- {item}" for item in baseline_ui_quality_dimensions],
+                "",
+            ]
+        if task_specific_acceptance_extensions:
+            requirement_lines += [
+                "## Task-Specific Acceptance Extensions",
+                *[f"- {item}" for item in task_specific_acceptance_extensions],
+                "",
+            ]
+        if research_augmentation_sources:
+            requirement_lines += [
+                "## Research Augmentation Sources",
+                *[f"- {item}" for item in research_augmentation_sources],
+                "",
+            ]
         write_text(requirement_doc_path, "\n".join(requirement_lines) + "\n")
         write_text(
             execution_plan_path,
@@ -112,6 +166,8 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
                 "execution_manifest_path": str(execution_manifest_path),
                 "runtime_input_packet_path": str(runtime_input_packet_path),
                 "completion_claim_allowed": completion_claim_allowed,
+                "artifact_review": phase_execute_artifact_review or {},
+                "tdd_evidence": phase_execute_tdd_evidence or {},
             },
         )
         write_json(
@@ -120,6 +176,10 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
                 "cleanup_mode": cleanup_mode,
             },
         )
+        if sidecar_artifact_review is not None:
+            write_json(session_root / "artifact-review.json", sidecar_artifact_review)
+        if sidecar_tdd_evidence is not None:
+            write_json(session_root / "tdd-evidence.json", sidecar_tdd_evidence)
         return session_root
 
     def test_runtime_delivery_acceptance_passes_for_clean_root_run(self) -> None:
@@ -128,6 +188,7 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
 
         self.assertEqual("PASS", report["summary"]["gate_result"])
         self.assertTrue(report["summary"]["completion_language_allowed"])
+        self.assertEqual("not_applicable", report["truth_results"]["code_task_tdd_evidence_truth"]["state"])
         self.assertEqual("passing", report["truth_results"]["product_acceptance_truth"]["state"])
 
     def test_runtime_delivery_acceptance_requires_manual_review_when_spot_checks_pending(self) -> None:
@@ -154,3 +215,478 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
         self.assertFalse(report["summary"]["completion_language_allowed"])
         self.assertGreaterEqual(report["summary"]["forbidden_completion_hit_count"], 1)
         self.assertEqual("partial", report["truth_results"]["engineering_verification_truth"]["state"])
+
+    def test_runtime_delivery_acceptance_requires_manual_review_when_artifact_review_is_missing(self) -> None:
+        session_root = self._build_session(
+            artifact_review_requirements=[
+                "Inspect the delivered artifact directly and confirm the required controls and layout are present."
+            ]
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertFalse(report["summary"]["completion_language_allowed"])
+        self.assertEqual("manual_review_required", report["truth_results"]["artifact_review_truth"]["state"])
+        self.assertEqual("manual_review_required", report["truth_results"]["product_acceptance_truth"]["state"])
+        self.assertEqual(
+            [
+                "Inspect the delivered artifact directly and confirm the required controls and layout are present."
+            ],
+            report["frozen_requirement_sections"]["artifact_review_requirements"],
+        )
+
+    def test_runtime_delivery_acceptance_requires_document_baseline_coverage_when_dimensions_are_frozen(self) -> None:
+        session_root = self._build_session(
+            artifact_review_requirements=[
+                "Inspect the final document artifact directly and confirm the formatting remains intact."
+            ],
+            baseline_document_quality_dimensions=[
+                "Structure Integrity",
+                "Formatting Consistency",
+            ],
+            phase_execute_artifact_review={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-artifact-review-notes.md"
+                ],
+                "notes": "Reviewed the document artifact, but did not map frozen document baseline dimensions.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertEqual("manual_review_required", report["truth_results"]["artifact_review_truth"]["state"])
+        self.assertEqual(
+            [
+                "Structure Integrity",
+                "Formatting Consistency",
+            ],
+            report["artifact_review_coverage"]["missing_baseline_document_quality_dimensions"],
+        )
+
+    def test_runtime_delivery_acceptance_passes_when_document_baseline_coverage_is_explicit(self) -> None:
+        session_root = self._build_session(
+            artifact_review_requirements=[
+                "Inspect the final document artifact directly and confirm the formatting remains intact."
+            ],
+            baseline_document_quality_dimensions=[
+                "Structure Integrity",
+                "Formatting Consistency",
+            ],
+            phase_execute_artifact_review={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-artifact-review-notes.md"
+                ],
+                "covered_baseline_document_quality_dimensions": [
+                    "Structure Integrity",
+                    "Formatting Consistency",
+                ],
+                "notes": "Reviewed the document artifact against frozen document baseline dimensions.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("PASS", report["summary"]["gate_result"])
+        self.assertEqual("passing", report["truth_results"]["artifact_review_truth"]["state"])
+        self.assertEqual(
+            [
+                "Structure Integrity",
+                "Formatting Consistency",
+            ],
+            report["artifact_review_coverage"]["covered_baseline_document_quality_dimensions"],
+        )
+        self.assertEqual(
+            [],
+            report["artifact_review_coverage"]["missing_baseline_document_quality_dimensions"],
+        )
+        self.assertEqual(
+            [
+                "Structure Integrity",
+                "Formatting Consistency",
+            ],
+            report["frozen_requirement_sections"]["baseline_document_quality_dimensions"],
+        )
+
+    def test_runtime_delivery_acceptance_requires_manual_review_when_code_task_tdd_evidence_is_missing(self) -> None:
+        requirements = [
+            "Record failing-first evidence for the changed behavior before implementation or defect correction.",
+            "Record the green rerun that proves the targeted behavior passed after implementation.",
+        ]
+        session_root = self._build_session(
+            code_task_tdd_evidence_requirements=requirements,
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertFalse(report["summary"]["completion_language_allowed"])
+        self.assertEqual("manual_review_required", report["truth_results"]["code_task_tdd_evidence_truth"]["state"])
+        self.assertEqual("manual_review_required", report["truth_results"]["product_acceptance_truth"]["state"])
+        self.assertEqual(
+            requirements,
+            report["frozen_requirement_sections"]["code_task_tdd_evidence_requirements"],
+        )
+
+    def test_runtime_delivery_acceptance_requires_red_and_green_phase_evidence_for_code_tasks(self) -> None:
+        requirements = [
+            "Record failing-first evidence for the changed behavior before implementation or defect correction.",
+            "Record the green rerun that proves the targeted behavior passed after implementation.",
+        ]
+        session_root = self._build_session(
+            code_task_tdd_evidence_requirements=requirements,
+            phase_execute_tdd_evidence={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-tdd-evidence.md"
+                ],
+                "covered_code_task_tdd_evidence_requirements": requirements,
+                "green_phase_evidence_paths": [
+                    "/tmp/pytest-tdd-green.txt"
+                ],
+                "notes": "Recorded only the green phase and omitted the failing-first evidence.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertEqual("manual_review_required", report["truth_results"]["code_task_tdd_evidence_truth"]["state"])
+        self.assertEqual(
+            [],
+            report["tdd_evidence_coverage"]["red_phase_evidence_paths"],
+        )
+        self.assertEqual(
+            ["/tmp/pytest-tdd-green.txt"],
+            report["tdd_evidence_coverage"]["green_phase_evidence_paths"],
+        )
+
+    def test_runtime_delivery_acceptance_passes_when_code_task_tdd_evidence_is_recorded(self) -> None:
+        requirements = [
+            "Record failing-first evidence for the changed behavior before implementation or defect correction.",
+            "Record the green rerun that proves the targeted behavior passed after implementation.",
+            "Map the changed behavior to targeted verification evidence; generic suite success alone is insufficient.",
+        ]
+        session_root = self._build_session(
+            code_task_tdd_evidence_requirements=requirements,
+            phase_execute_tdd_evidence={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-tdd-evidence.md"
+                ],
+                "red_phase_evidence_paths": [
+                    "/tmp/pytest-tdd-red.txt"
+                ],
+                "green_phase_evidence_paths": [
+                    "/tmp/pytest-tdd-green.txt"
+                ],
+                "covered_code_task_tdd_evidence_requirements": requirements,
+                "notes": "Captured red/green proof for the targeted behavior.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("PASS", report["summary"]["gate_result"])
+        self.assertTrue(report["summary"]["completion_language_allowed"])
+        self.assertEqual("passing", report["truth_results"]["code_task_tdd_evidence_truth"]["state"])
+        self.assertEqual(
+            requirements,
+            report["tdd_evidence_coverage"]["covered_code_task_tdd_evidence_requirements"],
+        )
+        self.assertEqual(
+            [],
+            report["tdd_evidence_coverage"]["missing_code_task_tdd_evidence_requirements"],
+        )
+
+    def test_runtime_delivery_acceptance_passes_when_code_task_tdd_exception_is_recorded(self) -> None:
+        requirements = [
+            "Record failing-first evidence for the changed behavior before implementation or defect correction.",
+        ]
+        exceptions = [
+            "A bounded hotfix exception was approved because failing-first replay would have required production-state mutation."
+        ]
+        session_root = self._build_session(
+            code_task_tdd_evidence_requirements=requirements,
+            code_task_tdd_exceptions=exceptions,
+            phase_execute_tdd_evidence={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-tdd-exception.md"
+                ],
+                "covered_code_task_tdd_exceptions": exceptions,
+                "notes": "Recorded the approved exception and bounded fallback evidence.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("PASS", report["summary"]["gate_result"])
+        self.assertEqual("passing", report["truth_results"]["code_task_tdd_evidence_truth"]["state"])
+        self.assertEqual(
+            exceptions,
+            report["tdd_evidence_coverage"]["covered_code_task_tdd_exceptions"],
+        )
+        self.assertEqual(
+            [],
+            report["tdd_evidence_coverage"]["missing_code_task_tdd_exceptions"],
+        )
+
+    def test_runtime_delivery_acceptance_passes_when_artifact_review_evidence_is_recorded(self) -> None:
+        session_root = self._build_session(
+            artifact_review_requirements=[
+                "Inspect the final deliverable directly and confirm the primary CTA provides visible feedback."
+            ],
+            task_specific_acceptance_extensions=[
+                "The CTA should show a loading state before the success message."
+            ],
+            research_augmentation_sources=[
+                "NN/g feedback visibility heuristics"
+            ],
+            phase_execute_artifact_review={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-artifact-review-notes.md"
+                ],
+                "covered_task_specific_acceptance_extensions": [
+                    "The CTA should show a loading state before the success message."
+                ],
+                "considered_research_augmentation_sources": [
+                    "NN/g feedback visibility heuristics"
+                ],
+                "notes": "Reviewed final artifact against frozen task-specific acceptance.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("PASS", report["summary"]["gate_result"])
+        self.assertTrue(report["summary"]["completion_language_allowed"])
+        self.assertEqual("passing", report["truth_results"]["artifact_review_truth"]["state"])
+        self.assertEqual("passing", report["truth_results"]["product_acceptance_truth"]["state"])
+        self.assertEqual(
+            ["The CTA should show a loading state before the success message."],
+            report["frozen_requirement_sections"]["task_specific_acceptance_extensions"],
+        )
+        self.assertEqual(
+            ["NN/g feedback visibility heuristics"],
+            report["frozen_requirement_sections"]["research_augmentation_sources"],
+        )
+
+    def test_runtime_delivery_acceptance_requires_task_specific_coverage_when_extensions_are_frozen(self) -> None:
+        session_root = self._build_session(
+            artifact_review_requirements=[
+                "Inspect the final deliverable directly and confirm the primary CTA provides visible feedback."
+            ],
+            task_specific_acceptance_extensions=[
+                "The CTA should show a loading state before the success message."
+            ],
+            phase_execute_artifact_review={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-artifact-review-notes.md"
+                ],
+                "notes": "Reviewed the artifact, but did not record extension coverage.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertEqual("manual_review_required", report["truth_results"]["artifact_review_truth"]["state"])
+        self.assertEqual(
+            ["The CTA should show a loading state before the success message."],
+            report["artifact_review_coverage"]["missing_task_specific_acceptance_extensions"],
+        )
+
+    def test_runtime_delivery_acceptance_requires_ui_baseline_coverage_when_dimensions_are_frozen(self) -> None:
+        session_root = self._build_session(
+            artifact_review_requirements=[
+                "Inspect the final deliverable directly and confirm the primary CTA provides visible feedback."
+            ],
+            baseline_ui_quality_dimensions=[
+                "Structure and visual hierarchy",
+                "Interaction feedback and affordances",
+            ],
+            phase_execute_artifact_review={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-artifact-review-notes.md"
+                ],
+                "notes": "Reviewed the artifact, but did not map frozen UI baseline dimensions.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertEqual("manual_review_required", report["truth_results"]["artifact_review_truth"]["state"])
+        self.assertEqual(
+            [
+                "Structure and visual hierarchy",
+                "Interaction feedback and affordances",
+            ],
+            report["artifact_review_coverage"]["missing_baseline_ui_quality_dimensions"],
+        )
+
+    def test_runtime_delivery_acceptance_passes_when_ui_baseline_coverage_is_explicit(self) -> None:
+        session_root = self._build_session(
+            artifact_review_requirements=[
+                "Inspect the final deliverable directly and confirm the primary CTA provides visible feedback."
+            ],
+            baseline_ui_quality_dimensions=[
+                "Structure and visual hierarchy",
+                "Interaction feedback and affordances",
+            ],
+            phase_execute_artifact_review={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-artifact-review-notes.md"
+                ],
+                "covered_baseline_ui_quality_dimensions": [
+                    "Structure and visual hierarchy",
+                    "Interaction feedback and affordances",
+                ],
+                "notes": "Reviewed the artifact against frozen UI baseline dimensions.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("PASS", report["summary"]["gate_result"])
+        self.assertTrue(report["summary"]["completion_language_allowed"])
+        self.assertEqual("passing", report["truth_results"]["artifact_review_truth"]["state"])
+        self.assertEqual(
+            [
+                "Structure and visual hierarchy",
+                "Interaction feedback and affordances",
+            ],
+            report["artifact_review_coverage"]["covered_baseline_ui_quality_dimensions"],
+        )
+        self.assertEqual(
+            [],
+            report["artifact_review_coverage"]["missing_baseline_ui_quality_dimensions"],
+        )
+        self.assertEqual(
+            [
+                "Structure and visual hierarchy",
+                "Interaction feedback and affordances",
+            ],
+            report["frozen_requirement_sections"]["baseline_ui_quality_dimensions"],
+        )
+
+    def test_runtime_delivery_acceptance_requires_research_source_consideration_when_sources_are_frozen(self) -> None:
+        session_root = self._build_session(
+            artifact_review_requirements=[
+                "Inspect the final deliverable directly and confirm the primary CTA provides visible feedback."
+            ],
+            research_augmentation_sources=[
+                "NN/g feedback visibility heuristics"
+            ],
+            phase_execute_artifact_review={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-artifact-review-notes.md"
+                ],
+                "notes": "Reviewed the artifact, but did not record research-source consideration.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertEqual("manual_review_required", report["truth_results"]["artifact_review_truth"]["state"])
+        self.assertEqual(
+            ["NN/g feedback visibility heuristics"],
+            report["artifact_review_coverage"]["missing_research_augmentation_sources"],
+        )
+
+    def test_runtime_delivery_acceptance_accepts_sidecar_artifact_review_evidence(self) -> None:
+        session_root = self._build_session(
+            artifact_review_requirements=[
+                "Inspect the final document artifact directly and confirm the formatting remains intact."
+            ],
+            sidecar_artifact_review={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-sidecar-artifact-review.md"
+                ],
+                "notes": "Sidecar review confirmed the final artifact formatting remained intact.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("PASS", report["summary"]["gate_result"])
+        self.assertTrue(report["summary"]["completion_language_allowed"])
+        self.assertEqual("passing", report["truth_results"]["artifact_review_truth"]["state"])
+
+    def test_runtime_delivery_acceptance_report_surfaces_frozen_sections_and_coverage(self) -> None:
+        session_root = self._build_session(
+            artifact_review_requirements=[
+                "Inspect the final deliverable directly and confirm the primary CTA provides visible feedback."
+            ],
+            code_task_tdd_evidence_requirements=[
+                "Record failing-first evidence for the changed behavior before implementation or defect correction.",
+                "Record the green rerun that proves the targeted behavior passed after implementation.",
+            ],
+            baseline_document_quality_dimensions=[
+                "Structure Integrity",
+                "Formatting Consistency",
+            ],
+            task_specific_acceptance_extensions=[
+                "The CTA should show a loading state before the success message."
+            ],
+            baseline_ui_quality_dimensions=[
+                "Structure and visual hierarchy",
+                "Interaction feedback and affordances",
+            ],
+            research_augmentation_sources=[
+                "NN/g feedback visibility heuristics"
+            ],
+            phase_execute_artifact_review={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-artifact-review-notes.md"
+                ],
+                "covered_task_specific_acceptance_extensions": [
+                    "The CTA should show a loading state before the success message."
+                ],
+                "covered_baseline_document_quality_dimensions": [
+                    "Structure Integrity",
+                    "Formatting Consistency",
+                ],
+                "covered_baseline_ui_quality_dimensions": [
+                    "Structure and visual hierarchy",
+                    "Interaction feedback and affordances",
+                ],
+                "considered_research_augmentation_sources": [
+                    "NN/g feedback visibility heuristics"
+                ],
+                "notes": "Reviewed final artifact against frozen task-specific acceptance.",
+            },
+            phase_execute_tdd_evidence={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-tdd-evidence.md"
+                ],
+                "red_phase_evidence_paths": [
+                    "/tmp/pytest-tdd-red.txt"
+                ],
+                "green_phase_evidence_paths": [
+                    "/tmp/pytest-tdd-green.txt"
+                ],
+                "covered_code_task_tdd_evidence_requirements": [
+                    "Record failing-first evidence for the changed behavior before implementation or defect correction.",
+                    "Record the green rerun that proves the targeted behavior passed after implementation.",
+                ],
+                "notes": "Captured red/green TDD evidence for the code change.",
+            },
+        )
+        artifact = evaluate(REPO_ROOT, session_root)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            output_root = Path(tempdir)
+            write_artifacts(artifact, output_root)
+            md_text = (output_root / "delivery-acceptance-report.md").read_text(encoding="utf-8")
+            self.assertIn("Frozen Baseline Document Quality Dimensions", md_text)
+            self.assertIn("Frozen Code Task TDD Evidence Requirements", md_text)
+            self.assertIn("Frozen Baseline UI Quality Dimensions", md_text)
+            self.assertIn("Frozen Task-Specific Acceptance Extensions", md_text)
+            self.assertIn("Frozen Research Augmentation Sources", md_text)
+            self.assertIn("Code Task TDD Evidence Coverage", md_text)
+            self.assertIn("Artifact Review Coverage", md_text)
+            self.assertIn("Covered baseline document quality dimension: Structure Integrity", md_text)
+            self.assertIn("Covered code-task TDD evidence requirement: Record failing-first evidence for the changed behavior before implementation or defect correction.", md_text)
+            self.assertIn("Covered baseline UI quality dimension: Structure and visual hierarchy", md_text)
+            self.assertIn("NN/g feedback visibility heuristics", md_text)

--- a/tests/runtime_neutral/test_runtime_delivery_acceptance.py
+++ b/tests/runtime_neutral/test_runtime_delivery_acceptance.py
@@ -46,6 +46,8 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
         phase_execute_tdd_evidence: dict[str, object] | None = None,
         sidecar_artifact_review: dict[str, object] | None = None,
         sidecar_tdd_evidence: dict[str, object] | None = None,
+        artifact_review_path: str | None = None,
+        tdd_evidence_path: str | None = None,
         governance_scope: str = "root",
         completion_claim_allowed: bool = True,
         cleanup_mode: str = "bounded_cleanup_executed",
@@ -158,17 +160,22 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
                 }
             },
         )
+        phase_execute_payload = {
+            "requirement_doc_path": str(requirement_doc_path),
+            "execution_plan_path": str(execution_plan_path),
+            "execution_manifest_path": str(execution_manifest_path),
+            "runtime_input_packet_path": str(runtime_input_packet_path),
+            "completion_claim_allowed": completion_claim_allowed,
+            "artifact_review": phase_execute_artifact_review or {},
+            "tdd_evidence": phase_execute_tdd_evidence or {},
+        }
+        if artifact_review_path:
+            phase_execute_payload["artifact_review_path"] = artifact_review_path
+        if tdd_evidence_path:
+            phase_execute_payload["tdd_evidence_path"] = tdd_evidence_path
         write_json(
             session_root / "phase-execute.json",
-            {
-                "requirement_doc_path": str(requirement_doc_path),
-                "execution_plan_path": str(execution_plan_path),
-                "execution_manifest_path": str(execution_manifest_path),
-                "runtime_input_packet_path": str(runtime_input_packet_path),
-                "completion_claim_allowed": completion_claim_allowed,
-                "artifact_review": phase_execute_artifact_review or {},
-                "tdd_evidence": phase_execute_tdd_evidence or {},
-            },
+            phase_execute_payload,
         )
         write_json(
             session_root / "cleanup-receipt.json",
@@ -190,6 +197,32 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
         self.assertTrue(report["summary"]["completion_language_allowed"])
         self.assertEqual("not_applicable", report["truth_results"]["code_task_tdd_evidence_truth"]["state"])
         self.assertEqual("passing", report["truth_results"]["product_acceptance_truth"]["state"])
+
+    def test_runtime_delivery_acceptance_report_covers_contract_required_fields(self) -> None:
+        contract = json.loads(
+            (REPO_ROOT / "config" / "project-delivery-acceptance-contract.json").read_text(encoding="utf-8")
+        )
+        session_root = self._build_session()
+        report = evaluate(REPO_ROOT, session_root)
+
+        reported_fields = set(report["truth_results"].keys())
+        reported_fields.update(
+            {
+                "completion_language_allowed",
+                "artifact_review_coverage",
+                "tdd_evidence_coverage",
+                "residual_risks",
+                "manual_spot_checks",
+            }
+        )
+        missing_fields = [
+            field
+            for field in contract["report_requirements"]["must_report_fields"]
+            if field not in reported_fields
+        ]
+
+        self.assertEqual([], missing_fields)
+        self.assertIn("completion_language_allowed", report["summary"])
 
     def test_runtime_delivery_acceptance_requires_manual_review_when_spot_checks_pending(self) -> None:
         session_root = self._build_session(
@@ -396,7 +429,7 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
             report["tdd_evidence_coverage"]["missing_code_task_tdd_evidence_requirements"],
         )
 
-    def test_runtime_delivery_acceptance_passes_when_code_task_tdd_exception_is_recorded(self) -> None:
+    def test_runtime_delivery_acceptance_requires_full_tdd_evidence_when_exception_is_recorded(self) -> None:
         requirements = [
             "Record failing-first evidence for the changed behavior before implementation or defect correction.",
         ]
@@ -413,6 +446,40 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
                 ],
                 "covered_code_task_tdd_exceptions": exceptions,
                 "notes": "Recorded the approved exception and bounded fallback evidence.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertEqual("manual_review_required", report["truth_results"]["code_task_tdd_evidence_truth"]["state"])
+        self.assertEqual(requirements, report["tdd_evidence_coverage"]["missing_code_task_tdd_evidence_requirements"])
+        self.assertEqual([], report["tdd_evidence_coverage"]["red_phase_evidence_paths"])
+        self.assertEqual([], report["tdd_evidence_coverage"]["green_phase_evidence_paths"])
+
+    def test_runtime_delivery_acceptance_passes_when_code_task_tdd_exception_and_required_evidence_are_recorded(self) -> None:
+        requirements = [
+            "Record failing-first evidence for the changed behavior before implementation or defect correction.",
+        ]
+        exceptions = [
+            "A bounded hotfix exception was approved because failing-first replay would have required production-state mutation."
+        ]
+        session_root = self._build_session(
+            code_task_tdd_evidence_requirements=requirements,
+            code_task_tdd_exceptions=exceptions,
+            phase_execute_tdd_evidence={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-tdd-exception.md"
+                ],
+                "covered_code_task_tdd_evidence_requirements": requirements,
+                "covered_code_task_tdd_exceptions": exceptions,
+                "red_phase_evidence_paths": [
+                    "/tmp/pytest-tdd-red.txt"
+                ],
+                "green_phase_evidence_paths": [
+                    "/tmp/pytest-tdd-green.txt"
+                ],
+                "notes": "Recorded the approved exception with requirement and red/green evidence coverage.",
             },
         )
         report = evaluate(REPO_ROOT, session_root)
@@ -592,6 +659,34 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
             report["artifact_review_coverage"]["missing_research_augmentation_sources"],
         )
 
+    def test_runtime_delivery_acceptance_reports_residual_risks_for_unresolved_ui_task_and_research_reviews(self) -> None:
+        session_root = self._build_session(
+            baseline_ui_quality_dimensions=[
+                "Structure and visual hierarchy",
+                "Interaction feedback and affordances",
+            ],
+            task_specific_acceptance_extensions=[
+                "The CTA should show a loading state before the success message."
+            ],
+            research_augmentation_sources=[
+                "NN/g feedback visibility heuristics"
+            ],
+            phase_execute_artifact_review={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-artifact-review-notes.md"
+                ],
+                "notes": "Reviewed artifact, but did not map frozen review dimensions.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertEqual("manual_review_required", report["truth_results"]["artifact_review_truth"]["state"])
+        self.assertIn("Frozen baseline UI quality dimensions remain unresolved.", report["residual_risks"])
+        self.assertIn("Frozen task-specific acceptance extensions remain unresolved.", report["residual_risks"])
+        self.assertIn("Frozen research augmentation sources remain unresolved.", report["residual_risks"])
+
     def test_runtime_delivery_acceptance_accepts_sidecar_artifact_review_evidence(self) -> None:
         session_root = self._build_session(
             artifact_review_requirements=[
@@ -610,6 +705,129 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
         self.assertEqual("PASS", report["summary"]["gate_result"])
         self.assertTrue(report["summary"]["completion_language_allowed"])
         self.assertEqual("passing", report["truth_results"]["artifact_review_truth"]["state"])
+
+    def test_runtime_delivery_acceptance_rejects_explicit_artifact_review_paths_outside_session_root(self) -> None:
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "status": "passing",
+                    "evidence_paths": ["/tmp/pytest-explicit-artifact-review.md"],
+                },
+                handle,
+            )
+            explicit_path = handle.name
+        self.addCleanup(lambda: Path(explicit_path).unlink(missing_ok=True))
+
+        session_root = self._build_session(
+            artifact_review_requirements=[
+                "Inspect the final document artifact directly and confirm the formatting remains intact."
+            ],
+            artifact_review_path=explicit_path,
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertEqual("manual_review_required", report["truth_results"]["artifact_review_truth"]["state"])
+        self.assertNotIn(explicit_path, report["truth_results"]["artifact_review_truth"]["evidence"])
+
+    def test_runtime_delivery_acceptance_requires_requirements_and_red_green_when_exception_is_recorded(self) -> None:
+        requirements = [
+            "Record failing-first evidence for the changed behavior before implementation or defect correction.",
+        ]
+        exceptions = [
+            "A bounded hotfix exception was approved because failing-first replay would have required production-state mutation."
+        ]
+        session_root = self._build_session(
+            code_task_tdd_evidence_requirements=requirements,
+            code_task_tdd_exceptions=exceptions,
+            phase_execute_tdd_evidence={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-tdd-exception.md"
+                ],
+                "covered_code_task_tdd_exceptions": exceptions,
+                "notes": "Recorded the approved exception but skipped the remaining TDD proof obligations.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertEqual("manual_review_required", report["truth_results"]["code_task_tdd_evidence_truth"]["state"])
+        self.assertEqual(requirements, report["tdd_evidence_coverage"]["missing_code_task_tdd_evidence_requirements"])
+        self.assertEqual([], report["tdd_evidence_coverage"]["red_phase_evidence_paths"])
+        self.assertEqual([], report["tdd_evidence_coverage"]["green_phase_evidence_paths"])
+
+    def test_runtime_delivery_acceptance_surfaces_specific_residual_risks_for_unresolved_artifact_review_sources(self) -> None:
+        session_root = self._build_session(
+            artifact_review_requirements=[
+                "Inspect the final deliverable directly and confirm the primary CTA provides visible feedback."
+            ],
+            baseline_ui_quality_dimensions=[
+                "Structure and visual hierarchy",
+            ],
+            task_specific_acceptance_extensions=[
+                "The CTA should show a loading state before the success message."
+            ],
+            research_augmentation_sources=[
+                "NN/g feedback visibility heuristics",
+            ],
+            phase_execute_artifact_review={
+                "status": "passing",
+                "evidence_paths": [
+                    "/tmp/pytest-artifact-review-notes.md"
+                ],
+                "notes": "Reviewed the artifact, but did not record the frozen source coverage.",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertIn("Frozen baseline UI quality dimensions remain unresolved.", report["residual_risks"])
+        self.assertIn("Frozen task-specific acceptance extensions remain unresolved.", report["residual_risks"])
+        self.assertIn("Frozen research augmentation sources remain unresolved.", report["residual_risks"])
+
+    def test_runtime_delivery_acceptance_rejects_explicit_payload_paths_outside_session_root(self) -> None:
+        tdd_requirements = [
+            "Record failing-first evidence for the changed behavior before implementation or defect correction.",
+        ]
+        with tempfile.TemporaryDirectory() as tempdir:
+            outside_root = Path(tempdir)
+            artifact_payload_path = outside_root / "outside-artifact-review.json"
+            tdd_payload_path = outside_root / "outside-tdd-evidence.json"
+            write_json(
+                artifact_payload_path,
+                {
+                    "status": "passing",
+                    "evidence_paths": ["/tmp/outside-artifact-review.md"],
+                },
+            )
+            write_json(
+                tdd_payload_path,
+                {
+                    "status": "passing",
+                    "evidence_paths": ["/tmp/outside-tdd-evidence.md"],
+                    "covered_code_task_tdd_evidence_requirements": tdd_requirements,
+                    "red_phase_evidence_paths": ["/tmp/outside-tdd-red.txt"],
+                    "green_phase_evidence_paths": ["/tmp/outside-tdd-green.txt"],
+                },
+            )
+            session_root = self._build_session(
+                artifact_review_requirements=[
+                    "Inspect the final artifact directly and confirm required controls are present."
+                ],
+                code_task_tdd_evidence_requirements=tdd_requirements,
+                artifact_review_path=str(artifact_payload_path),
+                tdd_evidence_path=str(tdd_payload_path),
+            )
+            self.assertTrue(artifact_payload_path.exists())
+            self.assertTrue(tdd_payload_path.exists())
+
+            report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertEqual("manual_review_required", report["truth_results"]["artifact_review_truth"]["state"])
+        self.assertEqual("manual_review_required", report["truth_results"]["code_task_tdd_evidence_truth"]["state"])
+        self.assertEqual("", report["execution_context"]["artifact_review_source_path"])
+        self.assertEqual("", report["execution_context"]["tdd_evidence_source_path"])
 
     def test_runtime_delivery_acceptance_report_surfaces_frozen_sections_and_coverage(self) -> None:
         session_root = self._build_session(

--- a/tests/runtime_neutral/test_workflow_acceptance_runner.py
+++ b/tests/runtime_neutral/test_workflow_acceptance_runner.py
@@ -32,6 +32,8 @@ class WorkflowAcceptanceRunnerTests(unittest.TestCase):
         self.assertEqual("PASS", artifact["summary"]["gate_result"])
         self.assertTrue(artifact["summary"]["completion_language_allowed"])
         self.assertEqual(0, artifact["summary"]["forbidden_completion_hit_count"])
+        self.assertEqual("passing", artifact["truth_results"]["code_task_tdd_evidence_truth"]["state"])
+        self.assertEqual("passing", artifact["truth_results"]["artifact_review_truth"]["state"])
 
     def test_manual_review_scenario_blocks_completion_language(self) -> None:
         scenario_path = REPO_ROOT / "tests" / "scenarios" / "project_delivery" / "xl-composite-manual-review.json"
@@ -42,6 +44,11 @@ class WorkflowAcceptanceRunnerTests(unittest.TestCase):
             "manual_review_required",
             artifact["truth_results"]["product_acceptance_truth"]["state"],
         )
+        self.assertEqual(
+            "manual_review_required",
+            artifact["truth_results"]["artifact_review_truth"]["state"],
+        )
+        self.assertEqual("passing", artifact["truth_results"]["code_task_tdd_evidence_truth"]["state"])
 
     def test_completed_with_failures_is_forbidden_completion_hit(self) -> None:
         scenario_path = REPO_ROOT / "tests" / "scenarios" / "project_delivery" / "partial-completion-blocked.json"
@@ -51,6 +58,10 @@ class WorkflowAcceptanceRunnerTests(unittest.TestCase):
         self.assertGreaterEqual(artifact["summary"]["forbidden_completion_hit_count"], 1)
         self.assertIn(
             "product_acceptance_truth",
+            artifact["summary"]["incomplete_layers"],
+        )
+        self.assertIn(
+            "code_task_tdd_evidence_truth",
             artifact["summary"]["incomplete_layers"],
         )
 
@@ -76,6 +87,8 @@ class WorkflowAcceptanceRunnerTests(unittest.TestCase):
                             "governance_truth": {"state": "passing"},
                             "engineering_verification_truth": {"state": "passing"},
                             "workflow_completion_truth": {"state": "passing"},
+                            "code_task_tdd_evidence_truth": {"state": "not_applicable"},
+                            "artifact_review_truth": {"state": "passing"},
                             "product_acceptance_truth": {"state": "passing"}
                         }
                     },

--- a/tests/scenarios/project_delivery/README.md
+++ b/tests/scenarios/project_delivery/README.md
@@ -18,11 +18,12 @@ Each scenario should define:
 
 ## Truth Layers
 
-Each scenario must provide four truth-layer states:
+Each scenario must provide five truth-layer states:
 
 - `governance_truth`
 - `engineering_verification_truth`
 - `workflow_completion_truth`
+- `artifact_review_truth`
 - `product_acceptance_truth`
 
 ## Purpose

--- a/tests/scenarios/project_delivery/README.md
+++ b/tests/scenarios/project_delivery/README.md
@@ -18,10 +18,11 @@ Each scenario should define:
 
 ## Truth Layers
 
-Each scenario must provide five truth-layer states:
+Each scenario must provide six truth-layer states:
 
 - `governance_truth`
 - `engineering_verification_truth`
+- `code_task_tdd_evidence_truth`
 - `workflow_completion_truth`
 - `artifact_review_truth`
 - `product_acceptance_truth`

--- a/tests/scenarios/project_delivery/l-grade-feature-complete.json
+++ b/tests/scenarios/project_delivery/l-grade-feature-complete.json
@@ -28,6 +28,20 @@
         "required outputs emitted"
       ]
     },
+    "code_task_tdd_evidence_truth": {
+      "state": "passing",
+      "evidence": [
+        "failing-first evidence captured for the targeted behavior",
+        "green rerun captured for the same behavior"
+      ]
+    },
+    "artifact_review_truth": {
+      "state": "passing",
+      "evidence": [
+        "final artifact reviewed against frozen acceptance expectations",
+        "artifact review notes archived with delivery evidence"
+      ]
+    },
     "product_acceptance_truth": {
       "state": "passing",
       "evidence": [

--- a/tests/scenarios/project_delivery/partial-completion-blocked.json
+++ b/tests/scenarios/project_delivery/partial-completion-blocked.json
@@ -26,6 +26,18 @@
         "some units failed"
       ]
     },
+    "code_task_tdd_evidence_truth": {
+      "state": "not_run",
+      "evidence": [
+        "the bounded TDD evidence package was not closed because the target behavior still failed"
+      ]
+    },
+    "artifact_review_truth": {
+      "state": "not_run",
+      "evidence": [
+        "artifact review was not attempted because critical behavior remained broken"
+      ]
+    },
     "product_acceptance_truth": {
       "state": "failing",
       "evidence": [

--- a/tests/scenarios/project_delivery/xl-composite-manual-review.json
+++ b/tests/scenarios/project_delivery/xl-composite-manual-review.json
@@ -26,6 +26,19 @@
         "approved specialist units executed"
       ]
     },
+    "code_task_tdd_evidence_truth": {
+      "state": "passing",
+      "evidence": [
+        "implementation lane captured failing-first and green verification evidence before handoff"
+      ]
+    },
+    "artifact_review_truth": {
+      "state": "manual_review_required",
+      "evidence": [
+        "final scientific artifact still requires direct expert review"
+      ],
+      "notes": "Artifact exists, but the required domain review has not been closed."
+    },
     "product_acceptance_truth": {
       "state": "manual_review_required",
       "evidence": [


### PR DESCRIPTION
## Summary
- freeze document artifact review, code-task TDD, baseline document/UI, task-specific acceptance, and research augmentation sections in governed requirement and plan surfaces
- extend delivery acceptance truth evaluation and contract semantics so completion language is blocked until artifact review and TDD evidence are explicitly covered when required
- add regression coverage for document/UI task classification, delivery acceptance, workflow acceptance, and governed template sections

## Test Plan
- `python3 -m pytest /home/lqf/table/table9/wt-document-artifact-governance-pr/tests/runtime_neutral/test_governed_runtime_bridge.py /home/lqf/table/table9/wt-document-artifact-governance-pr/tests/runtime_neutral/test_governed_templates.py /home/lqf/table/table9/wt-document-artifact-governance-pr/tests/runtime_neutral/test_runtime_delivery_acceptance.py /home/lqf/table/table9/wt-document-artifact-governance-pr/tests/runtime_neutral/test_workflow_acceptance_runner.py /home/lqf/table/table9/wt-document-artifact-governance-pr/tests/integration/test_verification_core_cutover.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delivery acceptance contract moved to a new version; added artifact-review and code-task TDD evidence truth layers, a "not_applicable" truth state, and required coverage fields in reports.
  * Requirement and plan templates plus runtime reporting now include Artifact Review, Code Task TDD Evidence, baseline document/UI quality dimensions, frozen-requirement sections, and coverage summaries.

* **Tests**
  * Expanded tests validating freezing behavior, coverage reporting, gating/manual-review rules, template/contract requirements, and end-to-end report contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->