### PR TITLE
Add host-global vibe bootstrap lifecycle with safe checks

### DIFF
--- a/adapters/claude-code/host-profile.json
+++ b/adapters/claude-code/host-profile.json
@@ -19,6 +19,22 @@
     "managed_by_repo": true,
     "notes": "The repository preserves existing Claude settings while adding a bounded vibeskills-managed stanza."
   },
+  "global_instruction_surface": {
+    "relpath": "CLAUDE.md",
+    "documented_path": "~/.claude/CLAUDE.md",
+    "format": "markdown-rules",
+    "managed_block_id": "global-vibe-bootstrap",
+    "merge_policy": "managed-block-only",
+    "overwrite_policy": "forbidden",
+    "trigger_tokens": [
+      "$vibe",
+      "/vibe"
+    ],
+    "authority_owner": "vibe",
+    "bootstrap_only": true,
+    "template_relpath": "config/global-bootstrap/claude-code-vibe-bootstrap.md",
+    "template_version": 1
+  },
   "discoverable_entries": {
     "shared_source": "config/vibe-entry-surfaces.json",
     "authority_owner": "vibe",

--- a/adapters/codex/host-profile.json
+++ b/adapters/codex/host-profile.json
@@ -15,6 +15,22 @@
     "managed_by_repo": true,
     "notes": "The repository can materialize runtime payload and template settings into the Codex root, but host plugins remain host-managed."
   },
+  "global_instruction_surface": {
+    "relpath": "AGENTS.md",
+    "documented_path": "~/.codex/AGENTS.md",
+    "format": "markdown-rules",
+    "managed_block_id": "global-vibe-bootstrap",
+    "merge_policy": "managed-block-only",
+    "overwrite_policy": "forbidden",
+    "trigger_tokens": [
+      "$vibe",
+      "/vibe"
+    ],
+    "authority_owner": "vibe",
+    "bootstrap_only": true,
+    "template_relpath": "config/global-bootstrap/codex-vibe-bootstrap.md",
+    "template_version": 1
+  },
   "discoverable_entries": {
     "shared_source": "config/vibe-entry-surfaces.json",
     "authority_owner": "vibe",

--- a/adapters/opencode/host-profile.json
+++ b/adapters/opencode/host-profile.json
@@ -17,6 +17,22 @@
     "managed_by_repo": false,
     "notes": "The repository installs skills, commands, agents, host-closure metadata, and an opencode.json.example scaffold; the real opencode.json stays host-managed."
   },
+  "global_instruction_surface": {
+    "relpath": "AGENTS.md",
+    "documented_path": "~/.config/opencode/AGENTS.md",
+    "format": "markdown-rules",
+    "managed_block_id": "global-vibe-bootstrap",
+    "merge_policy": "managed-block-only",
+    "overwrite_policy": "forbidden",
+    "trigger_tokens": [
+      "$vibe",
+      "/vibe"
+    ],
+    "authority_owner": "vibe",
+    "bootstrap_only": true,
+    "template_relpath": "config/global-bootstrap/opencode-vibe-bootstrap.md",
+    "template_version": 1
+  },
   "discoverable_entries": {
     "shared_source": "config/vibe-entry-surfaces.json",
     "authority_owner": "vibe",

--- a/check.ps1
+++ b/check.ps1
@@ -760,9 +760,6 @@ function Invoke-AdapterSpecificChecks {
 
   if ([string]$Adapter.id -eq 'codex' -and [string]$Adapter.check_mode -eq 'governed') {
     $codexCommandNames = @('vibe', 'vibe-what-do-i-want', 'vibe-how-do-we-do', 'vibe-do-it')
-    if ($env:OS -ne 'Windows_NT') {
-      $codexCommandNames = @('vibe', 'vibe:what-do-i-want', 'vibe:how-do-we-do', 'vibe:do-it')
-    }
     foreach ($name in $codexCommandNames) {
       Check-Path -Label "codex command/$name" -Path (Join-Path (Join-Path $TargetRoot 'commands') "$name.md") -Required:$false
     }

--- a/check.sh
+++ b/check.sh
@@ -888,10 +888,6 @@ if [[ "${HOST_ID}" == "codex" && "${ADAPTER_CHECK_MODE}" == "governed" && "${PRO
 fi
 if [[ "${HOST_ID}" == "codex" && "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   codex_command_names=(vibe vibe-what-do-i-want vibe-how-do-we-do vibe-do-it)
-  codex_kernel="$(uname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')"
-  if [[ "${codex_kernel}" != mingw* && "${codex_kernel}" != msys* && "${codex_kernel}" != cygwin* ]]; then
-    codex_command_names=("vibe" "vibe:what-do-i-want" "vibe:how-do-we-do" "vibe:do-it")
-  fi
   for n in "${codex_command_names[@]}"; do
     check_path "codex command/${n}" "${TARGET_ROOT}/commands/${n}.md" false
   done

--- a/config/global-bootstrap/claude-code-vibe-bootstrap.md
+++ b/config/global-bootstrap/claude-code-vibe-bootstrap.md
@@ -1,0 +1,4 @@
+If the user explicitly invokes `$vibe` or `/vibe`, enter canonical `vibe` before normal execution.
+Do not silently continue in ordinary mode first.
+If canonical `vibe` cannot be loaded, report blocked instead of falling back silently.
+This `CLAUDE.md` block is bootstrap guidance only; runtime authority remains canonical `vibe`.

--- a/config/global-bootstrap/codex-vibe-bootstrap.md
+++ b/config/global-bootstrap/codex-vibe-bootstrap.md
@@ -1,0 +1,4 @@
+If the user explicitly invokes `$vibe` or `/vibe`, enter canonical `vibe` before normal execution.
+Do not silently continue in ordinary mode first.
+If canonical `vibe` cannot be loaded, report blocked instead of falling back silently.
+This file is a bootstrap entry surface only; runtime authority remains canonical `vibe`.

--- a/config/global-bootstrap/opencode-vibe-bootstrap.md
+++ b/config/global-bootstrap/opencode-vibe-bootstrap.md
@@ -1,0 +1,4 @@
+If the user explicitly invokes `$vibe` or `/vibe`, enter canonical `vibe` before normal execution.
+Do not silently continue in ordinary mode first.
+If canonical `vibe` cannot be loaded, report blocked instead of falling back silently.
+This `AGENTS.md` block is bootstrap guidance only; runtime authority remains canonical `vibe`.

--- a/docs/plans/2026-04-15-pr164-rabbit-followup-fixes-execution-plan.md
+++ b/docs/plans/2026-04-15-pr164-rabbit-followup-fixes-execution-plan.md
@@ -1,0 +1,61 @@
+# PR164 Rabbit Follow-up Fixes Execution Plan
+
+## Execution Summary
+
+Freeze the remaining verified PR `#164` review follow-up defects, add failing regression coverage for them, implement the smallest lifecycle and doctor fixes, rerun the focused verification slice, and update the PR branch plus review threads.
+
+## Frozen Inputs
+
+- Requirement doc: `docs/requirements/2026-04-15-pr164-rabbit-followup-fixes.md`
+- PR: `#164`
+- Base branch: `main`
+- Head branch: `feat/host-global-bootstrap-pr`
+- Review source: the unresolved CodeRabbit follow-up comments still open on PR `#164`
+
+## Specialist Recommendation
+
+- `receiving-code-review`: applicable and used as bounded review specialist assistance for validating the remaining review findings
+- no separate GitHub review-bot or doc-copy specialist exists in the current skill set
+- dispatch mode: native fallback for git/GitHub MCP operations and minor requirement-doc wording cleanup
+
+## Internal Grade Decision
+
+`L`
+
+The remaining work is tightly coupled and sequence-sensitive: reproduce, write red tests, implement small fixes, verify, then update the PR.
+
+## Step Plan
+
+1. Freeze governed requirement and plan artifacts for this follow-up run.
+2. Add failing regression tests for:
+   - shared-root multi-host bootstrap merge/update/remove keyed by `(host_id, block_id)`
+   - malformed scoped bootstrap receipt fields returning unhealthy doctor state instead of raising
+3. Implement the minimal production fixes in:
+   - `packages/installer-core/src/vgo_installer/global_instruction_merge.py`
+   - `packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py`
+4. Apply the non-blocking wording fix in the new requirement artifact if convenient.
+5. Rerun the focused verification slice and `git diff --check`.
+6. Update the PR branch and reply to the remaining review threads with technical resolution notes.
+
+## TDD Plan
+
+- red first in the relevant unit/runtime-neutral tests
+- confirm the new tests fail for the expected reason
+- implement the smallest behavior changes needed to turn them green
+- avoid unrelated refactors during the green phase
+
+## Verification Commands
+
+- `python3 -m pytest tests/unit/test_global_instruction_merge.py tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py tests/runtime_neutral/test_bootstrap_doctor.py tests/runtime_neutral/test_installed_runtime_uninstall.py tests/runtime_neutral/test_claude_preview_scaffold.py tests/runtime_neutral/test_opencode_managed_preview.py tests/integration/test_host_global_bootstrap_shell_lifecycle.py -q`
+- `git diff --check`
+
+## Rollback Rules
+
+- if a new regression test does not fail first, fix the test before changing production code
+- if the shared-root block identity fix requires broader bootstrap migration redesign, stop and narrow the change
+- do not resolve the remaining review threads until the fresh verification slice passes
+
+## Phase Cleanup Expectations
+
+- leave behind only the new requirement/plan artifacts, regression tests, production fixes, and truthful PR-thread replies
+- do not leave temporary repro files in the repository

--- a/docs/plans/2026-04-15-pr164-rabbit-review-fixes-execution-plan.md
+++ b/docs/plans/2026-04-15-pr164-rabbit-review-fixes-execution-plan.md
@@ -1,0 +1,66 @@
+# PR164 Rabbit Review Fixes Execution Plan
+
+## Execution Summary
+
+Freeze the confirmed PR `#164` review defects, write failing regression coverage for them, implement the minimal lifecycle and doctor fixes, rerun the focused verification slice, and update the PR branch plus review threads.
+
+## Frozen Inputs
+
+- Requirement doc: `docs/requirements/2026-04-15-pr164-rabbit-review-fixes.md`
+- PR: `#164`
+- Base branch: `main`
+- Head branch: `feat/host-global-bootstrap-pr`
+- Review source: unresolved CodeRabbit review comments on PR `#164`
+
+## Specialist Recommendation
+
+- `receiving-code-review`: applicable and used as bounded review specialist assistance for validating external review findings
+- no separate GitHub review-bot specialist exists in the current skill set
+- dispatch mode: native fallback for git/GitHub MCP operations
+
+## Internal Grade Decision
+
+`L`
+
+The work is tightly coupled and sequence-sensitive: confirm defects, add failing tests, implement minimal fixes, verify, then update the PR.
+
+## Step Plan
+
+1. Freeze governed requirement and plan artifacts for this repair run.
+2. Add failing regression tests for the confirmed defects:
+   - literal end-marker text must not corrupt parsing
+   - host bootstrap receipts must stay surface-scoped
+   - pre-existing empty instruction files must survive uninstall
+   - uninstall receipts must classify file-preserved removal as mutation
+   - bootstrap doctor must report `missing_receipt` without depending on a healthy host closure
+3. Implement the minimal production fixes in:
+   - `packages/installer-core/src/vgo_installer/global_instruction_merge.py`
+   - `packages/installer-core/src/vgo_installer/global_instruction_service.py`
+   - `packages/installer-core/src/vgo_installer/uninstall_service.py`
+   - `packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py`
+   - `packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py`
+4. Rerun the focused verification slice and `git diff --check`.
+5. Update the PR branch and reply to the relevant CodeRabbit threads with technical resolution notes.
+
+## TDD Plan
+
+- Red first in the relevant unit/runtime-neutral tests
+- confirm the new tests fail for the expected reason
+- implement the smallest behavior changes needed to turn them green
+- avoid unrelated refactors during the green phase
+
+## Verification Commands
+
+- `python3 -m pytest tests/unit/test_global_instruction_merge.py tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py tests/runtime_neutral/test_bootstrap_doctor.py tests/runtime_neutral/test_installed_runtime_uninstall.py tests/runtime_neutral/test_claude_preview_scaffold.py tests/runtime_neutral/test_opencode_managed_preview.py tests/integration/test_host_global_bootstrap_shell_lifecycle.py -q`
+- `git diff --check`
+
+## Rollback Rules
+
+- if a new regression test does not fail first, fix the test before changing production code
+- if a proposed fix requires broad redesign beyond the confirmed defect, stop and narrow the change
+- do not resolve review threads until the fresh verification slice passes
+
+## Phase Cleanup Expectations
+
+- leave behind only the new requirement/plan artifacts, regression tests, production fixes, and truthful PR-thread replies
+- do not leave temporary repro files in the repository

--- a/docs/plans/2026-04-15-vibe-host-bootstrap-deep-validation-execution-plan.md
+++ b/docs/plans/2026-04-15-vibe-host-bootstrap-deep-validation-execution-plan.md
@@ -1,0 +1,80 @@
+# Vibe Host Bootstrap Deep Validation Execution Plan
+
+**Goal:** Validate, in isolated temp roots only, that host global bootstrap injection is safe, idempotent, uninstall-clean, and materially useful for routing explicit `$vibe` and `/vibe` back to canonical `vibe`.
+
+**Internal grade:** `L`
+
+**Execution strategy:** Native serial validation. No subagents needed because the critical path is short and tightly coupled to local verification output.
+
+## Step 1: Inspect Coverage and Freeze Evidence Targets
+
+- review current host bootstrap templates, merge service, install integration, uninstall integration, and bootstrap doctor surfaces
+- identify what is already covered by unit and runtime-neutral tests
+- identify any missing end-to-end proof around:
+  - preserved user-authored instruction text
+  - exact managed-block content
+  - reinstall idempotency
+  - uninstall-only-owned-block semantics
+
+## Step 2: Fill the Highest-Value Coverage Gap
+
+- if an important guarantee is currently implicit rather than tested, add one focused test
+- prefer one integration-style shell test that covers:
+  - pre-existing user instruction content
+  - install
+  - check
+  - reinvoke install
+  - uninstall
+  - post-uninstall preservation
+- avoid broad refactors unless the test reveals a real defect
+
+## Step 3: Run Focused Automated Verification
+
+- run the existing focused bootstrap suites
+- run the new or adjusted deep-validation test slice
+- keep the commands bounded to bootstrap/install/check/uninstall surfaces
+
+Planned commands:
+
+`python3 -m pytest tests/unit/test_global_instruction_merge.py tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py tests/runtime_neutral/test_bootstrap_doctor.py tests/runtime_neutral/test_installed_runtime_uninstall.py tests/runtime_neutral/test_claude_preview_scaffold.py tests/runtime_neutral/test_opencode_managed_preview.py tests/runtime_neutral/test_discoverable_wrapper_host_visibility.py -q`
+
+plus any new focused integration test added in this run.
+
+## Step 4: Perform Manual Temp-Root Spot Checks
+
+- run manual temp-root install and uninstall flows for:
+  - `codex`
+  - `claude-code`
+  - `opencode`
+- inspect:
+  - target file name
+  - managed block markers
+  - preserved user text
+  - receipt presence
+  - idempotent second install behavior
+  - uninstall residue
+
+## Step 5: Final Verification and Truthful Reporting
+
+- run `git diff --check` on touched files
+- report:
+  - what is definitely proven safe
+  - what is definitely proven injected
+  - what is definitely proven useful at repo/bootstrap level
+  - what is not fully proven because real host consumption is outside this environment
+
+## Verification Rules
+
+- no success claim without fresh command output
+- any discovered defect must be fixed before final completion wording
+- if no defect is found, say the result is validated within the tested boundary rather than universally guaranteed
+
+## Rollback Rules
+
+- if a new test demonstrates destructive behavior, stop and fix implementation before any more expansion
+- do not touch real host roots under any circumstance
+
+## Phase Cleanup Expectations
+
+- leave behind only the new requirement doc, execution plan, and any necessary focused test additions
+- do not keep ad hoc temp artifacts in the repo

--- a/docs/plans/2026-04-15-vibe-host-bootstrap-pr-packaging-execution-plan.md
+++ b/docs/plans/2026-04-15-vibe-host-bootstrap-pr-packaging-execution-plan.md
@@ -1,0 +1,32 @@
+# Vibe Host Bootstrap PR Packaging Execution Plan
+
+**Goal:** Package the host bootstrap enhancement into a clean branch and publish a truthful GitHub PR without pulling unrelated worktree changes.
+
+**Internal grade:** `L`
+
+## Step 1: Scope the PR
+
+- enumerate the exact modified and new files that belong to the enhancement
+- exclude unrelated dirty-worktree changes
+
+## Step 2: Run Fresh Verification
+
+- run the focused bootstrap verification slice on the current scoped changes
+- inspect the results before any commit or PR action
+
+## Step 3: Prepare Git State
+
+- create a dedicated branch for the PR
+- stage only scoped files
+- commit with a message describing the enhancement
+
+## Step 4: Publish and Open PR
+
+- push the branch
+- use GitHub MCP to create the pull request
+- include a concise but evidence-backed PR body
+
+## Step 5: Final Truth Check
+
+- verify branch name, commit, and PR URL
+- report only what is actually completed

--- a/docs/plans/2026-04-15-vibe-host-global-bootstrap-injection-execution-plan.md
+++ b/docs/plans/2026-04-15-vibe-host-global-bootstrap-injection-execution-plan.md
@@ -1,0 +1,297 @@
+# Vibe Host Global Bootstrap Injection Execution Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an install-time, non-destructive, idempotent bootstrap injection path for `codex`, `claude-code`, and `opencode` so explicit `$vibe` and `/vibe` invocations are pulled into canonical `vibe` through the host's official global instruction file.
+
+**Architecture:** Extend host profiles with a `global_instruction_surface` contract, add short host-specific bootstrap templates, and implement a dedicated managed-block service that can insert, update, verify, and remove one uniquely identified bootstrap block without overwriting the target file. Install, upgrade, uninstall, and check flows consume this service and emit receipts proving the block state.
+
+**Tech Stack:** Python installer core, JSON host metadata, Markdown bootstrap templates, runtime-neutral pytest suite, install ledger and host closure receipts
+
+---
+
+## Chunk 1: Freeze Contract, Metadata, and Red Tests
+
+### Task 1: Lock the bootstrap contract before implementation
+
+**Files:**
+- Modify: `adapters/codex/host-profile.json`
+- Modify: `adapters/claude-code/host-profile.json`
+- Modify: `adapters/opencode/host-profile.json`
+- Add: `docs/requirements/2026-04-15-vibe-host-global-bootstrap-injection.md`
+- Add: `docs/plans/2026-04-15-vibe-host-global-bootstrap-injection-execution-plan.md`
+- Add: `tests/unit/test_global_instruction_merge.py`
+- Add: `tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py`
+- Modify: `tests/runtime_neutral/test_bootstrap_doctor.py`
+
+- [ ] **Step 1: Add a host metadata contract**
+
+Define a `global_instruction_surface` object for each supported host. Minimum fields:
+
+- target path
+- format
+- managed block id
+- merge policy
+- overwrite policy
+- trigger tokens
+- bootstrap-only authority note
+
+- [ ] **Step 2: Write red unit tests for managed-block semantics**
+
+Write failing tests that prove:
+
+- missing file -> inserted
+- existing file + no block -> inserted without content loss
+- existing file + same block -> unchanged
+- existing file + older block -> updated
+- duplicate block -> failure
+- corrupted delimiters -> failure
+
+- [ ] **Step 3: Write red runtime-neutral tests for user-visible install behavior**
+
+Write failing tests that prove:
+
+- Codex install targets `AGENTS.md`
+- Claude install targets `CLAUDE.md`
+- OpenCode install targets `AGENTS.md`
+- the managed block is visible to check surfaces and receipts
+
+- [ ] **Step 4: Freeze duplicate and corruption policy**
+
+Make the tests explicit that duplicate and corrupted blocks do not get auto-overwritten.
+
+- [ ] **Step 5: Run the new focused red test slice**
+
+Run:
+
+`python3 -m pytest tests/unit/test_global_instruction_merge.py tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py tests/runtime_neutral/test_bootstrap_doctor.py -q`
+
+Expected: FAIL until the merge service and integration are implemented.
+
+## Chunk 2: Add Host Templates and Managed-Block Core
+
+### Task 2: Build a single merge service with clear boundaries
+
+**Files:**
+- Add: `config/global-bootstrap/codex-vibe-bootstrap.md`
+- Add: `config/global-bootstrap/claude-code-vibe-bootstrap.md`
+- Add: `config/global-bootstrap/opencode-vibe-bootstrap.md`
+- Add: `packages/installer-core/src/vgo_installer/global_instruction_contract.py`
+- Add: `packages/installer-core/src/vgo_installer/global_instruction_merge.py`
+- Add: `packages/installer-core/src/vgo_installer/global_instruction_service.py`
+
+- [ ] **Step 1: Create short host bootstrap templates**
+
+Each template should:
+
+- mention explicit `$vibe` and `/vibe`
+- require entry into canonical `vibe`
+- forbid silent normal-mode fallback
+- state that the file is bootstrap only and does not own runtime authority
+
+- [ ] **Step 2: Implement stable managed-block markers**
+
+Render each template inside a machine-detectable block with:
+
+- host id
+- block id
+- template version
+- content hash or equivalent signature
+
+- [ ] **Step 3: Implement pure merge operations**
+
+The merge core should support:
+
+- `insert_block`
+- `update_block`
+- `remove_block`
+- `detect_duplicate_blocks`
+- `detect_corruption`
+
+Keep it pure and text-focused so installer entrypoints do not contain markdown surgery logic.
+
+- [ ] **Step 4: Implement typed result semantics**
+
+Return structured actions instead of ad hoc booleans:
+
+- `inserted`
+- `updated`
+- `unchanged`
+- `removed`
+- `error_duplicate_managed_blocks`
+- `error_corrupt_managed_block`
+- `error_unsafe_merge`
+
+- [ ] **Step 5: Re-run the unit tests**
+
+Run:
+
+`python3 -m pytest tests/unit/test_global_instruction_merge.py -q`
+
+Expected: PASS
+
+## Chunk 3: Integrate Install, Upgrade, Ledger, and Receipts
+
+### Task 3: Wire the managed-block service into the installer lifecycle
+
+**Files:**
+- Modify: `packages/installer-core/src/vgo_installer/install_runtime.py`
+- Modify: `packages/installer-core/src/vgo_installer/ledger_service.py`
+- Modify: `packages/installer-core/src/vgo_installer/materializer.py`
+- Modify: `apps/vgo-cli/src/vgo_cli/upgrade_service.py`
+- Modify: `apps/vgo-cli/src/vgo_cli/install_support.py`
+
+- [ ] **Step 1: Invoke bootstrap injection during install**
+
+After adapter resolution and host payload materialization, call the global-instruction service for hosts that declare the new surface.
+
+- [ ] **Step 2: Persist receipt evidence**
+
+Emit a receipt under the host target root, for example:
+
+- `.vibeskills/global-instruction-bootstrap.json`
+
+Receipt should record:
+
+- host
+- target file
+- block id
+- action
+- template version
+- content hash
+- timestamp
+
+- [ ] **Step 3: Extend install ledger state**
+
+Track enough information to support uninstall and drift reasoning without treating the whole file as installer-owned.
+
+Minimum tracked data:
+
+- target file path
+- block id
+- created-if-absent
+- template version
+
+- [ ] **Step 4: Keep upgrade idempotent**
+
+Ensure reinstall and upgrade call the same service so host bootstrap evolves by in-place block update, not append.
+
+- [ ] **Step 5: Re-run lifecycle-focused tests**
+
+Run:
+
+`python3 -m pytest tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py tests/runtime_neutral/test_claude_preview_scaffold.py -q`
+
+Expected: PASS
+
+## Chunk 4: Integrate Uninstall and Drift-Safe Check Logic
+
+### Task 4: Remove only owned blocks and surface health truth
+
+**Files:**
+- Modify: `packages/installer-core/src/vgo_installer/uninstall_service.py`
+- Modify: `packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py`
+- Modify: `packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py`
+- Modify: `packages/verification-core/src/vgo_verify/opencode_preview_smoke_runtime.py`
+- Modify: `tests/runtime_neutral/test_bootstrap_doctor.py`
+- Modify: `tests/runtime_neutral/test_opencode_managed_preview.py`
+
+- [ ] **Step 1: Add uninstall block-removal semantics**
+
+Uninstall should:
+
+- remove only the managed block
+- preserve non-managed file content
+- delete the file only if it was installer-created and empty after removal
+
+- [ ] **Step 2: Add check visibility for bootstrap health**
+
+Bootstrap doctor and related check surfaces should report:
+
+- target file exists
+- block present
+- duplicate count
+- corruption state
+- template version
+- last receipt action
+
+- [ ] **Step 3: Keep duplicate and corruption states non-green**
+
+Checks must fail when:
+
+- duplicate managed blocks exist
+- delimiters are corrupted
+- the receipt points at a missing block
+
+- [ ] **Step 4: Keep truthful wording**
+
+Do not report bootstrap healthy merely because the host root exists or `skills/vibe` exists. The managed block itself must be proven.
+
+- [ ] **Step 5: Re-run check-oriented tests**
+
+Run:
+
+`python3 -m pytest tests/runtime_neutral/test_bootstrap_doctor.py tests/runtime_neutral/test_opencode_managed_preview.py -q`
+
+Expected: PASS
+
+## Chunk 5: User-Facing Docs, Diff Audit, and Final Verification
+
+### Task 5: Explain exactly what the installer changes and verify only touched surfaces
+
+**Files:**
+- Modify: `docs/install/one-click-install-release-copy.en.md`
+- Modify: `docs/install/one-click-install-release-copy.md`
+- Optionally add: `docs/install/host-global-bootstrap.md`
+
+- [ ] **Step 1: Document user-visible behavior**
+
+Explain in plain language:
+
+- which file each host uses
+- that only a managed `vibeskills` block is inserted
+- that repeated install is safe
+- that uninstall removes only the managed block
+
+- [ ] **Step 2: Document limitations honestly**
+
+State clearly that Phase 1 is host bootstrap guidance, not host-kernel hard enforcement.
+
+- [ ] **Step 3: Run the focused verification slice**
+
+Run:
+
+`python3 -m pytest tests/unit/test_global_instruction_merge.py tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py tests/runtime_neutral/test_bootstrap_doctor.py tests/runtime_neutral/test_claude_preview_scaffold.py tests/runtime_neutral/test_opencode_managed_preview.py -q`
+
+Expected: PASS
+
+- [ ] **Step 4: Inspect only the touched diff**
+
+Run:
+
+`git diff -- adapters/codex/host-profile.json adapters/claude-code/host-profile.json adapters/opencode/host-profile.json config/global-bootstrap/codex-vibe-bootstrap.md config/global-bootstrap/claude-code-vibe-bootstrap.md config/global-bootstrap/opencode-vibe-bootstrap.md packages/installer-core/src/vgo_installer/global_instruction_contract.py packages/installer-core/src/vgo_installer/global_instruction_merge.py packages/installer-core/src/vgo_installer/global_instruction_service.py packages/installer-core/src/vgo_installer/install_runtime.py packages/installer-core/src/vgo_installer/ledger_service.py packages/installer-core/src/vgo_installer/materializer.py packages/installer-core/src/vgo_installer/uninstall_service.py packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py packages/verification-core/src/vgo_verify/opencode_preview_smoke_runtime.py apps/vgo-cli/src/vgo_cli/upgrade_service.py apps/vgo-cli/src/vgo_cli/install_support.py tests/unit/test_global_instruction_merge.py tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py tests/runtime_neutral/test_bootstrap_doctor.py tests/runtime_neutral/test_claude_preview_scaffold.py tests/runtime_neutral/test_opencode_managed_preview.py docs/requirements/2026-04-15-vibe-host-global-bootstrap-injection.md docs/plans/2026-04-15-vibe-host-global-bootstrap-injection-execution-plan.md docs/install/one-click-install-release-copy.en.md docs/install/one-click-install-release-copy.md`
+
+Expected: only host bootstrap metadata, merge service, lifecycle integration, tests, and docs.
+
+- [ ] **Step 5: Record residual risks**
+
+Call out the still-open Phase 2 area:
+
+- host bootstrap increases entry stability but does not replace a future hard structured handoff if near-guaranteed invocation is required under extreme context pressure
+
+- [ ] **Step 6: Verify before any completion claim**
+
+Re-run the exact focused verification command immediately before claiming this enhancement complete and report the actual result.
+
+## Plain-Language Outcome
+
+After this plan is implemented:
+
+- install will add one small `vibe` bootstrap block to the right host-wide instruction file
+- it will never overwrite the rest of that file
+- reinstall and upgrade will touch the same block instead of adding more copies
+- uninstall will remove only that one block
+- users will keep invoking `vibe` the same way they already do:
+  - `$vibe`
+  - `/vibe`
+- `check` will be able to tell users whether the bootstrap block is healthy, duplicated, corrupted, or missing

--- a/docs/requirements/2026-04-15-pr164-rabbit-followup-fixes.md
+++ b/docs/requirements/2026-04-15-pr164-rabbit-followup-fixes.md
@@ -1,0 +1,66 @@
+# PR164 Rabbit Follow-up Fixes
+
+## Goal
+
+Repair the remaining technically real CodeRabbit findings on PR `#164` without widening the bootstrap lifecycle scope beyond the current shared-root and doctor contracts.
+
+## Deliverable
+
+- fix the remaining shared-root block identity collision in host global-instruction bootstrap handling
+- make bootstrap doctor robust against malformed receipt scalar fields instead of raising
+- add regression coverage for both repaired paths before implementation
+- optionally clean the non-blocking requirement-document wording nit while touching the follow-up artifact set
+- rerun the focused verification slice and update the existing PR head plus review threads
+
+## Constraints
+
+- treat external review comments as findings to verify, not instructions to copy verbatim
+- keep canonical governed runtime authority with `vibe`
+- do not widen this bugfix into a full migration framework for historic host-surface moves
+- do not regress the already-repaired receipt scoping, uninstall truth contract, or bootstrap doctor missing-receipt behavior
+
+## Acceptance Criteria
+
+- shared-root installs that place multiple host bootstrap blocks in the same instruction file distinguish blocks by `(host_id, block_id)` rather than `block_id` alone
+- bootstrap merge/update/remove logic no longer targets another host's block when the file and `managed_block_id` are shared
+- malformed bootstrap receipt scalar values such as non-integer `template_version` do not raise from doctor inspection and instead produce an unhealthy result
+- focused regression coverage proves the repaired behavior
+
+## Product Acceptance Criteria
+
+- installing `codex` then `opencode` into the same temp target root preserves two independent managed bootstrap blocks in `AGENTS.md`
+- removing the `codex` block from a shared-root `AGENTS.md` leaves the `opencode` block intact
+- doctor inspection with a malformed scoped bootstrap receipt reports a result object instead of throwing
+
+## Manual Spot Checks
+
+- reproduce the shared-root `codex` then `opencode` install case and confirm both bootstrap blocks remain present
+- reproduce shared-root removal of one host block and confirm the sibling host block survives
+- reproduce doctor inspection with `template_version: "oops"` and confirm it returns an unhealthy payload instead of raising
+
+## Completion Language Policy
+
+Do not claim the PR follow-up is repaired until the new regression tests fail first, pass after the fixes, the focused verification slice passes fresh, and the PR branch has been updated.
+
+## Delivery Truth Contract
+
+- report whether the two remaining technical CodeRabbit findings were fixed
+- report whether the wording nit was fixed or intentionally left as non-blocking
+- report the exact verification commands and outputs used for the updated PR head
+- report the updated PR head commit and review-thread reply status
+
+## Non-Goals
+
+- building a generic migration system for future host bootstrap surface renames
+- redesigning receipt schema beyond what is required for the defensive parse
+- unrelated README or install-surface documentation cleanup
+
+## Autonomy Mode
+
+Interactive governed execution with local TDD-first bug-fixing, bounded to the remaining PR `#164` review follow-up scope.
+
+## Inferred Assumptions
+
+- the user wants the existing PR `#164` updated in place
+- the shared-root multi-host lifecycle is in scope because the current PR already scopes receipts per host/surface and tests same-root host installs
+- review-thread replies should clearly separate fixed defects from broader deferred design work

--- a/docs/requirements/2026-04-15-pr164-rabbit-review-fixes.md
+++ b/docs/requirements/2026-04-15-pr164-rabbit-review-fixes.md
@@ -1,0 +1,70 @@
+# PR164 Rabbit Review Fixes
+
+## Goal
+
+Repair the confirmed lifecycle and doctor defects on PR `#164` without adding cosmetic churn or changing unrelated host-bootstrap behavior.
+
+## Deliverable
+
+- fix the confirmed bootstrap parser, receipt, uninstall, and doctor defects on `feat/host-global-bootstrap-pr`
+- add regression coverage for every confirmed defect before implementation
+- rerun the focused verification slice and push the repaired PR head
+- reply to the review threads with evidence-backed resolution notes
+
+## Constraints
+
+- treat CodeRabbit comments as suggestions to verify, not instructions to implement blindly
+- fix only the findings that are technically real for the current codebase
+- keep canonical governed runtime authority with `vibe`
+- do not widen scope into README, install-copy, or unrelated delivery-contract work
+- do not regress the already-proven managed-block insertion, update, and uninstall behavior for supported hosts
+
+## Acceptance Criteria
+
+- managed-block parsing no longer treats literal end-marker text inside user-authored Markdown as a real terminator
+- bootstrap receipts are scoped so one host bootstrap surface does not overwrite another host's receipt inside the same target root
+- uninstall removes an empty host instruction file only when that file was installer-created for the managed block
+- uninstall receipts distinguish real file deletion from managed-block-only mutation truthfully
+- bootstrap doctor can surface `missing_receipt` even when `host-closure.json` is absent or corrupt
+- focused regression coverage proves each repaired path
+
+## Product Acceptance Criteria
+
+- a pre-existing empty `AGENTS.md` or `CLAUDE.md` is preserved on uninstall
+- a host instruction file that keeps user content after managed-block removal is reported as mutated, not deleted
+- explicit bootstrap-health checks do not silently downgrade a real missing-receipt state into `not_applicable`
+- lifecycle evidence remains auditable even if multiple host installs share one temp-root test target
+
+## Manual Spot Checks
+
+- reproduce the empty pre-existing file uninstall case and confirm the file survives
+- reproduce the installer-created file plus user-tail case and confirm uninstall receipt reports mutation, not deletion
+- reproduce the literal end-marker-in-code-fence case and confirm parsing stays healthy
+- reproduce doctor evaluation with bootstrap target present but no host-closure and no receipt, and confirm `missing_receipt`
+
+## Completion Language Policy
+
+Do not claim the PR is repaired until the new regression tests fail first, pass after the fixes, the focused verification slice passes fresh, and the PR branch has been updated.
+
+## Delivery Truth Contract
+
+- report which CodeRabbit findings were fixed
+- report which review comments were intentionally left as non-blocking nits
+- report the exact verification commands and outputs used for the repaired branch
+- report the updated PR head commit and thread-resolution status
+
+## Non-Goals
+
+- refactoring duplicate test scaffolding only for style
+- renaming variables or narrowing exception types unless needed for a real fix
+- broad redesign of host bootstrap governance beyond the confirmed defects
+
+## Autonomy Mode
+
+Interactive governed execution with local TDD-first bugfixing, bounded to the PR `#164` review-fix scope.
+
+## Inferred Assumptions
+
+- the user wants PR `#164` repaired in place, not replaced with a new PR
+- the clean worktree branch `feat/host-global-bootstrap-pr` remains the correct repair surface
+- review-thread replies should be grounded in fresh local verification rather than generic acknowledgements

--- a/docs/requirements/2026-04-15-pr164-rabbit-review-fixes.md
+++ b/docs/requirements/2026-04-15-pr164-rabbit-review-fixes.md
@@ -61,7 +61,7 @@ Do not claim the PR is repaired until the new regression tests fail first, pass 
 
 ## Autonomy Mode
 
-Interactive governed execution with local TDD-first bugfixing, bounded to the PR `#164` review-fix scope.
+Interactive governed execution with local TDD-first bug-fixing, bounded to the PR `#164` review-fix scope.
 
 ## Inferred Assumptions
 

--- a/docs/requirements/2026-04-15-vibe-host-bootstrap-deep-validation.md
+++ b/docs/requirements/2026-04-15-vibe-host-bootstrap-deep-validation.md
@@ -1,0 +1,120 @@
+# Vibe Host Bootstrap Deep Validation Requirement
+
+## Summary
+
+Perform a deep, temp-root-only validation of the new host global bootstrap injection path for `codex`, `claude-code`, and `opencode` so we can truthfully answer whether it is safe to use, whether it actually injects the managed bootstrap block, and whether the injected block materially pulls explicit `$vibe` or `/vibe` into canonical `vibe`.
+
+## Goal
+
+Prove the current implementation is non-destructive and operationally useful within the validated boundary, without touching real user home directories or host-native live environments.
+
+## Deliverable
+
+A governed validation result consisting of:
+
+- one frozen execution plan for this validation run
+- focused automated tests covering install, check, reinvoke, and uninstall safety
+- temp-root manual spot-check evidence for all three supported hosts
+- a truthful final report that distinguishes:
+  - what is proven
+  - what is strongly indicated but not host-kernel-proven
+  - what remains out of scope
+
+## Constraints
+
+- do not install into or mutate the real user host roots
+- do not write to:
+  - `~/.codex`
+  - `~/.claude`
+  - `~/.config/opencode`
+- all install, check, and uninstall validation must use isolated temporary target roots
+- keep `vibe` as the only canonical governed runtime authority
+- do not claim host-kernel hard enforcement if only bootstrap-level evidence exists
+- if a useful guarantee cannot be proven in this environment, say so explicitly
+
+## Acceptance Criteria
+
+- automated validation covers `codex`, `claude-code`, and `opencode`
+- for each supported host, install into a temp target root proves:
+  - the correct global instruction file path is materialized
+  - exactly one managed bootstrap block is inserted
+  - the bootstrap receipt exists under `.vibeskills/global-instruction-bootstrap.json`
+  - the bootstrap block contains explicit `$vibe` and `/vibe` entry wording
+  - the bootstrap block states or implies canonical `vibe` authority rather than second-runtime authority
+- install into an existing host instruction file preserves pre-existing user-authored content outside the managed block
+- repeated install is idempotent and does not append a second managed block
+- uninstall removes only the managed bootstrap block and preserves user-authored content
+- if the file becomes installer-only and empty after removal, cleanup behavior is verified and reported truthfully
+- check surfaces and bootstrap doctor stay green for healthy installs
+- duplicate or corrupted managed blocks are detected as non-green states by automated tests or focused spot checks
+
+## Product Acceptance Criteria
+
+- within validated temp-root boundaries, a user can run install repeatedly without bootstrap duplication
+- within validated temp-root boundaries, a user can uninstall without losing unrelated content in `AGENTS.md` or `CLAUDE.md`
+- the injected text is short, explicit, and clearly routes explicit `$vibe` and `/vibe` toward canonical `vibe`
+- final reporting does not overstate what this proves about real host runtime behavior
+
+## Manual Spot Checks
+
+- Codex temp root:
+  - preseed `AGENTS.md` with user text
+  - run install
+  - inspect managed block markers and preserved user text
+  - run check
+  - rerun install
+  - uninstall and verify block removal only
+- Claude Code temp root:
+  - preseed `CLAUDE.md` and `settings.json`
+  - run install
+  - inspect managed block, preserved text, managed `settings.json` node, and bootstrap receipt
+  - run check
+  - rerun install
+  - uninstall and verify preserved user text
+- OpenCode temp root:
+  - preseed `AGENTS.md` and `opencode.json`
+  - run install
+  - inspect managed block and preserved text
+  - run check
+  - rerun install
+  - uninstall and verify preserved user text while real config remains untouched
+
+## Completion Language Policy
+
+Do not claim the feature is fully safe or fully effective unless the final report separates:
+
+- proven temp-root installer behavior
+- repository-level routing pull evidence
+- unproven live-host execution behavior
+
+## Delivery Truth Contract
+
+This validation succeeds only if the final report can point to fresh evidence showing all of the following:
+
+- managed bootstrap injection happens for the three supported hosts
+- injection is idempotent
+- injection preserves unrelated user content
+- uninstall removes only the managed block
+- the injected text explicitly points `$vibe` and `/vibe` back to canonical `vibe`
+- the system does not overclaim live-host enforcement beyond what temp-root and repo-level evidence can support
+
+## Non-Goals
+
+- do not prove undocumented host internals
+- do not claim the host UI or host kernel definitely executes the injected guidance unless directly verified
+- do not extend validation to unsupported hosts in this run
+- do not redesign bootstrap wording unless testing exposes a real gap
+
+## Autonomy Mode
+
+Interactive governed execution with implementation allowed for missing or weak validation coverage.
+
+## Assumptions
+
+- temp-root installs exercise the same installer logic used for real installs
+- the documented host instruction surfaces remain the intended consumption points
+- usefulness can be partially proven by:
+  - correct target file placement
+  - explicit routing wording in the injected block
+  - healthy `check` and bootstrap-doctor evidence
+  - existing discoverability/runtime-neutral tests

--- a/docs/requirements/2026-04-15-vibe-host-bootstrap-pr-packaging.md
+++ b/docs/requirements/2026-04-15-vibe-host-bootstrap-pr-packaging.md
@@ -1,0 +1,51 @@
+# Vibe Host Bootstrap PR Packaging Requirement
+
+## Summary
+
+Prepare a clean pull request for the host global bootstrap injection enhancement and the follow-up deep validation work, while avoiding unrelated dirty-worktree changes.
+
+## Goal
+
+Package only the relevant implementation, verification, and governance artifacts into a reviewable branch and publish a GitHub pull request through GitHub MCP.
+
+## Deliverable
+
+- one isolated git branch containing only the host bootstrap enhancement files
+- one commit or coherent commit set for the scoped changes
+- one GitHub pull request with a truthful summary, verification evidence, and limitations
+
+## Constraints
+
+- do not include unrelated worktree changes
+- do not revert or overwrite unrelated user changes
+- keep PR scope limited to:
+  - host global bootstrap metadata/templates/services
+  - install/uninstall/check/bootstrap-doctor integration
+  - focused tests and validation docs for this enhancement
+- PR body must distinguish:
+  - proven installer/bootstrap behavior
+  - proven temp-root safety
+  - remaining live-host limitations
+
+## Acceptance Criteria
+
+- the branch contains only scoped files for this enhancement
+- the verification slice for the scoped files passes fresh before PR creation
+- PR description includes:
+  - enhancement summary
+  - safety guarantees actually proven
+  - verification commands/results
+  - residual limitation that this is bootstrap guidance, not host-kernel hard enforcement
+
+## Completion Language Policy
+
+Do not claim the PR is ready until the scoped verification slice passes on the current branch and the created PR text reflects the tested boundary honestly.
+
+## Non-Goals
+
+- do not include unrelated README or delivery-contract changes unless they are required for this enhancement
+- do not claim full real-host runtime enforcement
+
+## Autonomy Mode
+
+Interactive governed execution with direct implementation, commit preparation, and PR creation.

--- a/docs/requirements/2026-04-15-vibe-host-global-bootstrap-injection.md
+++ b/docs/requirements/2026-04-15-vibe-host-global-bootstrap-injection.md
@@ -1,0 +1,225 @@
+# Vibe Host Global Bootstrap Injection Requirement
+
+## Summary
+
+Add a non-destructive, idempotent install-time bootstrap layer for supported hosts so explicit `$vibe` and `/vibe` invocations are pulled into canonical `vibe` through each host's official global instruction surface without turning that surface into a second runtime authority.
+
+## Goal
+
+Make `vibe` entry materially more stable on Codex CLI, Claude Code, and OpenCode by injecting a short managed bootstrap block into the correct host-level instruction file during install and upgrade while preserving user-authored content.
+
+## Deliverable
+
+A host-bootstrap capability that:
+
+- declares each supported host's official global instruction surface in adapter metadata
+- writes a uniquely identified `vibeskills` managed block into that file at install time
+- updates the same managed block on upgrade instead of appending duplicates
+- removes only the managed block on uninstall
+- exposes check and receipt evidence for block presence, drift, corruption, and duplicate insertion
+
+## Constraints
+
+- `vibe` remains the only governed runtime authority
+- host global instruction files are bootstrap entry surfaces only, not canonical governance truth
+- do not overwrite user-authored global instruction files under any circumstance
+- do not replace an existing file with a repo template
+- only manage a uniquely identified `vibeskills` block inside the target file
+- repeated install, repair, and upgrade must be idempotent
+- if safe merge cannot be proven, fail closed instead of writing
+- if duplicate managed blocks are found, fail and surface drift instead of guessing which block to keep
+- Phase 1 is limited to official host instruction files:
+  - Codex CLI: `~/.codex/AGENTS.md`
+  - Claude Code: `~/.claude/CLAUDE.md`
+  - OpenCode: `~/.config/opencode/AGENTS.md`
+- `~/.claude/settings.json`, `~/.codex/settings.json`, and `~/.config/opencode/opencode.json` do not become the main prompt-governance surface in this change
+- OpenCode real `opencode.json` remains host-managed in this phase
+- this phase strengthens bootstrap entry, not host-kernel hard enforcement
+
+## Acceptance Criteria
+
+- each of `codex`, `claude-code`, and `opencode` declares a `global_instruction_surface` contract in host metadata
+- the repo contains short host-specific bootstrap templates for:
+  - `codex`
+  - `claude-code`
+  - `opencode`
+- installation into a missing global instruction file creates a new file containing exactly one managed bootstrap block
+- installation into an existing global instruction file preserves all user-authored content outside the managed block
+- repeated install on an unchanged target yields `unchanged` and does not append a second block
+- upgrade updates the existing managed block in place and does not duplicate it
+- uninstall removes only the managed block and preserves user-authored content
+- if the file was created solely by the installer and becomes empty after block removal, uninstall may delete the empty file
+- duplicate managed blocks produce a failed check state instead of auto-repair by overwrite
+- corrupted block delimiters produce a failed check state instead of silent rewrite
+- receipts record one of:
+  - `inserted`
+  - `updated`
+  - `unchanged`
+  - `removed`
+- check surfaces can prove:
+  - target file path
+  - block id
+  - template version
+  - content hash
+  - duplicate or corruption status
+
+## Product Acceptance Criteria
+
+- a user can run install multiple times without their global instruction file growing duplicate `vibe` bootstrap text
+- a user can already have personal guidance in `AGENTS.md` or `CLAUDE.md` and keep it intact after install or upgrade
+- a user can remove Vibe-Skills without losing unrelated host-wide instructions
+- explicit `$vibe` or `/vibe` usage has a clearer and more durable host-side entry pull toward canonical `vibe`
+- product messaging remains truthful that this is bootstrap guidance backed by checks and receipts, not hidden second-runtime authority
+
+## User-Visible Behavior
+
+- Codex install updates `~/.codex/AGENTS.md` by inserting a small managed `vibe` bootstrap block if needed
+- Claude Code install updates `~/.claude/CLAUDE.md` by inserting the same kind of managed block adapted to Claude's instruction file
+- OpenCode install updates `~/.config/opencode/AGENTS.md` by inserting the managed block without taking over `opencode.json`
+- users continue invoking `vibe` the same way as before:
+  - `$vibe`
+  - `/vibe`
+- users do not need to hand-edit the bootstrap block during normal install or upgrade flows
+- if the managed block drifts or duplicates, `check` should report that clearly instead of silently repairing by overwrite
+
+## Manual Spot Checks
+
+- Install into a clean temporary Codex root with no `AGENTS.md`; confirm a single managed block is created.
+- Install into a temporary Claude root that already has handwritten `CLAUDE.md` content; confirm that content is preserved and only one managed block is inserted.
+- Run the same install command twice; confirm the second run reports `unchanged` and the file still contains a single managed block.
+- Simulate an upgrade with a newer template version; confirm the managed block changes in place and unrelated file content is unchanged.
+- Uninstall from a file that contains both user text and the managed block; confirm only the managed block is removed.
+- Corrupt one block delimiter manually; confirm `check` fails instead of rewriting the file silently.
+- Insert a second managed block manually; confirm `check` fails with duplicate-block drift.
+
+## Completion Language Policy
+
+Do not claim this enhancement is complete until install, upgrade, uninstall, and check flows all prove non-destructive managed-block behavior for the three supported hosts.
+
+## Delivery Truth Contract
+
+This enhancement is successful only when the system can prove all of the following at the same time:
+
+- explicit `$vibe` and `/vibe` invocations have an official host bootstrap path
+- bootstrap content is traceable to a single managed block identity
+- user-authored host instruction content is never overwritten
+- repeated install and upgrade do not multiply the bootstrap block
+- canonical governed runtime authority still belongs to `vibe`, not the host rule file
+
+## Artifact Review Requirements
+
+- review the managed block wording for each host and confirm it does not imply second-runtime authority
+- review uninstall semantics and confirm no whole-file delete happens unless the file is installer-created and empty after block removal
+- review check output language and confirm duplicate and corruption states are explicit and actionable
+
+## Code Task TDD Evidence Requirements
+
+- add red tests proving a missing target file can be created with a single managed block
+- add red tests proving existing user-authored content survives insertion
+- add red tests proving repeated install produces `unchanged` and no duplicate block
+- add red tests proving upgrade performs in-place block update
+- add red tests proving uninstall removes only the managed block
+- add red tests proving duplicate or corrupted blocks fail check instead of being overwritten
+
+## Code Task TDD Exceptions
+
+No code-task TDD exceptions were frozen for this run.
+
+## Task-Specific Acceptance Extensions
+
+- the managed block must have a stable block id such as `global-vibe-bootstrap`
+- the managed block must carry enough identity for drift detection:
+  - host
+  - block id
+  - template version
+  - content hash or equivalent verifiable signature
+- block markers must be explicit and machine-detectable
+- the bootstrap template must stay short and must not inline the full `vibe` runtime contract
+- the bootstrap text must instruct blocked reporting instead of silent fallback when canonical `vibe` cannot be loaded
+
+## Research Augmentation Sources
+
+- OpenAI Codex AGENTS.md guide: `https://developers.openai.com/codex/guides/agents-md`
+- Claude Code memory and `CLAUDE.md` guide: `https://code.claude.com/docs/en/memory`
+- OpenCode rules guide: `https://opencode.ai/docs/rules`
+- `adapters/codex/host-profile.json`
+- `adapters/claude-code/host-profile.json`
+- `adapters/opencode/host-profile.json`
+- `packages/installer-core/src/vgo_installer/install_runtime.py`
+- `packages/installer-core/src/vgo_installer/materializer.py`
+- `packages/installer-core/src/vgo_installer/host_closure.py`
+- `packages/installer-core/src/vgo_installer/uninstall_service.py`
+- `tests/runtime_neutral/test_bootstrap_doctor.py`
+- `tests/runtime_neutral/test_claude_preview_scaffold.py`
+
+## Primary Objective
+
+Turn host-side `vibe` bootstrap into an officially declared, non-destructive, testable install capability instead of an implicit text convention.
+
+## Non-Objective Proxy Signals
+
+- appending more forceful prompt text without idempotent merge semantics
+- treating host instruction files as the canonical runtime authority
+- passing install even when duplicate or corrupted blocks are present
+- preserving bootstrap convenience by overwriting user content
+
+## Validation Material Role
+
+Installer-core tests, runtime-neutral host checks, and generated bootstrap receipts are the source of truth for this enhancement.
+
+## Anti-Proxy-Goal-Drift Tier
+
+Tier 1 host-bootstrap integrity and governance-boundary preservation.
+
+## Intended Scope
+
+Global host instruction bootstrap for explicit `vibe` entry on Codex CLI, Claude Code, and OpenCode.
+
+## Abstraction Layer Target
+
+Adapter metadata, installer-core merge services, install and uninstall integration, and runtime-neutral host verification.
+
+## Completion State
+
+Complete only when the managed-block contract is encoded in metadata, templates, installer logic, uninstall logic, verification, and tests.
+
+## Generalization Evidence Bundle
+
+- host-profile metadata updates for three hosts
+- bootstrap template files for three hosts
+- merge-service unit tests
+- runtime-neutral install and check tests
+- uninstall and drift-detection tests
+
+## Non-Goals
+
+- do not make host global instruction files the canonical route authority
+- do not implement a hidden second runtime behind `AGENTS.md` or `CLAUDE.md`
+- do not promise host-kernel hard enforcement in this phase
+- do not expand this turn to every preview host beyond `codex`, `claude-code`, and `opencode`
+- do not take ownership of unrelated user-level instruction content
+- do not redesign `vibe`'s six-stage runtime contract in this change
+
+## Autonomy Mode
+
+Interactive governed planning with implementation deferred until the requirement and execution plan are approved.
+
+## Assumptions
+
+- each target host will continue to load its documented global instruction surface
+- explicit `$vibe` and `/vibe` remain the primary user-visible invocation tokens
+- the current installer architecture can absorb a new managed-markdown-block service without changing canonical runtime authority
+- existing host closure and bootstrap doctor surfaces are the right downstream places to expose proof that the bootstrap block is present and healthy
+
+## Evidence Inputs
+
+- Source task: design a detailed landing plan for install-time host global bootstrap injection under `$vibe`
+- Relevant host surfaces:
+  - `~/.codex/AGENTS.md`
+  - `~/.claude/CLAUDE.md`
+  - `~/.config/opencode/AGENTS.md`
+- Relevant repo surfaces:
+  - `packages/installer-core/src/vgo_installer/*`
+  - `apps/vgo-cli/src/vgo_cli/*`
+  - `tests/unit/*installer*`
+  - `tests/runtime_neutral/test_bootstrap_doctor.py`

--- a/packages/installer-core/src/vgo_installer/global_instruction_contract.py
+++ b/packages/installer-core/src/vgo_installer/global_instruction_contract.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class GlobalInstructionSurface:
+    relpath: str
+    documented_path: str
+    format: str
+    managed_block_id: str
+    merge_policy: str
+    overwrite_policy: str
+    trigger_tokens: tuple[str, ...]
+    authority_owner: str
+    bootstrap_only: bool
+    template_relpath: str
+    template_version: int
+
+    @property
+    def target_relpath(self) -> str:
+        return self.relpath
+
+    def target_path(self, target_root: Path) -> Path:
+        return (target_root / self.relpath).resolve(strict=False)
+
+    def template_path(self, repo_root: Path) -> Path:
+        return (repo_root / self.template_relpath).resolve(strict=False)
+
+
+def _expect_text(mapping: dict[str, Any], key: str) -> str:
+    value = str(mapping.get(key) or "").strip()
+    if not value:
+        raise ValueError(f"missing global_instruction_surface.{key}")
+    return value
+
+
+def _expect_string_list(mapping: dict[str, Any], key: str) -> tuple[str, ...]:
+    raw = mapping.get(key)
+    if not isinstance(raw, list):
+        raise ValueError(f"missing global_instruction_surface.{key}")
+    values = tuple(str(item).strip() for item in raw if str(item).strip())
+    if not values:
+        raise ValueError(f"missing global_instruction_surface.{key}")
+    return values
+
+
+def resolve_global_instruction_surface(adapter: dict[str, Any]) -> GlobalInstructionSurface | None:
+    raw = adapter.get("host_profile_json") if isinstance(adapter.get("host_profile_json"), dict) else adapter
+    if not isinstance(raw, dict):
+        return None
+    surface = raw.get("global_instruction_surface")
+    if surface is None:
+        return None
+    if not isinstance(surface, dict):
+        raise ValueError("global_instruction_surface must be a JSON object")
+    version = int(surface.get("template_version") or 1)
+    return GlobalInstructionSurface(
+        relpath=_expect_text(surface, "relpath"),
+        documented_path=_expect_text(surface, "documented_path"),
+        format=_expect_text(surface, "format"),
+        managed_block_id=_expect_text(surface, "managed_block_id"),
+        merge_policy=_expect_text(surface, "merge_policy"),
+        overwrite_policy=_expect_text(surface, "overwrite_policy"),
+        trigger_tokens=_expect_string_list(surface, "trigger_tokens"),
+        authority_owner=_expect_text(surface, "authority_owner"),
+        bootstrap_only=bool(surface.get("bootstrap_only", True)),
+        template_relpath=_expect_text(surface, "template_relpath"),
+        template_version=version,
+    )

--- a/packages/installer-core/src/vgo_installer/global_instruction_merge.py
+++ b/packages/installer-core/src/vgo_installer/global_instruction_merge.py
@@ -10,6 +10,7 @@ BEGIN_PATTERN = re.compile(
     r"^<!-- VIBESKILLS:BEGIN managed-block host=(?P<host>\S+) block=(?P<block>\S+) version=(?P<version>\d+) hash=(?P<hash>[a-f0-9]+) -->$",
     re.MULTILINE,
 )
+END_PATTERN = re.compile(r"^<!-- VIBESKILLS:END managed-block -->$", re.MULTILINE)
 
 
 class ManagedBlockMutationError(ValueError):
@@ -63,21 +64,24 @@ def render_managed_block(*, body: str, host_id: str, block_id: str, version: int
 def parse_managed_blocks(text: str) -> list[ParsedManagedBlock]:
     normalized = text.replace("\r\n", "\n").replace("\r", "\n")
     begin_matches = list(BEGIN_PATTERN.finditer(normalized))
-    end_count = normalized.count(END_MARKER)
-    if not begin_matches and end_count == 0:
+    if not begin_matches:
         return []
-    if len(begin_matches) != end_count:
-        raise ManagedBlockMutationError("error_corrupt_managed_block", "corrupt managed block delimiters")
 
     blocks: list[ParsedManagedBlock] = []
     search_from = 0
-    for match in begin_matches:
+    for index, match in enumerate(begin_matches):
         if match.start() < search_from:
             raise ManagedBlockMutationError("error_corrupt_managed_block", "corrupt managed block nesting")
-        end_index = normalized.find(END_MARKER, match.end())
-        if end_index == -1:
+        next_begin_start = begin_matches[index + 1].start() if index + 1 < len(begin_matches) else None
+        end_match = None
+        for candidate in END_PATTERN.finditer(normalized, match.end()):
+            if next_begin_start is not None and candidate.start() > next_begin_start:
+                break
+            end_match = candidate
+            break
+        if end_match is None:
             raise ManagedBlockMutationError("error_corrupt_managed_block", "corrupt managed block terminator")
-        block_end = end_index + len(END_MARKER)
+        block_end = end_match.end()
         if block_end < len(normalized) and normalized[block_end:block_end + 1] == "\n":
             block_end += 1
         blocks.append(

--- a/packages/installer-core/src/vgo_installer/global_instruction_merge.py
+++ b/packages/installer-core/src/vgo_installer/global_instruction_merge.py
@@ -40,6 +40,19 @@ class ParsedManagedBlock:
     raw: str
 
 
+def _matching_blocks(
+    blocks: list[ParsedManagedBlock],
+    *,
+    block_id: str,
+    host_id: str | None,
+) -> list[ParsedManagedBlock]:
+    return [
+        block
+        for block in blocks
+        if block.block_id == block_id and (host_id is None or block.host_id == host_id)
+    ]
+
+
 def compute_content_hash(body: str) -> str:
     normalized = normalize_body(body).encode("utf-8")
     return hashlib.sha256(normalized).hexdigest()[:16]
@@ -121,7 +134,7 @@ def merge_managed_block_text(
 ) -> ManagedBlockMutation:
     source = (existing_text or "").replace("\r\n", "\n").replace("\r", "\n")
     blocks = parse_managed_blocks(source)
-    matching = [block for block in blocks if block.block_id == block_id]
+    matching = _matching_blocks(blocks, block_id=block_id, host_id=host_id)
     if len(matching) > 1:
         raise ManagedBlockMutationError("error_duplicate_managed_blocks", "duplicate managed block detected")
 
@@ -168,10 +181,11 @@ def remove_managed_block_text(
     existing_text: str,
     *,
     block_id: str,
+    host_id: str | None = None,
 ) -> ManagedBlockMutation:
     source = existing_text.replace("\r\n", "\n").replace("\r", "\n")
     blocks = parse_managed_blocks(source)
-    matching = [block for block in blocks if block.block_id == block_id]
+    matching = _matching_blocks(blocks, block_id=block_id, host_id=host_id)
     if len(matching) > 1:
         raise ManagedBlockMutationError("error_duplicate_managed_blocks", "duplicate managed block detected")
     if not matching:

--- a/packages/installer-core/src/vgo_installer/global_instruction_merge.py
+++ b/packages/installer-core/src/vgo_installer/global_instruction_merge.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import re
+
+
+END_MARKER = "<!-- VIBESKILLS:END managed-block -->"
+BEGIN_PATTERN = re.compile(
+    r"^<!-- VIBESKILLS:BEGIN managed-block host=(?P<host>\S+) block=(?P<block>\S+) version=(?P<version>\d+) hash=(?P<hash>[a-f0-9]+) -->$",
+    re.MULTILINE,
+)
+
+
+class ManagedBlockMutationError(ValueError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedBlockMutation:
+    action: str
+    text: str
+    block_id: str
+    host_id: str
+    version: int
+    content_hash: str
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedManagedBlock:
+    block_id: str
+    host_id: str
+    version: int
+    content_hash: str
+    start: int
+    end: int
+    raw: str
+
+
+def compute_content_hash(body: str) -> str:
+    normalized = normalize_body(body).encode("utf-8")
+    return hashlib.sha256(normalized).hexdigest()[:16]
+
+
+def normalize_body(body: str) -> str:
+    normalized = body.replace("\r\n", "\n").replace("\r", "\n").strip("\n")
+    return normalized + "\n"
+
+
+def render_managed_block(*, body: str, host_id: str, block_id: str, version: int) -> tuple[str, str]:
+    normalized_body = normalize_body(body)
+    content_hash = compute_content_hash(normalized_body)
+    block = (
+        f"<!-- VIBESKILLS:BEGIN managed-block host={host_id} block={block_id} version={version} hash={content_hash} -->\n"
+        f"{normalized_body}"
+        f"{END_MARKER}\n"
+    )
+    return block, content_hash
+
+
+def parse_managed_blocks(text: str) -> list[ParsedManagedBlock]:
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    begin_matches = list(BEGIN_PATTERN.finditer(normalized))
+    end_count = normalized.count(END_MARKER)
+    if not begin_matches and end_count == 0:
+        return []
+    if len(begin_matches) != end_count:
+        raise ManagedBlockMutationError("error_corrupt_managed_block", "corrupt managed block delimiters")
+
+    blocks: list[ParsedManagedBlock] = []
+    search_from = 0
+    for match in begin_matches:
+        if match.start() < search_from:
+            raise ManagedBlockMutationError("error_corrupt_managed_block", "corrupt managed block nesting")
+        end_index = normalized.find(END_MARKER, match.end())
+        if end_index == -1:
+            raise ManagedBlockMutationError("error_corrupt_managed_block", "corrupt managed block terminator")
+        block_end = end_index + len(END_MARKER)
+        if block_end < len(normalized) and normalized[block_end:block_end + 1] == "\n":
+            block_end += 1
+        blocks.append(
+            ParsedManagedBlock(
+                block_id=match.group("block"),
+                host_id=match.group("host"),
+                version=int(match.group("version")),
+                content_hash=match.group("hash"),
+                start=match.start(),
+                end=block_end,
+                raw=normalized[match.start():block_end],
+            )
+        )
+        search_from = block_end
+    return blocks
+
+
+def _replace_slice(text: str, start: int, end: int, replacement: str) -> str:
+    return text[:start] + replacement + text[end:]
+
+
+def _append_block(existing_text: str, block: str) -> str:
+    normalized = existing_text.replace("\r\n", "\n").replace("\r", "\n")
+    if not normalized.strip():
+        return block
+    base = normalized.rstrip("\n")
+    return base + "\n\n" + block
+
+
+def merge_managed_block_text(
+    existing_text: str | None,
+    *,
+    body: str,
+    host_id: str,
+    block_id: str,
+    version: int,
+) -> ManagedBlockMutation:
+    source = (existing_text or "").replace("\r\n", "\n").replace("\r", "\n")
+    blocks = parse_managed_blocks(source)
+    matching = [block for block in blocks if block.block_id == block_id]
+    if len(matching) > 1:
+        raise ManagedBlockMutationError("error_duplicate_managed_blocks", "duplicate managed block detected")
+
+    rendered_block, content_hash = render_managed_block(
+        body=body,
+        host_id=host_id,
+        block_id=block_id,
+        version=version,
+    )
+
+    if not matching:
+        return ManagedBlockMutation(
+            action="inserted",
+            text=_append_block(source, rendered_block),
+            block_id=block_id,
+            host_id=host_id,
+            version=version,
+            content_hash=content_hash,
+        )
+
+    current = matching[0]
+    if current.raw == rendered_block:
+        return ManagedBlockMutation(
+            action="unchanged",
+            text=source,
+            block_id=block_id,
+            host_id=host_id,
+            version=version,
+            content_hash=content_hash,
+        )
+
+    updated = _replace_slice(source, current.start, current.end, rendered_block)
+    return ManagedBlockMutation(
+        action="updated",
+        text=updated,
+        block_id=block_id,
+        host_id=host_id,
+        version=version,
+        content_hash=content_hash,
+    )
+
+
+def remove_managed_block_text(
+    existing_text: str,
+    *,
+    block_id: str,
+) -> ManagedBlockMutation:
+    source = existing_text.replace("\r\n", "\n").replace("\r", "\n")
+    blocks = parse_managed_blocks(source)
+    matching = [block for block in blocks if block.block_id == block_id]
+    if len(matching) > 1:
+        raise ManagedBlockMutationError("error_duplicate_managed_blocks", "duplicate managed block detected")
+    if not matching:
+        return ManagedBlockMutation(
+            action="unchanged",
+            text=source,
+            block_id=block_id,
+            host_id="",
+            version=0,
+            content_hash="",
+        )
+
+    current = matching[0]
+    updated = source[:current.start].rstrip("\n")
+    tail = source[current.end:].lstrip("\n")
+    if updated and tail:
+        next_text = updated + "\n\n" + tail
+    else:
+        next_text = updated or tail
+    if next_text:
+        next_text += "\n"
+    return ManagedBlockMutation(
+        action="removed",
+        text=next_text,
+        block_id=block_id,
+        host_id=current.host_id,
+        version=current.version,
+        content_hash=current.content_hash,
+    )

--- a/packages/installer-core/src/vgo_installer/global_instruction_service.py
+++ b/packages/installer-core/src/vgo_installer/global_instruction_service.py
@@ -181,7 +181,11 @@ def inspect_global_instruction_bootstrap(target_root: Path, adapter: dict[str, o
     text = target_path.read_text(encoding="utf-8") if target_path.exists() else ""
     try:
         blocks = parse_managed_blocks(text) if target_path.exists() else []
-        matching = [block for block in blocks if block.block_id == surface.managed_block_id]
+        matching = [
+            block
+            for block in blocks
+            if block.block_id == surface.managed_block_id and block.host_id == host_id
+        ]
         duplicate_count = len(matching)
         corruption = False
     except ManagedBlockMutationError as exc:
@@ -222,7 +226,11 @@ def remove_global_instruction_bootstrap(
             _remove_receipts(target_root, surface=surface, host_id=host_id)
         return None
     existing_text = target_path.read_text(encoding="utf-8")
-    mutation = remove_managed_block_text(existing_text, block_id=surface.managed_block_id)
+    mutation = remove_managed_block_text(
+        existing_text,
+        block_id=surface.managed_block_id,
+        host_id=host_id,
+    )
     removed_file = mutation.action == "removed" and not mutation.text.strip() and allow_delete_empty_target
     if not preview:
         if mutation.action == "removed" and removed_file:

--- a/packages/installer-core/src/vgo_installer/global_instruction_service.py
+++ b/packages/installer-core/src/vgo_installer/global_instruction_service.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Any
+
+from ._io import load_json, write_json_file
+from .global_instruction_contract import GlobalInstructionSurface, resolve_global_instruction_surface
+from .global_instruction_merge import (
+    ManagedBlockMutationError,
+    merge_managed_block_text,
+    parse_managed_blocks,
+    remove_managed_block_text,
+)
+
+
+TrackCreatedPath = Callable[[Path | str], None]
+RecordMergedFile = Callable[..., None]
+
+
+def _write_text_file(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _receipt_path(target_root: Path) -> Path:
+    return target_root / ".vibeskills" / "global-instruction-bootstrap.json"
+
+
+def _build_receipt(
+    *,
+    surface: GlobalInstructionSurface,
+    target_path: Path,
+    mutation: Any,
+    status: str = "ok",
+    error_code: str | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "status": status,
+        "host": mutation.host_id if getattr(mutation, "host_id", "") else None,
+        "target_file": str(target_path.resolve(strict=False)),
+        "target_relpath": surface.relpath,
+        "documented_path": surface.documented_path,
+        "block_id": surface.managed_block_id,
+        "action": getattr(mutation, "action", None),
+        "template_version": surface.template_version,
+        "content_hash": getattr(mutation, "content_hash", None),
+        "error_code": error_code,
+    }
+
+
+def materialize_global_instruction_bootstrap(
+    repo_root: Path,
+    target_root: Path,
+    adapter: dict[str, object],
+    *,
+    track_created_path: TrackCreatedPath,
+    record_merged_file: RecordMergedFile,
+) -> dict[str, object] | None:
+    surface = resolve_global_instruction_surface(adapter)
+    if surface is None:
+        return None
+
+    target_path = surface.target_path(target_root)
+    template_path = surface.template_path(repo_root)
+    created_if_absent = not target_path.exists()
+    existing_text = target_path.read_text(encoding="utf-8") if target_path.exists() else None
+    body = template_path.read_text(encoding="utf-8")
+    mutation = merge_managed_block_text(
+        existing_text,
+        body=body,
+        host_id=str(adapter.get("id") or adapter.get("adapter_id") or ""),
+        block_id=surface.managed_block_id,
+        version=surface.template_version,
+    )
+    if mutation.action != "unchanged":
+        _write_text_file(target_path, mutation.text)
+    if created_if_absent and target_path.exists():
+        track_created_path(target_path)
+    record_merged_file(target_path, created_if_absent=created_if_absent, managed_block_id=surface.managed_block_id)
+
+    receipt_path = _receipt_path(target_root)
+    receipt = _build_receipt(surface=surface, target_path=target_path, mutation=mutation)
+    write_json_file(receipt_path, receipt)
+    track_created_path(receipt_path)
+    return {
+        **receipt,
+        "receipt_path": str(receipt_path.resolve(strict=False)),
+    }
+
+
+def inspect_global_instruction_bootstrap(target_root: Path, adapter: dict[str, object]) -> dict[str, object] | None:
+    surface = resolve_global_instruction_surface(adapter)
+    if surface is None:
+        return None
+    target_path = surface.target_path(target_root)
+    receipt_path = _receipt_path(target_root)
+    receipt = load_json(receipt_path) if receipt_path.exists() else None
+    text = target_path.read_text(encoding="utf-8") if target_path.exists() else ""
+    try:
+        blocks = parse_managed_blocks(text) if target_path.exists() else []
+        matching = [block for block in blocks if block.block_id == surface.managed_block_id]
+        duplicate_count = len(matching)
+        corruption = False
+    except ManagedBlockMutationError as exc:
+        matching = []
+        duplicate_count = 0
+        corruption = exc.code == "error_corrupt_managed_block"
+    return {
+        "target_file": str(target_path.resolve(strict=False)),
+        "target_relpath": surface.relpath,
+        "documented_path": surface.documented_path,
+        "exists": target_path.exists(),
+        "block_id": surface.managed_block_id,
+        "duplicate_count": duplicate_count,
+        "corruption": corruption,
+        "healthy": target_path.exists() and duplicate_count == 1 and not corruption,
+        "template_version": surface.template_version,
+        "receipt_path": str(receipt_path.resolve(strict=False)),
+        "receipt_exists": receipt_path.exists(),
+        "receipt": receipt if isinstance(receipt, dict) else None,
+    }
+
+
+def remove_global_instruction_bootstrap(
+    target_root: Path,
+    adapter: dict[str, object],
+    *,
+    preview: bool,
+) -> dict[str, object] | None:
+    surface = resolve_global_instruction_surface(adapter)
+    if surface is None:
+        return None
+    target_path = surface.target_path(target_root)
+    receipt_path = _receipt_path(target_root)
+    if not target_path.exists():
+        if not preview and receipt_path.exists():
+            receipt_path.unlink()
+        return None
+    existing_text = target_path.read_text(encoding="utf-8")
+    mutation = remove_managed_block_text(existing_text, block_id=surface.managed_block_id)
+    removed_file = False
+    if not preview:
+        if mutation.action == "removed" and not mutation.text.strip():
+            target_path.unlink()
+            removed_file = True
+        elif mutation.action == "removed":
+            _write_text_file(target_path, mutation.text)
+        if receipt_path.exists():
+            receipt_path.unlink()
+    return {
+        "action": mutation.action,
+        "target_file": str(target_path.resolve(strict=False)),
+        "block_id": surface.managed_block_id,
+        "removed_file": removed_file,
+        "receipt_path": str(receipt_path.resolve(strict=False)),
+    }

--- a/packages/installer-core/src/vgo_installer/global_instruction_service.py
+++ b/packages/installer-core/src/vgo_installer/global_instruction_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 from typing import Callable, Any
 
 from ._io import load_json, write_json_file
@@ -15,6 +16,7 @@ from .global_instruction_merge import (
 
 TrackCreatedPath = Callable[[Path | str], None]
 RecordMergedFile = Callable[..., None]
+LEGACY_RECEIPT_NAME = "global-instruction-bootstrap.json"
 
 
 def _write_text_file(path: Path, text: str) -> None:
@@ -22,8 +24,82 @@ def _write_text_file(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
-def _receipt_path(target_root: Path) -> Path:
-    return target_root / ".vibeskills" / "global-instruction-bootstrap.json"
+def _sanitize_receipt_token(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") or "surface"
+
+
+def _legacy_receipt_path(target_root: Path) -> Path:
+    return target_root / ".vibeskills" / LEGACY_RECEIPT_NAME
+
+
+def _receipt_path(target_root: Path, *, surface: GlobalInstructionSurface, host_id: str) -> Path:
+    scoped_name = (
+        "global-instruction-bootstrap."
+        f"{_sanitize_receipt_token(host_id)}."
+        f"{_sanitize_receipt_token(surface.relpath)}.json"
+    )
+    return target_root / ".vibeskills" / scoped_name
+
+
+def _receipt_matches(
+    receipt: dict[str, object] | None,
+    *,
+    surface: GlobalInstructionSurface,
+    host_id: str,
+) -> bool:
+    if not isinstance(receipt, dict):
+        return False
+    receipt_host = str(receipt.get("host") or "").strip()
+    target_relpath = str(receipt.get("target_relpath") or "").strip()
+    block_id = str(receipt.get("block_id") or "").strip()
+    if receipt_host and receipt_host != host_id:
+        return False
+    if target_relpath and target_relpath != surface.relpath:
+        return False
+    if block_id and block_id != surface.managed_block_id:
+        return False
+    return True
+
+
+def _try_load_receipt(path: Path) -> dict[str, object] | None:
+    try:
+        loaded = load_json(path)
+    except Exception:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _load_receipt(
+    target_root: Path,
+    *,
+    surface: GlobalInstructionSurface,
+    host_id: str,
+) -> tuple[Path, dict[str, object] | None]:
+    scoped_path = _receipt_path(target_root, surface=surface, host_id=host_id)
+    if scoped_path.exists():
+        loaded = _try_load_receipt(scoped_path)
+        if _receipt_matches(loaded, surface=surface, host_id=host_id):
+            return scoped_path, loaded
+
+    legacy_path = _legacy_receipt_path(target_root)
+    if legacy_path.exists():
+        loaded = _try_load_receipt(legacy_path)
+        if _receipt_matches(loaded, surface=surface, host_id=host_id):
+            return legacy_path, loaded
+
+    return scoped_path, None
+
+
+def _remove_receipts(target_root: Path, *, surface: GlobalInstructionSurface, host_id: str) -> None:
+    scoped_path = _receipt_path(target_root, surface=surface, host_id=host_id)
+    if scoped_path.exists():
+        scoped_path.unlink()
+
+    legacy_path = _legacy_receipt_path(target_root)
+    if legacy_path.exists():
+        loaded = _try_load_receipt(legacy_path)
+        if _receipt_matches(loaded, surface=surface, host_id=host_id):
+            legacy_path.unlink()
 
 
 def _build_receipt(
@@ -63,13 +139,14 @@ def materialize_global_instruction_bootstrap(
 
     target_path = surface.target_path(target_root)
     template_path = surface.template_path(repo_root)
+    host_id = str(adapter.get("id") or adapter.get("adapter_id") or "")
     created_if_absent = not target_path.exists()
     existing_text = target_path.read_text(encoding="utf-8") if target_path.exists() else None
     body = template_path.read_text(encoding="utf-8")
     mutation = merge_managed_block_text(
         existing_text,
         body=body,
-        host_id=str(adapter.get("id") or adapter.get("adapter_id") or ""),
+        host_id=host_id,
         block_id=surface.managed_block_id,
         version=surface.template_version,
     )
@@ -79,10 +156,15 @@ def materialize_global_instruction_bootstrap(
         track_created_path(target_path)
     record_merged_file(target_path, created_if_absent=created_if_absent, managed_block_id=surface.managed_block_id)
 
-    receipt_path = _receipt_path(target_root)
+    receipt_path = _receipt_path(target_root, surface=surface, host_id=host_id)
     receipt = _build_receipt(surface=surface, target_path=target_path, mutation=mutation)
     write_json_file(receipt_path, receipt)
     track_created_path(receipt_path)
+    legacy_path = _legacy_receipt_path(target_root)
+    if legacy_path.exists():
+        loaded = _try_load_receipt(legacy_path)
+        if _receipt_matches(loaded, surface=surface, host_id=host_id):
+            legacy_path.unlink()
     return {
         **receipt,
         "receipt_path": str(receipt_path.resolve(strict=False)),
@@ -94,8 +176,8 @@ def inspect_global_instruction_bootstrap(target_root: Path, adapter: dict[str, o
     if surface is None:
         return None
     target_path = surface.target_path(target_root)
-    receipt_path = _receipt_path(target_root)
-    receipt = load_json(receipt_path) if receipt_path.exists() else None
+    host_id = str(adapter.get("id") or adapter.get("adapter_id") or "")
+    receipt_path, receipt = _load_receipt(target_root, surface=surface, host_id=host_id)
     text = target_path.read_text(encoding="utf-8") if target_path.exists() else ""
     try:
         blocks = parse_managed_blocks(text) if target_path.exists() else []
@@ -126,28 +208,28 @@ def remove_global_instruction_bootstrap(
     target_root: Path,
     adapter: dict[str, object],
     *,
+    allow_delete_empty_target: bool,
     preview: bool,
 ) -> dict[str, object] | None:
     surface = resolve_global_instruction_surface(adapter)
     if surface is None:
         return None
     target_path = surface.target_path(target_root)
-    receipt_path = _receipt_path(target_root)
+    host_id = str(adapter.get("id") or adapter.get("adapter_id") or "")
+    receipt_path = _receipt_path(target_root, surface=surface, host_id=host_id)
     if not target_path.exists():
-        if not preview and receipt_path.exists():
-            receipt_path.unlink()
+        if not preview:
+            _remove_receipts(target_root, surface=surface, host_id=host_id)
         return None
     existing_text = target_path.read_text(encoding="utf-8")
     mutation = remove_managed_block_text(existing_text, block_id=surface.managed_block_id)
-    removed_file = False
+    removed_file = mutation.action == "removed" and not mutation.text.strip() and allow_delete_empty_target
     if not preview:
-        if mutation.action == "removed" and not mutation.text.strip():
+        if mutation.action == "removed" and removed_file:
             target_path.unlink()
-            removed_file = True
         elif mutation.action == "removed":
             _write_text_file(target_path, mutation.text)
-        if receipt_path.exists():
-            receipt_path.unlink()
+        _remove_receipts(target_root, surface=surface, host_id=host_id)
     return {
         "action": mutation.action,
         "target_file": str(target_path.resolve(strict=False)),

--- a/packages/installer-core/src/vgo_installer/install_runtime.py
+++ b/packages/installer-core/src/vgo_installer/install_runtime.py
@@ -19,6 +19,7 @@ from .host_closure import (
     is_closed_ready_required,
     materialize_host_closure,
 )
+from .global_instruction_service import materialize_global_instruction_bootstrap
 from .install_plan import build_install_plan
 from .ledger_service import (
     MaterializationLedgerState,
@@ -119,16 +120,20 @@ def record_managed_json(path: Path) -> None:
     record_config_rollback(path, created_if_absent=False)
 
 
-def record_merged_file(path: Path, *, created_if_absent: bool) -> None:
+def record_merged_file(path: Path, *, created_if_absent: bool, managed_block_id: str | None = None) -> None:
     try:
         resolved = path.resolve()
     except FileNotFoundError:
         resolved = path
-    ledger_state["merged_files"][str(resolved)] = {
+    entry = {
         "path": str(resolved),
         "created_if_absent": bool(created_if_absent),
     }
-    record_config_rollback(path, created_if_absent=created_if_absent)
+    if managed_block_id:
+        entry["managed_block_id"] = str(managed_block_id)
+    ledger_state["merged_files"][str(resolved)] = entry
+    if not managed_block_id:
+        record_config_rollback(path, created_if_absent=created_if_absent)
 
 
 def record_generated_from_template(path: Path) -> None:
@@ -592,6 +597,13 @@ def main(argv: list[str] | None = None):
         record_managed_json=record_managed_json,
         record_bridge_launcher=record_bridge_launcher,
     )
+    global_instruction_bootstrap = materialize_global_instruction_bootstrap(
+        repo_root,
+        target_root,
+        adapter,
+        track_created_path=track_created_path,
+        record_merged_file=record_merged_file,
+    )
     record_sidecar_root(target_root / ".vibeskills")
     require_closed_ready_effective = bool(args.require_closed_ready and is_closed_ready_required(adapter))
     if require_closed_ready_effective and closure["host_closure_state"] != "closed_ready":
@@ -640,6 +652,11 @@ def main(argv: list[str] | None = None):
             "host_closure_path": str(closure_path),
             "host_closure_state": closure["host_closure_state"],
             "settings_materialized": closure["settings_materialized"],
+            "global_instruction_bootstrap_receipt": (
+                str(global_instruction_bootstrap["receipt_path"])
+                if isinstance(global_instruction_bootstrap, dict) and global_instruction_bootstrap.get("receipt_path")
+                else None
+            ),
             "legacy_opencode_config_cleanup": legacy_opencode_config_cleanup,
             "specialist_wrapper_ready": bool(closure["specialist_wrapper"]["ready"]),
             "require_closed_ready_requested": bool(args.require_closed_ready),

--- a/packages/installer-core/src/vgo_installer/uninstall_service.py
+++ b/packages/installer-core/src/vgo_installer/uninstall_service.py
@@ -589,16 +589,16 @@ def apply_uninstall(
         )
 
     for rel, config in managed_text_blocks.items():
-        created_if_absent = bool(config.get("created_if_absent", False))
         removal = remove_global_instruction_bootstrap(
             target_root,
             adapter,
+            allow_delete_empty_target=bool(config.get("created_if_absent", False)),
             preview=preview,
         )
         if not isinstance(removal, dict):
             continue
         if removal.get("action") == "removed":
-            if removal.get("removed_file") or created_if_absent:
+            if removal.get("removed_file"):
                 deleted_paths.append(rel)
             else:
                 mutated_text_paths.append(rel)

--- a/packages/installer-core/src/vgo_installer/uninstall_service.py
+++ b/packages/installer-core/src/vgo_installer/uninstall_service.py
@@ -17,6 +17,7 @@ from vgo_contracts.mirror_topology_contract import resolve_generated_nested_comp
 from .adapter_registry import resolve_adapter
 from .materializer import compatibility_projection_names
 from .runtime_packaging import resolve_runtime_core_packaging
+from .global_instruction_service import remove_global_instruction_bootstrap
 
 
 def should_remove_claude_pretooluse_hook_entry(
@@ -247,7 +248,11 @@ def parse_merged_files(values: object, target_root: Path) -> dict[str, dict[str,
             continue
         rel = relativize_to_target(entry.get("path"), target_root)
         if rel:
-            merged[rel] = {"created_if_absent": bool(entry.get("created_if_absent", False))}
+            merged_entry = {"created_if_absent": bool(entry.get("created_if_absent", False))}
+            managed_block_id = str(entry.get("managed_block_id") or "").strip()
+            if managed_block_id:
+                merged_entry["managed_block_id"] = managed_block_id
+            merged[rel] = merged_entry
     return merged
 
 
@@ -492,12 +497,20 @@ def plan_uninstall(repo_root: Path, target_root: Path, adapter: dict) -> dict[st
     if not managed_json_paths:
         managed_json_paths = parse_managed_json_paths(ledger.get("managed_json_paths") if isinstance(ledger, dict) else None, target_root)
     merged_files = parse_merged_files(ledger.get("merged_files") if isinstance(ledger, dict) else None, target_root)
+    managed_text_blocks = {
+        rel: dict(config)
+        for rel, config in merged_files.items()
+        if str(config.get("managed_block_id") or "").strip()
+    }
+    for rel in managed_text_blocks:
+        managed_files.discard(rel)
 
     return {
         "managed_files": {entry for entry in managed_files if entry},
         "deleted_dirs": deleted_dirs,
         "managed_json_paths": managed_json_paths,
         "merged_files": merged_files,
+        "managed_text_blocks": managed_text_blocks,
         "template_candidates": template_candidates,
         "warnings": warnings,
         "ownership_source": ownership_source,
@@ -516,12 +529,14 @@ def apply_uninstall(
     plan = plan_uninstall(repo_root, target_root, adapter)
     deleted_paths: list[str] = []
     mutated_json_paths: list[str] = []
+    mutated_text_paths: list[str] = []
     warnings = list(plan["warnings"])
 
     managed_files = sorted(plan["managed_files"])
     deleted_dirs = sorted(plan["deleted_dirs"])
     managed_json_paths = dict(plan["managed_json_paths"])
     merged_files = dict(plan["merged_files"])
+    managed_text_blocks = dict(plan.get("managed_text_blocks") or {})
     protected_relpaths = set(plan["protected_relpaths"])
 
     for rel in plan["template_candidates"]:
@@ -573,6 +588,21 @@ def apply_uninstall(
             preview=preview,
         )
 
+    for rel, config in managed_text_blocks.items():
+        created_if_absent = bool(config.get("created_if_absent", False))
+        removal = remove_global_instruction_bootstrap(
+            target_root,
+            adapter,
+            preview=preview,
+        )
+        if not isinstance(removal, dict):
+            continue
+        if removal.get("action") == "removed":
+            if removal.get("removed_file") or created_if_absent:
+                deleted_paths.append(rel)
+            else:
+                mutated_text_paths.append(rel)
+
     empty_dirs_removed: list[str] = []
     if purge_empty and not preview:
         empty_dirs_removed = purge_empty_dirs(target_root)
@@ -588,6 +618,7 @@ def apply_uninstall(
         "mode": "preview" if preview else "apply",
         "deleted_paths": deleted_paths,
         "mutated_json_paths": mutated_json_paths,
+        "mutated_text_paths": mutated_text_paths,
         "skipped_foreign_paths": skipped_foreign_paths,
         "warnings": warnings,
         "empty_dirs_removed": empty_dirs_removed,

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor.py
@@ -40,6 +40,20 @@ def write_artifacts(repo_root: Path, artifact: dict[str, Any], output_directory:
         f"- `VCO_VECTOR_DIFF_MODEL`: `{artifact['settings']['vector_diff_model_state']}` via `{artifact['settings']['vector_diff_model_source']}`",
         "",
     ]
+    global_instruction_bootstrap = ((artifact.get("host_runtime") or {}).get("global_instruction_bootstrap") or {})
+    if global_instruction_bootstrap:
+        lines += [
+            "## Global Instruction Bootstrap",
+            "",
+            f"- Status: `{global_instruction_bootstrap.get('status')}`",
+            f"- Applicable: `{global_instruction_bootstrap.get('applicable')}`",
+            f"- Healthy: `{global_instruction_bootstrap.get('healthy')}`",
+            f"- Target: `{global_instruction_bootstrap.get('target_relpath')}`",
+            f"- Receipt Exists: `{global_instruction_bootstrap.get('receipt_exists')}`",
+            f"- Duplicate Count: `{global_instruction_bootstrap.get('duplicate_count')}`",
+            f"- Corruption: `{global_instruction_bootstrap.get('corruption')}`",
+            "",
+        ]
     if artifact["plugins"]:
         lines += ["## Plugin Readiness", ""]
         for plugin in artifact["plugins"]:

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from .bootstrap_doctor_support import (
     command_present,
+    inspect_global_instruction_bootstrap,
     load_json,
     os_environ,
     resolved_setting_state,
@@ -179,6 +180,7 @@ def collect_host_runtime(target_root: Path) -> dict[str, Any]:
 
     host_closure_payload: dict[str, Any] = {}
     host_closure_valid = False
+    host_id = ""
     if host_closure_path.exists():
         try:
             loaded = load_json(host_closure_path)
@@ -187,6 +189,7 @@ def collect_host_runtime(target_root: Path) -> dict[str, Any]:
         if isinstance(loaded, dict):
             host_closure_payload = loaded
             host_closure_valid = True
+            host_id = str(host_closure_payload.get("host_id") or "").strip()
 
     runtime_skill_entry_path = str(runtime_skill_entry.resolve())
     commands_root_path = str(commands_root.resolve())
@@ -208,6 +211,10 @@ def collect_host_runtime(target_root: Path) -> dict[str, Any]:
         and host_closure_commands_match
         and host_closure_commands_materialized
     )
+    global_instruction_bootstrap = inspect_global_instruction_bootstrap(
+        target_root,
+        host_id=host_id or None,
+    )
     return {
         "runtime_skill_entry_path": runtime_skill_entry_path,
         "runtime_skill_entry_exists": runtime_skill_entry.exists(),
@@ -223,6 +230,7 @@ def collect_host_runtime(target_root: Path) -> dict[str, Any]:
         "settings_surface_exists": settings_surface_exists,
         "settings_surface_kind": settings_surface_kind,
         "vibe_host_ready": vibe_host_ready,
+        "global_instruction_bootstrap": global_instruction_bootstrap,
     }
 
 
@@ -313,6 +321,7 @@ def build_summary(
     plugins: list[dict[str, Any]],
     mcp_servers: list[dict[str, Any]],
     external_tools: list[dict[str, Any]],
+    global_instruction_bootstrap: dict[str, Any] | None,
 ) -> dict[str, Any]:
     blocking_issues: list[str] = []
     manual_actions: list[str] = []
@@ -320,6 +329,12 @@ def build_summary(
 
     if not settings_path.exists():
         blocking_issues.append("settings.json is missing in target root.")
+    if isinstance(global_instruction_bootstrap, dict) and bool(global_instruction_bootstrap.get("applicable")):
+        if not bool(global_instruction_bootstrap.get("healthy")):
+            status = str(global_instruction_bootstrap.get("status") or "unhealthy")
+            blocking_issues.append(
+                f"global instruction bootstrap is unhealthy ({status})"
+            )
     if install_state != "installed_locally":
         warnings.append(f"Install state is '{install_state}'; verify the local install receipt.")
     intent_advice_api_key_state, intent_advice_api_key_source = resolved_setting_state(settings, "VCO_INTENT_ADVICE_API_KEY")
@@ -416,6 +431,7 @@ def build_bootstrap_artifact(
         plugins=plugins,
         mcp_servers=mcp_servers,
         external_tools=external_tools,
+        global_instruction_bootstrap=host_runtime.get("global_instruction_bootstrap"),
     )
 
     return {

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py
@@ -15,6 +15,7 @@ BEGIN_MANAGED_BLOCK = re.compile(
     r"^<!-- VIBESKILLS:BEGIN managed-block host=(?P<host>\S+) block=(?P<block>\S+) version=(?P<version>\d+) hash=(?P<hash>[a-f0-9]+) -->$",
     re.MULTILINE,
 )
+END_MANAGED_BLOCK_PATTERN = re.compile(r"^<!-- VIBESKILLS:END managed-block -->$", re.MULTILINE)
 HOST_GLOBAL_INSTRUCTION_TARGETS = {
     "codex": {"relpath": "AGENTS.md", "documented_path": "~/.codex/AGENTS.md"},
     "claude-code": {"relpath": "CLAUDE.md", "documented_path": "~/.claude/CLAUDE.md"},
@@ -76,80 +77,180 @@ def command_present(name: str) -> bool:
     return shutil.which(name) is not None
 
 
+def _load_bootstrap_receipts(target_root: Path) -> list[dict[str, Any]]:
+    sidecar_root = target_root / ".vibeskills"
+    receipts: list[dict[str, Any]] = []
+    seen: set[Path] = set()
+    for path in sorted(sidecar_root.glob("global-instruction-bootstrap*.json")):
+        if path in seen:
+            continue
+        seen.add(path)
+        try:
+            loaded = load_json(path)
+        except Exception:
+            loaded = None
+        if isinstance(loaded, dict):
+            receipts.append({"path": path, "receipt": loaded})
+    return receipts
+
+
+def _parse_bootstrap_blocks(text: str) -> tuple[list[dict[str, str]], bool]:
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    begin_matches = list(BEGIN_MANAGED_BLOCK.finditer(normalized))
+    if not begin_matches:
+        return [], False
+
+    blocks: list[dict[str, str]] = []
+    search_from = 0
+    for index, match in enumerate(begin_matches):
+        if match.start() < search_from:
+            return [], True
+        next_begin_start = begin_matches[index + 1].start() if index + 1 < len(begin_matches) else None
+        end_match = None
+        for candidate in END_MANAGED_BLOCK_PATTERN.finditer(normalized, match.end()):
+            if next_begin_start is not None and candidate.start() > next_begin_start:
+                break
+            end_match = candidate
+            break
+        if end_match is None:
+            return [], True
+        search_from = end_match.end()
+        blocks.append(
+            {
+                "host_id": str(match.group("host") or "").strip(),
+                "block_id": str(match.group("block") or "").strip(),
+            }
+        )
+    return blocks, False
+
+
+def _select_receipt(
+    receipts: list[dict[str, Any]],
+    *,
+    host_id: str | None,
+    target_relpath: str | None,
+) -> dict[str, Any] | None:
+    for entry in receipts:
+        receipt = entry["receipt"]
+        receipt_host = str(receipt.get("host") or "").strip()
+        receipt_target_relpath = str(receipt.get("target_relpath") or "").strip()
+        if host_id and receipt_host and receipt_host != host_id:
+            continue
+        if target_relpath and receipt_target_relpath and receipt_target_relpath != target_relpath:
+            continue
+        return entry
+    return None
+
+
 def inspect_global_instruction_bootstrap(
     target_root: Path,
     *,
     host_id: str | None,
 ) -> dict[str, Any]:
-    receipt_path = target_root / ".vibeskills" / "global-instruction-bootstrap.json"
-    receipt = None
-    if receipt_path.exists():
-        try:
-            loaded = load_json(receipt_path)
-        except Exception:
-            loaded = None
-        if isinstance(loaded, dict):
-            receipt = loaded
+    receipts = _load_bootstrap_receipts(target_root)
+    ordered_hosts = [str(host_id).strip()] if host_id else list(HOST_GLOBAL_INSTRUCTION_TARGETS)
 
-    receipt_host = str(receipt.get("host") or "").strip() if isinstance(receipt, dict) else ""
-    effective_host = receipt_host or str(host_id or "").strip()
-    host_surface = HOST_GLOBAL_INSTRUCTION_TARGETS.get(effective_host or "")
-    target_relpath = str(receipt.get("target_relpath") or "").strip() if isinstance(receipt, dict) else ""
-    documented_path = str(receipt.get("documented_path") or "").strip() if isinstance(receipt, dict) else ""
-    if host_surface:
-        target_relpath = target_relpath or str(host_surface["relpath"])
-        documented_path = documented_path or str(host_surface["documented_path"])
-    target_path = (target_root / target_relpath).resolve(strict=False) if target_relpath else None
-    applicable = bool(receipt_path.exists() or (target_path is not None and target_path.exists()))
+    def build_result(
+        *,
+        candidate_host: str,
+        candidate_surface: dict[str, str],
+    ) -> dict[str, Any]:
+        target_relpath = str(candidate_surface["relpath"])
+        target_path = (target_root / target_relpath).resolve(strict=False) if target_relpath else None
+        file_exists = bool(target_path and target_path.exists())
+        text = target_path.read_text(encoding="utf-8") if target_path is not None and file_exists else ""
+        blocks, corruption = _parse_bootstrap_blocks(text) if file_exists else ([], False)
+        managed_blocks = [block for block in blocks if block.get("block_id") == "global-vibe-bootstrap"]
+        parsed_hosts = {str(block.get("host_id") or "").strip() for block in managed_blocks if str(block.get("host_id") or "").strip()}
+        parsed_host = next(iter(parsed_hosts)) if len(parsed_hosts) == 1 else ""
+        effective_host = parsed_host or candidate_host
+        effective_surface = HOST_GLOBAL_INSTRUCTION_TARGETS.get(effective_host, candidate_surface)
+        receipt_entry = _select_receipt(receipts, host_id=effective_host or None, target_relpath=str(effective_surface["relpath"]))
+        if receipt_entry is None:
+            receipt_entry = _select_receipt(receipts, host_id=None, target_relpath=str(effective_surface["relpath"]))
+        receipt = receipt_entry["receipt"] if isinstance(receipt_entry, dict) else None
+        receipt_path = receipt_entry["path"] if isinstance(receipt_entry, dict) else target_root / ".vibeskills" / "global-instruction-bootstrap.json"
+        receipt_host = str(receipt.get("host") or "").strip() if isinstance(receipt, dict) else ""
+        effective_host = receipt_host or effective_host
+        documented_path = (
+            str(receipt.get("documented_path") or "").strip()
+            if isinstance(receipt, dict)
+            else str(effective_surface["documented_path"])
+        )
+        target_relpath = (
+            str(receipt.get("target_relpath") or "").strip()
+            if isinstance(receipt, dict) and str(receipt.get("target_relpath") or "").strip()
+            else str(effective_surface["relpath"])
+        )
+        duplicate_count = len(managed_blocks)
+        applicable = bool(receipt or managed_blocks or corruption)
+        block_id = str(receipt.get("block_id") or "global-vibe-bootstrap").strip() if isinstance(receipt, dict) else "global-vibe-bootstrap"
+        template_version = int(receipt.get("template_version") or 0) if isinstance(receipt, dict) else 0
+        content_hash = str(receipt.get("content_hash") or "").strip() if isinstance(receipt, dict) else ""
+        healthy = applicable and bool(receipt) and file_exists and not corruption and duplicate_count == 1
+        if not applicable:
+            status = "not_applicable"
+        elif healthy:
+            status = "healthy"
+        elif corruption:
+            status = "corrupt"
+        elif duplicate_count > 1:
+            status = "duplicate"
+        elif not file_exists:
+            status = "missing_target"
+        elif not receipt:
+            status = "missing_receipt"
+        else:
+            status = "unhealthy"
 
-    block_id = str(receipt.get("block_id") or "global-vibe-bootstrap").strip() if isinstance(receipt, dict) else "global-vibe-bootstrap"
-    template_version = int(receipt.get("template_version") or 0) if isinstance(receipt, dict) else 0
-    content_hash = str(receipt.get("content_hash") or "").strip() if isinstance(receipt, dict) else ""
-    file_exists = bool(target_path and target_path.exists())
-    duplicate_count = 0
-    corruption = False
+        return {
+            "applicable": applicable,
+            "status": status,
+            "healthy": healthy,
+            "host_id": effective_host or None,
+            "target_relpath": target_relpath or None,
+            "documented_path": documented_path or None,
+            "target_file": str(target_path) if target_path is not None else None,
+            "exists": file_exists,
+            "receipt_exists": isinstance(receipt, dict),
+            "receipt_path": str(receipt_path.resolve(strict=False)),
+            "receipt": receipt,
+            "block_id": block_id,
+            "template_version": template_version,
+            "content_hash": content_hash or None,
+            "duplicate_count": duplicate_count,
+            "corruption": corruption,
+        }
 
-    if file_exists and target_path is not None:
-        text = target_path.read_text(encoding="utf-8")
-        begin_matches = list(BEGIN_MANAGED_BLOCK.finditer(text))
-        end_count = text.count(END_MANAGED_BLOCK)
-        if begin_matches or end_count:
-            if len(begin_matches) != end_count:
-                corruption = True
-            else:
-                duplicate_count = sum(1 for match in begin_matches if match.group("block") == block_id)
+    for candidate_host in ordered_hosts:
+        surface = HOST_GLOBAL_INSTRUCTION_TARGETS.get(candidate_host)
+        if surface is None:
+            continue
+        result = build_result(candidate_host=candidate_host, candidate_surface=surface)
+        if result["applicable"]:
+            return result
 
-    healthy = applicable and bool(receipt) and file_exists and not corruption and duplicate_count == 1
-    if not applicable:
-        status = "not_applicable"
-    elif healthy:
-        status = "healthy"
-    elif corruption:
-        status = "corrupt"
-    elif duplicate_count > 1:
-        status = "duplicate"
-    elif not file_exists:
-        status = "missing_target"
-    elif not receipt:
-        status = "missing_receipt"
-    else:
-        status = "unhealthy"
+    if receipts:
+        first_receipt = receipts[0]["receipt"]
+        receipt_host = str(first_receipt.get("host") or "").strip()
+        surface = HOST_GLOBAL_INSTRUCTION_TARGETS.get(receipt_host or "", {"relpath": str(first_receipt.get("target_relpath") or ""), "documented_path": str(first_receipt.get("documented_path") or "")})
+        return build_result(candidate_host=receipt_host, candidate_surface=surface)
 
     return {
-        "applicable": applicable,
-        "status": status,
-        "healthy": healthy,
-        "host_id": effective_host or None,
-        "target_relpath": target_relpath or None,
-        "documented_path": documented_path or None,
-        "target_file": str(target_path) if target_path is not None else None,
-        "exists": file_exists,
-        "receipt_exists": receipt_path.exists(),
-        "receipt_path": str(receipt_path.resolve(strict=False)),
-        "receipt": receipt,
-        "block_id": block_id,
-        "template_version": template_version,
-        "content_hash": content_hash or None,
-        "duplicate_count": duplicate_count,
-        "corruption": corruption,
+        "applicable": False,
+        "status": "not_applicable",
+        "healthy": False,
+        "host_id": str(host_id or "").strip() or None,
+        "target_relpath": None,
+        "documented_path": None,
+        "target_file": None,
+        "exists": False,
+        "receipt_exists": False,
+        "receipt_path": str((target_root / ".vibeskills" / "global-instruction-bootstrap.json").resolve(strict=False)),
+        "receipt": None,
+        "block_id": "global-vibe-bootstrap",
+        "template_version": 0,
+        "content_hash": None,
+        "duplicate_count": 0,
+        "corruption": False,
     }

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py
@@ -1,12 +1,25 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 from pathlib import Path
 from typing import Any
 
 from ._io import load_json, utc_now, write_text
 from ._repo import resolve_repo_root
+
+
+END_MANAGED_BLOCK = "<!-- VIBESKILLS:END managed-block -->"
+BEGIN_MANAGED_BLOCK = re.compile(
+    r"^<!-- VIBESKILLS:BEGIN managed-block host=(?P<host>\S+) block=(?P<block>\S+) version=(?P<version>\d+) hash=(?P<hash>[a-f0-9]+) -->$",
+    re.MULTILINE,
+)
+HOST_GLOBAL_INSTRUCTION_TARGETS = {
+    "codex": {"relpath": "AGENTS.md", "documented_path": "~/.codex/AGENTS.md"},
+    "claude-code": {"relpath": "CLAUDE.md", "documented_path": "~/.claude/CLAUDE.md"},
+    "opencode": {"relpath": "AGENTS.md", "documented_path": "~/.config/opencode/AGENTS.md"},
+}
 
 
 def setting_value(settings: dict[str, Any] | None, name: str) -> str | None:
@@ -61,3 +74,82 @@ def resolved_setting_state(settings: dict[str, Any] | None, name: str) -> tuple[
 
 def command_present(name: str) -> bool:
     return shutil.which(name) is not None
+
+
+def inspect_global_instruction_bootstrap(
+    target_root: Path,
+    *,
+    host_id: str | None,
+) -> dict[str, Any]:
+    receipt_path = target_root / ".vibeskills" / "global-instruction-bootstrap.json"
+    receipt = None
+    if receipt_path.exists():
+        try:
+            loaded = load_json(receipt_path)
+        except Exception:
+            loaded = None
+        if isinstance(loaded, dict):
+            receipt = loaded
+
+    receipt_host = str(receipt.get("host") or "").strip() if isinstance(receipt, dict) else ""
+    effective_host = receipt_host or str(host_id or "").strip()
+    host_surface = HOST_GLOBAL_INSTRUCTION_TARGETS.get(effective_host or "")
+    target_relpath = str(receipt.get("target_relpath") or "").strip() if isinstance(receipt, dict) else ""
+    documented_path = str(receipt.get("documented_path") or "").strip() if isinstance(receipt, dict) else ""
+    if host_surface:
+        target_relpath = target_relpath or str(host_surface["relpath"])
+        documented_path = documented_path or str(host_surface["documented_path"])
+    target_path = (target_root / target_relpath).resolve(strict=False) if target_relpath else None
+    applicable = bool(receipt_path.exists() or (target_path is not None and target_path.exists()))
+
+    block_id = str(receipt.get("block_id") or "global-vibe-bootstrap").strip() if isinstance(receipt, dict) else "global-vibe-bootstrap"
+    template_version = int(receipt.get("template_version") or 0) if isinstance(receipt, dict) else 0
+    content_hash = str(receipt.get("content_hash") or "").strip() if isinstance(receipt, dict) else ""
+    file_exists = bool(target_path and target_path.exists())
+    duplicate_count = 0
+    corruption = False
+
+    if file_exists and target_path is not None:
+        text = target_path.read_text(encoding="utf-8")
+        begin_matches = list(BEGIN_MANAGED_BLOCK.finditer(text))
+        end_count = text.count(END_MANAGED_BLOCK)
+        if begin_matches or end_count:
+            if len(begin_matches) != end_count:
+                corruption = True
+            else:
+                duplicate_count = sum(1 for match in begin_matches if match.group("block") == block_id)
+
+    healthy = applicable and bool(receipt) and file_exists and not corruption and duplicate_count == 1
+    if not applicable:
+        status = "not_applicable"
+    elif healthy:
+        status = "healthy"
+    elif corruption:
+        status = "corrupt"
+    elif duplicate_count > 1:
+        status = "duplicate"
+    elif not file_exists:
+        status = "missing_target"
+    elif not receipt:
+        status = "missing_receipt"
+    else:
+        status = "unhealthy"
+
+    return {
+        "applicable": applicable,
+        "status": status,
+        "healthy": healthy,
+        "host_id": effective_host or None,
+        "target_relpath": target_relpath or None,
+        "documented_path": documented_path or None,
+        "target_file": str(target_path) if target_path is not None else None,
+        "exists": file_exists,
+        "receipt_exists": receipt_path.exists(),
+        "receipt_path": str(receipt_path.resolve(strict=False)),
+        "receipt": receipt,
+        "block_id": block_id,
+        "template_version": template_version,
+        "content_hash": content_hash or None,
+        "duplicate_count": duplicate_count,
+        "corruption": corruption,
+    }

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py
@@ -142,6 +142,13 @@ def _select_receipt(
     return None
 
 
+def _safe_int(value: object, default: int = 0) -> tuple[int, bool]:
+    try:
+        return int(value or default), False
+    except (TypeError, ValueError):
+        return default, True
+
+
 def inspect_global_instruction_bootstrap(
     target_root: Path,
     *,
@@ -160,18 +167,14 @@ def inspect_global_instruction_bootstrap(
         file_exists = bool(target_path and target_path.exists())
         text = target_path.read_text(encoding="utf-8") if target_path is not None and file_exists else ""
         blocks, corruption = _parse_bootstrap_blocks(text) if file_exists else ([], False)
-        managed_blocks = [block for block in blocks if block.get("block_id") == "global-vibe-bootstrap"]
-        parsed_hosts = {str(block.get("host_id") or "").strip() for block in managed_blocks if str(block.get("host_id") or "").strip()}
-        parsed_host = next(iter(parsed_hosts)) if len(parsed_hosts) == 1 else ""
-        effective_host = parsed_host or candidate_host
-        effective_surface = HOST_GLOBAL_INSTRUCTION_TARGETS.get(effective_host, candidate_surface)
-        receipt_entry = _select_receipt(receipts, host_id=effective_host or None, target_relpath=str(effective_surface["relpath"]))
+        receipt_entry = _select_receipt(receipts, host_id=candidate_host or None, target_relpath=str(candidate_surface["relpath"]))
         if receipt_entry is None:
-            receipt_entry = _select_receipt(receipts, host_id=None, target_relpath=str(effective_surface["relpath"]))
+            receipt_entry = _select_receipt(receipts, host_id=None, target_relpath=str(candidate_surface["relpath"]))
         receipt = receipt_entry["receipt"] if isinstance(receipt_entry, dict) else None
         receipt_path = receipt_entry["path"] if isinstance(receipt_entry, dict) else target_root / ".vibeskills" / "global-instruction-bootstrap.json"
         receipt_host = str(receipt.get("host") or "").strip() if isinstance(receipt, dict) else ""
-        effective_host = receipt_host or effective_host
+        effective_host = receipt_host or candidate_host
+        effective_surface = HOST_GLOBAL_INSTRUCTION_TARGETS.get(effective_host, candidate_surface)
         documented_path = (
             str(receipt.get("documented_path") or "").strip()
             if isinstance(receipt, dict)
@@ -182,12 +185,18 @@ def inspect_global_instruction_bootstrap(
             if isinstance(receipt, dict) and str(receipt.get("target_relpath") or "").strip()
             else str(effective_surface["relpath"])
         )
+        managed_blocks = [
+            block
+            for block in blocks
+            if block.get("block_id") == "global-vibe-bootstrap"
+            and str(block.get("host_id") or "").strip() == effective_host
+        ]
         duplicate_count = len(managed_blocks)
         applicable = bool(receipt or managed_blocks or corruption)
         block_id = str(receipt.get("block_id") or "global-vibe-bootstrap").strip() if isinstance(receipt, dict) else "global-vibe-bootstrap"
-        template_version = int(receipt.get("template_version") or 0) if isinstance(receipt, dict) else 0
+        template_version, receipt_invalid = _safe_int(receipt.get("template_version") if isinstance(receipt, dict) else 0)
         content_hash = str(receipt.get("content_hash") or "").strip() if isinstance(receipt, dict) else ""
-        healthy = applicable and bool(receipt) and file_exists and not corruption and duplicate_count == 1
+        healthy = applicable and bool(receipt) and file_exists and not corruption and not receipt_invalid and duplicate_count == 1
         if not applicable:
             status = "not_applicable"
         elif healthy:

--- a/tests/integration/test_host_global_bootstrap_shell_lifecycle.py
+++ b/tests/integration/test_host_global_bootstrap_shell_lifecycle.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = REPO_ROOT / "install.sh"
+CHECK_SCRIPT = REPO_ROOT / "check.sh"
+UNINSTALL_SCRIPT = REPO_ROOT / "uninstall.sh"
+BEGIN_MARKER = "<!-- VIBESKILLS:BEGIN managed-block"
+
+
+class HostGlobalBootstrapShellLifecycleTests(unittest.TestCase):
+    def run_install(self, host: str, target_root: Path) -> None:
+        subprocess.run(
+            [
+                "bash",
+                str(INSTALL_SCRIPT),
+                "--host",
+                host,
+                "--profile",
+                "full",
+                "--target-root",
+                str(target_root),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    def run_check(self, host: str, target_root: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "bash",
+                str(CHECK_SCRIPT),
+                "--host",
+                host,
+                "--profile",
+                "full",
+                "--target-root",
+                str(target_root),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    def run_uninstall(self, host: str, target_root: Path) -> dict[str, object]:
+        result = subprocess.run(
+            [
+                "bash",
+                str(UNINSTALL_SCRIPT),
+                "--host",
+                host,
+                "--profile",
+                "full",
+                "--target-root",
+                str(target_root),
+                "--purge-empty-dirs",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return json.loads(result.stdout)
+
+    def test_shell_lifecycle_keeps_user_instruction_files_safe_and_bootstrap_useful(self) -> None:
+        cases = [
+            {
+                "host": "codex",
+                "instruction_relpath": "AGENTS.md",
+                "instruction_text": "# Personal Codex rules\n\n- keep this line\n",
+                "check_signal": "[OK] codex command/vibe-how-do-we-do",
+                "unexpected_check_signal": "[WARN] codex command/",
+            },
+            {
+                "host": "claude-code",
+                "instruction_relpath": "CLAUDE.md",
+                "instruction_text": "# Personal Claude rules\n\n- keep this line\n",
+                "check_signal": "managed settings.json surface",
+                "settings_relpath": "settings.json",
+                "settings_payload": {
+                    "env": {"ANTHROPIC_API_KEY": "secret"},
+                    "model": "claude-sonnet-4-6",
+                },
+            },
+            {
+                "host": "opencode",
+                "instruction_relpath": "AGENTS.md",
+                "instruction_text": "# Personal OpenCode rules\n\n- keep this line\n",
+                "check_signal": "[OK] opencode preview config example",
+                "settings_relpath": "opencode.json",
+                "settings_payload": {
+                    "$schema": "https://opencode.ai/config.json",
+                    "provider": {"default": "openai"},
+                },
+            },
+        ]
+
+        for case in cases:
+            with self.subTest(host=case["host"]):
+                with tempfile.TemporaryDirectory() as tempdir:
+                    target_root = Path(tempdir)
+                    instruction_path = target_root / case["instruction_relpath"]
+                    instruction_path.parent.mkdir(parents=True, exist_ok=True)
+                    instruction_path.write_text(case["instruction_text"], encoding="utf-8")
+
+                    settings_path = None
+                    if "settings_relpath" in case:
+                        settings_path = target_root / case["settings_relpath"]
+                        settings_path.parent.mkdir(parents=True, exist_ok=True)
+                        settings_path.write_text(
+                            json.dumps(case["settings_payload"], ensure_ascii=False, indent=2) + "\n",
+                            encoding="utf-8",
+                        )
+
+                    self.run_install(case["host"], target_root)
+
+                    merged = instruction_path.read_text(encoding="utf-8")
+                    self.assertIn(case["instruction_text"].strip(), merged)
+                    self.assertEqual(1, merged.count(BEGIN_MARKER))
+                    self.assertIn("$vibe", merged)
+                    self.assertIn("/vibe", merged)
+                    self.assertIn("canonical `vibe`", merged)
+
+                    receipt_path = target_root / ".vibeskills" / "global-instruction-bootstrap.json"
+                    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+                    self.assertEqual(case["host"], receipt["host"])
+                    self.assertEqual(case["instruction_relpath"], receipt["target_relpath"])
+                    self.assertEqual("inserted", receipt["action"])
+                    self.assertEqual("global-vibe-bootstrap", receipt["block_id"])
+
+                    if case["host"] == "claude-code":
+                        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+                        self.assertEqual(case["settings_payload"]["env"], settings["env"])
+                        self.assertEqual(case["settings_payload"]["model"], settings["model"])
+                        self.assertEqual("claude-code", settings["vibeskills"]["host_id"])
+                    elif case["host"] == "opencode":
+                        self.assertEqual(case["settings_payload"], json.loads(settings_path.read_text(encoding="utf-8")))
+
+                    check_result = self.run_check(case["host"], target_root)
+                    self.assertIn(case["check_signal"], check_result.stdout)
+                    if "unexpected_check_signal" in case:
+                        self.assertNotIn(case["unexpected_check_signal"], check_result.stdout)
+
+                    self.run_install(case["host"], target_root)
+
+                    merged_again = instruction_path.read_text(encoding="utf-8")
+                    receipt_again = json.loads(receipt_path.read_text(encoding="utf-8"))
+                    self.assertEqual(1, merged_again.count(BEGIN_MARKER))
+                    self.assertEqual("unchanged", receipt_again["action"])
+
+                    uninstall_payload = self.run_uninstall(case["host"], target_root)
+                    self.assertIn("PASS", uninstall_payload["gate_result"])
+
+                    self.assertTrue(instruction_path.exists())
+                    self.assertEqual(case["instruction_text"], instruction_path.read_text(encoding="utf-8"))
+
+                    if case["host"] == "claude-code":
+                        self.assertTrue(settings_path.exists())
+                        self.assertEqual(case["settings_payload"], json.loads(settings_path.read_text(encoding="utf-8")))
+                    elif case["host"] == "opencode":
+                        self.assertTrue(settings_path.exists())
+                        self.assertEqual(case["settings_payload"], json.loads(settings_path.read_text(encoding="utf-8")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_host_global_bootstrap_shell_lifecycle.py
+++ b/tests/integration/test_host_global_bootstrap_shell_lifecycle.py
@@ -32,6 +32,11 @@ class HostGlobalBootstrapShellLifecycleTests(unittest.TestCase):
             check=True,
         )
 
+    def bootstrap_receipt_path(self, target_root: Path) -> Path:
+        matches = sorted((target_root / ".vibeskills").glob("global-instruction-bootstrap*.json"))
+        self.assertTrue(matches)
+        return matches[0]
+
     def run_check(self, host: str, target_root: Path) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [
@@ -127,7 +132,7 @@ class HostGlobalBootstrapShellLifecycleTests(unittest.TestCase):
                     self.assertIn("/vibe", merged)
                     self.assertIn("canonical `vibe`", merged)
 
-                    receipt_path = target_root / ".vibeskills" / "global-instruction-bootstrap.json"
+                    receipt_path = self.bootstrap_receipt_path(target_root)
                     receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
                     self.assertEqual(case["host"], receipt["host"])
                     self.assertEqual(case["instruction_relpath"], receipt["target_relpath"])
@@ -150,7 +155,7 @@ class HostGlobalBootstrapShellLifecycleTests(unittest.TestCase):
                     self.run_install(case["host"], target_root)
 
                     merged_again = instruction_path.read_text(encoding="utf-8")
-                    receipt_again = json.loads(receipt_path.read_text(encoding="utf-8"))
+                    receipt_again = json.loads(self.bootstrap_receipt_path(target_root).read_text(encoding="utf-8"))
                     self.assertEqual(1, merged_again.count(BEGIN_MARKER))
                     self.assertEqual("unchanged", receipt_again["action"])
 

--- a/tests/runtime_neutral/test_bootstrap_doctor.py
+++ b/tests/runtime_neutral/test_bootstrap_doctor.py
@@ -279,6 +279,143 @@ class BootstrapDoctorTests(unittest.TestCase):
         self.assertTrue(artifact["host_runtime"]["host_closure_exists"])
         self.assertTrue(artifact["host_runtime"]["settings_surface_exists"])
 
+    def test_bootstrap_doctor_reports_healthy_global_instruction_bootstrap(self) -> None:
+        sidecar_root = self.target_root / ".vibeskills"
+        sidecar_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "mcp-auto-provision.json").write_text(
+            json.dumps(
+                {
+                    "install_state": "installed_locally",
+                    "mcp_auto_provision_attempted": True,
+                    "mcp_results": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        runtime_skill_entry = self.target_root / "skills" / "vibe" / "SKILL.md"
+        runtime_skill_entry.parent.mkdir(parents=True, exist_ok=True)
+        runtime_skill_entry.write_text("---\nname: vibe\n---\n", encoding="utf-8")
+        commands_root = self.target_root / "commands"
+        commands_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "host-closure.json").write_text(
+            json.dumps(
+                {
+                    "host_id": "codex",
+                    "runtime_skill_entry": str(runtime_skill_entry.resolve()),
+                    "commands_root": str(commands_root.resolve()),
+                    "commands_materialized": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.target_root / "mcp").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp" / "servers.active.json").write_text('{"profile":"full"}\n', encoding="utf-8")
+        (self.target_root / "settings.json").write_text(
+            json.dumps({"vco": {"mcp_profile": "full"}, "env": {"VCO_INTENT_ADVICE_API_KEY": "<pending>"}}) + "\n",
+            encoding="utf-8",
+        )
+        bootstrap_path = self.target_root / "AGENTS.md"
+        bootstrap_path.write_text(
+            "<!-- VIBESKILLS:BEGIN managed-block host=codex block=global-vibe-bootstrap version=1 hash=deadbeef -->\n"
+            "Use canonical vibe.\n"
+            "<!-- VIBESKILLS:END managed-block -->\n",
+            encoding="utf-8",
+        )
+        (sidecar_root / "global-instruction-bootstrap.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "ok",
+                    "host": "codex",
+                    "target_file": str(bootstrap_path.resolve()),
+                    "target_relpath": "AGENTS.md",
+                    "documented_path": "~/.codex/AGENTS.md",
+                    "block_id": "global-vibe-bootstrap",
+                    "action": "inserted",
+                    "template_version": 1,
+                    "content_hash": "deadbeef",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        artifact = self.module.evaluate(self.root, self.target_root)
+
+        self.assertIn("global_instruction_bootstrap", artifact["host_runtime"])
+        self.assertTrue(artifact["host_runtime"]["global_instruction_bootstrap"]["healthy"])
+        self.assertEqual("AGENTS.md", artifact["host_runtime"]["global_instruction_bootstrap"]["target_relpath"])
+
+    def test_bootstrap_doctor_fails_when_global_instruction_bootstrap_is_duplicated(self) -> None:
+        sidecar_root = self.target_root / ".vibeskills"
+        sidecar_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "mcp-auto-provision.json").write_text(
+            json.dumps(
+                {
+                    "install_state": "installed_locally",
+                    "mcp_auto_provision_attempted": True,
+                    "mcp_results": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        runtime_skill_entry = self.target_root / "skills" / "vibe" / "SKILL.md"
+        runtime_skill_entry.parent.mkdir(parents=True, exist_ok=True)
+        runtime_skill_entry.write_text("---\nname: vibe\n---\n", encoding="utf-8")
+        commands_root = self.target_root / "commands"
+        commands_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "host-closure.json").write_text(
+            json.dumps(
+                {
+                    "host_id": "codex",
+                    "runtime_skill_entry": str(runtime_skill_entry.resolve()),
+                    "commands_root": str(commands_root.resolve()),
+                    "commands_materialized": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.target_root / "mcp").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp" / "servers.active.json").write_text('{"profile":"full"}\n', encoding="utf-8")
+        (self.target_root / "settings.json").write_text(
+            json.dumps({"vco": {"mcp_profile": "full"}, "env": {"VCO_INTENT_ADVICE_API_KEY": "<pending>"}}) + "\n",
+            encoding="utf-8",
+        )
+        block = (
+            "<!-- VIBESKILLS:BEGIN managed-block host=codex block=global-vibe-bootstrap version=1 hash=deadbeef -->\n"
+            "Use canonical vibe.\n"
+            "<!-- VIBESKILLS:END managed-block -->\n"
+        )
+        bootstrap_path = self.target_root / "AGENTS.md"
+        bootstrap_path.write_text(block + "\n" + block, encoding="utf-8")
+        (sidecar_root / "global-instruction-bootstrap.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "ok",
+                    "host": "codex",
+                    "target_file": str(bootstrap_path.resolve()),
+                    "target_relpath": "AGENTS.md",
+                    "documented_path": "~/.codex/AGENTS.md",
+                    "block_id": "global-vibe-bootstrap",
+                    "action": "inserted",
+                    "template_version": 1,
+                    "content_hash": "deadbeef",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        artifact = self.module.evaluate(self.root, self.target_root)
+
+        self.assertEqual("FAIL", artifact["gate_result"])
+        self.assertIn("global instruction bootstrap", " ".join(artifact["summary"]["blocking_issues"]))
+
     def test_malformed_non_dict_mcp_receipt_degrades_to_unknown_state(self) -> None:
         (self.target_root / ".vibeskills").mkdir(parents=True, exist_ok=True)
         (self.target_root / ".vibeskills" / "mcp-auto-provision.json").write_text("[1]\n", encoding="utf-8")

--- a/tests/runtime_neutral/test_bootstrap_doctor.py
+++ b/tests/runtime_neutral/test_bootstrap_doctor.py
@@ -416,6 +416,44 @@ class BootstrapDoctorTests(unittest.TestCase):
         self.assertEqual("FAIL", artifact["gate_result"])
         self.assertIn("global instruction bootstrap", " ".join(artifact["summary"]["blocking_issues"]))
 
+    def test_bootstrap_doctor_reports_missing_receipt_without_host_closure(self) -> None:
+        sidecar_root = self.target_root / ".vibeskills"
+        sidecar_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "mcp-auto-provision.json").write_text(
+            json.dumps(
+                {
+                    "install_state": "installed_locally",
+                    "mcp_auto_provision_attempted": True,
+                    "mcp_results": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        runtime_skill_entry = self.target_root / "skills" / "vibe" / "SKILL.md"
+        runtime_skill_entry.parent.mkdir(parents=True, exist_ok=True)
+        runtime_skill_entry.write_text("---\nname: vibe\n---\n", encoding="utf-8")
+        commands_root = self.target_root / "commands"
+        commands_root.mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp" / "servers.active.json").write_text('{"profile":"full"}\n', encoding="utf-8")
+        (self.target_root / "settings.json").write_text(
+            json.dumps({"vco": {"mcp_profile": "full"}, "env": {"VCO_INTENT_ADVICE_API_KEY": "<pending>"}}) + "\n",
+            encoding="utf-8",
+        )
+        bootstrap_path = self.target_root / "AGENTS.md"
+        bootstrap_path.write_text(
+            "<!-- VIBESKILLS:BEGIN managed-block host=codex block=global-vibe-bootstrap version=1 hash=deadbeef -->\n"
+            "Use canonical vibe.\n"
+            "<!-- VIBESKILLS:END managed-block -->\n",
+            encoding="utf-8",
+        )
+
+        artifact = self.module.evaluate(self.root, self.target_root)
+
+        self.assertEqual("missing_receipt", artifact["host_runtime"]["global_instruction_bootstrap"]["status"])
+        self.assertTrue(artifact["host_runtime"]["global_instruction_bootstrap"]["applicable"])
+
     def test_malformed_non_dict_mcp_receipt_degrades_to_unknown_state(self) -> None:
         (self.target_root / ".vibeskills").mkdir(parents=True, exist_ok=True)
         (self.target_root / ".vibeskills" / "mcp-auto-provision.json").write_text("[1]\n", encoding="utf-8")

--- a/tests/runtime_neutral/test_bootstrap_doctor.py
+++ b/tests/runtime_neutral/test_bootstrap_doctor.py
@@ -454,6 +454,147 @@ class BootstrapDoctorTests(unittest.TestCase):
         self.assertEqual("missing_receipt", artifact["host_runtime"]["global_instruction_bootstrap"]["status"])
         self.assertTrue(artifact["host_runtime"]["global_instruction_bootstrap"]["applicable"])
 
+    def test_bootstrap_doctor_treats_malformed_bootstrap_receipt_as_unhealthy(self) -> None:
+        sidecar_root = self.target_root / ".vibeskills"
+        sidecar_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "mcp-auto-provision.json").write_text(
+            json.dumps(
+                {
+                    "install_state": "installed_locally",
+                    "mcp_auto_provision_attempted": True,
+                    "mcp_results": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        runtime_skill_entry = self.target_root / "skills" / "vibe" / "SKILL.md"
+        runtime_skill_entry.parent.mkdir(parents=True, exist_ok=True)
+        runtime_skill_entry.write_text("---\nname: vibe\n---\n", encoding="utf-8")
+        commands_root = self.target_root / "commands"
+        commands_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "host-closure.json").write_text(
+            json.dumps(
+                {
+                    "host_id": "codex",
+                    "runtime_skill_entry": str(runtime_skill_entry.resolve()),
+                    "commands_root": str(commands_root.resolve()),
+                    "commands_materialized": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.target_root / "mcp").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp" / "servers.active.json").write_text('{"profile":"full"}\n', encoding="utf-8")
+        (self.target_root / "settings.json").write_text(
+            json.dumps({"vco": {"mcp_profile": "full"}, "env": {"VCO_INTENT_ADVICE_API_KEY": "<pending>"}}) + "\n",
+            encoding="utf-8",
+        )
+        bootstrap_path = self.target_root / "AGENTS.md"
+        bootstrap_path.write_text(
+            "<!-- VIBESKILLS:BEGIN managed-block host=codex block=global-vibe-bootstrap version=1 hash=deadbeef -->\n"
+            "Use canonical vibe.\n"
+            "<!-- VIBESKILLS:END managed-block -->\n",
+            encoding="utf-8",
+        )
+        (sidecar_root / "global-instruction-bootstrap.codex.agents-md.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "ok",
+                    "host": "codex",
+                    "target_file": str(bootstrap_path.resolve()),
+                    "target_relpath": "AGENTS.md",
+                    "documented_path": "~/.codex/AGENTS.md",
+                    "block_id": "global-vibe-bootstrap",
+                    "action": "inserted",
+                    "template_version": "oops",
+                    "content_hash": "deadbeef",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        artifact = self.module.evaluate(self.root, self.target_root)
+
+        self.assertEqual("FAIL", artifact["gate_result"])
+        self.assertFalse(artifact["host_runtime"]["global_instruction_bootstrap"]["healthy"])
+        self.assertEqual("unhealthy", artifact["host_runtime"]["global_instruction_bootstrap"]["status"])
+
+    def test_bootstrap_doctor_does_not_treat_other_host_block_as_duplicate(self) -> None:
+        sidecar_root = self.target_root / ".vibeskills"
+        sidecar_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "mcp-auto-provision.json").write_text(
+            json.dumps(
+                {
+                    "install_state": "installed_locally",
+                    "mcp_auto_provision_attempted": True,
+                    "mcp_results": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        runtime_skill_entry = self.target_root / "skills" / "vibe" / "SKILL.md"
+        runtime_skill_entry.parent.mkdir(parents=True, exist_ok=True)
+        runtime_skill_entry.write_text("---\nname: vibe\n---\n", encoding="utf-8")
+        commands_root = self.target_root / "commands"
+        commands_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "host-closure.json").write_text(
+            json.dumps(
+                {
+                    "host_id": "codex",
+                    "runtime_skill_entry": str(runtime_skill_entry.resolve()),
+                    "commands_root": str(commands_root.resolve()),
+                    "commands_materialized": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.target_root / "mcp").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp" / "servers.active.json").write_text('{"profile":"full"}\n', encoding="utf-8")
+        (self.target_root / "settings.json").write_text(
+            json.dumps({"vco": {"mcp_profile": "full"}, "env": {"VCO_INTENT_ADVICE_API_KEY": "<pending>"}}) + "\n",
+            encoding="utf-8",
+        )
+        bootstrap_path = self.target_root / "AGENTS.md"
+        bootstrap_path.write_text(
+            "<!-- VIBESKILLS:BEGIN managed-block host=codex block=global-vibe-bootstrap version=1 hash=deadbeef -->\n"
+            "Use canonical vibe.\n"
+            "<!-- VIBESKILLS:END managed-block -->\n\n"
+            "<!-- VIBESKILLS:BEGIN managed-block host=opencode block=global-vibe-bootstrap version=1 hash=beadfeed -->\n"
+            "Use canonical vibe.\n"
+            "<!-- VIBESKILLS:END managed-block -->\n",
+            encoding="utf-8",
+        )
+        (sidecar_root / "global-instruction-bootstrap.codex.agents-md.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "ok",
+                    "host": "codex",
+                    "target_file": str(bootstrap_path.resolve()),
+                    "target_relpath": "AGENTS.md",
+                    "documented_path": "~/.codex/AGENTS.md",
+                    "block_id": "global-vibe-bootstrap",
+                    "action": "inserted",
+                    "template_version": 1,
+                    "content_hash": "deadbeef",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        artifact = self.module.evaluate(self.root, self.target_root)
+
+        self.assertEqual("PASS", artifact["gate_result"])
+        self.assertTrue(artifact["host_runtime"]["global_instruction_bootstrap"]["healthy"])
+        self.assertEqual(1, artifact["host_runtime"]["global_instruction_bootstrap"]["duplicate_count"])
+
     def test_malformed_non_dict_mcp_receipt_degrades_to_unknown_state(self) -> None:
         (self.target_root / ".vibeskills").mkdir(parents=True, exist_ok=True)
         (self.target_root / ".vibeskills" / "mcp-auto-provision.json").write_text("[1]\n", encoding="utf-8")

--- a/tests/runtime_neutral/test_claude_preview_scaffold.py
+++ b/tests/runtime_neutral/test_claude_preview_scaffold.py
@@ -132,6 +132,7 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
         settings_path = self.target_root / 'settings.json'
         closure_path = self.target_root / '.vibeskills' / 'host-closure.json'
         host_settings_path = self.target_root / '.vibeskills' / 'host-settings.json'
+        bootstrap_receipt_path = Path(str(payload['global_instruction_bootstrap_receipt']))
         settings = json.loads(settings_path.read_text(encoding='utf-8'))
         self.assertEqual(self.existing_settings['env'], settings['env'])
         self.assertEqual(self.existing_settings['model'], settings['model'])
@@ -140,6 +141,7 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
         self.assertEqual(str((self.target_root / 'skills').resolve()), settings['vibeskills']['skills_root'])
         self.assertTrue(closure_path.exists())
         self.assertTrue(host_settings_path.exists())
+        self.assertTrue(bootstrap_receipt_path.exists())
         for name in self.EXPECTED_WRAPPER_SKILLS:
             self.assertTrue((self.target_root / 'skills' / name / 'SKILL.md').exists())
         self.assertFalse((self.target_root / 'commands').exists())
@@ -179,7 +181,7 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
         self.assertEqual(self.existing_settings['model'], settings['model'])
         self.assertEqual('claude-code', settings['vibeskills']['host_id'])
         self.assertTrue((self.target_root / '.vibeskills' / 'host-settings.json').exists())
-        self.assertTrue((self.target_root / '.vibeskills' / 'global-instruction-bootstrap.json').exists())
+        self.assertTrue(list((self.target_root / '.vibeskills').glob('global-instruction-bootstrap*.json')))
         self.assertTrue((self.target_root / 'CLAUDE.md').exists())
         for name in self.EXPECTED_WRAPPER_SKILLS:
             self.assertTrue((self.target_root / 'skills' / name / 'SKILL.md').exists())

--- a/tests/runtime_neutral/test_claude_preview_scaffold.py
+++ b/tests/runtime_neutral/test_claude_preview_scaffold.py
@@ -173,13 +173,14 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
 
         self.assertIn('[OK] host closure manifest', result.stdout)
         self.assertIn('[OK] host settings sidecar', result.stdout)
-        self.assertIn('skills-only activation', result.stdout)
+        self.assertIn('managed settings.json surface', result.stdout)
         settings = json.loads((self.target_root / 'settings.json').read_text(encoding='utf-8'))
         self.assertEqual(self.existing_settings['env'], settings['env'])
         self.assertEqual(self.existing_settings['model'], settings['model'])
         self.assertEqual('claude-code', settings['vibeskills']['host_id'])
         self.assertTrue((self.target_root / '.vibeskills' / 'host-settings.json').exists())
-        self.assertIn('[OK] host-visible discoverable entries', result.stdout)
+        self.assertTrue((self.target_root / '.vibeskills' / 'global-instruction-bootstrap.json').exists())
+        self.assertTrue((self.target_root / 'CLAUDE.md').exists())
         for name in self.EXPECTED_WRAPPER_SKILLS:
             self.assertTrue((self.target_root / 'skills' / name / 'SKILL.md').exists())
         self.assertFalse((self.target_root / 'commands').exists())

--- a/tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py
+++ b/tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACTS_SRC = REPO_ROOT / "packages" / "contracts" / "src"
+INSTALLER_CORE_SRC = REPO_ROOT / "packages" / "installer-core" / "src"
+
+
+def run_package_install(*, host: str, target_root: Path, profile: str = "full") -> tuple[subprocess.CompletedProcess[str], dict[str, object]]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join([str(CONTRACTS_SRC), str(INSTALLER_CORE_SRC), env.get("PYTHONPATH", "")]).strip(os.pathsep)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vgo_installer.install_runtime",
+            "--repo-root",
+            str(REPO_ROOT),
+            "--target-root",
+            str(target_root),
+            "--host",
+            host,
+            "--profile",
+            profile,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    return result, json.loads(result.stdout)
+
+
+class GlobalInstructionBootstrapRuntimeTests(unittest.TestCase):
+    def test_codex_install_materializes_single_global_bootstrap_block(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir)
+
+            _, payload = run_package_install(host="codex", target_root=target_root)
+
+            bootstrap_path = target_root / "AGENTS.md"
+            receipt_path = target_root / ".vibeskills" / "global-instruction-bootstrap.json"
+            self.assertTrue(bootstrap_path.exists())
+            self.assertTrue(receipt_path.exists())
+            self.assertEqual("codex", payload["host_id"])
+            self.assertEqual(1, bootstrap_path.read_text(encoding="utf-8").count("<!-- VIBESKILLS:BEGIN managed-block"))
+
+    def test_reinstall_keeps_single_block_and_reports_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir)
+
+            run_package_install(host="codex", target_root=target_root)
+            _, payload = run_package_install(host="codex", target_root=target_root)
+
+            receipt_path = target_root / ".vibeskills" / "global-instruction-bootstrap.json"
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            bootstrap_text = (target_root / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertEqual("unchanged", receipt["action"])
+            self.assertEqual(1, bootstrap_text.count("<!-- VIBESKILLS:BEGIN managed-block"))
+            self.assertEqual(str(receipt_path), payload["global_instruction_bootstrap_receipt"])
+
+    def test_claude_install_preserves_existing_claude_md_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir)
+            bootstrap_path = target_root / "CLAUDE.md"
+            bootstrap_path.write_text("# Personal CLAUDE rules\n\n- Keep this line.\n", encoding="utf-8")
+
+            run_package_install(host="claude-code", target_root=target_root)
+
+            merged = bootstrap_path.read_text(encoding="utf-8")
+            self.assertIn("# Personal CLAUDE rules", merged)
+            self.assertIn("Keep this line.", merged)
+            self.assertEqual(1, merged.count("<!-- VIBESKILLS:BEGIN managed-block"))
+
+    def test_opencode_install_preserves_existing_agents_md_and_real_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir)
+            agents_path = target_root / "AGENTS.md"
+            agents_path.write_text("# Existing OpenCode rules\n", encoding="utf-8")
+            real_config = target_root / "opencode.json"
+            original = {"$schema": "https://opencode.ai/config.json", "mcp": {"playwright": {"enabled": True}}}
+            real_config.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8")
+
+            run_package_install(host="opencode", target_root=target_root)
+
+            self.assertIn("# Existing OpenCode rules", agents_path.read_text(encoding="utf-8"))
+            self.assertEqual(1, agents_path.read_text(encoding="utf-8").count("<!-- VIBESKILLS:BEGIN managed-block"))
+            self.assertEqual(original, json.loads(real_config.read_text(encoding="utf-8")))

--- a/tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py
+++ b/tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py
@@ -47,7 +47,7 @@ class GlobalInstructionBootstrapRuntimeTests(unittest.TestCase):
             _, payload = run_package_install(host="codex", target_root=target_root)
 
             bootstrap_path = target_root / "AGENTS.md"
-            receipt_path = target_root / ".vibeskills" / "global-instruction-bootstrap.json"
+            receipt_path = Path(str(payload["global_instruction_bootstrap_receipt"]))
             self.assertTrue(bootstrap_path.exists())
             self.assertTrue(receipt_path.exists())
             self.assertEqual("codex", payload["host_id"])
@@ -60,7 +60,7 @@ class GlobalInstructionBootstrapRuntimeTests(unittest.TestCase):
             run_package_install(host="codex", target_root=target_root)
             _, payload = run_package_install(host="codex", target_root=target_root)
 
-            receipt_path = target_root / ".vibeskills" / "global-instruction-bootstrap.json"
+            receipt_path = Path(str(payload["global_instruction_bootstrap_receipt"]))
             receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
             bootstrap_text = (target_root / "AGENTS.md").read_text(encoding="utf-8")
             self.assertEqual("unchanged", receipt["action"])
@@ -94,3 +94,19 @@ class GlobalInstructionBootstrapRuntimeTests(unittest.TestCase):
             self.assertIn("# Existing OpenCode rules", agents_path.read_text(encoding="utf-8"))
             self.assertEqual(1, agents_path.read_text(encoding="utf-8").count("<!-- VIBESKILLS:BEGIN managed-block"))
             self.assertEqual(original, json.loads(real_config.read_text(encoding="utf-8")))
+
+    def test_bootstrap_receipts_are_scoped_per_host_surface_with_shared_target_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir)
+
+            _, codex_payload = run_package_install(host="codex", target_root=target_root)
+            _, opencode_payload = run_package_install(host="opencode", target_root=target_root)
+
+            codex_receipt = Path(str(codex_payload["global_instruction_bootstrap_receipt"]))
+            opencode_receipt = Path(str(opencode_payload["global_instruction_bootstrap_receipt"]))
+
+            self.assertTrue(codex_receipt.exists())
+            self.assertTrue(opencode_receipt.exists())
+            self.assertNotEqual(codex_receipt, opencode_receipt)
+            self.assertEqual("codex", json.loads(codex_receipt.read_text(encoding="utf-8"))["host"])
+            self.assertEqual("opencode", json.loads(opencode_receipt.read_text(encoding="utf-8"))["host"])

--- a/tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py
+++ b/tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py
@@ -110,3 +110,16 @@ class GlobalInstructionBootstrapRuntimeTests(unittest.TestCase):
             self.assertNotEqual(codex_receipt, opencode_receipt)
             self.assertEqual("codex", json.loads(codex_receipt.read_text(encoding="utf-8"))["host"])
             self.assertEqual("opencode", json.loads(opencode_receipt.read_text(encoding="utf-8"))["host"])
+
+    def test_shared_target_root_keeps_independent_codex_and_opencode_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            target_root = Path(tempdir)
+
+            run_package_install(host="codex", target_root=target_root)
+            run_package_install(host="opencode", target_root=target_root)
+
+            merged = (target_root / "AGENTS.md").read_text(encoding="utf-8")
+
+            self.assertEqual(2, merged.count("<!-- VIBESKILLS:BEGIN managed-block"))
+            self.assertIn("host=codex block=global-vibe-bootstrap", merged)
+            self.assertIn("host=opencode block=global-vibe-bootstrap", merged)

--- a/tests/runtime_neutral/test_installed_runtime_uninstall.py
+++ b/tests/runtime_neutral/test_installed_runtime_uninstall.py
@@ -70,6 +70,29 @@ class InstalledRuntimeUninstallTests(unittest.TestCase):
         self.assertTrue(sentinel.exists())
         self.assertIn("PASS", payload["gate_result"])
 
+    def test_codex_uninstall_preserves_user_agents_file_and_removes_only_managed_block(self) -> None:
+        target_root = self.root / "codex-root-user-agents"
+        agents_path = target_root / "AGENTS.md"
+        agents_path.parent.mkdir(parents=True, exist_ok=True)
+        agents_path.write_text("# My rules\n\n- keep me\n", encoding="utf-8")
+
+        self.install_host("codex", target_root)
+        self.uninstall_host("codex", target_root)
+
+        self.assertTrue(agents_path.exists())
+        remaining = agents_path.read_text(encoding="utf-8")
+        self.assertIn("# My rules", remaining)
+        self.assertIn("keep me", remaining)
+        self.assertNotIn("VIBESKILLS:BEGIN", remaining)
+
+    def test_codex_uninstall_removes_agents_file_if_installer_created_it_only_for_managed_block(self) -> None:
+        target_root = self.root / "codex-root-managed-agents-only"
+
+        self.install_host("codex", target_root)
+        self.uninstall_host("codex", target_root)
+
+        self.assertFalse((target_root / "AGENTS.md").exists())
+
     def test_claude_code_uninstall_removes_vibe_managed_surface(self) -> None:
         target_root = self.root / "claude-root"
         self.install_host("claude-code", target_root)
@@ -230,6 +253,20 @@ class InstalledRuntimeUninstallTests(unittest.TestCase):
         remaining = json.loads(settings_path.read_text(encoding="utf-8"))
         self.assertIn("vibeskills", remaining)
         self.assertTrue(remaining["user.keep"])
+
+    def test_opencode_uninstall_preserves_user_agents_file_and_removes_only_managed_block(self) -> None:
+        target_root = self.root / "opencode-root-user-agents"
+        agents_path = target_root / "AGENTS.md"
+        agents_path.parent.mkdir(parents=True, exist_ok=True)
+        agents_path.write_text("# Existing OpenCode rules\n", encoding="utf-8")
+
+        self.install_host("opencode", target_root)
+        self.uninstall_host("opencode", target_root)
+
+        self.assertTrue(agents_path.exists())
+        remaining = agents_path.read_text(encoding="utf-8")
+        self.assertIn("# Existing OpenCode rules", remaining)
+        self.assertNotIn("VIBESKILLS:BEGIN", remaining)
 
 
 if __name__ == "__main__":

--- a/tests/runtime_neutral/test_installed_runtime_uninstall.py
+++ b/tests/runtime_neutral/test_installed_runtime_uninstall.py
@@ -38,6 +38,11 @@ class InstalledRuntimeUninstallTests(unittest.TestCase):
             check=True,
         )
 
+    def bootstrap_receipt_path(self, target_root: Path) -> Path:
+        matches = sorted((target_root / ".vibeskills").glob("global-instruction-bootstrap*.json"))
+        self.assertTrue(matches)
+        return matches[0]
+
     def uninstall_host(self, host: str, target_root: Path) -> dict[str, object]:
         result = subprocess.run(
             [
@@ -89,9 +94,48 @@ class InstalledRuntimeUninstallTests(unittest.TestCase):
         target_root = self.root / "codex-root-managed-agents-only"
 
         self.install_host("codex", target_root)
+        receipt_path = self.bootstrap_receipt_path(target_root)
+        self.assertTrue((target_root / "AGENTS.md").exists())
+        self.assertTrue(receipt_path.exists())
         self.uninstall_host("codex", target_root)
 
         self.assertFalse((target_root / "AGENTS.md").exists())
+
+    def test_codex_uninstall_preserves_preexisting_empty_agents_file(self) -> None:
+        target_root = self.root / "codex-root-empty-agents"
+        agents_path = target_root / "AGENTS.md"
+        agents_path.parent.mkdir(parents=True, exist_ok=True)
+        agents_path.write_text("", encoding="utf-8")
+
+        self.install_host("codex", target_root)
+        receipt_path = self.bootstrap_receipt_path(target_root)
+        self.assertTrue(receipt_path.exists())
+        self.assertIn("VIBESKILLS:BEGIN", agents_path.read_text(encoding="utf-8"))
+
+        payload = self.uninstall_host("codex", target_root)
+
+        self.assertTrue(agents_path.exists())
+        self.assertEqual("", agents_path.read_text(encoding="utf-8"))
+        self.assertIn("AGENTS.md", payload["mutated_text_paths"])
+        self.assertNotIn("AGENTS.md", payload["deleted_paths"])
+
+    def test_codex_uninstall_reports_mutated_text_when_user_tail_survives(self) -> None:
+        target_root = self.root / "codex-root-managed-agents-with-user-tail"
+
+        self.install_host("codex", target_root)
+        receipt_path = self.bootstrap_receipt_path(target_root)
+        agents_path = target_root / "AGENTS.md"
+        self.assertTrue(receipt_path.exists())
+        agents_path.write_text(agents_path.read_text(encoding="utf-8") + "\n# user tail\n", encoding="utf-8")
+
+        payload = self.uninstall_host("codex", target_root)
+
+        self.assertTrue(agents_path.exists())
+        remaining = agents_path.read_text(encoding="utf-8")
+        self.assertIn("# user tail", remaining)
+        self.assertNotIn("VIBESKILLS:BEGIN", remaining)
+        self.assertIn("AGENTS.md", payload["mutated_text_paths"])
+        self.assertNotIn("AGENTS.md", payload["deleted_paths"])
 
     def test_claude_code_uninstall_removes_vibe_managed_surface(self) -> None:
         target_root = self.root / "claude-root"

--- a/tests/runtime_neutral/test_installed_runtime_uninstall.py
+++ b/tests/runtime_neutral/test_installed_runtime_uninstall.py
@@ -137,6 +137,22 @@ class InstalledRuntimeUninstallTests(unittest.TestCase):
         self.assertIn("AGENTS.md", payload["mutated_text_paths"])
         self.assertNotIn("AGENTS.md", payload["deleted_paths"])
 
+    def test_shared_target_root_codex_uninstall_preserves_opencode_block(self) -> None:
+        target_root = self.root / "shared-root-codex-opencode"
+
+        self.install_host("codex", target_root)
+        self.install_host("opencode", target_root)
+        before = (target_root / "AGENTS.md").read_text(encoding="utf-8")
+        self.assertIn("host=codex block=global-vibe-bootstrap", before)
+        self.assertIn("host=opencode block=global-vibe-bootstrap", before)
+
+        payload = self.uninstall_host("codex", target_root)
+
+        remaining = (target_root / "AGENTS.md").read_text(encoding="utf-8")
+        self.assertNotIn("host=codex block=global-vibe-bootstrap", remaining)
+        self.assertIn("host=opencode block=global-vibe-bootstrap", remaining)
+        self.assertIn("AGENTS.md", payload["mutated_text_paths"])
+
     def test_claude_code_uninstall_removes_vibe_managed_surface(self) -> None:
         target_root = self.root / "claude-root"
         self.install_host("claude-code", target_root)

--- a/tests/runtime_neutral/test_opencode_managed_preview.py
+++ b/tests/runtime_neutral/test_opencode_managed_preview.py
@@ -45,12 +45,16 @@ class OpenCodeManagedPreviewTests(unittest.TestCase):
             target_root = Path(tempdir)
             _, payload = run_package_install(host="opencode", target_root=target_root)
             closure_path = target_root / ".vibeskills" / "host-closure.json"
+            bootstrap_receipt_path = target_root / ".vibeskills" / "global-instruction-bootstrap.json"
+            agents_path = target_root / "AGENTS.md"
             settings_path = target_root / "opencode.json"
             example_path = target_root / "opencode.json.example"
 
             self.assertEqual("opencode", payload["host_id"])
             self.assertEqual("preview-guidance", payload["install_mode"])
             self.assertTrue(closure_path.exists())
+            self.assertTrue(bootstrap_receipt_path.exists())
+            self.assertTrue(agents_path.exists())
             self.assertFalse(settings_path.exists())
             self.assertTrue(example_path.exists())
             self.assertTrue((target_root / ".vibeskills" / "host-settings.json").exists())

--- a/tests/runtime_neutral/test_opencode_managed_preview.py
+++ b/tests/runtime_neutral/test_opencode_managed_preview.py
@@ -45,7 +45,7 @@ class OpenCodeManagedPreviewTests(unittest.TestCase):
             target_root = Path(tempdir)
             _, payload = run_package_install(host="opencode", target_root=target_root)
             closure_path = target_root / ".vibeskills" / "host-closure.json"
-            bootstrap_receipt_path = target_root / ".vibeskills" / "global-instruction-bootstrap.json"
+            bootstrap_receipt_path = Path(str(payload["global_instruction_bootstrap_receipt"]))
             agents_path = target_root / "AGENTS.md"
             settings_path = target_root / "opencode.json"
             example_path = target_root / "opencode.json.example"

--- a/tests/unit/test_global_instruction_merge.py
+++ b/tests/unit/test_global_instruction_merge.py
@@ -16,7 +16,9 @@ for src in (INSTALLER_CORE_SRC, CONTRACTS_SRC):
 from vgo_installer.global_instruction_merge import (  # type: ignore[attr-defined]
     ManagedBlockMutationError,
     merge_managed_block_text,
+    parse_managed_blocks,
     remove_managed_block_text,
+    render_managed_block,
 )
 
 
@@ -136,6 +138,27 @@ def test_merge_managed_block_rejects_corrupted_delimiters() -> None:
             block_id="global-vibe-bootstrap",
             version=1,
         )
+
+
+def test_parse_managed_blocks_ignores_literal_end_marker_inside_user_markdown() -> None:
+    block, _ = render_managed_block(
+        body="Use canonical vibe for explicit $vibe and /vibe.",
+        host_id="codex",
+        block_id="global-vibe-bootstrap",
+        version=1,
+    )
+    mixed_text = (
+        block
+        + "\n# User notes\n\n```md\n"
+        + "<!-- VIBESKILLS:END managed-block -->\n"
+        + "```\n"
+    )
+
+    parsed = parse_managed_blocks(mixed_text)
+
+    assert len(parsed) == 1
+    assert parsed[0].block_id == "global-vibe-bootstrap"
+    assert parsed[0].host_id == "codex"
 
 
 def test_remove_managed_block_only_removes_owned_block() -> None:

--- a/tests/unit/test_global_instruction_merge.py
+++ b/tests/unit/test_global_instruction_merge.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER_CORE_SRC = REPO_ROOT / "packages" / "installer-core" / "src"
+CONTRACTS_SRC = REPO_ROOT / "packages" / "contracts" / "src"
+for src in (INSTALLER_CORE_SRC, CONTRACTS_SRC):
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+
+from vgo_installer.global_instruction_merge import (  # type: ignore[attr-defined]
+    ManagedBlockMutationError,
+    merge_managed_block_text,
+    remove_managed_block_text,
+)
+
+
+def _marker_count(text: str) -> int:
+    return text.count("<!-- VIBESKILLS:BEGIN managed-block")
+
+
+def test_merge_managed_block_inserts_new_block_into_missing_file() -> None:
+    result = merge_managed_block_text(
+        None,
+        body="Use canonical vibe for explicit $vibe and /vibe.",
+        host_id="codex",
+        block_id="global-vibe-bootstrap",
+        version=1,
+    )
+
+    assert result.action == "inserted"
+    assert _marker_count(result.text) == 1
+    assert "Use canonical vibe" in result.text
+    assert "host=codex" in result.text
+    assert "block=global-vibe-bootstrap" in result.text
+
+
+def test_merge_managed_block_preserves_existing_content_when_inserting() -> None:
+    existing = "# Personal rules\n\n- Keep my own guidance.\n"
+
+    result = merge_managed_block_text(
+        existing,
+        body="Use canonical vibe for explicit $vibe and /vibe.",
+        host_id="claude-code",
+        block_id="global-vibe-bootstrap",
+        version=1,
+    )
+
+    assert result.action == "inserted"
+    assert "# Personal rules" in result.text
+    assert "Keep my own guidance." in result.text
+    assert _marker_count(result.text) == 1
+
+
+def test_merge_managed_block_is_idempotent_when_content_matches() -> None:
+    first = merge_managed_block_text(
+        None,
+        body="Use canonical vibe for explicit $vibe and /vibe.",
+        host_id="opencode",
+        block_id="global-vibe-bootstrap",
+        version=1,
+    )
+
+    second = merge_managed_block_text(
+        first.text,
+        body="Use canonical vibe for explicit $vibe and /vibe.",
+        host_id="opencode",
+        block_id="global-vibe-bootstrap",
+        version=1,
+    )
+
+    assert second.action == "unchanged"
+    assert second.text == first.text
+    assert _marker_count(second.text) == 1
+
+
+def test_merge_managed_block_updates_existing_block_in_place() -> None:
+    first = merge_managed_block_text(
+        None,
+        body="Use canonical vibe for explicit $vibe and /vibe.",
+        host_id="codex",
+        block_id="global-vibe-bootstrap",
+        version=1,
+    )
+
+    second = merge_managed_block_text(
+        first.text,
+        body="Use canonical vibe first. Report blocked instead of silent fallback.",
+        host_id="codex",
+        block_id="global-vibe-bootstrap",
+        version=2,
+    )
+
+    assert second.action == "updated"
+    assert _marker_count(second.text) == 1
+    assert "silent fallback" in second.text
+    assert "version=2" in second.text
+
+
+def test_merge_managed_block_rejects_duplicate_blocks() -> None:
+    first = merge_managed_block_text(
+        None,
+        body="Use canonical vibe for explicit $vibe and /vibe.",
+        host_id="codex",
+        block_id="global-vibe-bootstrap",
+        version=1,
+    )
+    duplicated = first.text + "\n" + first.text
+
+    with pytest.raises(ManagedBlockMutationError, match="duplicate"):
+        merge_managed_block_text(
+            duplicated,
+            body="Use canonical vibe for explicit $vibe and /vibe.",
+            host_id="codex",
+            block_id="global-vibe-bootstrap",
+            version=1,
+        )
+
+
+def test_merge_managed_block_rejects_corrupted_delimiters() -> None:
+    corrupted = (
+        "<!-- VIBESKILLS:BEGIN managed-block host=codex block=global-vibe-bootstrap version=1 hash=deadbeef -->\n"
+        "Use canonical vibe.\n"
+    )
+
+    with pytest.raises(ManagedBlockMutationError, match="corrupt"):
+        merge_managed_block_text(
+            corrupted,
+            body="Use canonical vibe for explicit $vibe and /vibe.",
+            host_id="codex",
+            block_id="global-vibe-bootstrap",
+            version=1,
+        )
+
+
+def test_remove_managed_block_only_removes_owned_block() -> None:
+    existing = "# User rules\n\n- keep me\n"
+    merged = merge_managed_block_text(
+        existing,
+        body="Use canonical vibe for explicit $vibe and /vibe.",
+        host_id="claude-code",
+        block_id="global-vibe-bootstrap",
+        version=1,
+    )
+
+    removed = remove_managed_block_text(
+        merged.text,
+        block_id="global-vibe-bootstrap",
+    )
+
+    assert removed.action == "removed"
+    assert "# User rules" in removed.text
+    assert "keep me" in removed.text
+    assert _marker_count(removed.text) == 0


### PR DESCRIPTION
## Summary
- declare official host global-instruction bootstrap surfaces for Codex, Claude Code, and OpenCode
- install a short managed `vibeskills` bootstrap block for explicit `$vibe` and `/vibe` entry without taking runtime authority away from canonical `vibe`
- make install/upgrade idempotent and uninstall remove only the owned managed block
- extend bootstrap doctor and lifecycle checks to surface duplicate, corrupt, missing-target, and missing-receipt states
- align Codex shell/PowerShell checks with the actual generated discoverable command names

## Verification
- `python3 -m pytest tests/unit/test_global_instruction_merge.py tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py tests/runtime_neutral/test_bootstrap_doctor.py tests/runtime_neutral/test_installed_runtime_uninstall.py tests/runtime_neutral/test_claude_preview_scaffold.py tests/runtime_neutral/test_opencode_managed_preview.py tests/integration/test_host_global_bootstrap_shell_lifecycle.py -q`
- result: `40 passed, 5 subtests passed in 83.36s`
- `git diff --check`

## Proven Safety
- managed-block-only merge for host instruction files; user-authored content outside the block is preserved
- reinstall/upgrade are idempotent and do not append duplicate bootstrap text
- uninstall removes only the owned managed block and may delete the file only when it was installer-created and becomes empty
- deep validation covers temp-root install/check/uninstall lifecycle behavior for the supported hosts in scope

## Limitation
- this strengthens host bootstrap guidance and route pull for explicit `vibe` entry, but it is not host-kernel hard enforcement
- OpenCode remains on the documented preview/host-managed configuration lane; the real `opencode.json` is still not owned by this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now injects a managed bootstrap guidance block into host instruction files to route explicit $vibe / /vibe to the canonical vibe authority, preserve user content, record receipts, and behave idempotently.

* **Bug Fixes**
  * Platform-consistent activation tokens for guidance detection across environments.

* **Documentation**
  * Added detailed plans, requirements, and execution guidance for safe validation and packaging.

* **Tests**
  * Expanded unit, integration, and runtime tests covering install, idempotency, inspect, check/doctor, and uninstall flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->