### PR TITLE
fix: harden vgo self upgrade metadata

### DIFF
--- a/apps/vgo-cli/src/vgo_cli/upgrade_service.py
+++ b/apps/vgo-cli/src/vgo_cli/upgrade_service.py
@@ -24,7 +24,13 @@ def resolve_upgrade_repo_root(repo_root: Path) -> Path | None:
     return resolve_canonical_repo_root(repo_root)
 
 
-def refresh_installed_status(repo_root: Path, target_root: Path, host_id: str) -> dict[str, object]:
+def refresh_installed_status(
+    repo_root: Path,
+    target_root: Path,
+    host_id: str,
+    *,
+    persist: bool = True,
+) -> dict[str, object]:
     official_repo = get_official_self_repo_metadata(repo_root)
     release = get_local_release_metadata(repo_root)
     merged = merge_upgrade_status(
@@ -39,7 +45,8 @@ def refresh_installed_status(repo_root: Path, target_root: Path, host_id: str) -
             'installed_recorded_at': None,
         },
     )
-    save_upgrade_status(target_root, merged)
+    if persist:
+        save_upgrade_status(target_root, merged)
     return merged
 
 
@@ -54,7 +61,15 @@ def refresh_upstream_status(
         return current_status
 
     repo_url = str(current_status.get('repo_remote') or '').strip()
-    branch = str(current_status.get('repo_default_branch') or 'main').strip() or 'main'
+    branch = str(current_status.get('repo_default_branch') or '').strip()
+    if not repo_url or not branch:
+        official_repo = get_official_self_repo_metadata(repo_root)
+        repo_url = repo_url or str(official_repo.get('repo_url') or '').strip()
+        branch = branch or str(official_repo.get('default_branch') or '').strip()
+    branch = branch or 'main'
+    if not repo_url:
+        raise CliError('Official self repository URL is not configured in version-governance.json.')
+
     fetch_result = run_subprocess(['git', 'fetch', '--quiet', repo_url, branch], cwd=repo_root)
     if fetch_result.returncode != 0:
         raise CliError(fetch_result.stderr.strip() or 'Failed to refresh upstream repository state.')
@@ -193,7 +208,7 @@ def upgrade_runtime(
             'Pass --repo-root pointing at a Vibe-Skills git checkout before invoking the upgrade runtime.'
         )
 
-    before = refresh_installed_status(resolved_repo_root, target_root, host_id)
+    before = refresh_installed_status(resolved_repo_root, target_root, host_id, persist=False)
     status = refresh_upstream_status(resolved_repo_root, target_root, before, force_refresh=True)
     if not bool(status.get('update_available')):
         print(

--- a/config/version-governance.json
+++ b/config/version-governance.json
@@ -7,7 +7,11 @@
     "notes": "mainline upgrade flow / workspace memory plane / document artifact governance / specialist lifecycle disclosure / release truth refresh"
   },
   "source_of_truth": {
-    "canonical_root": "."
+    "canonical_root": ".",
+    "official_self_repo": {
+      "repo_url": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+      "default_branch": "main"
+    }
   },
   "mirror_topology": {
     "canonical_target_id": "canonical",

--- a/docs/plans/2026-04-15-vgo-upgrade-self-repo-hardening-execution-plan.md
+++ b/docs/plans/2026-04-15-vgo-upgrade-self-repo-hardening-execution-plan.md
@@ -30,7 +30,7 @@ Write a failing test in `tests/unit/test_vgo_cli_repo.py` that reads the reposit
 
 - [ ] **Step 2: Add a failed-refresh persistence test**
 
-Write a failing test in `tests/unit/test_vgo_cli_upgradeService.py` that seeds `upgrade-status.json` with a known-good remote and branch, forces `git fetch` to fail, and asserts the file on disk still contains the old good values after the exception.
+Write a failing test in `tests/unit/test_vgo_cli_upgrade_service.py` that seeds `upgrade-status.json` with a known-good remote and branch, forces `git fetch` to fail, and asserts the file on disk still contains the old good values after the exception.
 
 - [ ] **Step 3: Add a missing-persisted-metadata fallback test**
 

--- a/docs/plans/2026-04-15-vgo-upgrade-self-repo-hardening-execution-plan.md
+++ b/docs/plans/2026-04-15-vgo-upgrade-self-repo-hardening-execution-plan.md
@@ -1,0 +1,110 @@
+# Vgo Upgrade Self Repo Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Repair the shared upgrader so official self-repo metadata is always available and failed refreshes cannot corrupt installed upgrade status.
+
+**Architecture:** Restore the missing `official_self_repo` contract in release governance, then tighten the upgrade service so it resolves upstream fetch inputs from validated repo metadata and only persists installed or remote status after the required values are known-good. Cover the regression with focused unit tests plus one runtime-neutral contract test that reads the generated upgrade-status file.
+
+**Tech Stack:** Python CLI runtime, JSON governance config, pytest unit tests, runtime-neutral install verification
+
+---
+
+## Chunk 1: Freeze the Contract and Write Red Tests
+
+### Task 1: Encode the expected upgrade metadata contract
+
+**Files:**
+- Add: `docs/requirements/2026-04-15-vgo-upgrade-self-repo-hardening.md`
+- Add: `docs/plans/2026-04-15-vgo-upgrade-self-repo-hardening-execution-plan.md`
+- Modify: `tests/unit/test_vgo_cli_repo.py`
+- Modify: `tests/unit/test_vgo_cli_upgrade_service.py`
+
+- [ ] **Step 1: Add a repo-config guard test**
+
+Write a failing test in `tests/unit/test_vgo_cli_repo.py` that reads the repository's real `config/version-governance.json` and asserts:
+
+- `repo_url` ends with `/Vibe-Skills.git`
+- `default_branch` is `main`
+- `canonical_root` is `.`
+
+- [ ] **Step 2: Add a failed-refresh persistence test**
+
+Write a failing test in `tests/unit/test_vgo_cli_upgradeService.py` that seeds `upgrade-status.json` with a known-good remote and branch, forces `git fetch` to fail, and asserts the file on disk still contains the old good values after the exception.
+
+- [ ] **Step 3: Add a missing-persisted-metadata fallback test**
+
+Write a failing test in `tests/unit/test_vgo_cli_upgrade_service.py` that passes `current_status` with blank `repo_remote` and `repo_default_branch`, stubs repo governance lookup, and asserts refresh uses governance-derived values for `git fetch`.
+
+- [ ] **Step 4: Run the red test slice**
+
+Run:
+
+`python3 -m pytest tests/unit/test_vgo_cli_repo.py tests/unit/test_vgo_cli_upgrade_service.py -q`
+
+Expected: FAIL until the repo config and upgrade-service changes are implemented.
+
+## Chunk 2: Implement the Metadata and Persistence Fix
+
+### Task 2: Make official self-repo metadata authoritative and safe
+
+**Files:**
+- Modify: `config/version-governance.json`
+- Modify: `apps/vgo-cli/src/vgo_cli/repo.py`
+- Modify: `apps/vgo-cli/src/vgo_cli/upgrade_service.py`
+- Modify: `apps/vgo-cli/src/vgo_cli/install_support.py`
+
+- [ ] **Step 1: Restore official self-repo metadata in governance**
+
+Add `source_of_truth.official_self_repo` to `config/version-governance.json` with the official GitHub repository URL and default branch.
+
+- [ ] **Step 2: Centralize metadata fallback behavior**
+
+Update `get_official_self_repo_metadata()` or a helper alongside it so blank or missing persisted upgrade-status values can be replaced by repo-governance values before upstream refresh runs.
+
+- [ ] **Step 3: Stop pre-failure status pollution**
+
+Change the upgrade flow so a failed refresh does not write an empty `repo_remote` or `repo_default_branch` into `.vibeskills/upgrade-status.json`. Preserve last known-good state when refresh fails.
+
+- [ ] **Step 4: Keep install postconditions truthful**
+
+Ensure install-time upgrade-status writes also use the restored authoritative metadata and still record installed version and commit as before.
+
+- [ ] **Step 5: Re-run the focused unit tests**
+
+Run:
+
+`python3 -m pytest tests/unit/test_vgo_cli_repo.py tests/unit/test_vgo_cli_upgrade_service.py -q`
+
+Expected: PASS
+
+## Chunk 3: Add the Release Guardrail and Final Verification
+
+### Task 3: Prove the bug fix survives the packaged runtime path
+
+**Files:**
+- Modify: `tests/runtime_neutral/test_installed_runtime_scripts.py`
+
+- [ ] **Step 1: Strengthen the runtime-neutral assertion if needed**
+
+Keep or extend the existing assertion so installed runtime output proves `upgrade-status.json` contains `main` and an official repo URL derived from the patched governance contract.
+
+- [ ] **Step 2: Run the focused verification slice**
+
+Run:
+
+`python3 -m pytest tests/unit/test_vgo_cli_repo.py tests/unit/test_vgo_cli_upgrade_service.py tests/runtime_neutral/test_installed_runtime_scripts.py -q`
+
+Expected: PASS
+
+- [ ] **Step 3: Review diff risk before completion**
+
+Confirm the patch only changes:
+
+- upgrade metadata contract
+- status-persistence boundary
+- regression tests tied to the bug
+
+- [ ] **Step 4: Report release implications truthfully**
+
+State explicitly that a new release can carry the fix forward, but already-installed users need the fixed upgrader path or a documented recovery path because the previous release shipped a broken self-upgrade contract.

--- a/docs/requirements/2026-04-15-vgo-upgrade-self-repo-hardening.md
+++ b/docs/requirements/2026-04-15-vgo-upgrade-self-repo-hardening.md
@@ -1,0 +1,117 @@
+# Vgo Upgrade Self Repo Hardening Requirement
+
+## Summary
+
+Repair the shared Vibe-Skills upgrade path so it can always resolve the official self-repository metadata needed for upstream refresh, and prevent failed refresh attempts from polluting the installed upgrade-status state.
+
+## Goal
+
+Make `vgo upgrade` trustworthy for already-installed users by fixing the runtime's own upgrade metadata source and by ensuring failed upstream refreshes do not leave behind misleading or unusable upgrade state.
+
+## Deliverable
+
+A bounded hardening change that:
+
+- restores authoritative `official_self_repo` metadata in `config/version-governance.json`
+- makes repo metadata resolution safe even when governance data is partially populated
+- avoids persisting broken `repo_remote` and `repo_default_branch` values before upstream refresh succeeds
+- proves the behavior with focused unit and runtime-neutral tests
+
+## Constraints
+
+- canonical governed runtime authority remains `vibe`
+- the fix must target the shared upgrader path, not just a one-off recovery script
+- do not rely on manual fallback copying as the primary success path
+- do not overwrite unrelated user state under target roots
+- do not regress the existing successful install and upgrade reminder flows
+- keep the change narrowly scoped to upgrade metadata resolution and status persistence hardening
+
+## Acceptance Criteria
+
+- `config/version-governance.json` declares `source_of_truth.official_self_repo.repo_url`
+- `config/version-governance.json` declares `source_of_truth.official_self_repo.default_branch`
+- `get_official_self_repo_metadata()` returns the official repo URL and default branch for the real repository config
+- `refresh_upstream_status()` can refresh from official upstream metadata without requiring previously persisted non-empty `repo_remote`
+- if upstream refresh fails, `.vibeskills/upgrade-status.json` is not rewritten with empty `repo_remote` or `repo_default_branch`
+- `upgrade_runtime()` still no-ops cleanly when already current and still runs reset, reinstall, and check when an update is available
+
+## Product Acceptance Criteria
+
+- an already-installed user can upgrade from the official repo checkout without hitting `git fetch '' main`
+- `upgrade-status.json` remains a truthful cache of the last known-good install/upstream state, not a record of partial failed attempts
+- future releases cannot omit `official_self_repo` metadata without a red test
+
+## User-Visible Behavior
+
+- successful upgrades continue to report exact before/after version and commit evidence
+- failed upstream refreshes still fail closed, but they no longer corrupt the recorded repo remote or branch
+- the official repository metadata is now encoded directly in release governance and can be audited in-repo
+
+## Manual Spot Checks
+
+- run the focused repo and upgrade unit tests and confirm the new contract passes
+- run the runtime-neutral slice that asserts install-generated `upgrade-status.json` contains `main` and an official repo URL
+- inspect `config/version-governance.json` and confirm `official_self_repo` matches the official GitHub repository and default branch
+
+## Completion Language Policy
+
+Do not claim this hardening is complete until the shared upgrader tests and the runtime-neutral `upgrade-status` check both pass from the patched repository state.
+
+## Delivery Truth Contract
+
+This work is successful only if all of the following are true at the same time:
+
+- the repo can self-describe its official upstream remote and default branch
+- the shared upgrader can use that metadata without depending on stale installed status
+- failed refresh attempts do not write misleading empty upstream metadata into installed state
+- targeted tests prove both the bug fix and the future-release guardrail
+
+## Specialist Recommendation
+
+- no dedicated release-engineering or upgrader specialist skill is available in the current skill set
+- fallback: native bounded implementation under canonical `vibe`
+- dispatch mode: native fallback, no second runtime
+
+## Artifact Review Requirements
+
+- review the metadata source of truth and confirm it points to the official repository only
+- review the upgrade-status persistence boundary and confirm writes happen only after validated data is available
+- review the new tests and confirm they would fail if `official_self_repo` were removed again
+
+## Code Task TDD Evidence Requirements
+
+- add a red test proving the live repo config exposes official self-repo metadata
+- add a red test proving failed upstream refresh does not persist an empty remote or branch
+- add a red test proving refresh can derive missing persisted metadata from repo governance when needed
+
+## Code Task TDD Exceptions
+
+No code-task TDD exceptions were frozen for this run.
+
+## Non-Goals
+
+- redesigning the full release process
+- adding a new recovery UI or interactive upgrader wizard
+- changing host bootstrap or router governance behavior
+- supporting arbitrary non-official upgrade remotes in this change
+
+## Autonomy Mode
+
+Interactive governed execution with serial native implementation in an isolated git worktree.
+
+## Assumptions
+
+- the official repository remains `https://github.com/foryourhealth111-pixel/Vibe-Skills.git`
+- the official default branch remains `main`
+- the broken upgrade behavior is in shared Python upgrade code, not only in a single host wrapper
+
+## Evidence Inputs
+
+- `apps/vgo-cli/src/vgo_cli/repo.py`
+- `apps/vgo-cli/src/vgo_cli/upgrade_service.py`
+- `apps/vgo-cli/src/vgo_cli/install_support.py`
+- `apps/vgo-cli/src/vgo_cli/upgrade_state.py`
+- `config/version-governance.json`
+- `tests/unit/test_vgo_cli_repo.py`
+- `tests/unit/test_vgo_cli_upgrade_service.py`
+- `tests/runtime_neutral/test_installed_runtime_scripts.py`

--- a/tests/unit/test_vgo_cli_repo.py
+++ b/tests/unit/test_vgo_cli_repo.py
@@ -70,6 +70,16 @@ def test_get_official_self_repo_metadata_reads_explicit_governance_source(tmp_pa
     }
 
 
+def test_real_version_governance_declares_official_self_repo_metadata() -> None:
+    payload = get_official_self_repo_metadata(REPO_ROOT)
+
+    assert payload == {
+        'repo_url': 'https://github.com/foryourhealth111-pixel/Vibe-Skills.git',
+        'default_branch': 'main',
+        'canonical_root': '.',
+    }
+
+
 def test_get_local_release_metadata_reads_release_block(tmp_path: Path) -> None:
     repo_root = tmp_path / 'repo'
     (repo_root / 'config').mkdir(parents=True)

--- a/tests/unit/test_vgo_cli_upgrade_service.py
+++ b/tests/unit/test_vgo_cli_upgrade_service.py
@@ -28,10 +28,17 @@ def test_upgrade_runtime_resolves_canonical_git_root_before_refresh(monkeypatch:
 
     monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: canonical_root)
 
-    def fake_refresh_installed_status(repo_root_arg: Path, target_root_arg: Path, host_id: str) -> dict[str, object]:
+    def fake_refresh_installed_status(
+        repo_root_arg: Path,
+        target_root_arg: Path,
+        host_id: str,
+        *,
+        persist: bool = True,
+    ) -> dict[str, object]:
         recorded["repo_root"] = repo_root_arg
         recorded["target_root"] = target_root_arg
         recorded["host_id"] = host_id
+        recorded["persist"] = persist
         return {
             "installed_version": "3.0.1",
             "installed_commit": "same",
@@ -64,6 +71,7 @@ def test_upgrade_runtime_resolves_canonical_git_root_before_refresh(monkeypatch:
     assert recorded["repo_root"] == canonical_root
     assert recorded["target_root"] == target_root
     assert recorded["host_id"] == "codex"
+    assert recorded["persist"] is False
 
 
 def test_upgrade_runtime_noops_when_install_is_already_current(
@@ -80,7 +88,7 @@ def test_upgrade_runtime_noops_when_install_is_already_current(
     monkeypatch.setattr(
         upgrade_service,
         "refresh_installed_status",
-        lambda repo_root_arg, target_root_arg, host_id: {
+        lambda repo_root_arg, target_root_arg, host_id, **kwargs: {
             "installed_version": "3.0.1",
             "installed_commit": "same",
             "remote_latest_version": "3.0.1",
@@ -197,7 +205,11 @@ def test_upgrade_runtime_refreshes_repo_reinstalls_and_checks_when_update_is_ava
     )
 
     monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
-    monkeypatch.setattr(upgrade_service, "refresh_installed_status", lambda repo_root_arg, target_root_arg, host_id: next(statuses))
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_installed_status",
+        lambda repo_root_arg, target_root_arg, host_id, **kwargs: next(statuses),
+    )
 
     def fake_refresh_upstream(
         repo_root_arg: Path,
@@ -263,7 +275,7 @@ def test_upgrade_runtime_forces_fresh_upstream_refresh_before_deciding_update(
     monkeypatch.setattr(
         upgrade_service,
         "refresh_installed_status",
-        lambda repo_root_arg, target_root_arg, host_id: {
+        lambda repo_root_arg, target_root_arg, host_id, **kwargs: {
             "installed_version": "3.0.0",
             "installed_commit": "local",
             "remote_latest_version": "3.0.1",
@@ -374,6 +386,141 @@ def test_refresh_upstream_status_reads_release_metadata_from_resolved_commit(
     ]
 
 
+def test_refresh_upstream_status_falls_back_to_repo_governance_when_cached_remote_metadata_is_blank(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        upgrade_service,
+        "get_official_self_repo_metadata",
+        lambda repo_root_arg: {
+            "repo_url": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+            "default_branch": "main",
+            "canonical_root": ".",
+        },
+    )
+
+    def fake_run_subprocess(command: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        assert cwd == repo_root
+        if command[:3] == ["git", "fetch", "--quiet"]:
+            assert command == [
+                "git",
+                "fetch",
+                "--quiet",
+                "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+                "main",
+            ]
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if command == ["git", "rev-parse", "FETCH_HEAD"]:
+            return subprocess.CompletedProcess(command, 0, stdout="abc123\n", stderr="")
+        if command == ["git", "show", "abc123:config/version-governance.json"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout='{"release":{"version":"3.0.1"}}\n',
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(upgrade_service, "run_subprocess", fake_run_subprocess)
+
+    status = upgrade_service.refresh_upstream_status(
+        repo_root,
+        target_root,
+        {
+            "repo_remote": "",
+            "repo_default_branch": "",
+            "installed_version": "3.0.0",
+            "installed_commit": "old",
+        },
+        force_refresh=True,
+    )
+
+    assert status["remote_latest_commit"] == "abc123"
+    assert status["remote_latest_version"] == "3.0.1"
+    assert commands[0] == [
+        "git",
+        "fetch",
+        "--quiet",
+        "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+        "main",
+    ]
+
+
+def test_upgrade_runtime_does_not_rewrite_existing_status_when_upstream_refresh_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    previous_status = {
+        "host_id": "codex",
+        "target_root": str(target_root.resolve()),
+        "repo_remote": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+        "repo_default_branch": "main",
+        "installed_version": "3.0.0",
+        "installed_commit": "old",
+        "installed_recorded_at": "2026-04-10T00:00:00Z",
+        "remote_latest_commit": "old",
+        "remote_latest_version": "3.0.0",
+        "remote_latest_checked_at": "2026-04-10T00:00:00Z",
+        "update_available": False,
+    }
+    upgrade_service.save_upgrade_status(target_root, previous_status)
+
+    monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
+    monkeypatch.setattr(
+        upgrade_service,
+        "get_official_self_repo_metadata",
+        lambda repo_root_arg: {
+            "repo_url": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+            "default_branch": "main",
+            "canonical_root": ".",
+        },
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "get_local_release_metadata",
+        lambda repo_root_arg: {"version": "3.0.1", "updated": "2026-04-15", "channel": "stable"},
+    )
+    monkeypatch.setattr(upgrade_service, "get_repo_head_commit", lambda repo_root_arg: "new")
+
+    def fake_run_subprocess(command: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        assert cwd == repo_root
+        if command[:3] == ["git", "fetch", "--quiet"]:
+            return subprocess.CompletedProcess(command, 1, stdout="", stderr="network down")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(upgrade_service, "run_subprocess", fake_run_subprocess)
+
+    with pytest.raises(upgrade_service.CliError, match="network down"):
+        upgrade_service.upgrade_runtime(
+            repo_root=repo_root,
+            target_root=target_root,
+            host_id="codex",
+            profile="full",
+            frontend="shell",
+            install_external=False,
+            strict_offline=False,
+            require_closed_ready=False,
+            allow_external_skill_fallback=False,
+            skip_runtime_freshness_gate=False,
+        )
+
+    assert upgrade_service.load_upgrade_status(target_root) == previous_status
+
+
 def test_upgrade_runtime_propagates_refresh_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
 
@@ -386,7 +533,7 @@ def test_upgrade_runtime_propagates_refresh_failures(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(
         upgrade_service,
         "refresh_installed_status",
-        lambda repo_root_arg, target_root_arg, host_id: {"installed_version": "3.0.0", "installed_commit": "old"},
+        lambda repo_root_arg, target_root_arg, host_id, **kwargs: {"installed_version": "3.0.0", "installed_commit": "old"},
     )
     monkeypatch.setattr(
         upgrade_service,
@@ -424,7 +571,11 @@ def test_upgrade_runtime_propagates_check_failures(monkeypatch: pytest.MonkeyPat
     )
 
     monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
-    monkeypatch.setattr(upgrade_service, "refresh_installed_status", lambda repo_root_arg, target_root_arg, host_id: next(statuses))
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_installed_status",
+        lambda repo_root_arg, target_root_arg, host_id, **kwargs: next(statuses),
+    )
     monkeypatch.setattr(
         upgrade_service,
         "refresh_upstream_status",


### PR DESCRIPTION
## Summary
- restore `source_of_truth.official_self_repo` in `config/version-governance.json` so the shared upgrader has an authoritative repo URL and default branch
- make `refresh_upstream_status()` fall back to repo governance metadata when cached `repo_remote` or `repo_default_branch` is blank, instead of attempting `git fetch '' main`
- stop `upgrade_runtime()` from persisting refreshed installed status before upstream refresh succeeds, and add regression tests for the metadata contract and failed-refresh state preservation

## Test Plan
- [x] `python3 -m pytest tests/unit/test_vgo_cli_repo.py tests/unit/test_vgo_cli_upgrade_service.py tests/runtime_neutral/test_installed_runtime_scripts.py::InstalledRuntimeScriptsTests::test_shell_install_writes_upgrade_status_sidecar tests/runtime_neutral/test_vibe_upgrade_reminder.py::test_build_update_reminder_refreshes_stale_cache_and_emits_advisory tests/runtime_neutral/test_vibe_upgrade_reminder.py::test_build_update_reminder_uses_fresh_cache_without_refresh tests/runtime_neutral/test_vibe_upgrade_reminder.py::test_build_update_reminder_returns_none_when_no_update_is_available tests/runtime_neutral/test_vibe_upgrade_reminder.py::test_build_update_reminder_swallows_refresh_failures -q`
- [x] Result: `25 passed in 2.46s`

## Notes
- I also rechecked the broader runtime-neutral failures seen in this repo. The following failures reproduce on a clean `origin/main` baseline and are not introduced by this branch:
  - `test_installed_check_sh_deep_does_not_reference_unbound_runtime_target_rel`
  - `test_installed_runtime_bootstrap_supports_openclaw_without_self_deleting_source`
  - `test_powershell_install_succeeds_without_python_on_path`
  - `test_powershell_upgrade_reminder_uses_python_command_spec`
- This release fix carries the contract forward, but already-installed users with the previously broken self-upgrader still need a recovery path or a repo-sourced fixed upgrader for the first hop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced upgrade service to better recover missing repository metadata from governance configuration when standard metadata is unavailable.
  * Upgrade operations now prevent corrupting stored upgrade status when remote metadata refresh fails, improving reliability.

* **Configuration**
  * Added official repository URL and default branch to version governance configuration for improved metadata resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->