### PR TITLE
feat: add explicit specialist decision fallback governance

### DIFF
--- a/config/project-delivery-acceptance-contract.json
+++ b/config/project-delivery-acceptance-contract.json
@@ -1,5 +1,5 @@
 {
-  "contract_id": "vibe-project-delivery-acceptance-v3",
+  "contract_id": "vibe-project-delivery-acceptance-v5",
   "version": 5,
   "truth_layers": [
     "governance_truth",

--- a/config/project-delivery-acceptance-contract.json
+++ b/config/project-delivery-acceptance-contract.json
@@ -1,9 +1,11 @@
 {
   "contract_id": "vibe-project-delivery-acceptance-v3",
-  "version": 3,
+  "version": 5,
   "truth_layers": [
     "governance_truth",
     "engineering_verification_truth",
+    "specialist_disclosure_truth",
+    "specialist_decision_truth",
     "code_task_tdd_evidence_truth",
     "workflow_completion_truth",
     "artifact_review_truth",
@@ -60,6 +62,8 @@
     "must_report_fields": [
       "governance_truth",
       "engineering_verification_truth",
+      "specialist_disclosure_truth",
+      "specialist_decision_truth",
       "code_task_tdd_evidence_truth",
       "workflow_completion_truth",
       "artifact_review_truth",

--- a/docs/plans/2026-04-15-vibe-specialist-decision-fallback-execution-plan.md
+++ b/docs/plans/2026-04-15-vibe-specialist-decision-fallback-execution-plan.md
@@ -1,0 +1,164 @@
+# Vibe Specialist Decision And Repo-Asset Fallback Execution Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a governed `specialist_decision` contract that keeps no-match specialist resolution explicit, including traceable repo-asset fallback.
+
+**Architecture:** Extend the runtime artifact projections with a shared `specialist_decision` object, surface it in requirement and plan docs, and evaluate it through a new `specialist_decision_truth` delivery-acceptance layer. Keep approved specialist disclosure logic intact and use an optional `specialist-decision.json` session sidecar only for task-specific repo-asset fallback details.
+
+**Tech Stack:** PowerShell runtime scripts, Python verification core, Markdown governed docs, runtime-neutral pytest suite
+
+---
+
+## Chunk 1: Red Tests And Contract Freeze
+
+### Task 1: Lock the behavior in docs and runtime-neutral tests
+
+**Files:**
+- Modify: `config/project-delivery-acceptance-contract.json`
+- Modify: `tests/runtime_neutral/test_runtime_delivery_acceptance.py`
+- Modify: `tests/runtime_neutral/test_governed_runtime_bridge.py`
+- Add: `docs/requirements/2026-04-15-vibe-specialist-decision-fallback.md`
+- Add: `docs/plans/2026-04-15-vibe-specialist-decision-fallback-execution-plan.md`
+
+- [ ] **Step 1: Extend the delivery-acceptance contract**
+
+Add `specialist_decision_truth` to the contract truth-layer vocabulary and required report fields.
+
+- [ ] **Step 2: Add failing delivery-acceptance tests**
+
+Write red tests proving:
+
+- missing no-match resolution becomes non-green
+- traceable repo-asset fallback becomes `PASS_DEGRADED`
+- incomplete repo-asset fallback disclosure becomes `FAIL`
+
+- [ ] **Step 3: Add failing governed-runtime bridge assertions**
+
+Require runtime artifacts, requirement docs, and execution plans to expose `specialist_decision`.
+
+- [ ] **Step 4: Run the targeted red suite**
+
+Run:
+
+`pytest -q tests/runtime_neutral/test_runtime_delivery_acceptance.py -k "specialist_decision or repo_asset_fallback or clean_root_run"`
+
+Expected: FAIL until implementation lands.
+
+## Chunk 2: Runtime Artifact Projection
+
+### Task 2: Project `specialist_decision` through the governed runtime
+
+**Files:**
+- Modify: `scripts/runtime/VibeRuntime.Common.ps1`
+- Modify: `scripts/runtime/Invoke-PlanExecute.ps1`
+- Modify: `scripts/runtime/invoke-vibe-runtime.ps1`
+
+- [ ] **Step 1: Add a shared specialist-decision projection**
+
+Create a runtime helper that derives structural decision state from approved dispatch, blocked, degraded, and advisory-only specialist outcomes.
+
+- [ ] **Step 2: Support a governed repo-asset fallback sidecar**
+
+Allow `specialist-decision.json` in the session root to enrich the structural decision with repo-asset fallback paths, reason, legal basis, and traceability basis.
+
+- [ ] **Step 3: Write the decision into execution artifacts**
+
+Emit `specialist_decision` into `runtime-input-packet.json`, `execution-manifest.json`, `phase-execute.json`, and `runtime-summary.json`.
+
+- [ ] **Step 4: Re-run the bridge test**
+
+Run:
+
+`pytest -q tests/runtime_neutral/test_governed_runtime_bridge.py -k six_stage_closure`
+
+Expected: PASS
+
+## Chunk 3: Governed Requirement And Plan Surfaces
+
+### Task 3: Make the decision visible in docs
+
+**Files:**
+- Modify: `scripts/runtime/Write-RequirementDoc.ps1`
+- Modify: `scripts/runtime/Write-XlPlan.ps1`
+
+- [ ] **Step 1: Add `## Specialist Decision` to requirement docs**
+
+Always record the frozen specialist decision, including pending no-match resolution guidance when no dedicated specialist exists.
+
+- [ ] **Step 2: Add `## Specialist Decision Plan` to execution plans**
+
+Tell execution exactly when `specialist-decision.json` must be written and what fields it must contain for repo-asset fallback.
+
+- [ ] **Step 3: Keep the existing dispatch section intact**
+
+Do not regress the existing approved specialist dispatch and disclosure documentation.
+
+## Chunk 4: Delivery-Acceptance Semantics
+
+### Task 4: Gate no-match specialist resolution explicitly
+
+**Files:**
+- Modify: `packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_support.py`
+- Modify: `packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py`
+
+- [ ] **Step 1: Resolve the optional specialist-decision payload**
+
+Support inline `phase-execute.json`, explicit `specialist_decision_path`, and default `specialist-decision.json` sidecar loading.
+
+- [ ] **Step 2: Add `specialist_decision_truth` evaluation**
+
+Implement the minimum rules:
+
+- approved dispatch without matching decision -> `FAIL`
+- no-match with pending resolution -> `MANUAL_REVIEW_REQUIRED`
+- no-match with `no_specialist_needed` -> `PASS`
+- no-match with complete repo-asset fallback -> `PASS_DEGRADED`
+- no-match with incomplete repo-asset fallback -> `FAIL`
+
+- [ ] **Step 3: Keep completion wording blocked for non-green fallback**
+
+Do not allow repo-asset fallback to collapse into green completion.
+
+- [ ] **Step 4: Re-run delivery-acceptance tests**
+
+Run:
+
+`pytest -q tests/runtime_neutral/test_runtime_delivery_acceptance.py`
+
+Expected: PASS
+
+## Chunk 5: Focused Verification
+
+### Task 5: Verify the touched surfaces only
+
+**Files:**
+- No additional files expected beyond the runtime scripts, verification core, tests, and governed docs above
+
+- [ ] **Step 1: Run the focused verification slice**
+
+Run:
+
+`pytest -q tests/runtime_neutral/test_runtime_delivery_acceptance.py tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_skill_promotion_freeze_contract.py`
+
+Expected: PASS
+
+- [ ] **Step 2: Re-run the no-silent-fallback contract gate**
+
+Run:
+
+`pwsh -NoLogo -File scripts/verify/vibe-no-silent-fallback-contract-gate.ps1`
+
+Expected: PASS
+
+- [ ] **Step 3: Inspect only the touched diff**
+
+Run:
+
+`git diff -- config/project-delivery-acceptance-contract.json scripts/runtime/VibeRuntime.Common.ps1 scripts/runtime/Write-RequirementDoc.ps1 scripts/runtime/Write-XlPlan.ps1 scripts/runtime/Invoke-PlanExecute.ps1 scripts/runtime/invoke-vibe-runtime.ps1 packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_support.py packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py tests/runtime_neutral/test_runtime_delivery_acceptance.py tests/runtime_neutral/test_governed_runtime_bridge.py docs/requirements/2026-04-15-vibe-specialist-decision-fallback.md docs/plans/2026-04-15-vibe-specialist-decision-fallback-execution-plan.md`
+
+Expected: only specialist-decision governance changes.
+
+- [ ] **Step 4: Verify before claiming completion**
+
+Re-run the exact focused verification commands immediately before any completion claim and report the actual results.

--- a/docs/requirements/2026-04-15-vibe-specialist-decision-fallback.md
+++ b/docs/requirements/2026-04-15-vibe-specialist-decision-fallback.md
@@ -36,6 +36,16 @@ A governed runtime and delivery-acceptance update that:
 - a declared repo-asset fallback without asset paths, reason, legal basis, or traceability fails delivery acceptance
 - a declared, traceable repo-asset fallback produces `PASS_DEGRADED`
 
+## Specialist Decision
+
+- `runtime-input-packet.json` must freeze `specialist_decision` as the canonical structural decision surface for the run.
+- `execution-manifest.json`, `phase-execute.json`, and `runtime-summary.json` must mirror the same `specialist_decision` payload instead of reopening the decision in prose.
+- execution plans must include `## Specialist Decision Plan` so no-match handling stays explicit before `plan_execute`.
+- delivery acceptance reports must evaluate the same payload through `specialist_decision_truth`.
+- `specialist_decision` must record `decision_state` and `resolution_mode`.
+- approved specialist execution must record `approved_dispatch_skill_ids`.
+- repo-asset fallback must record `used`, `asset_paths`, `reason`, `legal_basis`, and `traceability_basis`.
+
 ## Product Acceptance Criteria
 
 - users can always tell whether a specialist existed for the task

--- a/docs/requirements/2026-04-15-vibe-specialist-decision-fallback.md
+++ b/docs/requirements/2026-04-15-vibe-specialist-decision-fallback.md
@@ -1,0 +1,162 @@
+# Vibe Specialist Decision And Repo-Asset Fallback Requirement
+
+## Summary
+
+Add a first-class `specialist_decision` contract so governed `vibe` always records whether specialist execution was approved, stayed advisory, or required an explicit no-match resolution, including traceable repo-asset fallback when no dedicated specialist exists.
+
+## Goal
+
+Close the remaining governance gap where a run could truthfully have no matched specialist but still rely on repo-local assets without leaving a structured, reviewable fallback decision artifact.
+
+## Deliverable
+
+A governed runtime and delivery-acceptance update that:
+
+- freezes a `specialist_decision` object in runtime artifacts
+- surfaces specialist decision truth in requirement and plan documents
+- allows explicit repo-asset fallback disclosure through `specialist-decision.json`
+- blocks green completion when no-specialist runs leave the resolution undeclared
+
+## Constraints
+
+- `vibe` remains the only governed runtime authority
+- do not introduce `AGENTS.md` or any second control plane
+- reuse existing governed artifacts and optional sidecars instead of adding a parallel receipt system
+- repo-asset fallback stays non-green even when it is explicit and traceable
+- approved specialist dispatch must keep the existing `specialist_user_disclosure` contract unchanged
+
+## Acceptance Criteria
+
+- `runtime-input-packet.json` includes `specialist_decision`
+- `execution-manifest.json`, `phase-execute.json`, and `runtime-summary.json` include `specialist_decision`
+- requirement docs include `## Specialist Decision`
+- execution plans include `## Specialist Decision Plan`
+- delivery acceptance reports include `specialist_decision_truth`
+- a no-specialist run without explicit resolution becomes non-green
+- a declared repo-asset fallback without asset paths, reason, legal basis, or traceability fails delivery acceptance
+- a declared, traceable repo-asset fallback produces `PASS_DEGRADED`
+
+## Product Acceptance Criteria
+
+- users can always tell whether a specialist existed for the task
+- users can always tell whether a no-match path was resolved as “no specialist needed” or “repo-asset fallback”
+- repo-asset fallback remains visible as a governed compromise rather than silently collapsing into `PASS`
+
+## Manual Spot Checks
+
+- Run delivery acceptance with no specialist recommendations and no explicit resolution; confirm the result is non-green.
+- Run delivery acceptance with explicit repo-asset fallback and complete traceability; confirm the result is `PASS_DEGRADED`.
+- Run delivery acceptance with repo-asset fallback missing traceability fields; confirm the result is `FAIL`.
+
+## Completion Language Policy
+
+Do not claim this work is complete unless fresh verification proves the new `specialist_decision` contract in runtime artifacts, docs, and delivery acceptance.
+
+## Delivery Truth Contract
+
+Specialist governance transparency is successful only when the system can distinguish:
+
+- approved specialist dispatch
+- advisory-only or blocked specialist outcomes
+- no-match runs that explicitly resolved to no-specialist-needed
+- no-match runs that explicitly resolved to repo-asset fallback with traceability
+- no-match runs that stayed unresolved and therefore cannot close green
+
+## Artifact Review Requirements
+
+No additional artifact review requirements were frozen for this run.
+
+## Code Task TDD Evidence Requirements
+
+- Add failing-first tests for missing no-match specialist resolution.
+- Add failing-first tests for traceable repo-asset fallback.
+- Add failing-first tests for incomplete repo-asset fallback disclosure.
+- Verify runtime bridge artifacts expose `specialist_decision`.
+
+## Code Task TDD Exceptions
+
+No code-task TDD exceptions were frozen for this run.
+
+## Baseline Document Quality Dimensions
+
+No baseline document quality dimensions were frozen for this run.
+
+## Baseline UI Quality Dimensions
+
+No baseline UI quality dimensions were frozen for this run.
+
+## Task-Specific Acceptance Extensions
+
+- `specialist_decision_truth` must remain distinct from `specialist_disclosure_truth`.
+- `repo_asset_fallback` must remain reviewable from governed artifact evidence, not chat-history inference.
+- missing no-match resolution must not silently collapse into green completion.
+
+## Research Augmentation Sources
+
+- `SKILL.md`
+- `scripts/runtime/VibeRuntime.Common.ps1`
+- `scripts/runtime/Write-RequirementDoc.ps1`
+- `scripts/runtime/Write-XlPlan.ps1`
+- `scripts/runtime/Invoke-PlanExecute.ps1`
+- `packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py`
+- `packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_support.py`
+- `tests/runtime_neutral/test_runtime_delivery_acceptance.py`
+- `tests/runtime_neutral/test_governed_runtime_bridge.py`
+
+## Primary Objective
+
+Make no-match specialist resolution explicit enough that repo-asset fallback cannot hide behind the absence of a dedicated specialist skill.
+
+## Non-Objective Proxy Signals
+
+- increasing the number of surfaced specialist recommendations without resolving no-match cases
+- treating repo-asset fallback as equivalent to approved specialist dispatch
+- keeping fallback explanation only in prose instead of governed artifacts
+
+## Validation Material Role
+
+Runtime-neutral tests, governed runtime bridge tests, and generated runtime artifacts are the source of truth for this change.
+
+## Anti-Proxy-Goal-Drift Tier
+
+Tier 1 governance-truth preservation.
+
+## Intended Scope
+
+Canonical governed runtime artifacts and delivery-acceptance semantics for specialist no-match resolution under `vibe`.
+
+## Abstraction Layer Target
+
+Runtime artifact projection, governed docs, and verification-core delivery acceptance.
+
+## Completion State
+
+Complete only when runtime artifacts, requirement/plan surfaces, and delivery acceptance all carry the new specialist decision truth.
+
+## Generalization Evidence Bundle
+
+- targeted runtime-delivery tests
+- governed runtime bridge test coverage
+- delivery-acceptance contract alignment
+
+## Non-Goals
+
+- do not redesign specialist ranking or router matching
+- do not auto-infer task-specific repo assets from arbitrary execution output
+- do not add a second runtime or second requirement/plan surface
+
+## Autonomy Mode
+
+Interactive governed execution with bounded runtime and verification updates.
+
+## Assumptions
+
+- approved specialist dispatch disclosure already has its own enforced contract
+- repo-asset fallback details can be carried by a governed session sidecar without creating a second authority surface
+- non-green no-match handling is preferable to silent green completion
+
+## Evidence Inputs
+
+- Source task: Close the remaining no-match specialist fallback governance gap under `$vibe`
+- Relevant runtime surfaces: `scripts/runtime/VibeRuntime.Common.ps1`, `scripts/runtime/Invoke-PlanExecute.ps1`
+- Relevant verification surfaces: `packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py`, `tests/runtime_neutral/test_runtime_delivery_acceptance.py`

--- a/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py
+++ b/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py
@@ -203,6 +203,8 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
             if not bool(record.get("entrypoint_requirement_satisfied", bool(record.get("native_skill_entrypoint"))))
         ]
     )
+    approved_dispatch_skill_id_set = set(approved_dispatch_skill_ids)
+    disclosure_skill_id_set = set(disclosure_skill_ids)
     specialist_degraded_skill_ids = _normalize_skill_id_list(
         specialist_accounting.get("degraded_skill_ids") or specialist_dispatch.get("degraded_skill_ids")
     )
@@ -249,7 +251,7 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
                 specialist_disclosure_notes.append(
                     "Specialist user disclosure path source did not stay aligned with native_skill_entrypoint."
                 )
-            if disclosure_skill_ids != approved_dispatch_skill_ids:
+            if disclosure_skill_id_set != approved_dispatch_skill_id_set:
                 specialist_disclosure_state = "failing"
                 specialist_disclosure_notes.append(
                     "Specialist user disclosure did not match effective approved dispatch."
@@ -282,6 +284,7 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
     decision_approved_dispatch_skill_ids = _normalize_skill_id_list(
         specialist_decision_payload.get("approved_dispatch_skill_ids")
     )
+    decision_approved_dispatch_skill_id_set = set(decision_approved_dispatch_skill_ids)
     repo_asset_fallback = specialist_decision_payload.get("repo_asset_fallback") or {}
     repo_asset_used = bool(repo_asset_fallback.get("used"))
     repo_asset_paths = _normalize_string_list(repo_asset_fallback.get("asset_paths"))
@@ -300,7 +303,10 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
             specialist_decision_notes.append(
                 "Specialist decision did not stay aligned with approved_dispatch."
             )
-        elif decision_approved_dispatch_skill_ids and decision_approved_dispatch_skill_ids != approved_dispatch_skill_ids:
+        elif (
+            decision_approved_dispatch_skill_ids
+            and decision_approved_dispatch_skill_id_set != approved_dispatch_skill_id_set
+        ):
             specialist_decision_state = "failing"
             specialist_decision_notes.append(
                 "Specialist decision approved dispatch skill ids did not match effective approved dispatch."
@@ -706,6 +712,7 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
             "code_task_tdd_evidence_state": _normalize_truth_state(code_task_tdd_evidence_state),
             "artifact_review_source_path": artifact_review_source_path,
             "artifact_review_state": _normalize_truth_state(artifact_review_state),
+            "specialist_decision_source_path": specialist_decision_source_path,
             "approved_dispatch_skill_ids": approved_dispatch_skill_ids,
             "disclosed_specialist_skill_ids": disclosure_skill_ids,
             "specialist_effective_execution_status": effective_specialist_execution_status,

--- a/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py
+++ b/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py
@@ -8,11 +8,13 @@ from .runtime_delivery_acceptance_support import (
     _extract_bullets,
     _manual_spot_checks_from_requirement,
     _missing_frozen_items,
+    _normalize_skill_id_list,
     _normalize_truth_state,
     _normalize_string_list,
     _read_text_if_exists,
     _requirement_optional_bullets,
     _resolve_artifact_review_payload,
+    _resolve_specialist_decision_payload,
     _resolve_tdd_evidence_payload,
     _truth_completion_allowed,
     _truth_success,
@@ -38,6 +40,8 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
     execution_plan_text = _read_text_if_exists(execution_plan_path)
     execution_manifest = load_json(execution_manifest_path)
     runtime_input_packet = load_json(runtime_input_packet_path) if runtime_input_packet_path.exists() else {}
+    specialist_dispatch = runtime_input_packet.get("specialist_dispatch") or {}
+    specialist_accounting = execution_manifest.get("specialist_accounting") or {}
 
     product_acceptance_criteria = _extract_bullets(requirement_text, "Product Acceptance Criteria")
     manual_spot_checks, manual_section_missing = _manual_spot_checks_from_requirement(requirement_text)
@@ -63,6 +67,7 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
         "Research Augmentation Sources",
     )
     artifact_review_payload = _resolve_artifact_review_payload(session_root, execute_receipt)
+    specialist_decision_payload = _resolve_specialist_decision_payload(session_root, execute_receipt)
     tdd_evidence_payload = _resolve_tdd_evidence_payload(session_root, execute_receipt)
 
     governance_truth_state = "passing"
@@ -183,6 +188,195 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
     elif execution_status != "completed":
         workflow_truth_state = "failing"
         workflow_truth_notes.append("Workflow did not reach a clean completed state.")
+
+    specialist_disclosure_state = "not_applicable"
+    specialist_disclosure_notes: list[str] = []
+    specialist_user_disclosure = execute_receipt.get("specialist_user_disclosure") or {}
+    approved_dispatch = specialist_accounting.get("approved_dispatch") or specialist_dispatch.get("approved_dispatch") or []
+    approved_dispatch_skill_ids = _normalize_skill_id_list(approved_dispatch)
+    disclosure_routed_skills = specialist_user_disclosure.get("routed_skills") or []
+    disclosure_skill_ids = _normalize_skill_id_list(disclosure_routed_skills)
+    disclosure_missing_entrypoint_skill_ids = _normalize_skill_id_list(
+        [
+            record
+            for record in disclosure_routed_skills
+            if not bool(record.get("entrypoint_requirement_satisfied", bool(record.get("native_skill_entrypoint"))))
+        ]
+    )
+    specialist_degraded_skill_ids = _normalize_skill_id_list(
+        specialist_accounting.get("degraded_skill_ids") or specialist_dispatch.get("degraded_skill_ids")
+    )
+    specialist_blocked_skill_ids = _normalize_skill_id_list(
+        specialist_accounting.get("blocked_skill_ids") or specialist_dispatch.get("blocked_skill_ids")
+    )
+    specialist_activity_skill_ids = _normalize_skill_id_list(
+        [
+            *approved_dispatch_skill_ids,
+            *disclosure_skill_ids,
+            *specialist_degraded_skill_ids,
+            *specialist_blocked_skill_ids,
+        ]
+    )
+    effective_specialist_execution_status = str(specialist_accounting.get("effective_execution_status") or "").strip()
+    specialist_disclosure_scope = str(specialist_user_disclosure.get("scope") or "").strip()
+    specialist_disclosure_timing = str(specialist_user_disclosure.get("timing") or "").strip()
+    specialist_disclosure_path_source = str(specialist_user_disclosure.get("path_source") or "").strip()
+
+    if specialist_activity_skill_ids:
+        if approved_dispatch_skill_ids and not specialist_user_disclosure:
+            specialist_disclosure_state = "failing"
+            specialist_disclosure_notes.append(
+                "Approved specialist dispatch was present but no specialist user disclosure was recorded."
+            )
+        elif not approved_dispatch_skill_ids and disclosure_skill_ids:
+            specialist_disclosure_state = "failing"
+            specialist_disclosure_notes.append(
+                "Specialist user disclosure was recorded without any effective approved dispatch."
+            )
+        elif approved_dispatch_skill_ids:
+            if specialist_disclosure_scope != "approved_dispatch_only":
+                specialist_disclosure_state = "failing"
+                specialist_disclosure_notes.append(
+                    "Specialist user disclosure scope did not stay aligned with approved_dispatch_only."
+                )
+            if specialist_disclosure_timing != "before_execution":
+                specialist_disclosure_state = "failing"
+                specialist_disclosure_notes.append(
+                    "Specialist user disclosure timing did not stay aligned with before_execution."
+                )
+            if specialist_disclosure_path_source != "native_skill_entrypoint":
+                specialist_disclosure_state = "failing"
+                specialist_disclosure_notes.append(
+                    "Specialist user disclosure path source did not stay aligned with native_skill_entrypoint."
+                )
+            if disclosure_skill_ids != approved_dispatch_skill_ids:
+                specialist_disclosure_state = "failing"
+                specialist_disclosure_notes.append(
+                    "Specialist user disclosure did not match effective approved dispatch."
+                )
+            if disclosure_missing_entrypoint_skill_ids:
+                specialist_disclosure_state = "failing"
+                specialist_disclosure_notes.append(
+                    "Specialist user disclosure omitted required native entrypoint truth for one or more skills."
+                )
+            if specialist_disclosure_state != "failing":
+                if effective_specialist_execution_status in {"explicitly_degraded", "blocked_before_execution"} or specialist_degraded_skill_ids:
+                    specialist_disclosure_state = "degraded"
+                    specialist_disclosure_notes.append(
+                        "Specialist disclosure stayed aligned, but specialist execution remained explicitly degraded."
+                    )
+                else:
+                    specialist_disclosure_state = "passing"
+                    specialist_disclosure_notes.append(
+                        "Specialist disclosure stayed aligned with effective approved dispatch."
+                    )
+
+    specialist_decision_state = "not_applicable"
+    specialist_decision_notes: list[str] = []
+    specialist_decision_evidence = _normalize_string_list(specialist_decision_payload.get("evidence_paths"))
+    specialist_decision_source_path = str(specialist_decision_payload.get("source_path") or "").strip()
+    if specialist_decision_source_path:
+        specialist_decision_evidence = [specialist_decision_source_path, *specialist_decision_evidence]
+    decision_state = str(specialist_decision_payload.get("decision_state") or "").strip()
+    resolution_mode = str(specialist_decision_payload.get("resolution_mode") or "").strip()
+    decision_approved_dispatch_skill_ids = _normalize_skill_id_list(
+        specialist_decision_payload.get("approved_dispatch_skill_ids")
+    )
+    repo_asset_fallback = specialist_decision_payload.get("repo_asset_fallback") or {}
+    repo_asset_used = bool(repo_asset_fallback.get("used"))
+    repo_asset_paths = _normalize_string_list(repo_asset_fallback.get("asset_paths"))
+    repo_asset_reason = str(repo_asset_fallback.get("reason") or "").strip()
+    repo_asset_legal_basis = str(repo_asset_fallback.get("legal_basis") or "").strip()
+    repo_asset_traceability = _normalize_string_list(repo_asset_fallback.get("traceability_basis"))
+
+    if approved_dispatch_skill_ids:
+        if not specialist_decision_payload:
+            specialist_decision_state = "failing"
+            specialist_decision_notes.append(
+                "Approved specialist dispatch was present but no specialist decision artifact was recorded."
+            )
+        elif decision_state != "approved_dispatch" or resolution_mode != "approved_dispatch":
+            specialist_decision_state = "failing"
+            specialist_decision_notes.append(
+                "Specialist decision did not stay aligned with approved_dispatch."
+            )
+        elif decision_approved_dispatch_skill_ids and decision_approved_dispatch_skill_ids != approved_dispatch_skill_ids:
+            specialist_decision_state = "failing"
+            specialist_decision_notes.append(
+                "Specialist decision approved dispatch skill ids did not match effective approved dispatch."
+            )
+        else:
+            specialist_decision_state = "passing"
+            specialist_decision_notes.append(
+                "Specialist decision stayed aligned with approved dispatch."
+            )
+    else:
+        if not specialist_decision_payload:
+            specialist_decision_state = "manual_review_required"
+            specialist_decision_notes.append(
+                "No bounded specialist recommendation path was frozen but no explicit specialist resolution was recorded."
+            )
+        elif decision_state == "no_specialist_recommendations":
+            if resolution_mode in {"", "pending_resolution"}:
+                specialist_decision_state = "manual_review_required"
+                specialist_decision_notes.append(
+                    "No specialist recommendation was frozen and the no-match resolution remained pending."
+                )
+            elif resolution_mode == "no_specialist_needed":
+                if repo_asset_used or repo_asset_paths or repo_asset_reason or repo_asset_legal_basis or repo_asset_traceability:
+                    specialist_decision_state = "failing"
+                    specialist_decision_notes.append(
+                        "Specialist decision claimed no_specialist_needed but also recorded repo-asset fallback details."
+                    )
+                else:
+                    specialist_decision_state = "passing"
+                    specialist_decision_notes.append(
+                        "Specialist decision explicitly recorded that no bounded specialist help was needed."
+                    )
+            elif resolution_mode == "repo_asset_fallback":
+                missing_fallback_fields: list[str] = []
+                if not repo_asset_used:
+                    missing_fallback_fields.append("used=true")
+                if not repo_asset_paths:
+                    missing_fallback_fields.append("asset_paths")
+                if not repo_asset_reason:
+                    missing_fallback_fields.append("reason")
+                if not repo_asset_legal_basis:
+                    missing_fallback_fields.append("legal_basis")
+                if not repo_asset_traceability:
+                    missing_fallback_fields.append("traceability_basis")
+                if missing_fallback_fields:
+                    specialist_decision_state = "failing"
+                    specialist_decision_notes.append(
+                        "Repo-asset fallback was declared but did not record all required fields: "
+                        + ", ".join(missing_fallback_fields)
+                        + "."
+                    )
+                else:
+                    specialist_decision_state = "degraded"
+                    specialist_decision_notes.append(
+                        "Repo-asset fallback stayed explicit and traceable when no dedicated specialist was available."
+                    )
+            else:
+                specialist_decision_state = "failing"
+                specialist_decision_notes.append(
+                    "Specialist decision recorded an unsupported no-match resolution mode."
+                )
+        elif decision_state == "local_suggestion_only":
+            specialist_decision_state = "manual_review_required"
+            specialist_decision_notes.append(
+                "Specialist decision remained advisory-only and still requires explicit escalation before closure."
+            )
+        elif decision_state in {"blocked", "degraded"}:
+            specialist_decision_state = "degraded"
+            specialist_decision_notes.append(
+                "Specialist decision stayed explicit, but the bounded specialist path remained non-green."
+            )
+        else:
+            specialist_decision_state = "failing"
+            specialist_decision_notes.append(
+                "Specialist decision artifact did not record a supported decision state."
+            )
 
     artifact_review_state = "passing"
     artifact_review_notes: list[str] = []
@@ -325,6 +519,20 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
             "evidence": [str(execution_manifest_path)],
             "notes": " ".join(engineering_truth_notes).strip(),
         },
+        "specialist_disclosure_truth": {
+            "state": _normalize_truth_state(specialist_disclosure_state),
+            "evidence": [
+                str(path)
+                for path in (runtime_input_packet_path, execute_receipt_path, execution_manifest_path)
+                if path.exists()
+            ],
+            "notes": " ".join(specialist_disclosure_notes).strip(),
+        },
+        "specialist_decision_truth": {
+            "state": _normalize_truth_state(specialist_decision_state),
+            "evidence": specialist_decision_evidence,
+            "notes": " ".join(specialist_decision_notes).strip(),
+        },
         "code_task_tdd_evidence_truth": {
             "state": _normalize_truth_state(code_task_tdd_evidence_state),
             "evidence": code_task_tdd_evidence_evidence,
@@ -347,11 +555,8 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
         },
     }
 
-    failing_layers = [
-        layer
-        for layer, info in truth_layers.items()
-        if info["state"] in {"failing", "degraded", "partial", "not_run"}
-    ]
+    failing_layers = [layer for layer, info in truth_layers.items() if info["state"] in {"failing", "partial", "not_run"}]
+    degraded_layers = [layer for layer, info in truth_layers.items() if info["state"] == "degraded"]
     manual_layers = [layer for layer, info in truth_layers.items() if info["state"] == "manual_review_required"]
     incomplete_layers = [layer for layer, info in truth_layers.items() if not _truth_success(contract, info["state"])]
 
@@ -360,6 +565,8 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
         gate_result = "FAIL"
     elif manual_layers:
         gate_result = "MANUAL_REVIEW_REQUIRED"
+    elif degraded_layers:
+        gate_result = "PASS_DEGRADED"
 
     readiness_state = _derive_readiness_state(gate_result, manual_spot_checks)
     forbidden_hits: list[dict[str, str]] = []
@@ -402,6 +609,16 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
         residual_risks.append("Cleanup degraded, so closure is not fully authoritative.")
     if execution_status == "completed_local_scope":
         residual_risks.append("This run is child-scoped and cannot justify root-level completion wording.")
+    if specialist_disclosure_state == "failing":
+        residual_risks.append("Specialist disclosure truth is internally inconsistent or missing.")
+    if specialist_disclosure_state == "degraded":
+        residual_risks.append("Specialist disclosure is traceable, but the specialist execution path remained degraded.")
+    if specialist_decision_state == "manual_review_required":
+        residual_risks.append("Specialist no-match resolution still requires explicit governance review.")
+    if specialist_decision_state == "failing":
+        residual_risks.append("Specialist decision truth is missing required fallback or dispatch detail.")
+    if specialist_decision_state == "degraded":
+        residual_risks.append("Specialist decision recorded a traceable but non-green specialist fallback path.")
 
     summary = {
         "gate_result": gate_result,
@@ -410,6 +627,7 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
         "readiness_state": readiness_state,
         "manual_review_layer_count": len(manual_layers),
         "failing_layer_count": len(failing_layers),
+        "degraded_layer_count": len(degraded_layers),
         "forbidden_completion_hit_count": len(forbidden_hits),
         "incomplete_layers": incomplete_layers,
         "manual_spot_check_count": len(manual_spot_checks),
@@ -488,6 +706,10 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
             "code_task_tdd_evidence_state": _normalize_truth_state(code_task_tdd_evidence_state),
             "artifact_review_source_path": artifact_review_source_path,
             "artifact_review_state": _normalize_truth_state(artifact_review_state),
+            "approved_dispatch_skill_ids": approved_dispatch_skill_ids,
+            "disclosed_specialist_skill_ids": disclosure_skill_ids,
+            "specialist_effective_execution_status": effective_specialist_execution_status,
+            "specialist_disclosure_state": _normalize_truth_state(specialist_disclosure_state),
         },
         "forbidden_completion_hits": forbidden_hits,
         "manual_spot_checks": manual_spot_checks,

--- a/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_support.py
+++ b/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_support.py
@@ -63,6 +63,29 @@ def _normalize_string_list(value: Any) -> list[str]:
     return [str(item).strip() for item in items if str(item).strip()]
 
 
+def _normalize_skill_id_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        items = value
+    elif value is None:
+        items = []
+    else:
+        items = [value]
+
+    skill_ids: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if isinstance(item, dict):
+            candidate = item.get("skill_id") or item.get("id") or item.get("name")
+        else:
+            candidate = item
+        skill_id = str(candidate or "").strip()
+        if not skill_id or skill_id in seen:
+            continue
+        seen.add(skill_id)
+        skill_ids.append(skill_id)
+    return skill_ids
+
+
 def _normalize_match_key(value: str) -> str:
     return " ".join(str(value).split()).strip().lower()
 
@@ -126,6 +149,17 @@ def _resolve_tdd_evidence_payload(session_root: Path, execute_receipt: dict[str,
     )
 
 
+def _resolve_specialist_decision_payload(session_root: Path, execute_receipt: dict[str, Any]) -> dict[str, Any]:
+    return _resolve_optional_payload(
+        session_root,
+        execute_receipt,
+        inline_key="specialist_decision",
+        explicit_path_key="specialist_decision_path",
+        sidecar_filename="specialist-decision.json",
+        inline_presence_keys=("decision_state", "resolution_mode", "notes"),
+    )
+
+
 def _resolve_optional_payload(
     session_root: Path,
     execute_receipt: dict[str, Any],
@@ -179,6 +213,8 @@ def _resolve_optional_payload(
 def _derive_readiness_state(gate_result: str, manual_spot_checks: list[str]) -> str:
     if gate_result == "PASS":
         return "fully_ready"
+    if gate_result == "PASS_DEGRADED":
+        return "degraded_but_traceable"
     if gate_result == "MANUAL_REVIEW_REQUIRED" or manual_spot_checks:
         return "manual_actions_pending"
     return "verification_failed"

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -1207,6 +1207,8 @@ $specialistDecision = New-VibeSpecialistDecisionProjection `
     -LocalSuggestions @($localSuggestions) `
     -BlockedDispatch @($blockedSpecialistUnits) `
     -DegradedDispatch @($degradedSpecialistUnits) `
+    -MatchedSkillIds $(if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch' -and $runtimeInputPacket.specialist_dispatch -and $runtimeInputPacket.specialist_dispatch.PSObject.Properties.Name -contains 'matched_skill_ids' -and $null -ne $runtimeInputPacket.specialist_dispatch.matched_skill_ids) { @($runtimeInputPacket.specialist_dispatch.matched_skill_ids) } else { @() }) `
+    -SurfacedSkillIds $(if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_dispatch' -and $runtimeInputPacket.specialist_dispatch -and $runtimeInputPacket.specialist_dispatch.PSObject.Properties.Name -contains 'surfaced_skill_ids' -and $null -ne $runtimeInputPacket.specialist_dispatch.surfaced_skill_ids) { @($runtimeInputPacket.specialist_dispatch.surfaced_skill_ids) } else { @() }) `
     -RecommendationCount @($specialistRecommendations).Count `
     -OverridePayload $(if ($specialistDecisionOverride) { $specialistDecisionOverride.payload } else { $null }) `
     -OverrideSourcePath $(if ($specialistDecisionOverride) { [string]$specialistDecisionOverride.path } else { '' })

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -1200,6 +1200,16 @@ $effectiveSpecialistExecutionStatus = if (@($liveSpecialistUnits).Count -gt 0 -a
     'none'
 }
 $specialistDispatchUnitCount = @($approvedDispatch).Count
+$specialistDecisionOverride = Get-VibeOptionalSpecialistDecisionOverride -SessionRoot $sessionRoot
+$specialistDecision = New-VibeSpecialistDecisionProjection `
+    -RuntimeInputPacket $runtimeInputPacket `
+    -ApprovedDispatch @($approvedDispatch) `
+    -LocalSuggestions @($localSuggestions) `
+    -BlockedDispatch @($blockedSpecialistUnits) `
+    -DegradedDispatch @($degradedSpecialistUnits) `
+    -RecommendationCount @($specialistRecommendations).Count `
+    -OverridePayload $(if ($specialistDecisionOverride) { $specialistDecisionOverride.payload } else { $null }) `
+    -OverrideSourcePath $(if ($specialistDecisionOverride) { [string]$specialistDecisionOverride.path } else { '' })
 $runtimePacketHostAdapterIdentity = Get-VibeRuntimePacketHostAdapterAlignment -RuntimeInputPacket $runtimeInputPacket
 $routeRuntimeAlignment = New-VibeRouteRuntimeAlignmentProjection -RuntimeInputPacket $runtimeInputPacket -DefaultRuntimeSkill 'vibe'
 $hierarchyProjection = New-VibeHierarchyProjection -HierarchyState $hierarchyState -IncludeGovernanceScope
@@ -1324,6 +1334,7 @@ $executionManifest = [pscustomobject]@{
         escalation_required = [bool]$escalationRequired
         escalation_request_path = $escalationPath
     }
+    specialist_decision = $specialistDecision
     specialist_user_disclosure = $specialistUserDisclosure
     dispatch_integrity = $dispatchIntegrity
     status = if ([string]$hierarchyState.governance_scope -eq 'child' -and $baseStatus -eq 'completed') { 'completed_local_scope' } else { $baseStatus }
@@ -1453,6 +1464,7 @@ $receipt = [pscustomobject]@{
     specialist_skills = @($specialistSkills)
     auto_approved_specialist_unit_count = @($autoApprovedDispatch).Count
     local_specialist_suggestion_count = @($localSuggestions).Count
+    specialist_decision = $specialistDecision
     specialist_user_disclosure = $specialistUserDisclosure
     dispatch_integrity_proof_passed = [bool]$dispatchIntegrity.proof_passed
     dispatch_integrity = $dispatchIntegrity

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -724,19 +724,25 @@ function New-VibeSpecialistDecisionProjection {
             if ($null -ne $_ -and (Test-VibeObjectHasProperty -InputObject $_ -PropertyName 'skill_id')) { [string]$_.skill_id } else { '' }
         } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
     }
-    $matchedSkillIds = if (@($MatchedSkillIds).Count -gt 0) {
-        @($MatchedSkillIds | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-    } elseif ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'matched_skill_ids')) {
-        @($dispatchSource.matched_skill_ids | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-    } else {
-        @()
+    $explicitMatchedSkillIds = @()
+    if ($null -ne $MatchedSkillIds) {
+        $explicitMatchedSkillIds = @($MatchedSkillIds | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
     }
-    $surfacedSkillIds = if (@($SurfacedSkillIds).Count -gt 0) {
-        @($SurfacedSkillIds | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $matchedSkillIds = @()
+    if (@($explicitMatchedSkillIds).Count -gt 0) {
+        $matchedSkillIds = @($explicitMatchedSkillIds)
+    } elseif ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'matched_skill_ids')) {
+        $matchedSkillIds = @($dispatchSource.matched_skill_ids | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    }
+    $explicitSurfacedSkillIds = @()
+    if ($null -ne $SurfacedSkillIds) {
+        $explicitSurfacedSkillIds = @($SurfacedSkillIds | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    }
+    $surfacedSkillIds = @()
+    if (@($explicitSurfacedSkillIds).Count -gt 0) {
+        $surfacedSkillIds = @($explicitSurfacedSkillIds)
     } elseif ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'surfaced_skill_ids')) {
-        @($dispatchSource.surfaced_skill_ids | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-    } else {
-        @()
+        $surfacedSkillIds = @($dispatchSource.surfaced_skill_ids | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
     }
     $recommendationCountResolved = if ($RecommendationCount -ge 0) {
         [int]$RecommendationCount
@@ -794,12 +800,20 @@ function New-VibeSpecialistDecisionProjection {
             } else {
                 @()
             }
+            $repoAssetFallbackTraceabilityBasis = if (
+                (Test-VibeObjectHasProperty -InputObject $repoAssetFallbackSource -PropertyName 'traceability_basis') -and
+                $null -ne $repoAssetFallbackSource.traceability_basis
+            ) {
+                @($repoAssetFallbackSource.traceability_basis | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+            } else {
+                @()
+            }
             $repoAssetFallback = [pscustomobject]@{
                 used = if (Test-VibeObjectHasProperty -InputObject $repoAssetFallbackSource -PropertyName 'used') { [bool]$repoAssetFallbackSource.used } else { @($repoAssetFallbackAssetPaths).Count -gt 0 }
                 asset_paths = @($repoAssetFallbackAssetPaths)
                 reason = if ((Test-VibeObjectHasProperty -InputObject $repoAssetFallbackSource -PropertyName 'reason') -and -not [string]::IsNullOrWhiteSpace([string]$repoAssetFallbackSource.reason)) { [string]$repoAssetFallbackSource.reason } else { '' }
                 legal_basis = if ((Test-VibeObjectHasProperty -InputObject $repoAssetFallbackSource -PropertyName 'legal_basis') -and -not [string]::IsNullOrWhiteSpace([string]$repoAssetFallbackSource.legal_basis)) { [string]$repoAssetFallbackSource.legal_basis } else { '' }
-                traceability_basis = @($repoAssetFallbackSource.traceability_basis | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+                traceability_basis = @($repoAssetFallbackTraceabilityBasis)
             }
         }
         if (-not $overrideProvidedNotes) {

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -622,6 +622,31 @@ function Get-VibeOptionalSpecialistDecisionOverride {
     }
 }
 
+function Get-VibeSpecialistDecisionDefaultNotes {
+    param(
+        [AllowEmptyString()] [string]$DecisionState = '',
+        [AllowEmptyString()] [string]$ResolutionMode = ''
+    )
+
+    switch ($ResolutionMode) {
+        'approved_dispatch' { return 'Bounded specialist recommendations were surfaced and auto-promoted into approved dispatch.' }
+        'degraded' { return 'Specialist recommendations existed, but execution remained explicitly degraded before live native dispatch closed cleanly.' }
+        'blocked' { return 'Specialist recommendations existed, but execution stayed blocked before live native dispatch could proceed.' }
+        'local_suggestion_only' { return 'Residual local specialist suggestions remained advisory and require explicit escalation before execution.' }
+        'no_specialist_needed' { return 'No bounded specialist recommendations were frozen for this run, and governed execution explicitly recorded that no specialist help was needed.' }
+        'repo_asset_fallback' { return 'No bounded specialist recommendations were frozen for this run, and governed execution explicitly recorded a repo-asset fallback that must remain traceable.' }
+        'pending_resolution' { return 'No bounded specialist recommendations were frozen for this run; execution must explicitly resolve whether no specialist was needed or a repo-asset fallback was used.' }
+    }
+
+    switch ($DecisionState) {
+        'approved_dispatch' { return 'Bounded specialist recommendations were surfaced and auto-promoted into approved dispatch.' }
+        'degraded' { return 'Specialist recommendations existed, but execution remained explicitly degraded before live native dispatch closed cleanly.' }
+        'blocked' { return 'Specialist recommendations existed, but execution stayed blocked before live native dispatch could proceed.' }
+        'local_suggestion_only' { return 'Residual local specialist suggestions remained advisory and require explicit escalation before execution.' }
+        default { return 'No bounded specialist recommendations were frozen for this run; execution must explicitly resolve whether no specialist was needed or a repo-asset fallback was used.' }
+    }
+}
+
 function New-VibeSpecialistDecisionProjection {
     param(
         [AllowNull()] [object]$RuntimeInputPacket = $null,
@@ -629,6 +654,8 @@ function New-VibeSpecialistDecisionProjection {
         [AllowEmptyCollection()] [AllowNull()] [object[]]$LocalSuggestions = @(),
         [AllowEmptyCollection()] [AllowNull()] [object[]]$BlockedDispatch = @(),
         [AllowEmptyCollection()] [AllowNull()] [object[]]$DegradedDispatch = @(),
+        [AllowEmptyCollection()] [AllowNull()] [string[]]$MatchedSkillIds = @(),
+        [AllowEmptyCollection()] [AllowNull()] [string[]]$SurfacedSkillIds = @(),
         [int]$RecommendationCount = -1,
         [AllowNull()] [object]$OverridePayload = $null,
         [AllowEmptyString()] [string]$OverrideSourcePath = ''
@@ -697,12 +724,16 @@ function New-VibeSpecialistDecisionProjection {
             if ($null -ne $_ -and (Test-VibeObjectHasProperty -InputObject $_ -PropertyName 'skill_id')) { [string]$_.skill_id } else { '' }
         } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
     }
-    $matchedSkillIds = if ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'matched_skill_ids')) {
+    $matchedSkillIds = if (@($MatchedSkillIds).Count -gt 0) {
+        @($MatchedSkillIds | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    } elseif ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'matched_skill_ids')) {
         @($dispatchSource.matched_skill_ids | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
     } else {
         @()
     }
-    $surfacedSkillIds = if ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'surfaced_skill_ids')) {
+    $surfacedSkillIds = if (@($SurfacedSkillIds).Count -gt 0) {
+        @($SurfacedSkillIds | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    } elseif ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'surfaced_skill_ids')) {
         @($dispatchSource.surfaced_skill_ids | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
     } else {
         @()
@@ -734,13 +765,7 @@ function New-VibeSpecialistDecisionProjection {
         'local_suggestion_only' { 'local_suggestion_only' }
         default { 'pending_resolution' }
     }
-    $resolutionNotes = switch ($decisionState) {
-        'approved_dispatch' { 'Bounded specialist recommendations were surfaced and auto-promoted into approved dispatch.' }
-        'degraded' { 'Specialist recommendations existed, but execution remained explicitly degraded before live native dispatch closed cleanly.' }
-        'blocked' { 'Specialist recommendations existed, but execution stayed blocked before live native dispatch could proceed.' }
-        'local_suggestion_only' { 'Residual local specialist suggestions remained advisory and require explicit escalation before execution.' }
-        default { 'No bounded specialist recommendations were frozen for this run; execution must explicitly resolve whether no specialist was needed or a repo-asset fallback was used.' }
-    }
+    $resolutionNotes = Get-VibeSpecialistDecisionDefaultNotes -DecisionState $decisionState -ResolutionMode $resolutionMode
 
     $repoAssetFallback = [pscustomobject]@{
         used = $false
@@ -751,6 +776,7 @@ function New-VibeSpecialistDecisionProjection {
     }
 
     if ($null -ne $OverridePayload) {
+        $overrideProvidedNotes = $false
         if ((Test-VibeObjectHasProperty -InputObject $OverridePayload -PropertyName 'decision_state') -and -not [string]::IsNullOrWhiteSpace([string]$OverridePayload.decision_state)) {
             $decisionState = [string]$OverridePayload.decision_state
         }
@@ -759,6 +785,7 @@ function New-VibeSpecialistDecisionProjection {
         }
         if ((Test-VibeObjectHasProperty -InputObject $OverridePayload -PropertyName 'notes') -and -not [string]::IsNullOrWhiteSpace([string]$OverridePayload.notes)) {
             $resolutionNotes = [string]$OverridePayload.notes
+            $overrideProvidedNotes = $true
         }
         if ((Test-VibeObjectHasProperty -InputObject $OverridePayload -PropertyName 'repo_asset_fallback') -and $null -ne $OverridePayload.repo_asset_fallback) {
             $repoAssetFallbackSource = $OverridePayload.repo_asset_fallback
@@ -774,6 +801,9 @@ function New-VibeSpecialistDecisionProjection {
                 legal_basis = if ((Test-VibeObjectHasProperty -InputObject $repoAssetFallbackSource -PropertyName 'legal_basis') -and -not [string]::IsNullOrWhiteSpace([string]$repoAssetFallbackSource.legal_basis)) { [string]$repoAssetFallbackSource.legal_basis } else { '' }
                 traceability_basis = @($repoAssetFallbackSource.traceability_basis | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
             }
+        }
+        if (-not $overrideProvidedNotes) {
+            $resolutionNotes = Get-VibeSpecialistDecisionDefaultNotes -DecisionState $decisionState -ResolutionMode $resolutionMode
         }
     }
 
@@ -845,6 +875,8 @@ function New-VibeRuntimeInputPacketProjection {
         -LocalSuggestions @($SpecialistDispatch.local_specialist_suggestions) `
         -BlockedDispatch $(if ($SpecialistDispatch.PSObject.Properties.Name -contains 'blocked' -and $null -ne $SpecialistDispatch.blocked) { @($SpecialistDispatch.blocked) } else { @() }) `
         -DegradedDispatch $(if ($SpecialistDispatch.PSObject.Properties.Name -contains 'degraded' -and $null -ne $SpecialistDispatch.degraded) { @($SpecialistDispatch.degraded) } else { @() }) `
+        -MatchedSkillIds $(if ($SpecialistDispatch.PSObject.Properties.Name -contains 'matched_skill_ids' -and $null -ne $SpecialistDispatch.matched_skill_ids) { @($SpecialistDispatch.matched_skill_ids) } else { @() }) `
+        -SurfacedSkillIds $(if ($SpecialistDispatch.PSObject.Properties.Name -contains 'surfaced_skill_ids' -and $null -ne $SpecialistDispatch.surfaced_skill_ids) { @($SpecialistDispatch.surfaced_skill_ids) } else { @() }) `
         -RecommendationCount @($SpecialistRecommendations).Count
 
     return [pscustomobject]@{

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -594,6 +594,206 @@ function New-VibeRuntimePacketAuthorityFlagsProjection {
     }
 }
 
+function Get-VibeSpecialistDecisionSidecarPath {
+    param(
+        [Parameter(Mandatory)] [string]$SessionRoot
+    )
+
+    return Join-Path $SessionRoot 'specialist-decision.json'
+}
+
+function Get-VibeOptionalSpecialistDecisionOverride {
+    param(
+        [AllowEmptyString()] [string]$SessionRoot
+    )
+
+    if ([string]::IsNullOrWhiteSpace($SessionRoot)) {
+        return $null
+    }
+
+    $path = Get-VibeSpecialistDecisionSidecarPath -SessionRoot $SessionRoot
+    if (-not (Test-Path -LiteralPath $path)) {
+        return $null
+    }
+
+    return [pscustomobject]@{
+        path = [string]$path
+        payload = (Get-Content -LiteralPath $path -Raw -Encoding UTF8 | ConvertFrom-Json)
+    }
+}
+
+function New-VibeSpecialistDecisionProjection {
+    param(
+        [AllowNull()] [object]$RuntimeInputPacket = $null,
+        [AllowEmptyCollection()] [AllowNull()] [object[]]$ApprovedDispatch = @(),
+        [AllowEmptyCollection()] [AllowNull()] [object[]]$LocalSuggestions = @(),
+        [AllowEmptyCollection()] [AllowNull()] [object[]]$BlockedDispatch = @(),
+        [AllowEmptyCollection()] [AllowNull()] [object[]]$DegradedDispatch = @(),
+        [int]$RecommendationCount = -1,
+        [AllowNull()] [object]$OverridePayload = $null,
+        [AllowEmptyString()] [string]$OverrideSourcePath = ''
+    )
+
+    $dispatchSource = if (
+        $null -ne $RuntimeInputPacket -and
+        (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket -PropertyName 'specialist_dispatch') -and
+        $null -ne $RuntimeInputPacket.specialist_dispatch
+    ) {
+        $RuntimeInputPacket.specialist_dispatch
+    } else {
+        $null
+    }
+
+    $approvedDispatchArray = if (@($ApprovedDispatch).Count -gt 0) {
+        @($ApprovedDispatch)
+    } elseif ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'approved_dispatch')) {
+        @($dispatchSource.approved_dispatch)
+    } else {
+        @()
+    }
+    $localSuggestionArray = if (@($LocalSuggestions).Count -gt 0) {
+        @($LocalSuggestions)
+    } elseif ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'local_specialist_suggestions')) {
+        @($dispatchSource.local_specialist_suggestions)
+    } else {
+        @()
+    }
+    $blockedDispatchArray = if (@($BlockedDispatch).Count -gt 0) {
+        @($BlockedDispatch)
+    } elseif ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'blocked')) {
+        @($dispatchSource.blocked)
+    } else {
+        @()
+    }
+    $degradedDispatchArray = if (@($DegradedDispatch).Count -gt 0) {
+        @($DegradedDispatch)
+    } elseif ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'degraded')) {
+        @($dispatchSource.degraded)
+    } else {
+        @()
+    }
+
+    $approvedDispatchSkillIds = @($approvedDispatchArray | ForEach-Object {
+        if ($null -ne $_ -and (Test-VibeObjectHasProperty -InputObject $_ -PropertyName 'skill_id')) { [string]$_.skill_id } else { '' }
+    } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $localSuggestionSkillIds = if ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'local_suggestion_skill_ids') -and @($dispatchSource.local_suggestion_skill_ids).Count -gt 0) {
+        @($dispatchSource.local_suggestion_skill_ids | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    } else {
+        @($localSuggestionArray | ForEach-Object {
+            if ($null -ne $_ -and (Test-VibeObjectHasProperty -InputObject $_ -PropertyName 'skill_id')) { [string]$_.skill_id } else { '' }
+        } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    }
+    $blockedSkillIds = if ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'blocked_skill_ids') -and @($dispatchSource.blocked_skill_ids).Count -gt 0) {
+        @($dispatchSource.blocked_skill_ids | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    } else {
+        @($blockedDispatchArray | ForEach-Object {
+            if ($null -ne $_ -and (Test-VibeObjectHasProperty -InputObject $_ -PropertyName 'skill_id')) { [string]$_.skill_id } else { '' }
+        } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    }
+    $degradedSkillIds = if ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'degraded_skill_ids') -and @($dispatchSource.degraded_skill_ids).Count -gt 0) {
+        @($dispatchSource.degraded_skill_ids | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    } else {
+        @($degradedDispatchArray | ForEach-Object {
+            if ($null -ne $_ -and (Test-VibeObjectHasProperty -InputObject $_ -PropertyName 'skill_id')) { [string]$_.skill_id } else { '' }
+        } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    }
+    $matchedSkillIds = if ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'matched_skill_ids')) {
+        @($dispatchSource.matched_skill_ids | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    } else {
+        @()
+    }
+    $surfacedSkillIds = if ($null -ne $dispatchSource -and (Test-VibeObjectHasProperty -InputObject $dispatchSource -PropertyName 'surfaced_skill_ids')) {
+        @($dispatchSource.surfaced_skill_ids | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    } else {
+        @()
+    }
+    $recommendationCountResolved = if ($RecommendationCount -ge 0) {
+        [int]$RecommendationCount
+    } elseif ($null -ne $RuntimeInputPacket -and (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket -PropertyName 'specialist_recommendations')) {
+        @($RuntimeInputPacket.specialist_recommendations).Count
+    } else {
+        @($surfacedSkillIds).Count
+    }
+
+    $decisionState = if (@($approvedDispatchSkillIds).Count -gt 0) {
+        'approved_dispatch'
+    } elseif (@($degradedSkillIds).Count -gt 0) {
+        'degraded'
+    } elseif (@($blockedSkillIds).Count -gt 0) {
+        'blocked'
+    } elseif (@($localSuggestionSkillIds).Count -gt 0) {
+        'local_suggestion_only'
+    } else {
+        'no_specialist_recommendations'
+    }
+
+    $resolutionMode = switch ($decisionState) {
+        'approved_dispatch' { 'approved_dispatch' }
+        'degraded' { 'degraded' }
+        'blocked' { 'blocked' }
+        'local_suggestion_only' { 'local_suggestion_only' }
+        default { 'pending_resolution' }
+    }
+    $resolutionNotes = switch ($decisionState) {
+        'approved_dispatch' { 'Bounded specialist recommendations were surfaced and auto-promoted into approved dispatch.' }
+        'degraded' { 'Specialist recommendations existed, but execution remained explicitly degraded before live native dispatch closed cleanly.' }
+        'blocked' { 'Specialist recommendations existed, but execution stayed blocked before live native dispatch could proceed.' }
+        'local_suggestion_only' { 'Residual local specialist suggestions remained advisory and require explicit escalation before execution.' }
+        default { 'No bounded specialist recommendations were frozen for this run; execution must explicitly resolve whether no specialist was needed or a repo-asset fallback was used.' }
+    }
+
+    $repoAssetFallback = [pscustomobject]@{
+        used = $false
+        asset_paths = @()
+        reason = ''
+        legal_basis = ''
+        traceability_basis = @()
+    }
+
+    if ($null -ne $OverridePayload) {
+        if ((Test-VibeObjectHasProperty -InputObject $OverridePayload -PropertyName 'decision_state') -and -not [string]::IsNullOrWhiteSpace([string]$OverridePayload.decision_state)) {
+            $decisionState = [string]$OverridePayload.decision_state
+        }
+        if ((Test-VibeObjectHasProperty -InputObject $OverridePayload -PropertyName 'resolution_mode') -and -not [string]::IsNullOrWhiteSpace([string]$OverridePayload.resolution_mode)) {
+            $resolutionMode = [string]$OverridePayload.resolution_mode
+        }
+        if ((Test-VibeObjectHasProperty -InputObject $OverridePayload -PropertyName 'notes') -and -not [string]::IsNullOrWhiteSpace([string]$OverridePayload.notes)) {
+            $resolutionNotes = [string]$OverridePayload.notes
+        }
+        if ((Test-VibeObjectHasProperty -InputObject $OverridePayload -PropertyName 'repo_asset_fallback') -and $null -ne $OverridePayload.repo_asset_fallback) {
+            $repoAssetFallbackSource = $OverridePayload.repo_asset_fallback
+            $repoAssetFallbackAssetPaths = if (Test-VibeObjectHasProperty -InputObject $repoAssetFallbackSource -PropertyName 'asset_paths') {
+                @($repoAssetFallbackSource.asset_paths | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+            } else {
+                @()
+            }
+            $repoAssetFallback = [pscustomobject]@{
+                used = if (Test-VibeObjectHasProperty -InputObject $repoAssetFallbackSource -PropertyName 'used') { [bool]$repoAssetFallbackSource.used } else { @($repoAssetFallbackAssetPaths).Count -gt 0 }
+                asset_paths = @($repoAssetFallbackAssetPaths)
+                reason = if ((Test-VibeObjectHasProperty -InputObject $repoAssetFallbackSource -PropertyName 'reason') -and -not [string]::IsNullOrWhiteSpace([string]$repoAssetFallbackSource.reason)) { [string]$repoAssetFallbackSource.reason } else { '' }
+                legal_basis = if ((Test-VibeObjectHasProperty -InputObject $repoAssetFallbackSource -PropertyName 'legal_basis') -and -not [string]::IsNullOrWhiteSpace([string]$repoAssetFallbackSource.legal_basis)) { [string]$repoAssetFallbackSource.legal_basis } else { '' }
+                traceability_basis = @($repoAssetFallbackSource.traceability_basis | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        decision_state = $decisionState
+        resolution_mode = $resolutionMode
+        recommendation_count = [int]$recommendationCountResolved
+        matched_skill_ids = @($matchedSkillIds)
+        surfaced_skill_ids = @($surfacedSkillIds)
+        approved_dispatch_skill_ids = @($approvedDispatchSkillIds)
+        local_suggestion_skill_ids = @($localSuggestionSkillIds)
+        blocked_skill_ids = @($blockedSkillIds)
+        degraded_skill_ids = @($degradedSkillIds)
+        repo_asset_fallback = $repoAssetFallback
+        notes = $resolutionNotes
+        source = if ([string]::IsNullOrWhiteSpace($OverrideSourcePath)) { 'runtime_structural_projection' } else { 'runtime_structural_projection_plus_sidecar' }
+        override_source_path = if ([string]::IsNullOrWhiteSpace($OverrideSourcePath)) { $null } else { [string]$OverrideSourcePath }
+    }
+}
+
 function New-VibeRuntimeInputPacketProjection {
     param(
         [Parameter(Mandatory)] [string]$RunId,
@@ -639,6 +839,13 @@ function New-VibeRuntimeInputPacketProjection {
     } else {
         $null
     }
+
+    $packetSpecialistDecision = New-VibeSpecialistDecisionProjection `
+        -ApprovedDispatch @($SpecialistDispatch.approved_dispatch) `
+        -LocalSuggestions @($SpecialistDispatch.local_specialist_suggestions) `
+        -BlockedDispatch $(if ($SpecialistDispatch.PSObject.Properties.Name -contains 'blocked' -and $null -ne $SpecialistDispatch.blocked) { @($SpecialistDispatch.blocked) } else { @() }) `
+        -DegradedDispatch $(if ($SpecialistDispatch.PSObject.Properties.Name -contains 'degraded' -and $null -ne $SpecialistDispatch.degraded) { @($SpecialistDispatch.degraded) } else { @() }) `
+        -RecommendationCount @($SpecialistRecommendations).Count
 
     return [pscustomobject]@{
         stage = 'runtime_input_freeze'
@@ -694,6 +901,7 @@ function New-VibeRuntimeInputPacketProjection {
             approval_owner = if ($Policy.child_specialist_suggestion_contract.PSObject.Properties.Name -contains 'approval_owner') { [string]$Policy.child_specialist_suggestion_contract.approval_owner } else { 'root_vibe' }
             status = if ($Policy.child_specialist_suggestion_contract.PSObject.Properties.Name -contains 'status') { [string]$Policy.child_specialist_suggestion_contract.status } else { 'auto_promote_when_safe_same_round' }
         }
+        specialist_decision = $packetSpecialistDecision
         overlay_decisions = @($OverlayDecisions)
         authority_flags = $AuthorityFlagsProjection
         storage = $StorageProjection
@@ -1898,6 +2106,7 @@ function New-VibeRuntimeSummaryProjection {
         [AllowNull()] [object]$StorageProjection = $null,
         [AllowNull()] [object]$MemoryActivationReport,
         [AllowNull()] [object]$DeliveryAcceptanceReport,
+        [AllowNull()] [object]$SpecialistDecision = $null,
         [AllowNull()] [object]$SpecialistUserDisclosure = $null,
         [AllowNull()] [object]$SpecialistConsultation = $null,
         [AllowNull()] [object]$SpecialistLifecycleDisclosure = $null,
@@ -1920,6 +2129,7 @@ function New-VibeRuntimeSummaryProjection {
         storage = $StorageProjection
         memory_activation = New-VibeRuntimeSummaryMemoryActivationProjection -MemoryActivationReport $MemoryActivationReport
         delivery_acceptance = New-VibeRuntimeSummaryDeliveryAcceptanceProjection -DeliveryAcceptanceReport $DeliveryAcceptanceReport
+        specialist_decision = $SpecialistDecision
         specialist_user_disclosure = $SpecialistUserDisclosure
         specialist_consultation = $SpecialistConsultation
         specialist_lifecycle_disclosure = $SpecialistLifecycleDisclosure

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -453,7 +453,7 @@ if ($runtimeInputPacket) {
                 ('- Repo-asset fallback traceability basis: {0}' -f [string]::Join(', ', @($specialistDecision.repo_asset_fallback.traceability_basis)))
             )
         } elseif ([string]$specialistDecision.resolution_mode -eq 'pending_resolution') {
-            $lines += '- If execution later relies on repo-local assets instead of a dedicated specialist skill, phase execute must record `specialist-decision.json` with the asset paths, fallback reason, and traceability basis before closure.'
+            $lines += '- If execution later relies on repo-local assets instead of a dedicated specialist skill, phase execute must record `specialist-decision.json` with the asset paths, fallback reason, legal basis, and traceability basis before closure.'
         }
     }
 

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -427,6 +427,36 @@ if ($runtimeInputPacket) {
         "- Confirm required: $([bool]$runtimeInputPacket.route_snapshot.confirm_required)"
     )
 
+    $specialistDecision = if (
+        $runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_decision' -and
+        $null -ne $runtimeInputPacket.specialist_decision
+    ) {
+        $runtimeInputPacket.specialist_decision
+    } else {
+        $null
+    }
+    if ($specialistDecision) {
+        $lines += @(
+            '',
+            '## Specialist Decision',
+            '- Governed `vibe` must explicitly record whether specialist execution is happening, stayed advisory, or remained unresolved before closeout.',
+            ('- Decision state: {0}' -f [string]$specialistDecision.decision_state),
+            ('- Resolution mode: {0}' -f [string]$specialistDecision.resolution_mode),
+            ('- Notes: {0}' -f [string]$specialistDecision.notes)
+        )
+        if ([string]$specialistDecision.resolution_mode -eq 'repo_asset_fallback') {
+            $lines += @(
+                ('- Repo-asset fallback used: {0}' -f [bool]$specialistDecision.repo_asset_fallback.used),
+                ('- Repo-asset fallback assets: {0}' -f [string]::Join(', ', @($specialistDecision.repo_asset_fallback.asset_paths))),
+                ('- Repo-asset fallback reason: {0}' -f [string]$specialistDecision.repo_asset_fallback.reason),
+                ('- Repo-asset fallback legal basis: {0}' -f [string]$specialistDecision.repo_asset_fallback.legal_basis),
+                ('- Repo-asset fallback traceability basis: {0}' -f [string]::Join(', ', @($specialistDecision.repo_asset_fallback.traceability_basis)))
+            )
+        } elseif ([string]$specialistDecision.resolution_mode -eq 'pending_resolution') {
+            $lines += '- If execution later relies on repo-local assets instead of a dedicated specialist skill, phase execute must record `specialist-decision.json` with the asset paths, fallback reason, and traceability basis before closure.'
+        }
+    }
+
     $specialistRecommendations = @($runtimeInputPacket.specialist_recommendations)
     if ($specialistRecommendations.Count -gt 0) {
         $lines += @(

--- a/scripts/runtime/Write-XlPlan.ps1
+++ b/scripts/runtime/Write-XlPlan.ps1
@@ -74,6 +74,15 @@ $runtimeInputPacket = if (-not [string]::IsNullOrWhiteSpace($RuntimeInputPacketP
 } else {
     $null
 }
+$specialistDecision = if (
+    $runtimeInputPacket -and
+    $runtimeInputPacket.PSObject.Properties.Name -contains 'specialist_decision' -and
+    $null -ne $runtimeInputPacket.specialist_decision
+) {
+    $runtimeInputPacket.specialist_decision
+} else {
+    $null
+}
 $planMemoryContext = if (-not [string]::IsNullOrWhiteSpace($PlanMemoryContextPath) -and (Test-Path -LiteralPath $PlanMemoryContextPath)) {
     Get-Content -LiteralPath $PlanMemoryContextPath -Raw -Encoding UTF8 | ConvertFrom-Json
 } else {
@@ -245,6 +254,21 @@ foreach ($topologyWave in @($executionTopology.waves)) {
     $lines += ('- Wave `{0}` has {1} executable step(s).' -f [string]$topologyWave.wave_id, @($topologyWave.steps).Count)
     foreach ($step in @($topologyWave.steps)) {
         $lines += ('  Step `{0}` -> mode `{1}`, units `{2}`.' -f [string]$step.step_id, [string]$step.execution_mode, @($step.units).Count)
+    }
+}
+if ($specialistDecision) {
+    $lines += @(
+        '',
+        '## Specialist Decision Plan',
+        '- The governed runtime must keep one explicit specialist decision surface from freeze through delivery acceptance.',
+        ('- Frozen decision state: {0}' -f [string]$specialistDecision.decision_state),
+        ('- Frozen resolution mode: {0}' -f [string]$specialistDecision.resolution_mode),
+        ('- Frozen decision notes: {0}' -f [string]$specialistDecision.notes)
+    )
+    if ([string]$specialistDecision.resolution_mode -eq 'pending_resolution') {
+        $lines += '- If no dedicated specialist is available but execution relies on repo-local assets instead, write `specialist-decision.json` in the session root with asset paths, fallback reason, legal basis, and traceability basis before closeout.'
+    } elseif ([string]$specialistDecision.resolution_mode -eq 'repo_asset_fallback') {
+        $lines += ('- Repo-asset fallback assets: {0}' -f [string]::Join(', ', @($specialistDecision.repo_asset_fallback.asset_paths)))
     }
 }
 if (@($approvedDispatch).Count -gt 0 -or @($localSuggestions).Count -gt 0) {

--- a/scripts/runtime/invoke-vibe-runtime.ps1
+++ b/scripts/runtime/invoke-vibe-runtime.ps1
@@ -474,7 +474,7 @@ $summary = New-VibeRuntimeSummaryProjection `
     -StorageProjection $storageProjection `
     -MemoryActivationReport $memoryActivation.report `
     -DeliveryAcceptanceReport $deliveryAcceptanceReport `
-    -SpecialistDecision $(if ($executionManifestDocument -and $executionManifestDocument.PSObject.Properties.Name -contains 'specialist_decision') { $executionManifestDocument.specialist_decision } elseif ($execute -and $execute.receipt -and $execute.receipt.PSObject.Properties.Name -contains 'specialist_decision') { $execute.receipt.specialist_decision } else { $null }) `
+    -SpecialistDecision $(if ($executionManifestDocument -and $executionManifestDocument.PSObject.Properties.Name -contains 'specialist_decision' -and $null -ne $executionManifestDocument.specialist_decision) { $executionManifestDocument.specialist_decision } elseif ($execute -and $execute.receipt -and $execute.receipt.PSObject.Properties.Name -contains 'specialist_decision' -and $null -ne $execute.receipt.specialist_decision) { $execute.receipt.specialist_decision } else { $null }) `
     -SpecialistUserDisclosure $(if ($execute -and $execute.receipt -and $execute.receipt.PSObject.Properties.Name -contains 'specialist_user_disclosure') { $execute.receipt.specialist_user_disclosure } else { $null }) `
     -SpecialistConsultation (New-VibeSpecialistConsultationRuntimeProjection -Receipts @($discussionConsultation.receipt, $planningConsultation.receipt)) `
     -SpecialistLifecycleDisclosure $specialistLifecycleDisclosure `

--- a/scripts/runtime/invoke-vibe-runtime.ps1
+++ b/scripts/runtime/invoke-vibe-runtime.ps1
@@ -474,6 +474,7 @@ $summary = New-VibeRuntimeSummaryProjection `
     -StorageProjection $storageProjection `
     -MemoryActivationReport $memoryActivation.report `
     -DeliveryAcceptanceReport $deliveryAcceptanceReport `
+    -SpecialistDecision $(if ($executionManifestDocument -and $executionManifestDocument.PSObject.Properties.Name -contains 'specialist_decision') { $executionManifestDocument.specialist_decision } elseif ($execute -and $execute.receipt -and $execute.receipt.PSObject.Properties.Name -contains 'specialist_decision') { $execute.receipt.specialist_decision } else { $null }) `
     -SpecialistUserDisclosure $(if ($execute -and $execute.receipt -and $execute.receipt.PSObject.Properties.Name -contains 'specialist_user_disclosure') { $execute.receipt.specialist_user_disclosure } else { $null }) `
     -SpecialistConsultation (New-VibeSpecialistConsultationRuntimeProjection -Receipts @($discussionConsultation.receipt, $planningConsultation.receipt)) `
     -SpecialistLifecycleDisclosure $specialistLifecycleDisclosure `

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -364,6 +364,11 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertEqual("approved_dispatch", specialist_decision["decision_state"])
             self.assertEqual("approved_dispatch", specialist_decision["resolution_mode"])
             self.assertEqual(
+                runtime_input_packet["specialist_dispatch"]["surfaced_skill_ids"],
+                specialist_decision["surfaced_skill_ids"],
+            )
+            self.assertIn("systematic-debugging", specialist_decision["surfaced_skill_ids"])
+            self.assertEqual(
                 specialist_decision["approved_dispatch_skill_ids"],
                 execute_receipt["specialist_decision"]["approved_dispatch_skill_ids"],
             )

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -274,6 +274,7 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
                 self.assertIn("## Acceptance Criteria", requirement_doc)
                 self.assertIn("## Assumptions", requirement_doc)
                 self.assertIn("## Runtime Input Truth", requirement_doc)
+                self.assertIn("## Specialist Decision", requirement_doc)
                 self.assertIn("## Specialist Recommendations", requirement_doc)
                 self.assertIn("## Artifact Review Requirements", requirement_doc)
                 self.assertIn("## Code Task TDD Evidence Requirements", requirement_doc)
@@ -290,6 +291,7 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertEqual("requirements", requirement_doc_path.parent.name)
             self.assertEqual("plans", execution_plan_path.parent.name)
             execution_plan = execution_plan_path.read_text(encoding="utf-8")
+            self.assertIn("## Specialist Decision Plan", execution_plan)
             self.assertIn("## Specialist Consultation", execution_plan)
             self.assertIn("## Unified Specialist Lifecycle Disclosure", execution_plan)
             self.assertIn("## Code Task TDD Evidence Plan", execution_plan)
@@ -314,6 +316,7 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertEqual("vibe", runtime_input_packet["route_snapshot"]["selected_skill"])
             self.assertFalse(runtime_input_packet["divergence_shadow"]["skill_mismatch"])
             self.assertGreaterEqual(len(runtime_input_packet["specialist_recommendations"]), 1)
+            self.assertIn("specialist_decision", runtime_input_packet)
             self.assertIn(
                 "systematic-debugging",
                 [item["skill_id"] for item in runtime_input_packet["specialist_recommendations"]],
@@ -325,6 +328,7 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertGreaterEqual(execute_receipt["specialist_recommendation_count"], 1)
             self.assertGreaterEqual(execute_receipt["specialist_dispatch_unit_count"], 1)
             self.assertIn("systematic-debugging", execute_receipt["specialist_skills"])
+            self.assertIn("specialist_decision", execute_receipt)
             self.assertEqual(execute_receipt["executed_unit_count"], execution_manifest["executed_unit_count"])
             self.assertEqual("completed", execution_manifest["status"])
             self.assertGreaterEqual(execution_manifest["successful_unit_count"], 2)
@@ -338,6 +342,8 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertGreaterEqual(execution_manifest["specialist_accounting"]["dispatch_unit_count"], 1)
             self.assertIn("systematic-debugging", execution_manifest["specialist_accounting"]["specialist_skills"])
             self.assertGreaterEqual(execution_manifest["plan_shadow"]["specialist_dispatch_unit_count"], 1)
+            self.assertIn("specialist_decision", execution_manifest)
+            self.assertIn("specialist_decision", summary)
 
             specialist_disclosure = execution_manifest["specialist_user_disclosure"]
             self.assertEqual("approved_dispatch_only", specialist_disclosure["scope"])
@@ -354,6 +360,14 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertIn(routed_entry["native_skill_entrypoint"], specialist_disclosure["rendered_text"])
             self.assertEqual(specialist_disclosure, execute_receipt["specialist_user_disclosure"])
             self.assertEqual(specialist_disclosure, summary["specialist_user_disclosure"])
+            specialist_decision = execution_manifest["specialist_decision"]
+            self.assertEqual("approved_dispatch", specialist_decision["decision_state"])
+            self.assertEqual("approved_dispatch", specialist_decision["resolution_mode"])
+            self.assertEqual(
+                specialist_decision["approved_dispatch_skill_ids"],
+                execute_receipt["specialist_decision"]["approved_dispatch_skill_ids"],
+            )
+            self.assertEqual(specialist_decision, summary["specialist_decision"])
 
             consultation_summary = summary["specialist_consultation"]
             self.assertTrue(bool(consultation_summary["enabled"]))

--- a/tests/runtime_neutral/test_governed_templates.py
+++ b/tests/runtime_neutral/test_governed_templates.py
@@ -66,3 +66,18 @@ class GovernedTemplateTests(unittest.TestCase):
 
         self.assertIn("artifact_review_coverage", must_report_fields)
         self.assertIn("tdd_evidence_coverage", must_report_fields)
+
+    def test_project_delivery_contract_id_suffix_tracks_declared_version(self) -> None:
+        contract = json.loads(
+            (REPO_ROOT / "config" / "project-delivery-acceptance-contract.json").read_text(encoding="utf-8")
+        )
+
+        version = int(contract.get("version") or 0)
+        self.assertTrue(str(contract.get("contract_id") or "").endswith(f"-v{version}"))
+
+    def test_frozen_specialist_decision_requirement_doc_defines_specialist_decision_section(self) -> None:
+        headings = _load_section_headings(
+            REPO_ROOT / "docs" / "requirements" / "2026-04-15-vibe-specialist-decision-fallback.md"
+        )
+
+        self.assertIn("Specialist Decision", headings)

--- a/tests/runtime_neutral/test_memory_progressive_disclosure.py
+++ b/tests/runtime_neutral/test_memory_progressive_disclosure.py
@@ -84,6 +84,7 @@ def run_write_requirement_doc(
     artifact_root: Path,
     *,
     memory_context_path: Path | None = None,
+    runtime_input_packet_path: Path | None = None,
 ) -> dict[str, object]:
     shell = resolve_powershell()
     if shell is None:
@@ -101,6 +102,8 @@ def run_write_requirement_doc(
     )
     if memory_context_path is not None:
         ps_command += f"-MemoryContextPath {_ps_single_quote(str(memory_context_path))} "
+    if runtime_input_packet_path is not None:
+        ps_command += f"-RuntimeInputPacketPath {_ps_single_quote(str(runtime_input_packet_path))} "
     ps_command += "$result | ConvertTo-Json -Depth 20 }"
 
     completed = subprocess.run(
@@ -529,6 +532,55 @@ class MemoryProgressiveDisclosureTests(unittest.TestCase):
 
             self.assertEqual(0, requirement["receipt"]["memory_capsule_count"])
             self.assertEqual(0, plan["receipt"]["plan_memory_capsule_count"])
+
+    def test_write_requirement_doc_pending_specialist_resolution_mentions_legal_basis(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_root = Path(tempdir)
+            runtime_input_packet_path = temp_root / "runtime-input-packet.json"
+            runtime_input_packet_path.write_text(
+                json.dumps(
+                    {
+                        "governance_scope": "root",
+                        "hierarchy": {"root_run_id": "pytest-root-run"},
+                        "route_snapshot": {
+                            "selected_pack": "vibe",
+                            "selected_skill": "vibe",
+                            "route_mode": "governed",
+                            "route_reason": "pytest specialist decision requirement coverage",
+                            "confirm_required": False,
+                        },
+                        "authority_flags": {
+                            "explicit_runtime_skill": "vibe",
+                        },
+                        "specialist_recommendations": [],
+                        "specialist_decision": {
+                            "decision_state": "no_specialist_recommendations",
+                            "resolution_mode": "pending_resolution",
+                            "notes": "Waiting for explicit no-match resolution before closeout.",
+                            "repo_asset_fallback": {
+                                "used": False,
+                                "asset_paths": [],
+                                "reason": "",
+                                "legal_basis": "",
+                                "traceability_basis": [],
+                            },
+                        }
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ) + "\n",
+                encoding="utf-8",
+            )
+
+            requirement = run_write_requirement_doc(
+                "Plan a governed fallback path when no dedicated plotting specialist exists.",
+                temp_root / "requirement-specialist-decision-artifacts",
+                runtime_input_packet_path=runtime_input_packet_path,
+            )
+
+            requirement_text = Path(requirement["requirement_doc_path"]).read_text(encoding="utf-8")
+            self.assertIn("specialist-decision.json", requirement_text)
+            self.assertIn("legal basis", requirement_text)
 
 
 if __name__ == "__main__":

--- a/tests/runtime_neutral/test_runtime_delivery_acceptance.py
+++ b/tests/runtime_neutral/test_runtime_delivery_acceptance.py
@@ -414,6 +414,60 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
             report["truth_results"]["specialist_disclosure_truth"]["notes"],
         )
 
+    def test_runtime_delivery_acceptance_treats_approved_dispatch_matching_as_order_independent(self) -> None:
+        approved_dispatch = [
+            {
+                "skill_id": "skill-b",
+                "native_skill_entrypoint": "/tmp/skill-b/SKILL.md",
+            },
+            {
+                "skill_id": "skill-a",
+                "native_skill_entrypoint": "/tmp/skill-a/SKILL.md",
+            },
+        ]
+        session_root = self._build_session(
+            approved_dispatch=approved_dispatch,
+            phase_execute_specialist_user_disclosure={
+                "scope": "approved_dispatch_only",
+                "timing": "before_execution",
+                "path_source": "native_skill_entrypoint",
+                "routed_skills": [
+                    {
+                        "skill_id": "skill-a",
+                        "native_skill_entrypoint": "/tmp/skill-a/SKILL.md",
+                        "entrypoint_requirement_satisfied": True,
+                    },
+                    {
+                        "skill_id": "skill-b",
+                        "native_skill_entrypoint": "/tmp/skill-b/SKILL.md",
+                        "entrypoint_requirement_satisfied": True,
+                    },
+                ],
+            },
+            specialist_accounting={
+                "approved_dispatch": approved_dispatch,
+                "approved_dispatch_count": 2,
+                "effective_execution_status": "live_native_executed",
+            },
+            phase_execute_specialist_decision={
+                "decision_state": "approved_dispatch",
+                "resolution_mode": "approved_dispatch",
+                "approved_dispatch_skill_ids": ["skill-a", "skill-b"],
+                "repo_asset_fallback": {
+                    "used": False,
+                    "asset_paths": [],
+                    "reason": "",
+                    "legal_basis": "",
+                    "traceability_basis": [],
+                },
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("PASS", report["summary"]["gate_result"])
+        self.assertEqual("passing", report["truth_results"]["specialist_disclosure_truth"]["state"])
+        self.assertEqual("passing", report["truth_results"]["specialist_decision_truth"]["state"])
+
     def test_runtime_delivery_acceptance_reports_pass_degraded_for_aligned_degraded_specialist_execution(self) -> None:
         approved_dispatch = [
             {
@@ -1080,6 +1134,44 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
         self.assertEqual("manual_review_required", report["truth_results"]["code_task_tdd_evidence_truth"]["state"])
         self.assertEqual("", report["execution_context"]["artifact_review_source_path"])
         self.assertEqual("", report["execution_context"]["tdd_evidence_source_path"])
+
+    def test_runtime_delivery_acceptance_rejects_explicit_specialist_decision_paths_outside_session_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            outside_root = Path(tempdir)
+            specialist_decision_payload_path = outside_root / "outside-specialist-decision.json"
+            write_json(
+                specialist_decision_payload_path,
+                {
+                    "decision_state": "no_specialist_recommendations",
+                    "resolution_mode": "repo_asset_fallback",
+                    "repo_asset_fallback": {
+                        "used": True,
+                        "asset_paths": [
+                            "outputs/agent-runs/2026-04-14-scheme-a-clean397-paper-report/scripts/plot_style.py"
+                        ],
+                        "reason": "Reuse the repo plotting asset.",
+                        "legal_basis": "Repo-local plotting asset already present inside governed workspace outputs.",
+                        "traceability_basis": [
+                            "outputs/agent-runs/2026-04-14-scheme-a-clean397-paper-report/scripts/plot_style.py"
+                        ],
+                    },
+                },
+            )
+            session_root = self._build_session(
+                specialist_decision_path=str(specialist_decision_payload_path),
+                omit_default_specialist_decision=True,
+            )
+            self.assertTrue(specialist_decision_payload_path.exists())
+
+            report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertEqual("manual_review_required", report["truth_results"]["specialist_decision_truth"]["state"])
+        self.assertEqual("", report["execution_context"]["specialist_decision_source_path"])
+        self.assertNotIn(
+            str(specialist_decision_payload_path),
+            report["truth_results"]["specialist_decision_truth"]["evidence"],
+        )
 
     def test_runtime_delivery_acceptance_report_surfaces_frozen_sections_and_coverage(self) -> None:
         session_root = self._build_session(

--- a/tests/runtime_neutral/test_runtime_delivery_acceptance.py
+++ b/tests/runtime_neutral/test_runtime_delivery_acceptance.py
@@ -51,6 +51,13 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
         governance_scope: str = "root",
         completion_claim_allowed: bool = True,
         cleanup_mode: str = "bounded_cleanup_executed",
+        approved_dispatch: list[dict[str, object]] | None = None,
+        phase_execute_specialist_user_disclosure: dict[str, object] | None = None,
+        specialist_accounting: dict[str, object] | None = None,
+        phase_execute_specialist_decision: dict[str, object] | None = None,
+        sidecar_specialist_decision: dict[str, object] | None = None,
+        specialist_decision_path: str | None = None,
+        omit_default_specialist_decision: bool = False,
     ) -> Path:
         tempdir = tempfile.TemporaryDirectory()
         self.addCleanup(tempdir.cleanup)
@@ -142,24 +149,57 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
             "# Pytest Plan\n\n## Delivery Acceptance Plan\n- Emit the runtime delivery report.\n",
         )
 
-        write_json(
-            execution_manifest_path,
-            {
-                "status": execution_status,
-                "governance_scope": governance_scope,
-                "executed_unit_count": 3,
-                "failed_unit_count": failed_unit_count,
-                "timed_out_unit_count": 0,
-            },
-        )
-        write_json(
-            runtime_input_packet_path,
-            {
-                "authority_flags": {
-                    "explicit_runtime_skill": "vibe",
-                }
-            },
-        )
+        execution_manifest_payload = {
+            "status": execution_status,
+            "governance_scope": governance_scope,
+            "executed_unit_count": 3,
+            "failed_unit_count": failed_unit_count,
+            "timed_out_unit_count": 0,
+        }
+        approved_dispatch_payload = list(approved_dispatch or [])
+        if approved_dispatch is not None or specialist_accounting is not None:
+            default_specialist_accounting = {
+                "approved_dispatch": approved_dispatch_payload,
+                "approved_dispatch_count": len(approved_dispatch_payload),
+                "degraded_skill_ids": [],
+                "blocked_skill_ids": [],
+                "effective_execution_status": "live_native_executed" if approved_dispatch_payload else "none",
+            }
+            if specialist_accounting:
+                default_specialist_accounting.update(specialist_accounting)
+            execution_manifest_payload["specialist_accounting"] = default_specialist_accounting
+        write_json(execution_manifest_path, execution_manifest_payload)
+
+        runtime_input_packet_payload = {
+            "authority_flags": {
+                "explicit_runtime_skill": "vibe",
+            }
+        }
+        if approved_dispatch is not None:
+            approved_skill_ids = [
+                str(item["skill_id"]).strip()
+                for item in approved_dispatch_payload
+                if str(item.get("skill_id", "")).strip()
+            ]
+            runtime_input_packet_payload["specialist_dispatch"] = {
+                "approved_dispatch": approved_dispatch_payload,
+                "local_specialist_suggestions": [],
+                "blocked": [],
+                "degraded": [],
+                "approved_skill_ids": approved_skill_ids,
+                "local_suggestion_skill_ids": [],
+                "matched_skill_ids": approved_skill_ids,
+                "surfaced_skill_ids": approved_skill_ids,
+                "blocked_skill_ids": [],
+                "degraded_skill_ids": [],
+                "ghost_match_skill_ids": [],
+                "promotion_outcomes": [],
+                "escalation_required": False,
+                "escalation_status": "not_required",
+                "approval_owner": "root_vibe",
+                "status": "auto_promote_when_safe_same_round",
+            }
+        write_json(runtime_input_packet_path, runtime_input_packet_payload)
         phase_execute_payload = {
             "requirement_doc_path": str(requirement_doc_path),
             "execution_plan_path": str(execution_plan_path),
@@ -169,10 +209,42 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
             "artifact_review": phase_execute_artifact_review or {},
             "tdd_evidence": phase_execute_tdd_evidence or {},
         }
+        if phase_execute_specialist_user_disclosure is not None:
+            phase_execute_payload["specialist_user_disclosure"] = phase_execute_specialist_user_disclosure
+        if phase_execute_specialist_decision is not None:
+            phase_execute_payload["specialist_decision"] = phase_execute_specialist_decision
+        elif not omit_default_specialist_decision and sidecar_specialist_decision is None and not specialist_decision_path:
+            if approved_dispatch_payload:
+                phase_execute_payload["specialist_decision"] = {
+                    "decision_state": "approved_dispatch",
+                    "resolution_mode": "approved_dispatch",
+                    "approved_dispatch_skill_ids": approved_skill_ids,
+                    "repo_asset_fallback": {
+                        "used": False,
+                        "asset_paths": [],
+                        "reason": "",
+                        "legal_basis": "",
+                        "traceability_basis": [],
+                    },
+                }
+            else:
+                phase_execute_payload["specialist_decision"] = {
+                    "decision_state": "no_specialist_recommendations",
+                    "resolution_mode": "no_specialist_needed",
+                    "repo_asset_fallback": {
+                        "used": False,
+                        "asset_paths": [],
+                        "reason": "",
+                        "legal_basis": "",
+                        "traceability_basis": [],
+                    },
+                }
         if artifact_review_path:
             phase_execute_payload["artifact_review_path"] = artifact_review_path
         if tdd_evidence_path:
             phase_execute_payload["tdd_evidence_path"] = tdd_evidence_path
+        if specialist_decision_path:
+            phase_execute_payload["specialist_decision_path"] = specialist_decision_path
         write_json(
             session_root / "phase-execute.json",
             phase_execute_payload,
@@ -187,16 +259,196 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
             write_json(session_root / "artifact-review.json", sidecar_artifact_review)
         if sidecar_tdd_evidence is not None:
             write_json(session_root / "tdd-evidence.json", sidecar_tdd_evidence)
+        if sidecar_specialist_decision is not None:
+            write_json(session_root / "specialist-decision.json", sidecar_specialist_decision)
         return session_root
 
     def test_runtime_delivery_acceptance_passes_for_clean_root_run(self) -> None:
-        session_root = self._build_session()
+        session_root = self._build_session(
+            phase_execute_specialist_decision={
+                "decision_state": "no_specialist_recommendations",
+                "resolution_mode": "no_specialist_needed",
+                "repo_asset_fallback": {
+                    "used": False,
+                    "asset_paths": [],
+                    "reason": "",
+                    "legal_basis": "",
+                    "traceability_basis": [],
+                },
+            }
+        )
         report = evaluate(REPO_ROOT, session_root)
 
         self.assertEqual("PASS", report["summary"]["gate_result"])
         self.assertTrue(report["summary"]["completion_language_allowed"])
         self.assertEqual("not_applicable", report["truth_results"]["code_task_tdd_evidence_truth"]["state"])
         self.assertEqual("passing", report["truth_results"]["product_acceptance_truth"]["state"])
+        self.assertEqual("not_applicable", report["truth_results"]["specialist_disclosure_truth"]["state"])
+        self.assertEqual("passing", report["truth_results"]["specialist_decision_truth"]["state"])
+
+    def test_runtime_delivery_acceptance_requires_explicit_specialist_resolution_when_no_recommendation_exists(self) -> None:
+        session_root = self._build_session(omit_default_specialist_decision=True)
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("MANUAL_REVIEW_REQUIRED", report["summary"]["gate_result"])
+        self.assertFalse(report["summary"]["completion_language_allowed"])
+        self.assertEqual("manual_review_required", report["truth_results"]["specialist_decision_truth"]["state"])
+        self.assertIn(
+            "no bounded specialist recommendation path was frozen but no explicit specialist resolution was recorded",
+            report["truth_results"]["specialist_decision_truth"]["notes"].lower(),
+        )
+
+    def test_runtime_delivery_acceptance_reports_pass_degraded_for_traceable_repo_asset_fallback(self) -> None:
+        session_root = self._build_session(
+            phase_execute_specialist_decision={
+                "decision_state": "no_specialist_recommendations",
+                "resolution_mode": "repo_asset_fallback",
+                "repo_asset_fallback": {
+                    "used": True,
+                    "asset_paths": [
+                        "outputs/agent-runs/2026-04-14-scheme-a-clean397-paper-report/scripts/plot_style.py"
+                    ],
+                    "reason": "Reuse the existing paper-report plotting style asset when no dedicated plotting specialist is available.",
+                    "legal_basis": "Repo-local plotting asset already present inside governed workspace outputs.",
+                    "traceability_basis": [
+                        "outputs/agent-runs/2026-04-14-scheme-a-clean397-paper-report/scripts/plot_style.py"
+                    ],
+                },
+            }
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("PASS_DEGRADED", report["summary"]["gate_result"])
+        self.assertFalse(report["summary"]["completion_language_allowed"])
+        self.assertEqual("degraded", report["truth_results"]["specialist_decision_truth"]["state"])
+        self.assertIn(
+            "repo-asset fallback stayed explicit and traceable",
+            report["truth_results"]["specialist_decision_truth"]["notes"].lower(),
+        )
+
+    def test_runtime_delivery_acceptance_fails_when_repo_asset_fallback_omits_traceability(self) -> None:
+        session_root = self._build_session(
+            phase_execute_specialist_decision={
+                "decision_state": "no_specialist_recommendations",
+                "resolution_mode": "repo_asset_fallback",
+                "repo_asset_fallback": {
+                    "used": True,
+                    "asset_paths": [
+                        "outputs/agent-runs/2026-04-14-scheme-a-clean397-paper-report/scripts/plot_style.py"
+                    ],
+                    "reason": "Reuse the repo plotting asset.",
+                    "legal_basis": "Repo-local plotting asset already present inside governed workspace outputs.",
+                    "traceability_basis": [],
+                },
+            }
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("FAIL", report["summary"]["gate_result"])
+        self.assertFalse(report["summary"]["completion_language_allowed"])
+        self.assertEqual("failing", report["truth_results"]["specialist_decision_truth"]["state"])
+        self.assertIn(
+            "traceability",
+            report["truth_results"]["specialist_decision_truth"]["notes"].lower(),
+        )
+
+    def test_runtime_delivery_acceptance_fails_when_approved_dispatch_lacks_disclosure(self) -> None:
+        approved_dispatch = [
+            {
+                "skill_id": "systematic-debugging",
+                "native_skill_entrypoint": "/tmp/systematic-debugging/SKILL.md",
+            }
+        ]
+        session_root = self._build_session(
+            approved_dispatch=approved_dispatch,
+            specialist_accounting={
+                "approved_dispatch": approved_dispatch,
+                "approved_dispatch_count": 1,
+                "effective_execution_status": "live_native_executed",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("FAIL", report["summary"]["gate_result"])
+        self.assertFalse(report["summary"]["completion_language_allowed"])
+        self.assertEqual("failing", report["truth_results"]["specialist_disclosure_truth"]["state"])
+        self.assertIn(
+            "approved specialist dispatch was present but no specialist user disclosure was recorded",
+            report["truth_results"]["specialist_disclosure_truth"]["notes"].lower(),
+        )
+
+    def test_runtime_delivery_acceptance_fails_when_disclosure_contradicts_approved_dispatch(self) -> None:
+        approved_dispatch = [
+            {
+                "skill_id": "systematic-debugging",
+                "native_skill_entrypoint": "/tmp/systematic-debugging/SKILL.md",
+            }
+        ]
+        session_root = self._build_session(
+            approved_dispatch=approved_dispatch,
+            phase_execute_specialist_user_disclosure={
+                "scope": "approved_dispatch_only",
+                "timing": "before_execution",
+                "path_source": "native_skill_entrypoint",
+                "routed_skills": [
+                    {
+                        "skill_id": "brainstorming",
+                        "native_skill_entrypoint": "/tmp/brainstorming/SKILL.md",
+                        "entrypoint_requirement_satisfied": True,
+                    }
+                ],
+            },
+            specialist_accounting={
+                "approved_dispatch": approved_dispatch,
+                "approved_dispatch_count": 1,
+                "effective_execution_status": "live_native_executed",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("FAIL", report["summary"]["gate_result"])
+        self.assertFalse(report["summary"]["completion_language_allowed"])
+        self.assertEqual("failing", report["truth_results"]["specialist_disclosure_truth"]["state"])
+        self.assertIn(
+            "did not match effective approved dispatch",
+            report["truth_results"]["specialist_disclosure_truth"]["notes"],
+        )
+
+    def test_runtime_delivery_acceptance_reports_pass_degraded_for_aligned_degraded_specialist_execution(self) -> None:
+        approved_dispatch = [
+            {
+                "skill_id": "systematic-debugging",
+                "native_skill_entrypoint": "/tmp/systematic-debugging/SKILL.md",
+            }
+        ]
+        session_root = self._build_session(
+            approved_dispatch=approved_dispatch,
+            phase_execute_specialist_user_disclosure={
+                "scope": "approved_dispatch_only",
+                "timing": "before_execution",
+                "path_source": "native_skill_entrypoint",
+                "routed_skills": [
+                    {
+                        "skill_id": "systematic-debugging",
+                        "native_skill_entrypoint": "/tmp/systematic-debugging/SKILL.md",
+                        "entrypoint_requirement_satisfied": True,
+                    }
+                ],
+            },
+            specialist_accounting={
+                "approved_dispatch": approved_dispatch,
+                "approved_dispatch_count": 1,
+                "degraded_skill_ids": ["systematic-debugging"],
+                "effective_execution_status": "explicitly_degraded",
+            },
+        )
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("PASS_DEGRADED", report["summary"]["gate_result"])
+        self.assertFalse(report["summary"]["completion_language_allowed"])
+        self.assertEqual("degraded", report["truth_results"]["specialist_disclosure_truth"]["state"])
+        self.assertGreaterEqual(report["summary"]["degraded_layer_count"], 1)
+        self.assertEqual("degraded_but_traceable", report["summary"]["readiness_state"])
 
     def test_runtime_delivery_acceptance_report_covers_contract_required_fields(self) -> None:
         contract = json.loads(

--- a/tests/runtime_neutral/test_specialist_decision_projection.py
+++ b/tests/runtime_neutral/test_specialist_decision_projection.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _ps_single_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def resolve_powershell() -> str | None:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("pwsh.exe"),
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files\PowerShell\7-preview\pwsh.exe",
+        shutil.which("powershell"),
+        shutil.which("powershell.exe"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
+class SpecialistDecisionProjectionTests(unittest.TestCase):
+    def _run_projection(self, script_body: str) -> dict[str, object]:
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        runtime_common = REPO_ROOT / "scripts" / "runtime" / "VibeRuntime.Common.ps1"
+        ps_command = (
+            "& { "
+            f". {_ps_single_quote(str(runtime_common))}; "
+            f"{script_body}"
+            " }"
+        )
+        completed = subprocess.run(
+            [shell, "-NoLogo", "-NoProfile", "-Command", ps_command],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=True,
+        )
+        return json.loads(completed.stdout)
+
+    def test_specialist_decision_projection_preserves_explicit_match_and_surface_ids(self) -> None:
+        payload = self._run_projection(
+            "$result = New-VibeSpecialistDecisionProjection "
+            "-ApprovedDispatch @([pscustomobject]@{ skill_id = 'systematic-debugging' }) "
+            "-MatchedSkillIds @('systematic-debugging', 'flashrag-evidence') "
+            "-SurfacedSkillIds @('systematic-debugging', 'flashrag-evidence', 'test-driven-development') "
+            "-RecommendationCount 3; "
+            "$result | ConvertTo-Json -Depth 10"
+        )
+
+        self.assertEqual(
+            ["systematic-debugging", "flashrag-evidence"],
+            payload["matched_skill_ids"],
+        )
+        self.assertEqual(
+            ["systematic-debugging", "flashrag-evidence", "test-driven-development"],
+            payload["surfaced_skill_ids"],
+        )
+
+    def test_specialist_decision_projection_recomputes_notes_when_override_changes_resolution(self) -> None:
+        payload = self._run_projection(
+            "$override = [pscustomobject]@{ "
+            "decision_state = 'no_specialist_recommendations'; "
+            "resolution_mode = 'no_specialist_needed'; "
+            "repo_asset_fallback = [pscustomobject]@{ "
+            "used = $false; "
+            "asset_paths = @(); "
+            "reason = ''; "
+            "legal_basis = ''; "
+            "traceability_basis = @() "
+            "} "
+            "}; "
+            "$result = New-VibeSpecialistDecisionProjection "
+            "-RecommendationCount 0 "
+            "-OverridePayload $override "
+            "-OverrideSourcePath 'specialist-decision.json'; "
+            "$result | ConvertTo-Json -Depth 10"
+        )
+
+        self.assertEqual("no_specialist_needed", payload["resolution_mode"])
+        self.assertIn("no specialist help was needed", str(payload["notes"]).lower())
+        self.assertNotIn("repo-asset fallback", str(payload["notes"]).lower())

--- a/tests/runtime_neutral/test_specialist_decision_projection.py
+++ b/tests/runtime_neutral/test_specialist_decision_projection.py
@@ -94,3 +94,34 @@ class SpecialistDecisionProjectionTests(unittest.TestCase):
         self.assertEqual("no_specialist_needed", payload["resolution_mode"])
         self.assertIn("no specialist help was needed", str(payload["notes"]).lower())
         self.assertNotIn("repo-asset fallback", str(payload["notes"]).lower())
+
+    def test_specialist_decision_projection_defaults_missing_traceability_basis_to_empty_list(self) -> None:
+        payload = self._run_projection(
+            "$override = [pscustomobject]@{ "
+            "decision_state = 'no_specialist_recommendations'; "
+            "resolution_mode = 'repo_asset_fallback'; "
+            "repo_asset_fallback = [pscustomobject]@{ "
+            "used = $true; "
+            "asset_paths = @('outputs/foo.py'); "
+            "reason = 'Reuse the repo-local plotting asset.'; "
+            "legal_basis = 'Repo-local governed asset.' "
+            "} "
+            "}; "
+            "$result = New-VibeSpecialistDecisionProjection "
+            "-RecommendationCount 0 "
+            "-OverridePayload $override; "
+            "$result | ConvertTo-Json -Depth 10"
+        )
+
+        self.assertEqual("repo_asset_fallback", payload["resolution_mode"])
+        self.assertEqual([], payload["repo_asset_fallback"]["traceability_basis"])
+
+    def test_specialist_decision_projection_defaults_empty_match_and_surface_ids_to_empty_lists(self) -> None:
+        payload = self._run_projection(
+            "$result = New-VibeSpecialistDecisionProjection "
+            "-RecommendationCount 0; "
+            "$result | ConvertTo-Json -Depth 10"
+        )
+
+        self.assertEqual([], payload["matched_skill_ids"])
+        self.assertEqual([], payload["surfaced_skill_ids"])


### PR DESCRIPTION
## Summary
- add first-class `specialist_decision` runtime artifacts and governed requirement/plan surfaces
- make explicit no-match resolution and repo-asset fallback reviewable through delivery acceptance
- keep repo-asset fallback non-green via `specialist_decision_truth` and focused runtime-neutral coverage

## Test Plan
- `pytest -q tests/runtime_neutral/test_runtime_delivery_acceptance.py tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_skill_promotion_freeze_contract.py`
- `pwsh -NoLogo -File scripts/verify/vibe-no-silent-fallback-contract-gate.ps1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added specialist decision and disclosure as required truth layers in delivery-acceptance reports; PASS_DEGRADED for degraded-but-traceable cases
  * Runtime now emits/consumes an optional specialist-decision sidecar to record repo-asset fallback details

* **Documentation**
  * New governance requirement and execution plan documenting specialist decision, repo-asset fallback, pass/fail rules, and required report sections

* **Chores**
  * Updated delivery-acceptance contract metadata to v5

* **Tests**
  * Expanded and new tests validating specialist decision surfaces, docs, and acceptance gating
<!-- end of auto-generated comment: release notes by coderabbit.ai -->