### PR TITLE
Fix native specialist codex sidecar bootstrap

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -40,7 +40,17 @@ python -m vgo_cli.main canonical-entry `
   --prompt "<full user request>"
 ```
 
-If `python` is unavailable in Windows PowerShell, try `py -3` with the same arguments.
+If `python` is unavailable in Windows PowerShell, use the same invocation with `py -3` instead, for example:
+
+```powershell
+$env:PYTHONPATH = "<skill_root>/apps/vgo-cli/src"
+py -3 -m vgo_cli.main canonical-entry `
+  --repo-root "<skill_root>" `
+  --artifact-root "<workspace_root>" `
+  --host-id "<host_id>" `
+  --entry-id "vibe" `
+  --prompt "<full user request>"
+```
 
 Discoverable wrapper ids still enter canonical `vibe`; only the bounded stop changes:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,6 +5,62 @@ description: Vibe Code Orchestrator (VCO) is a governed runtime entry that freez
 
 # Vibe Governed Runtime
 
+## Canonical Bootstrap
+
+If the user invoked `/vibe`, `$vibe`, or `vibe`, enter canonical `vibe` first and do nothing else first.
+
+Bootstrap sequence:
+
+1. Resolve `skill_root` as the directory that contains this `SKILL.md`.
+2. Resolve `workspace_root` as the current user task working root. This is where governed artifacts should be written when the user is working outside the Vibe installation itself.
+3. Resolve the current host adapter id. Use `codex` in Codex, `claude-code` in Claude Code, and `opencode` in OpenCode.
+4. Launch the proof-complete canonical entry before reading repo files, protocol docs, prior run folders, or writing any runtime artifact.
+
+POSIX / bash launch:
+
+```bash
+PYTHONPATH="<skill_root>/apps/vgo-cli/src" \
+python3 -m vgo_cli.main canonical-entry \
+  --repo-root "<skill_root>" \
+  --artifact-root "<workspace_root>" \
+  --host-id "<host_id>" \
+  --entry-id "vibe" \
+  --prompt "<full user request>"
+```
+
+Windows PowerShell launch:
+
+```powershell
+$env:PYTHONPATH = "<skill_root>/apps/vgo-cli/src"
+python -m vgo_cli.main canonical-entry `
+  --repo-root "<skill_root>" `
+  --artifact-root "<workspace_root>" `
+  --host-id "<host_id>" `
+  --entry-id "vibe" `
+  --prompt "<full user request>"
+```
+
+If `python` is unavailable in Windows PowerShell, try `py -3` with the same arguments.
+
+Discoverable wrapper ids still enter canonical `vibe`; only the bounded stop changes:
+
+- `vibe-want` -> add `--requested-stage-stop requirement_doc`
+- `vibe-how` -> add `--requested-stage-stop xl_plan --requested-grade-floor XL`
+- `vibe` and `vibe-do-it` -> add `--requested-stage-stop phase_cleanup`
+
+Hard rules:
+
+- Do not inspect the repo, protocol docs, or prior run outputs before canonical launch returns, except to resolve `skill_root` and current host id.
+- Do not use the Vibe installation root as the governed artifact root when the user asked you to work in another workspace or repository.
+- Do not manually create `outputs/runtime/vibe-sessions/<run-id>/`, `docs/requirements/`, or `docs/plans/` as a substitute for launch.
+- Do not simulate `skeleton_check`, `deep_interview`, `requirement_doc`, `xl_plan`, `plan_execute`, or `phase_cleanup` in chat or shell before canonical launch completes.
+- Do not treat `scripts/runtime/Invoke-VibeCanonicalEntry.ps1` alone as proof-complete canonical entry; it is a bridge used by the canonical launcher, not the canonical launcher itself.
+- Do not claim canonical vibe entry from reading this file, wrapper text, bootstrap text, or old artifacts.
+- Canonical launch claims require `host-launch-receipt.json`, `runtime-input-packet.json`, `governance-capsule.json`, and `stage-lineage.json`.
+- If canonical launch cannot run or cannot emit the required truth artifacts, report `blocked` with the concrete failure reason. Do not silently continue in ordinary mode.
+
+Everything below this bootstrap section is reference material to follow only after successful canonical launch.
+
 `vibe` is a host-syntax-neutral skill contract.
 
 `/vibe`, `$vibe`, and agent-invoked `vibe` all mean the same thing: enter the same governed runtime, not different runtime authorities.

--- a/config/native-specialist-execution-policy.json
+++ b/config/native-specialist-execution-policy.json
@@ -36,7 +36,6 @@
       "command": "codex",
       "arguments_prefix": [
         "exec",
-        "--json",
         "--ephemeral",
         "--full-auto"
       ],

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -337,6 +337,9 @@ function ConvertTo-VibeExecutedUnitReceipt {
         execution_driver = if ($Outcome.lane_result -and $Outcome.lane_result.PSObject.Properties.Name -contains 'execution_driver') { [string]$Outcome.lane_result.execution_driver } else { $null }
         live_native_execution = if ($Outcome.lane_result -and $Outcome.lane_result.PSObject.Properties.Name -contains 'live_native_execution') { [bool]$Outcome.lane_result.live_native_execution } else { $false }
         degraded = if ($Outcome.lane_result -and $Outcome.lane_result.PSObject.Properties.Name -contains 'degraded') { [bool]$Outcome.lane_result.degraded } else { $false }
+        prompt_path = if ($Outcome.lane_result -and $Outcome.lane_result.PSObject.Properties.Name -contains 'prompt_path' -and -not [string]::IsNullOrWhiteSpace([string]$Outcome.lane_result.prompt_path)) { [string]$Outcome.lane_result.prompt_path } else { $null }
+        prompt_injection_complete = if ($Outcome.lane_result -and $Outcome.lane_result.PSObject.Properties.Name -contains 'prompt_injection_complete') { [bool]$Outcome.lane_result.prompt_injection_complete } else { $false }
+        missing_prompt_injection_fields = if ($Outcome.lane_result -and $Outcome.lane_result.PSObject.Properties.Name -contains 'missing_prompt_injection_fields') { @($Outcome.lane_result.missing_prompt_injection_fields) } else { @() }
     }
 }
 

--- a/scripts/runtime/VibeConsultation.Common.ps1
+++ b/scripts/runtime/VibeConsultation.Common.ps1
@@ -613,13 +613,18 @@ function Invoke-VibeSpecialistConsultationUnit {
         -RepoRoot $RepoRoot `
         -SessionRoot $SessionRoot `
         -SourceArtifactPath $SourceArtifactPath
-    $environmentOverrides = Get-VibeNativeSpecialistCodexHomeEnvironmentOverrides `
+    $codexHomeBinding = Get-VibeNativeSpecialistCodexHomeEnvironmentOverrides `
         -AdapterResolution $adapterResolution `
         -SkillRecord $Consultation `
         -RunId $RunId `
         -UnitId $UnitId
+    $environmentOverrides = if ($null -ne $codexHomeBinding -and (Test-VibeObjectHasProperty -InputObject $codexHomeBinding -PropertyName 'environment_overrides')) {
+        $codexHomeBinding.environment_overrides
+    } else {
+        $null
+    }
 
-    $beforeSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $workingRoot
+    $beforeSnapshot = Get-VibePathStatusSnapshot -RootPath $workingRoot
     Write-VgoUtf8NoBomText -Path $beforeGitPath -Content ((@($beforeSnapshot.lines) -join [Environment]::NewLine) + [Environment]::NewLine)
 
     $arguments = @()
@@ -640,29 +645,34 @@ function Invoke-VibeSpecialistConsultationUnit {
     )
 
     $startedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.ffffffZ')
-    $processResult = Invoke-VibeCapturedProcess `
-        -Command ([string]$adapterResolution.command_path) `
-        -Arguments $arguments `
-        -WorkingDirectory $workingRoot `
-        -TimeoutSeconds ([int]$nativePolicy.default_timeout_seconds) `
-        -StdOutPath $stdoutPath `
-        -StdErrPath $stderrPath `
-        -EnvironmentOverrides $environmentOverrides
-    $finishedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.ffffffZ')
-
-    $afterSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $workingRoot
-    Write-VgoUtf8NoBomText -Path $afterGitPath -Content ((@($afterSnapshot.lines) -join [Environment]::NewLine) + [Environment]::NewLine)
-
-    $beforeLookup = @{}
-    foreach ($path in @($beforeSnapshot.paths)) {
-        $beforeLookup[[string]$path] = $true
-    }
-    $observedChangedFiles = @()
-    foreach ($path in @($afterSnapshot.paths)) {
-        if (-not $beforeLookup.ContainsKey([string]$path)) {
-            $observedChangedFiles += [string]$path
+    $processResult = $null
+    try {
+        $processResult = Invoke-VibeCapturedProcess `
+            -Command ([string]$adapterResolution.command_path) `
+            -Arguments $arguments `
+            -WorkingDirectory $workingRoot `
+            -TimeoutSeconds ([int]$nativePolicy.default_timeout_seconds) `
+            -StdOutPath $stdoutPath `
+            -StdErrPath $stderrPath `
+            -EnvironmentOverrides $environmentOverrides
+    } finally {
+        if (
+            $null -ne $codexHomeBinding -and
+            (Test-VibeObjectHasProperty -InputObject $codexHomeBinding -PropertyName 'codex_home_root')
+        ) {
+            Remove-VibeNativeSpecialistCodexHomeRoot -CodexHomeRoot ([string]$codexHomeBinding.codex_home_root)
         }
     }
+    $finishedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.ffffffZ')
+
+    $afterSnapshot = Get-VibePathStatusSnapshot -RootPath $workingRoot
+    Write-VgoUtf8NoBomText -Path $afterGitPath -Content ((@($afterSnapshot.lines) -join [Environment]::NewLine) + [Environment]::NewLine)
+
+    $observedChangedFiles = Get-VibeObservedChangedPaths `
+        -BeforeSnapshot $beforeSnapshot `
+        -AfterSnapshot $afterSnapshot `
+        -SnapshotRoot $workingRoot `
+        -IgnoredPaths @($SessionRoot)
 
     $parsedResponse = $null
     $responseParseError = $null

--- a/scripts/runtime/VibeConsultation.Common.ps1
+++ b/scripts/runtime/VibeConsultation.Common.ps1
@@ -609,7 +609,17 @@ function Invoke-VibeSpecialistConsultationUnit {
         -Policy $Policy
     Write-VgoUtf8NoBomText -Path $promptPath -Content ($prompt + [Environment]::NewLine)
 
-    $beforeSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $RepoRoot
+    $workingRoot = Resolve-VibeNativeSpecialistWorkingRoot `
+        -RepoRoot $RepoRoot `
+        -SessionRoot $SessionRoot `
+        -SourceArtifactPath $SourceArtifactPath
+    $environmentOverrides = Get-VibeNativeSpecialistCodexHomeEnvironmentOverrides `
+        -AdapterResolution $adapterResolution `
+        -SkillRecord $Consultation `
+        -RunId $RunId `
+        -UnitId $UnitId
+
+    $beforeSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $workingRoot
     Write-VgoUtf8NoBomText -Path $beforeGitPath -Content ((@($beforeSnapshot.lines) -join [Environment]::NewLine) + [Environment]::NewLine)
 
     $arguments = @()
@@ -619,8 +629,11 @@ function Invoke-VibeSpecialistConsultationUnit {
     foreach ($item in @($adapter.arguments_prefix)) {
         $arguments += [string]$item
     }
+    foreach ($item in @(Get-VibeNativeSpecialistRepoCheckBypassArguments -AdapterResolution $adapterResolution -WorkingRoot $workingRoot)) {
+        $arguments += [string]$item
+    }
     $arguments += @(
-        '-C', $RepoRoot,
+        '-C', $workingRoot,
         '--output-schema', $schemaPath,
         '-o', $responsePath,
         $prompt
@@ -630,13 +643,14 @@ function Invoke-VibeSpecialistConsultationUnit {
     $processResult = Invoke-VibeCapturedProcess `
         -Command ([string]$adapterResolution.command_path) `
         -Arguments $arguments `
-        -WorkingDirectory $RepoRoot `
+        -WorkingDirectory $workingRoot `
         -TimeoutSeconds ([int]$nativePolicy.default_timeout_seconds) `
         -StdOutPath $stdoutPath `
-        -StdErrPath $stderrPath
+        -StdErrPath $stderrPath `
+        -EnvironmentOverrides $environmentOverrides
     $finishedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.ffffffZ')
 
-    $afterSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $RepoRoot
+    $afterSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $workingRoot
     Write-VgoUtf8NoBomText -Path $afterGitPath -Content ((@($afterSnapshot.lines) -join [Environment]::NewLine) + [Environment]::NewLine)
 
     $beforeLookup = @{}
@@ -677,7 +691,7 @@ function Invoke-VibeSpecialistConsultationUnit {
         command = [string]$adapterResolution.command_path
         arguments = @($arguments)
         display_command = @([string]$adapterResolution.command_path) + @($arguments) -join ' '
-        cwd = $RepoRoot
+        cwd = $workingRoot
         timeout_seconds = [int]$nativePolicy.default_timeout_seconds
         expected_exit_code = 0
         exit_code = [int]$processResult.exit_code

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -341,26 +341,33 @@ function Initialize-VibeNativeSpecialistDirectoryCopy {
 function Resolve-VibeCurrentCodexHomeRoot {
     $homeDir = Resolve-VgoHomeDirectory
     $defaultCodexHome = Join-Path $homeDir '.codex'
-    $nativeSpecialistRoot = Join-Path $homeDir '.vibeskills'
-    $nativeSpecialistRoot = Join-Path $nativeSpecialistRoot 'runtime-native-specialist'
-    $nativeSpecialistRoot = Join-Path $nativeSpecialistRoot 'codex-home'
-    $nativeSpecialistRoot = [System.IO.Path]::GetFullPath($nativeSpecialistRoot)
 
     $envCodexHome = [Environment]::GetEnvironmentVariable('CODEX_HOME')
     if (-not [string]::IsNullOrWhiteSpace($envCodexHome) -and (Test-Path -LiteralPath $envCodexHome -PathType Container)) {
         $resolvedEnvCodexHome = [System.IO.Path]::GetFullPath([string]$envCodexHome)
-        $sidecarPrefix = $nativeSpecialistRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
-        $sidecarPrefixWithSeparator = $sidecarPrefix + [System.IO.Path]::DirectorySeparatorChar
-        if (-not $resolvedEnvCodexHome.StartsWith($sidecarPrefixWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $sidecarMarkerPath = Get-VibeNativeSpecialistCodexHomeMarkerPath -CodexHomeRoot $resolvedEnvCodexHome
+        if (-not (Test-Path -LiteralPath $sidecarMarkerPath -PathType Leaf)) {
             return $resolvedEnvCodexHome
         }
     }
 
     if (Test-Path -LiteralPath $defaultCodexHome -PathType Container) {
-        return [System.IO.Path]::GetFullPath($defaultCodexHome)
+        $resolvedDefaultCodexHome = [System.IO.Path]::GetFullPath($defaultCodexHome)
+        $sidecarMarkerPath = Get-VibeNativeSpecialistCodexHomeMarkerPath -CodexHomeRoot $resolvedDefaultCodexHome
+        if (-not (Test-Path -LiteralPath $sidecarMarkerPath -PathType Leaf)) {
+            return $resolvedDefaultCodexHome
+        }
     }
 
     return $null
+}
+
+function Get-VibeNativeSpecialistCodexHomeMarkerPath {
+    param(
+        [Parameter(Mandatory)] [string]$CodexHomeRoot
+    )
+
+    return [System.IO.Path]::GetFullPath((Join-Path $CodexHomeRoot '.vibe-native-specialist-sidecar'))
 }
 
 function Initialize-VibeNativeSpecialistCodexHomeSeed {
@@ -368,17 +375,22 @@ function Initialize-VibeNativeSpecialistCodexHomeSeed {
         [Parameter(Mandatory)] [string]$TargetCodexHomeRoot
     )
 
+    $targetRoot = [System.IO.Path]::GetFullPath($TargetCodexHomeRoot)
+    New-Item -ItemType Directory -Path $targetRoot -Force | Out-Null
+
+    $sidecarMarkerPath = Get-VibeNativeSpecialistCodexHomeMarkerPath -CodexHomeRoot $targetRoot
+    if (-not (Test-Path -LiteralPath $sidecarMarkerPath -PathType Leaf)) {
+        Write-VgoUtf8NoBomText -Path $sidecarMarkerPath -Content ''
+    }
+
     $sourceCodexHomeRoot = Resolve-VibeCurrentCodexHomeRoot
     if ([string]::IsNullOrWhiteSpace($sourceCodexHomeRoot)) {
         return $null
     }
 
-    $targetRoot = [System.IO.Path]::GetFullPath($TargetCodexHomeRoot)
     if ([System.StringComparer]::OrdinalIgnoreCase.Equals($sourceCodexHomeRoot, $targetRoot)) {
         return $sourceCodexHomeRoot
     }
-
-    New-Item -ItemType Directory -Path $targetRoot -Force | Out-Null
 
     $seedEntries = @(
         [pscustomobject]@{ relative_path = 'config.toml'; kind = 'file' },
@@ -447,13 +459,31 @@ function Get-VibeNativeSpecialistCodexHomeRoot {
         [Parameter(Mandatory)] [string]$UnitId
     )
 
-    $homeDir = Resolve-VgoHomeDirectory
-    $baseRoot = Join-Path $homeDir '.vibeskills'
-    $baseRoot = Join-Path $baseRoot 'runtime-native-specialist'
-    $baseRoot = Join-Path $baseRoot 'codex-home'
+    $baseRoot = Join-Path ([System.IO.Path]::GetTempPath()) 'vibe-native-specialist-codex-home'
     $runSegment = ConvertTo-VibeSlug -Text $RunId
     $unitSegment = ConvertTo-VibeSlug -Text $UnitId
-    return [System.IO.Path]::GetFullPath((Join-Path $baseRoot ("{0}-{1}" -f $runSegment, $unitSegment)))
+    $instanceSegment = [System.Guid]::NewGuid().ToString('N')
+    return [System.IO.Path]::GetFullPath((Join-Path $baseRoot ("{0}-{1}-{2}" -f $runSegment, $unitSegment, $instanceSegment)))
+}
+
+function Remove-VibeNativeSpecialistCodexHomeRoot {
+    param(
+        [AllowEmptyString()] [string]$CodexHomeRoot
+    )
+
+    if ([string]::IsNullOrWhiteSpace($CodexHomeRoot)) {
+        return
+    }
+
+    $candidatePath = [System.IO.Path]::GetFullPath($CodexHomeRoot)
+    if (-not (Test-Path -LiteralPath $candidatePath)) {
+        return
+    }
+
+    try {
+        Remove-Item -LiteralPath $candidatePath -Recurse -Force -ErrorAction Stop
+    } catch {
+    }
 }
 
 function Get-VibeNativeSpecialistCodexHomeEnvironmentOverrides {
@@ -510,8 +540,11 @@ function Get-VibeNativeSpecialistCodexHomeEnvironmentOverrides {
         Write-VgoUtf8NoBomText -Path $configPath -Content ''
     }
 
-    return @{
-        CODEX_HOME = [System.IO.Path]::GetFullPath($codexHomeRoot)
+    return [pscustomobject]@{
+        codex_home_root = [System.IO.Path]::GetFullPath($codexHomeRoot)
+        environment_overrides = @{
+            CODEX_HOME = [System.IO.Path]::GetFullPath($codexHomeRoot)
+        }
     }
 }
 
@@ -924,12 +957,13 @@ function Get-VibeGitStatusSnapshot {
         [Parameter(Mandatory)] [string]$RepoRoot
     )
 
-    $gitDir = Join-Path $RepoRoot '.git'
-    if (-not (Test-Path -LiteralPath $gitDir)) {
+    if (-not (Test-VibePathIsGitWorkTree -Path $RepoRoot)) {
         return [pscustomobject]@{
             available = $false
+            mode = 'git'
             paths = @()
             lines = @()
+            entries = @{}
         }
     }
 
@@ -937,8 +971,10 @@ function Get-VibeGitStatusSnapshot {
     if (-not $gitCommand) {
         return [pscustomobject]@{
             available = $false
+            mode = 'git'
             paths = @()
             lines = @()
+            entries = @{}
         }
     }
 
@@ -946,12 +982,15 @@ function Get-VibeGitStatusSnapshot {
     if ($LASTEXITCODE -ne 0) {
         return [pscustomobject]@{
             available = $false
+            mode = 'git'
             paths = @()
             lines = @()
+            entries = @{}
         }
     }
 
     $paths = @()
+    $entries = @{}
     foreach ($line in @($snapshot)) {
         $text = [string]$line
         if ([string]::IsNullOrWhiteSpace($text) -or $text.Length -lt 4) {
@@ -962,15 +1001,197 @@ function Get-VibeGitStatusSnapshot {
             $pathText = ($pathText -split ' -> ')[-1].Trim()
         }
         if (-not [string]::IsNullOrWhiteSpace($pathText)) {
-            $paths += $pathText
+            $normalizedPath = ConvertTo-VibeSnapshotComparablePath -RelativePath $pathText
+            $paths += $normalizedPath
+            $entries[$normalizedPath] = $text
         }
     }
 
     return [pscustomobject]@{
         available = $true
+        mode = 'git'
         paths = @($paths | Select-Object -Unique)
         lines = @($snapshot)
+        entries = $entries
     }
+}
+
+function ConvertTo-VibeSnapshotComparablePath {
+    param(
+        [AllowEmptyString()] [string]$RelativePath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RelativePath)) {
+        return ''
+    }
+
+    $normalized = [string]$RelativePath
+    $normalized = $normalized.Replace('\', '/')
+    while ($normalized.StartsWith('./', [System.StringComparison]::Ordinal)) {
+        $normalized = $normalized.Substring(2)
+    }
+    return $normalized.Trim('/')
+}
+
+function Get-VibeFileSystemStatusSnapshot {
+    param(
+        [Parameter(Mandatory)] [string]$RootPath
+    )
+
+    $resolvedRoot = [System.IO.Path]::GetFullPath($RootPath)
+    if (-not (Test-Path -LiteralPath $resolvedRoot -PathType Container)) {
+        return [pscustomobject]@{
+            available = $false
+            mode = 'filesystem'
+            paths = @()
+            lines = @()
+            entries = @{}
+        }
+    }
+
+    $entries = @{}
+    $lines = New-Object System.Collections.Generic.List[string]
+    $items = @(Get-ChildItem -LiteralPath $resolvedRoot -Recurse -Force -ErrorAction SilentlyContinue | Sort-Object FullName)
+    foreach ($item in @($items)) {
+        $relativePath = ConvertTo-VibeSnapshotComparablePath -RelativePath (Get-VibeRelativePathCompat -BasePath $resolvedRoot -TargetPath ([string]$item.FullName))
+        if ([string]::IsNullOrWhiteSpace($relativePath)) {
+            continue
+        }
+
+        if ($item.PSIsContainer) {
+            $fingerprint = 'dir'
+            $lineText = ('D {0}' -f $relativePath)
+        } else {
+            try {
+                $hashValue = [string](Get-FileHash -LiteralPath $item.FullName -Algorithm SHA256 -ErrorAction Stop).Hash
+            } catch {
+                $hashValue = ('fallback:{0}:{1}' -f [string]$item.Length, [string]$item.LastWriteTimeUtc.Ticks)
+            }
+            $fingerprint = ('file:{0}' -f $hashValue)
+            $lineText = ('F {0} {1}' -f $hashValue, $relativePath)
+        }
+
+        $entries[$relativePath] = $fingerprint
+        $lines.Add($lineText) | Out-Null
+    }
+
+    return [pscustomobject]@{
+        available = $true
+        mode = 'filesystem'
+        paths = @($entries.Keys | Sort-Object)
+        lines = @($lines)
+        entries = $entries
+    }
+}
+
+function Get-VibePathStatusSnapshot {
+    param(
+        [Parameter(Mandatory)] [string]$RootPath
+    )
+
+    $gitSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $RootPath
+    if ([bool]$gitSnapshot.available) {
+        return $gitSnapshot
+    }
+
+    return Get-VibeFileSystemStatusSnapshot -RootPath $RootPath
+}
+
+function Test-VibeSnapshotPathIgnored {
+    param(
+        [AllowEmptyString()] [string]$RelativePath,
+        [string[]]$IgnoredRelativePaths = @()
+    )
+
+    $candidate = ConvertTo-VibeSnapshotComparablePath -RelativePath $RelativePath
+    if ([string]::IsNullOrWhiteSpace($candidate)) {
+        return $false
+    }
+
+    foreach ($ignoredPath in @($IgnoredRelativePaths)) {
+        $normalizedIgnoredPath = ConvertTo-VibeSnapshotComparablePath -RelativePath ([string]$ignoredPath)
+        if ([string]::IsNullOrWhiteSpace($normalizedIgnoredPath)) {
+            continue
+        }
+        if (
+            [System.StringComparer]::OrdinalIgnoreCase.Equals($candidate, $normalizedIgnoredPath) -or
+            $candidate.StartsWith(($normalizedIgnoredPath + '/'), [System.StringComparison]::OrdinalIgnoreCase)
+        ) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Get-VibeObservedChangedPaths {
+    param(
+        [AllowNull()] [object]$BeforeSnapshot = $null,
+        [AllowNull()] [object]$AfterSnapshot = $null,
+        [Parameter(Mandatory)] [string]$SnapshotRoot,
+        [string[]]$IgnoredPaths = @()
+    )
+
+    $resolvedRoot = [System.IO.Path]::GetFullPath($SnapshotRoot)
+    $ignoredRelativePaths = New-Object System.Collections.Generic.List[string]
+    foreach ($ignoredPath in @($IgnoredPaths)) {
+        if ([string]::IsNullOrWhiteSpace([string]$ignoredPath)) {
+            continue
+        }
+
+        $resolvedIgnoredPath = [System.IO.Path]::GetFullPath([string]$ignoredPath)
+        if (-not (Test-Path -LiteralPath $resolvedIgnoredPath)) {
+            continue
+        }
+        if ([System.StringComparer]::OrdinalIgnoreCase.Equals($resolvedRoot, $resolvedIgnoredPath)) {
+            continue
+        }
+
+        $relativePath = ConvertTo-VibeSnapshotComparablePath -RelativePath (Get-VibeRelativePathCompat -BasePath $resolvedRoot -TargetPath $resolvedIgnoredPath)
+        if ([string]::IsNullOrWhiteSpace($relativePath)) {
+            continue
+        }
+        if (-not $ignoredRelativePaths.Contains($relativePath)) {
+            $ignoredRelativePaths.Add($relativePath) | Out-Null
+        }
+    }
+
+    $beforeEntries = if ($null -ne $BeforeSnapshot -and (Test-VibeObjectHasProperty -InputObject $BeforeSnapshot -PropertyName 'entries') -and $null -ne $BeforeSnapshot.entries) {
+        $BeforeSnapshot.entries
+    } else {
+        @{}
+    }
+    $afterEntries = if ($null -ne $AfterSnapshot -and (Test-VibeObjectHasProperty -InputObject $AfterSnapshot -PropertyName 'entries') -and $null -ne $AfterSnapshot.entries) {
+        $AfterSnapshot.entries
+    } else {
+        @{}
+    }
+
+    $candidatePaths = New-Object System.Collections.Generic.List[string]
+    foreach ($key in @($beforeEntries.Keys + $afterEntries.Keys | Select-Object -Unique)) {
+        $normalizedKey = ConvertTo-VibeSnapshotComparablePath -RelativePath ([string]$key)
+        if ([string]::IsNullOrWhiteSpace($normalizedKey)) {
+            continue
+        }
+        if (-not $candidatePaths.Contains($normalizedKey)) {
+            $candidatePaths.Add($normalizedKey) | Out-Null
+        }
+    }
+
+    $changedPaths = New-Object System.Collections.Generic.List[string]
+    foreach ($path in @($candidatePaths | Sort-Object)) {
+        if (Test-VibeSnapshotPathIgnored -RelativePath $path -IgnoredRelativePaths @($ignoredRelativePaths)) {
+            continue
+        }
+
+        $beforeExists = $beforeEntries.ContainsKey($path)
+        $afterExists = $afterEntries.ContainsKey($path)
+        if (-not $beforeExists -or -not $afterExists -or -not [System.StringComparer]::Ordinal.Equals([string]$beforeEntries[$path], [string]$afterEntries[$path])) {
+            $changedPaths.Add($path) | Out-Null
+        }
+    }
+
+    return @($changedPaths)
 }
 
 function Test-VibePathIsGitWorkTree {
@@ -1383,13 +1604,18 @@ function Invoke-VibeSpecialistDispatchUnit {
         -SessionRoot $SessionRoot `
         -RequirementDocPath $RequirementDocPath `
         -ExecutionPlanPath $ExecutionPlanPath
-    $environmentOverrides = Get-VibeNativeSpecialistCodexHomeEnvironmentOverrides `
+    $codexHomeBinding = Get-VibeNativeSpecialistCodexHomeEnvironmentOverrides `
         -AdapterResolution $adapterResolution `
         -SkillRecord $Dispatch `
         -RunId $RunId `
         -UnitId $UnitId
+    $environmentOverrides = if ($null -ne $codexHomeBinding -and (Test-VibeObjectHasProperty -InputObject $codexHomeBinding -PropertyName 'environment_overrides')) {
+        $codexHomeBinding.environment_overrides
+    } else {
+        $null
+    }
 
-    $beforeSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $workingRoot
+    $beforeSnapshot = Get-VibePathStatusSnapshot -RootPath $workingRoot
     Write-VgoUtf8NoBomText -Path $beforeGitPath -Content ((@($beforeSnapshot.lines) -join [Environment]::NewLine) + [Environment]::NewLine)
 
     $arguments = @()
@@ -1408,16 +1634,26 @@ function Invoke-VibeSpecialistDispatchUnit {
         '-o', $responsePath,
         $prompt
     )
-    $processResult = Invoke-VibeCapturedProcess `
-        -Command ([string]$adapterResolution.command_path) `
-        -Arguments $arguments `
-        -WorkingDirectory $workingRoot `
-        -TimeoutSeconds ([int]$policy.default_timeout_seconds) `
-        -StdOutPath $stdoutPath `
-        -StdErrPath $stderrPath `
-        -EnvironmentOverrides $environmentOverrides
+    $processResult = $null
+    try {
+        $processResult = Invoke-VibeCapturedProcess `
+            -Command ([string]$adapterResolution.command_path) `
+            -Arguments $arguments `
+            -WorkingDirectory $workingRoot `
+            -TimeoutSeconds ([int]$policy.default_timeout_seconds) `
+            -StdOutPath $stdoutPath `
+            -StdErrPath $stderrPath `
+            -EnvironmentOverrides $environmentOverrides
+    } finally {
+        if (
+            $null -ne $codexHomeBinding -and
+            (Test-VibeObjectHasProperty -InputObject $codexHomeBinding -PropertyName 'codex_home_root')
+        ) {
+            Remove-VibeNativeSpecialistCodexHomeRoot -CodexHomeRoot ([string]$codexHomeBinding.codex_home_root)
+        }
+    }
 
-    $afterSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $workingRoot
+    $afterSnapshot = Get-VibePathStatusSnapshot -RootPath $workingRoot
     Write-VgoUtf8NoBomText -Path $afterGitPath -Content ((@($afterSnapshot.lines) -join [Environment]::NewLine) + [Environment]::NewLine)
 
     $parsedResponse = $null
@@ -1432,16 +1668,11 @@ function Invoke-VibeSpecialistDispatchUnit {
         $responseParseError = 'native_specialist_response_missing'
     }
 
-    $beforeLookup = @{}
-    foreach ($path in @($beforeSnapshot.paths)) {
-        $beforeLookup[[string]$path] = $true
-    }
-    $observedChangedFiles = @()
-    foreach ($path in @($afterSnapshot.paths)) {
-        if (-not $beforeLookup.ContainsKey([string]$path)) {
-            $observedChangedFiles += [string]$path
-        }
-    }
+    $observedChangedFiles = Get-VibeObservedChangedPaths `
+        -BeforeSnapshot $beforeSnapshot `
+        -AfterSnapshot $afterSnapshot `
+        -SnapshotRoot $workingRoot `
+        -IgnoredPaths @($SessionRoot)
 
     $responseStatus = if ($parsedResponse -and $parsedResponse.PSObject.Properties.Name -contains 'status') {
         [string]$parsedResponse.status

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -49,13 +49,15 @@ function Invoke-VibeCapturedProcess {
         [Parameter(Mandatory)] [string]$WorkingDirectory,
         [Parameter(Mandatory)] [int]$TimeoutSeconds,
         [Parameter(Mandatory)] [string]$StdOutPath,
-        [Parameter(Mandatory)] [string]$StdErrPath
+        [Parameter(Mandatory)] [string]$StdErrPath,
+        [AllowNull()] [hashtable]$EnvironmentOverrides = $null
     )
 
     $startInfo = New-Object System.Diagnostics.ProcessStartInfo
     $startInfo.FileName = $Command
     $startInfo.WorkingDirectory = $WorkingDirectory
     $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardInput = $true
     $startInfo.RedirectStandardOutput = $true
     $startInfo.RedirectStandardError = $true
     $startInfo.CreateNoWindow = $true
@@ -67,6 +69,29 @@ function Invoke-VibeCapturedProcess {
     try {
         $startInfo.StandardErrorEncoding = $utf8NoBom
     } catch {
+    }
+    if ($null -ne $EnvironmentOverrides) {
+        foreach ($name in @($EnvironmentOverrides.Keys)) {
+            if ([string]::IsNullOrWhiteSpace([string]$name)) {
+                continue
+            }
+
+            $value = $EnvironmentOverrides[[string]$name]
+            try {
+                $environment = $startInfo.Environment
+                if ($null -eq $value) {
+                    [void]$environment.Remove([string]$name)
+                } else {
+                    $environment[[string]$name] = [string]$value
+                }
+            } catch {
+                if ($null -eq $value) {
+                    [void]$startInfo.EnvironmentVariables.Remove([string]$name)
+                } else {
+                    $startInfo.EnvironmentVariables[[string]$name] = [string]$value
+                }
+            }
+        }
     }
 
     $usedArgumentList = $false
@@ -100,6 +125,10 @@ function Invoke-VibeCapturedProcess {
     try {
         if (-not $process.Start()) {
             throw "Failed to start process: $Command"
+        }
+        try {
+            $process.StandardInput.Close()
+        } catch {
         }
 
         $stdoutTask = $process.StandardOutput.ReadToEndAsync()
@@ -275,6 +304,215 @@ function Test-VibeTruthyEnvironmentValue {
     }
 
     return @('1', 'true', 'yes', 'on') -contains $Value.Trim().ToLowerInvariant()
+}
+
+function Initialize-VibeNativeSpecialistDirectoryCopy {
+    param(
+        [Parameter(Mandatory)] [string]$SourcePath,
+        [Parameter(Mandatory)] [string]$TargetPath
+    )
+
+    $sourceFull = [System.IO.Path]::GetFullPath($SourcePath)
+    $targetFull = [System.IO.Path]::GetFullPath($TargetPath)
+    if (-not (Test-Path -LiteralPath $sourceFull -PathType Container)) {
+        throw "Specialist skill root is missing: $sourceFull"
+    }
+
+    if (Test-Path -LiteralPath $targetFull) {
+        Remove-Item -LiteralPath $targetFull -Recurse -Force
+    }
+
+    New-Item -ItemType Directory -Path $targetFull -Force | Out-Null
+    foreach ($child in @(Get-ChildItem -LiteralPath $sourceFull -Force -ErrorAction Stop)) {
+        $destinationPath = Join-Path $targetFull $child.Name
+        New-Item -ItemType Directory -Path (Split-Path -Parent $destinationPath) -Force | Out-Null
+        Copy-Item -LiteralPath $child.FullName -Destination $destinationPath -Recurse -Force
+    }
+
+    $skillMd = Join-Path $targetFull 'SKILL.md'
+    $mirrorPath = Join-Path $targetFull 'SKILL.runtime-mirror.md'
+    if (-not (Test-Path -LiteralPath $skillMd -PathType Leaf) -and (Test-Path -LiteralPath $mirrorPath -PathType Leaf)) {
+        Copy-Item -LiteralPath $mirrorPath -Destination $skillMd -Force
+    }
+
+    return $targetFull
+}
+
+function Resolve-VibeCurrentCodexHomeRoot {
+    $homeDir = Resolve-VgoHomeDirectory
+    $defaultCodexHome = Join-Path $homeDir '.codex'
+    $nativeSpecialistRoot = Join-Path $homeDir '.vibeskills'
+    $nativeSpecialistRoot = Join-Path $nativeSpecialistRoot 'runtime-native-specialist'
+    $nativeSpecialistRoot = Join-Path $nativeSpecialistRoot 'codex-home'
+    $nativeSpecialistRoot = [System.IO.Path]::GetFullPath($nativeSpecialistRoot)
+
+    $envCodexHome = [Environment]::GetEnvironmentVariable('CODEX_HOME')
+    if (-not [string]::IsNullOrWhiteSpace($envCodexHome) -and (Test-Path -LiteralPath $envCodexHome -PathType Container)) {
+        $resolvedEnvCodexHome = [System.IO.Path]::GetFullPath([string]$envCodexHome)
+        $sidecarPrefix = $nativeSpecialistRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+        $sidecarPrefixWithSeparator = $sidecarPrefix + [System.IO.Path]::DirectorySeparatorChar
+        if (-not $resolvedEnvCodexHome.StartsWith($sidecarPrefixWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $resolvedEnvCodexHome
+        }
+    }
+
+    if (Test-Path -LiteralPath $defaultCodexHome -PathType Container) {
+        return [System.IO.Path]::GetFullPath($defaultCodexHome)
+    }
+
+    return $null
+}
+
+function Initialize-VibeNativeSpecialistCodexHomeSeed {
+    param(
+        [Parameter(Mandatory)] [string]$TargetCodexHomeRoot
+    )
+
+    $sourceCodexHomeRoot = Resolve-VibeCurrentCodexHomeRoot
+    if ([string]::IsNullOrWhiteSpace($sourceCodexHomeRoot)) {
+        return $null
+    }
+
+    $targetRoot = [System.IO.Path]::GetFullPath($TargetCodexHomeRoot)
+    if ([System.StringComparer]::OrdinalIgnoreCase.Equals($sourceCodexHomeRoot, $targetRoot)) {
+        return $sourceCodexHomeRoot
+    }
+
+    New-Item -ItemType Directory -Path $targetRoot -Force | Out-Null
+
+    $seedEntries = @(
+        [pscustomobject]@{ relative_path = 'config.toml'; kind = 'file' },
+        [pscustomobject]@{ relative_path = 'auth.json'; kind = 'file' },
+        [pscustomobject]@{ relative_path = 'settings.json'; kind = 'file' },
+        [pscustomobject]@{ relative_path = 'config'; kind = 'directory' },
+        [pscustomobject]@{ relative_path = 'mcp'; kind = 'directory' }
+    )
+
+    foreach ($entry in @($seedEntries)) {
+        $relativePath = [string]$entry.relative_path
+        $sourcePath = Join-Path $sourceCodexHomeRoot $relativePath
+        if (-not (Test-Path -LiteralPath $sourcePath)) {
+            continue
+        }
+
+        $targetPath = Join-Path $targetRoot $relativePath
+        if ([string]$entry.kind -eq 'directory') {
+            [void](Initialize-VibeNativeSpecialistDirectoryCopy -SourcePath $sourcePath -TargetPath $targetPath)
+            continue
+        }
+
+        New-Item -ItemType Directory -Path (Split-Path -Parent $targetPath) -Force | Out-Null
+        Copy-Item -LiteralPath $sourcePath -Destination $targetPath -Force
+    }
+
+    return $sourceCodexHomeRoot
+}
+
+function Resolve-VibeNativeSpecialistSkillSourceRoot {
+    param(
+        [AllowNull()] [object]$SkillRecord = $null
+    )
+
+    $candidateRoot = if (
+        $null -ne $SkillRecord -and
+        (Test-VibeObjectHasProperty -InputObject $SkillRecord -PropertyName 'skill_root') -and
+        -not [string]::IsNullOrWhiteSpace([string]$SkillRecord.skill_root)
+    ) {
+        [string]$SkillRecord.skill_root
+    } elseif (
+        $null -ne $SkillRecord -and
+        (Test-VibeObjectHasProperty -InputObject $SkillRecord -PropertyName 'native_skill_entrypoint') -and
+        -not [string]::IsNullOrWhiteSpace([string]$SkillRecord.native_skill_entrypoint)
+    ) {
+        Split-Path -Parent ([string]$SkillRecord.native_skill_entrypoint)
+    } else {
+        $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($candidateRoot)) {
+        return $null
+    }
+
+    $resolvedRoot = [System.IO.Path]::GetFullPath([string]$candidateRoot)
+    if (-not (Test-Path -LiteralPath $resolvedRoot -PathType Container)) {
+        return $null
+    }
+
+    return $resolvedRoot
+}
+
+function Get-VibeNativeSpecialistCodexHomeRoot {
+    param(
+        [Parameter(Mandatory)] [string]$RunId,
+        [Parameter(Mandatory)] [string]$UnitId
+    )
+
+    $homeDir = Resolve-VgoHomeDirectory
+    $baseRoot = Join-Path $homeDir '.vibeskills'
+    $baseRoot = Join-Path $baseRoot 'runtime-native-specialist'
+    $baseRoot = Join-Path $baseRoot 'codex-home'
+    $runSegment = ConvertTo-VibeSlug -Text $RunId
+    $unitSegment = ConvertTo-VibeSlug -Text $UnitId
+    return [System.IO.Path]::GetFullPath((Join-Path $baseRoot ("{0}-{1}" -f $runSegment, $unitSegment)))
+}
+
+function Get-VibeNativeSpecialistCodexHomeEnvironmentOverrides {
+    param(
+        [AllowNull()] [object]$AdapterResolution = $null,
+        [AllowNull()] [object]$SkillRecord = $null,
+        [Parameter(Mandatory)] [string]$RunId,
+        [Parameter(Mandatory)] [string]$UnitId
+    )
+
+    $effectiveHostAdapterId = ''
+    if ($null -ne $AdapterResolution) {
+        if (
+            (Test-VibeObjectHasProperty -InputObject $AdapterResolution -PropertyName 'effective_host_adapter_id') -and
+            -not [string]::IsNullOrWhiteSpace([string]$AdapterResolution.effective_host_adapter_id)
+        ) {
+            $effectiveHostAdapterId = [string]$AdapterResolution.effective_host_adapter_id
+        } elseif (
+            (Test-VibeObjectHasProperty -InputObject $AdapterResolution -PropertyName 'requested_host_adapter_id') -and
+            -not [string]::IsNullOrWhiteSpace([string]$AdapterResolution.requested_host_adapter_id)
+        ) {
+            $effectiveHostAdapterId = [string]$AdapterResolution.requested_host_adapter_id
+        }
+    }
+
+    if ([string]$effectiveHostAdapterId -ne 'codex') {
+        return $null
+    }
+
+    $skillId = if (
+        $null -ne $SkillRecord -and
+        (Test-VibeObjectHasProperty -InputObject $SkillRecord -PropertyName 'skill_id') -and
+        -not [string]::IsNullOrWhiteSpace([string]$SkillRecord.skill_id)
+    ) {
+        [string]$SkillRecord.skill_id
+    } else {
+        'specialist'
+    }
+    $skillSourceRoot = Resolve-VibeNativeSpecialistSkillSourceRoot -SkillRecord $SkillRecord
+    if ([string]::IsNullOrWhiteSpace($skillSourceRoot)) {
+        return $null
+    }
+
+    $codexHomeRoot = Get-VibeNativeSpecialistCodexHomeRoot -RunId $RunId -UnitId $UnitId
+    [void](Initialize-VibeNativeSpecialistCodexHomeSeed -TargetCodexHomeRoot $codexHomeRoot)
+    $skillsRoot = Join-Path $codexHomeRoot 'skills'
+    $materializedSkillRoot = Join-Path $skillsRoot $skillId
+
+    New-Item -ItemType Directory -Path $skillsRoot -Force | Out-Null
+    [void](Initialize-VibeNativeSpecialistDirectoryCopy -SourcePath $skillSourceRoot -TargetPath $materializedSkillRoot)
+
+    $configPath = Join-Path $codexHomeRoot 'config.toml'
+    if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+        Write-VgoUtf8NoBomText -Path $configPath -Content ''
+    }
+
+    return @{
+        CODEX_HOME = [System.IO.Path]::GetFullPath($codexHomeRoot)
+    }
 }
 
 function Resolve-VibeProcessInvocationSpec {
@@ -735,6 +973,64 @@ function Get-VibeGitStatusSnapshot {
     }
 }
 
+function Test-VibePathIsGitWorkTree {
+    param(
+        [Parameter(Mandatory)] [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path -PathType Container)) {
+        return $false
+    }
+
+    $gitCommand = Get-Command git -ErrorAction SilentlyContinue
+    if (-not $gitCommand) {
+        return $false
+    }
+
+    $probe = @(& ([string]$gitCommand.Source) -C $Path rev-parse --is-inside-work-tree 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        return $false
+    }
+
+    return ((@($probe | ForEach-Object { [string]$_ }) -contains 'true'))
+}
+
+function Get-VibeNativeSpecialistRepoCheckBypassArguments {
+    param(
+        [AllowNull()] [object]$AdapterResolution = $null,
+        [Parameter(Mandatory)] [string]$WorkingRoot
+    )
+
+    if ([string]::IsNullOrWhiteSpace($WorkingRoot)) {
+        return @()
+    }
+
+    $effectiveHostAdapterId = ''
+    if ($null -ne $AdapterResolution) {
+        if (
+            (Test-VibeObjectHasProperty -InputObject $AdapterResolution -PropertyName 'effective_host_adapter_id') -and
+            -not [string]::IsNullOrWhiteSpace([string]$AdapterResolution.effective_host_adapter_id)
+        ) {
+            $effectiveHostAdapterId = [string]$AdapterResolution.effective_host_adapter_id
+        } elseif (
+            (Test-VibeObjectHasProperty -InputObject $AdapterResolution -PropertyName 'requested_host_adapter_id') -and
+            -not [string]::IsNullOrWhiteSpace([string]$AdapterResolution.requested_host_adapter_id)
+        ) {
+            $effectiveHostAdapterId = [string]$AdapterResolution.requested_host_adapter_id
+        }
+    }
+
+    if ([string]$effectiveHostAdapterId -ne 'codex') {
+        return @()
+    }
+
+    if (Test-VibePathIsGitWorkTree -Path $WorkingRoot) {
+        return @()
+    }
+
+    return @('--skip-git-repo-check')
+}
+
 function New-VibeNativeSpecialistPrompt {
     param(
         [Parameter(Mandatory)] [object]$Dispatch,
@@ -1082,7 +1378,18 @@ function Invoke-VibeSpecialistDispatchUnit {
             -MissingPromptInjectionFields @($promptInjection.missing_fields)
     }
 
-    $beforeSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $RepoRoot
+    $workingRoot = Resolve-VibeNativeSpecialistWorkingRoot `
+        -RepoRoot $RepoRoot `
+        -SessionRoot $SessionRoot `
+        -RequirementDocPath $RequirementDocPath `
+        -ExecutionPlanPath $ExecutionPlanPath
+    $environmentOverrides = Get-VibeNativeSpecialistCodexHomeEnvironmentOverrides `
+        -AdapterResolution $adapterResolution `
+        -SkillRecord $Dispatch `
+        -RunId $RunId `
+        -UnitId $UnitId
+
+    $beforeSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $workingRoot
     Write-VgoUtf8NoBomText -Path $beforeGitPath -Content ((@($beforeSnapshot.lines) -join [Environment]::NewLine) + [Environment]::NewLine)
 
     $arguments = @()
@@ -1092,8 +1399,11 @@ function Invoke-VibeSpecialistDispatchUnit {
     foreach ($item in @($adapter.arguments_prefix)) {
         $arguments += [string]$item
     }
+    foreach ($item in @(Get-VibeNativeSpecialistRepoCheckBypassArguments -AdapterResolution $adapterResolution -WorkingRoot $workingRoot)) {
+        $arguments += [string]$item
+    }
     $arguments += @(
-        '-C', $RepoRoot,
+        '-C', $workingRoot,
         '--output-schema', $schemaPath,
         '-o', $responsePath,
         $prompt
@@ -1101,12 +1411,13 @@ function Invoke-VibeSpecialistDispatchUnit {
     $processResult = Invoke-VibeCapturedProcess `
         -Command ([string]$adapterResolution.command_path) `
         -Arguments $arguments `
-        -WorkingDirectory $RepoRoot `
+        -WorkingDirectory $workingRoot `
         -TimeoutSeconds ([int]$policy.default_timeout_seconds) `
         -StdOutPath $stdoutPath `
-        -StdErrPath $stderrPath
+        -StdErrPath $stderrPath `
+        -EnvironmentOverrides $environmentOverrides
 
-    $afterSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $RepoRoot
+    $afterSnapshot = Get-VibeGitStatusSnapshot -RepoRoot $workingRoot
     Write-VgoUtf8NoBomText -Path $afterGitPath -Content ((@($afterSnapshot.lines) -join [Environment]::NewLine) + [Environment]::NewLine)
 
     $parsedResponse = $null
@@ -1180,7 +1491,7 @@ function Invoke-VibeSpecialistDispatchUnit {
         command = [string]$adapterResolution.command_path
         arguments = @($arguments)
         display_command = @([string]$adapterResolution.command_path) + @($arguments) -join ' '
-        cwd = $RepoRoot
+        cwd = $workingRoot
         timeout_seconds = [int]$policy.default_timeout_seconds
         expected_exit_code = 0
         exit_code = [int]$processResult.exit_code

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -328,6 +328,127 @@ function Get-VibeWorkspaceMemoryPlaneContract {
     }
 }
 
+function Test-VibeWritableDirectory {
+    param(
+        [AllowEmptyString()] [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $false
+    }
+
+    $candidate = [System.IO.Path]::GetFullPath($Path)
+    if (-not (Test-Path -LiteralPath $candidate)) {
+        return $false
+    }
+
+    try {
+        $item = Get-Item -LiteralPath $candidate -ErrorAction Stop
+        $directory = if ($item.PSIsContainer) { [string]$item.FullName } else { [string]$item.Directory.FullName }
+        if ([string]::IsNullOrWhiteSpace($directory)) {
+            return $false
+        }
+
+        $probePath = Join-Path $directory ('.vibe-write-probe-{0}.tmp' -f [System.Guid]::NewGuid().ToString('N'))
+        [System.IO.File]::WriteAllText($probePath, '')
+        Remove-Item -LiteralPath $probePath -Force -ErrorAction SilentlyContinue
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function Resolve-VibeGovernedArtifactRootFromPath {
+    param(
+        [AllowEmptyString()] [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $null
+    }
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    if (-not (Test-Path -LiteralPath $resolvedPath)) {
+        return $null
+    }
+
+    $container = if (Test-Path -LiteralPath $resolvedPath -PathType Container) {
+        $resolvedPath
+    } else {
+        Split-Path -Parent $resolvedPath
+    }
+    if ([string]::IsNullOrWhiteSpace($container)) {
+        return $null
+    }
+
+    $leafName = [System.IO.Path]::GetFileName($container)
+    $parent = Split-Path -Parent $container
+    if (($leafName -in @('requirements', 'plans')) -and ([System.IO.Path]::GetFileName($parent) -eq 'docs')) {
+        return [System.IO.Path]::GetFullPath((Split-Path -Parent $parent))
+    }
+
+    return [System.IO.Path]::GetFullPath($container)
+}
+
+function Resolve-VibeNativeSpecialistWorkingRoot {
+    param(
+        [Parameter(Mandatory)] [string]$RepoRoot,
+        [AllowEmptyString()] [string]$SessionRoot = '',
+        [AllowEmptyString()] [string]$RequirementDocPath = '',
+        [AllowEmptyString()] [string]$ExecutionPlanPath = '',
+        [AllowEmptyString()] [string]$SourceArtifactPath = ''
+    )
+
+    $preferArtifactWorkspace = (
+        (Test-Path -LiteralPath (Join-Path $RepoRoot 'scripts/runtime/Invoke-VibeCanonicalEntry.ps1') -PathType Leaf) -and
+        (Test-Path -LiteralPath (Join-Path $RepoRoot 'config/version-governance.json') -PathType Leaf)
+    )
+    $orderedCandidates = if ($preferArtifactWorkspace) {
+        @(
+            $(Resolve-VibeGovernedArtifactRootFromPath -Path $RequirementDocPath),
+            $(Resolve-VibeGovernedArtifactRootFromPath -Path $ExecutionPlanPath),
+            $(Resolve-VibeGovernedArtifactRootFromPath -Path $SourceArtifactPath),
+            $SessionRoot,
+            $RepoRoot
+        )
+    } else {
+        @(
+            $RepoRoot,
+            $(Resolve-VibeGovernedArtifactRootFromPath -Path $RequirementDocPath),
+            $(Resolve-VibeGovernedArtifactRootFromPath -Path $ExecutionPlanPath),
+            $(Resolve-VibeGovernedArtifactRootFromPath -Path $SourceArtifactPath),
+            $SessionRoot
+        )
+    }
+
+    $candidates = New-Object System.Collections.Generic.List[string]
+    foreach ($candidate in @($orderedCandidates)) {
+        if ([string]::IsNullOrWhiteSpace([string]$candidate)) {
+            continue
+        }
+
+        $resolvedCandidate = [System.IO.Path]::GetFullPath([string]$candidate)
+        if (-not (Test-Path -LiteralPath $resolvedCandidate)) {
+            continue
+        }
+        if (-not $candidates.Contains($resolvedCandidate)) {
+            $candidates.Add($resolvedCandidate) | Out-Null
+        }
+    }
+
+    foreach ($candidate in @($candidates)) {
+        if (Test-VibeWritableDirectory -Path $candidate) {
+            return $candidate
+        }
+    }
+
+    if ($candidates.Count -gt 0) {
+        return [string]$candidates[0]
+    }
+
+    return [System.IO.Path]::GetFullPath($RepoRoot)
+}
+
 function Get-VibeHostSidecarRoot {
     param(
         [AllowNull()] [object]$Runtime,

--- a/tests/integration/test_powershell_captured_process_argument_integrity.py
+++ b/tests/integration/test_powershell_captured_process_argument_integrity.py
@@ -66,3 +66,85 @@ Invoke-VibeCapturedProcess `
 
     captured_args = json.loads(captured_args_path.read_text(encoding="utf-8"))
     assert captured_args == ["--flag", "value with spaces", prompt]
+
+
+def test_invoke_vibe_captured_process_applies_environment_overrides(tmp_path: Path) -> None:
+    powershell = _require_powershell()
+    captured_env_path = tmp_path / "captured-env.json"
+    script_path = tmp_path / "capture_env.py"
+    stdout_path = tmp_path / "stdout.txt"
+    stderr_path = tmp_path / "stderr.txt"
+    script_path.write_text(
+        "import json, os, pathlib, sys\n"
+        "pathlib.Path(sys.argv[1]).write_text("
+        "json.dumps({'SPECIAL_TEST_ENV': os.environ.get('SPECIAL_TEST_ENV')}, ensure_ascii=False), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+
+    command = f"""
+. '{(REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1").as_posix()}'
+Invoke-VibeCapturedProcess `
+    -Command '{shutil.which("python3") or sys.executable}' `
+    -Arguments @(
+        '{script_path.as_posix()}',
+        '{captured_env_path.as_posix()}'
+    ) `
+    -WorkingDirectory '{REPO_ROOT.as_posix()}' `
+    -TimeoutSeconds 10 `
+    -StdOutPath '{stdout_path.as_posix()}' `
+    -StdErrPath '{stderr_path.as_posix()}' `
+    -EnvironmentOverrides @{{ SPECIAL_TEST_ENV = 'expected-value' }} | Out-Null
+"""
+
+    subprocess.run(
+        [powershell, "-NoLogo", "-NoProfile", "-Command", command],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    captured_env = json.loads(captured_env_path.read_text(encoding="utf-8"))
+    assert captured_env == {"SPECIAL_TEST_ENV": "expected-value"}
+
+
+def test_invoke_vibe_captured_process_closes_stdin_for_child_process(tmp_path: Path) -> None:
+    powershell = _require_powershell()
+    stdin_state_path = tmp_path / "stdin-state.json"
+    script_path = tmp_path / "capture_stdin.py"
+    stdout_path = tmp_path / "stdout.txt"
+    stderr_path = tmp_path / "stderr.txt"
+    script_path.write_text(
+        "import json, pathlib, sys\n"
+        "payload = sys.stdin.read()\n"
+        "pathlib.Path(sys.argv[1]).write_text("
+        "json.dumps({'stdin_closed': payload == ''}, ensure_ascii=False), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+
+    command = f"""
+. '{(REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1").as_posix()}'
+Invoke-VibeCapturedProcess `
+    -Command '{shutil.which("python3") or sys.executable}' `
+    -Arguments @(
+        '{script_path.as_posix()}',
+        '{stdin_state_path.as_posix()}'
+    ) `
+    -WorkingDirectory '{REPO_ROOT.as_posix()}' `
+    -TimeoutSeconds 10 `
+    -StdOutPath '{stdout_path.as_posix()}' `
+    -StdErrPath '{stderr_path.as_posix()}' | Out-Null
+"""
+
+    subprocess.run(
+        [powershell, "-NoLogo", "-NoProfile", "-Command", command],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    stdin_state = json.loads(stdin_state_path.read_text(encoding="utf-8"))
+    assert stdin_state == {"stdin_closed": True}

--- a/tests/integration/test_vibe_skill_bootstrap_contract.py
+++ b/tests/integration/test_vibe_skill_bootstrap_contract.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_vibe_skill_frontloads_canonical_bootstrap_contract() -> None:
+    content = (REPO_ROOT / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "## Canonical Bootstrap" in content
+    assert content.index("## Canonical Bootstrap") < content.index("## What `vibe` Does")
+    assert "python3 -m vgo_cli.main canonical-entry" in content
+    assert "python -m vgo_cli.main canonical-entry" in content
+    assert '--artifact-root "<workspace_root>"' in content
+    assert "Do not manually create `outputs/runtime/vibe-sessions/<run-id>/`" in content
+    assert "Do not use the Vibe installation root as the governed artifact root" in content
+    assert "Do not simulate `skeleton_check`" in content
+    assert "Do not treat `scripts/runtime/Invoke-VibeCanonicalEntry.ps1` alone as proof-complete canonical entry" in content
+    assert "Canonical launch claims require `host-launch-receipt.json`, `runtime-input-packet.json`, `governance-capsule.json`, and `stage-lineage.json`." in content
+    assert "report `blocked` with the concrete failure reason" in content
+    assert "Everything below this bootstrap section is reference material to follow only after successful canonical launch." in content

--- a/tests/runtime_neutral/test_plan_execute_receipts.py
+++ b/tests/runtime_neutral/test_plan_execute_receipts.py
@@ -52,6 +52,14 @@ def extract_powershell_function(script_path: Path, function_name: str) -> str:
     return text[start:index]
 
 
+def require_preview_line(preview_lines: object, prefix: str) -> str:
+    normalized = [str(line) for line in list(preview_lines)]
+    line = next((line for line in normalized if line.startswith(prefix)), None)
+    if line is None:
+        raise AssertionError(f"{prefix} line not found in preview: {normalized}")
+    return line
+
+
 def create_repo_check_fake_codex_command(directory: Path) -> Path:
     suffix = ".cmd" if os.name == "nt" else ""
     command_path = directory / f"codex-repo-check{suffix}"
@@ -222,6 +230,7 @@ def create_codex_home_seed_verifying_fake_dispatch_command(directory: Path) -> P
             "if not exist \"%CODEX_HOME%\\config\\seed.json\" exit /b 8\r\n"
             "if not exist \"%CODEX_HOME%\\mcp\\seed.json\" exit /b 9\r\n"
             "> \"%OUT%\" echo {\"status\":\"completed\",\"summary\":\"Executed specialist from a seeded codex home.\",\"verification_notes\":[\"Execution used copied auth and config in the sidecar.\"],\"changed_files\":[],\"bounded_output_notes\":[\"Sidecar was seeded from the current host codex home before launch.\"]}\r\n"
+            "echo CODEX_HOME=%CODEX_HOME%\r\n"
             "echo CODEX_HOME_SEEDED=1\r\n"
             "exit /b 0\r\n",
             encoding="utf-8",
@@ -263,6 +272,7 @@ def create_codex_home_seed_verifying_fake_dispatch_command(directory: Path) -> P
             "  exit 9\n"
             "fi\n"
             "printf '%s' '{\"status\":\"completed\",\"summary\":\"Executed specialist from a seeded codex home.\",\"verification_notes\":[\"Execution used copied auth and config in the sidecar.\"],\"changed_files\":[],\"bounded_output_notes\":[\"Sidecar was seeded from the current host codex home before launch.\"]}' > \"$OUT\"\n"
+            "printf 'CODEX_HOME=%s\\n' \"$CODEX_HOME\"\n"
             "printf 'CODEX_HOME_SEEDED=1\\n'\n",
             encoding="utf-8",
         )
@@ -540,7 +550,7 @@ class PlanExecuteReceiptTests(unittest.TestCase):
             result = json.loads(completed.stdout)
             self.assertEqual("completed", result["status"])
             self.assertTrue(result["live_native_execution"])
-            self.assertEqual(non_git_root.as_posix(), result["cwd"])
+            self.assertEqual(non_git_root.resolve(), Path(result["cwd"]).resolve())
             self.assertIn("--skip-git-repo-check", list(result["arguments"]))
             self.assertTrue(Path(result["response_json_path"]).exists())
             self.assertEqual([], list(result["observed_changed_files"]))
@@ -612,7 +622,7 @@ class PlanExecuteReceiptTests(unittest.TestCase):
 
             result = json.loads(completed.stdout)
             self.assertEqual("completed", result["status"])
-            self.assertEqual(temp_path.as_posix(), result["cwd"])
+            self.assertEqual(temp_path.resolve(), Path(result["cwd"]).resolve())
             self.assertIn("--skip-git-repo-check", list(result["arguments"]))
             self.assertTrue(Path(result["response_json_path"]).exists())
 
@@ -677,18 +687,15 @@ class PlanExecuteReceiptTests(unittest.TestCase):
             result = json.loads(completed.stdout)
             self.assertEqual("completed", result["status"])
             self.assertTrue(result["live_native_execution"])
-            self.assertEqual(non_git_root.as_posix(), result["cwd"])
-            codex_home_line = next(
-                line for line in list(result["stdout_preview"]) if str(line).startswith("CODEX_HOME=")
-            )
+            self.assertEqual(non_git_root.resolve(), Path(result["cwd"]).resolve())
+            codex_home_line = require_preview_line(result["stdout_preview"], "CODEX_HOME=")
             codex_home = codex_home_line.split("=", 1)[1]
             self.assertNotIn(str(session_root), codex_home)
             self.assertNotIn(str(temp_path), codex_home)
-            skill_surface_line = next(
-                line for line in list(result["stdout_preview"]) if str(line).startswith("SKILL_SURFACE=")
-            )
+            self.assertFalse(Path(codex_home).exists())
+            skill_surface_line = require_preview_line(result["stdout_preview"], "SKILL_SURFACE=")
             skill_surface = skill_surface_line.split("=", 1)[1]
-            self.assertTrue(Path(skill_surface).exists())
+            self.assertFalse(Path(skill_surface).exists())
             self.assertEqual("SKILL.md", Path(skill_surface).name)
 
     def test_specialist_dispatch_seeds_sidecar_codex_home_from_current_host(self) -> None:
@@ -760,7 +767,10 @@ class PlanExecuteReceiptTests(unittest.TestCase):
             result = json.loads(completed.stdout)
             self.assertEqual("completed", result["status"])
             self.assertTrue(result["live_native_execution"])
+            codex_home_line = require_preview_line(result["stdout_preview"], "CODEX_HOME=")
+            codex_home = codex_home_line.split("=", 1)[1]
             self.assertIn("CODEX_HOME_SEEDED=1", list(result["stdout_preview"]))
+            self.assertFalse(Path(codex_home).exists())
 
 
 if __name__ == "__main__":

--- a/tests/runtime_neutral/test_plan_execute_receipts.py
+++ b/tests/runtime_neutral/test_plan_execute_receipts.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
+import stat
 import subprocess
+import tempfile
 import unittest
+import uuid
 from pathlib import Path
 
 
@@ -46,6 +50,238 @@ def extract_powershell_function(script_path: Path, function_name: str) -> str:
                 break
         index += 1
     return text[start:index]
+
+
+def create_repo_check_fake_codex_command(directory: Path) -> Path:
+    suffix = ".cmd" if os.name == "nt" else ""
+    command_path = directory / f"codex-repo-check{suffix}"
+    if os.name == "nt":
+        command_path.write_text(
+            "@echo off\r\n"
+            "setlocal EnableDelayedExpansion\r\n"
+            "set OUT=\r\n"
+            "set HAS_SKIP=0\r\n"
+            ":loop\r\n"
+            "if \"%~1\"==\"\" goto done\r\n"
+            "if /I \"%~1\"==\"-o\" (\r\n"
+            "  set OUT=%~2\r\n"
+            "  shift\r\n"
+            "  shift\r\n"
+            "  goto loop\r\n"
+            ")\r\n"
+            "if /I \"%~1\"==\"--skip-git-repo-check\" (\r\n"
+            "  set HAS_SKIP=1\r\n"
+            "  shift\r\n"
+            "  goto loop\r\n"
+            ")\r\n"
+            "shift\r\n"
+            "goto loop\r\n"
+            ":done\r\n"
+            "if \"%HAS_SKIP%\"==\"0\" (\r\n"
+            "  >&2 echo Not inside a trusted directory and --skip-git-repo-check was not specified.\r\n"
+            "  exit /b 1\r\n"
+            ")\r\n"
+            "if \"%OUT%\"==\"\" exit /b 2\r\n"
+            "> \"%OUT%\" echo {\"status\":\"completed\",\"summary\":\"Executed specialist from a non-git workspace.\",\"verification_notes\":[\"Repo-check bypass was applied only for this codex exec.\"],\"changed_files\":[],\"bounded_output_notes\":[\"Execution stayed bounded to the provided artifacts.\"]}\r\n"
+            "echo fake codex repo-check ok\r\n"
+            "exit /b 0\r\n",
+            encoding="utf-8",
+        )
+    else:
+        command_path.write_text(
+            "#!/usr/bin/env sh\n"
+            "OUT=''\n"
+            "HAS_SKIP=0\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    -o)\n"
+            "      OUT=\"$2\"\n"
+            "      shift 2\n"
+            "      ;;\n"
+            "    --skip-git-repo-check)\n"
+            "      HAS_SKIP=1\n"
+            "      shift\n"
+            "      ;;\n"
+            "    *)\n"
+            "      shift\n"
+            "      ;;\n"
+            "  esac\n"
+            "done\n"
+            "if [ \"$HAS_SKIP\" != \"1\" ]; then\n"
+            "  printf 'Not inside a trusted directory and --skip-git-repo-check was not specified.\\n' >&2\n"
+            "  exit 1\n"
+            "fi\n"
+            "if [ -z \"$OUT\" ]; then\n"
+            "  exit 2\n"
+            "fi\n"
+            "printf '%s' '{\"status\":\"completed\",\"summary\":\"Executed specialist from a non-git workspace.\",\"verification_notes\":[\"Repo-check bypass was applied only for this codex exec.\"],\"changed_files\":[],\"bounded_output_notes\":[\"Execution stayed bounded to the provided artifacts.\"]}' > \"$OUT\"\n"
+            "printf 'fake codex repo-check ok\\n'\n",
+            encoding="utf-8",
+        )
+        command_path.chmod(command_path.stat().st_mode | stat.S_IXUSR)
+    return command_path
+
+
+def create_codex_home_verifying_fake_dispatch_command(directory: Path) -> Path:
+    suffix = ".cmd" if os.name == "nt" else ""
+    command_path = directory / f"codex-home-dispatch{suffix}"
+    if os.name == "nt":
+        command_path.write_text(
+            "@echo off\r\n"
+            "setlocal EnableDelayedExpansion\r\n"
+            "set OUT=\r\n"
+            ":loop\r\n"
+            "if \"%~1\"==\"\" goto done\r\n"
+            "if /I \"%~1\"==\"-o\" (\r\n"
+            "  set OUT=%~2\r\n"
+            "  shift\r\n"
+            "  shift\r\n"
+            "  goto loop\r\n"
+            ")\r\n"
+            "shift\r\n"
+            "goto loop\r\n"
+            ":done\r\n"
+            "if \"%OUT%\"==\"\" exit /b 2\r\n"
+            "if \"%CODEX_HOME%\"==\"\" (\r\n"
+            "  >&2 echo CODEX_HOME missing\r\n"
+            "  exit /b 3\r\n"
+            ")\r\n"
+            "if not exist \"%CODEX_HOME%\\skills\\systematic-debugging\\SKILL.md\" (\r\n"
+            "  >&2 echo skill surface missing\r\n"
+            "  exit /b 4\r\n"
+            ")\r\n"
+            "> \"%OUT%\" echo {\"status\":\"completed\",\"summary\":\"Executed specialist from a bounded sidecar home.\",\"verification_notes\":[\"Execution used a writable CODEX_HOME sidecar.\"],\"changed_files\":[],\"bounded_output_notes\":[\"Specialist skill surface was materialized before launch.\"]}\r\n"
+            "echo CODEX_HOME=%CODEX_HOME%\r\n"
+            "echo SKILL_SURFACE=%CODEX_HOME%\\skills\\systematic-debugging\\SKILL.md\r\n"
+            "exit /b 0\r\n",
+            encoding="utf-8",
+        )
+    else:
+        command_path.write_text(
+            "#!/usr/bin/env sh\n"
+            "OUT=''\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    -o)\n"
+            "      OUT=\"$2\"\n"
+            "      shift 2\n"
+            "      ;;\n"
+            "    *)\n"
+            "      shift\n"
+            "      ;;\n"
+            "  esac\n"
+            "done\n"
+            "if [ -z \"$OUT\" ]; then\n"
+            "  exit 2\n"
+            "fi\n"
+            "if [ -z \"$CODEX_HOME\" ]; then\n"
+            "  printf 'CODEX_HOME missing\\n' >&2\n"
+            "  exit 3\n"
+            "fi\n"
+            "if [ ! -f \"$CODEX_HOME/skills/systematic-debugging/SKILL.md\" ]; then\n"
+            "  printf 'skill surface missing\\n' >&2\n"
+            "  exit 4\n"
+            "fi\n"
+            "printf '%s' '{\"status\":\"completed\",\"summary\":\"Executed specialist from a bounded sidecar home.\",\"verification_notes\":[\"Execution used a writable CODEX_HOME sidecar.\"],\"changed_files\":[],\"bounded_output_notes\":[\"Specialist skill surface was materialized before launch.\"]}' > \"$OUT\"\n"
+            "printf 'CODEX_HOME=%s\\n' \"$CODEX_HOME\"\n"
+            "printf 'SKILL_SURFACE=%s\\n' \"$CODEX_HOME/skills/systematic-debugging/SKILL.md\"\n",
+            encoding="utf-8",
+        )
+        command_path.chmod(command_path.stat().st_mode | stat.S_IXUSR)
+    return command_path
+
+
+def create_codex_home_seed_verifying_fake_dispatch_command(directory: Path) -> Path:
+    suffix = ".cmd" if os.name == "nt" else ""
+    command_path = directory / f"codex-home-seed-dispatch{suffix}"
+    if os.name == "nt":
+        command_path.write_text(
+            "@echo off\r\n"
+            "setlocal EnableDelayedExpansion\r\n"
+            "set OUT=\r\n"
+            ":loop\r\n"
+            "if \"%~1\"==\"\" goto done\r\n"
+            "if /I \"%~1\"==\"-o\" (\r\n"
+            "  set OUT=%~2\r\n"
+            "  shift\r\n"
+            "  shift\r\n"
+            "  goto loop\r\n"
+            ")\r\n"
+            "shift\r\n"
+            "goto loop\r\n"
+            ":done\r\n"
+            "if \"%OUT%\"==\"\" exit /b 2\r\n"
+            "if \"%CODEX_HOME%\"==\"\" (\r\n"
+            "  >&2 echo CODEX_HOME missing\r\n"
+            "  exit /b 3\r\n"
+            ")\r\n"
+            "if not exist \"%CODEX_HOME%\\config.toml\" exit /b 4\r\n"
+            "findstr /c:\"config-seed-marker\" \"%CODEX_HOME%\\config.toml\" >nul || exit /b 5\r\n"
+            "if not exist \"%CODEX_HOME%\\auth.json\" exit /b 6\r\n"
+            "findstr /c:\"auth-seed-marker\" \"%CODEX_HOME%\\auth.json\" >nul || exit /b 7\r\n"
+            "if not exist \"%CODEX_HOME%\\config\\seed.json\" exit /b 8\r\n"
+            "if not exist \"%CODEX_HOME%\\mcp\\seed.json\" exit /b 9\r\n"
+            "> \"%OUT%\" echo {\"status\":\"completed\",\"summary\":\"Executed specialist from a seeded codex home.\",\"verification_notes\":[\"Execution used copied auth and config in the sidecar.\"],\"changed_files\":[],\"bounded_output_notes\":[\"Sidecar was seeded from the current host codex home before launch.\"]}\r\n"
+            "echo CODEX_HOME_SEEDED=1\r\n"
+            "exit /b 0\r\n",
+            encoding="utf-8",
+        )
+    else:
+        command_path.write_text(
+            "#!/usr/bin/env sh\n"
+            "OUT=''\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    -o)\n"
+            "      OUT=\"$2\"\n"
+            "      shift 2\n"
+            "      ;;\n"
+            "    *)\n"
+            "      shift\n"
+            "      ;;\n"
+            "  esac\n"
+            "done\n"
+            "if [ -z \"$OUT\" ]; then\n"
+            "  exit 2\n"
+            "fi\n"
+            "if [ -z \"$CODEX_HOME\" ]; then\n"
+            "  printf 'CODEX_HOME missing\\n' >&2\n"
+            "  exit 3\n"
+            "fi\n"
+            "if [ ! -f \"$CODEX_HOME/config.toml\" ]; then\n"
+            "  exit 4\n"
+            "fi\n"
+            "grep -q 'config-seed-marker' \"$CODEX_HOME/config.toml\" || exit 5\n"
+            "if [ ! -f \"$CODEX_HOME/auth.json\" ]; then\n"
+            "  exit 6\n"
+            "fi\n"
+            "grep -q 'auth-seed-marker' \"$CODEX_HOME/auth.json\" || exit 7\n"
+            "if [ ! -f \"$CODEX_HOME/config/seed.json\" ]; then\n"
+            "  exit 8\n"
+            "fi\n"
+            "if [ ! -f \"$CODEX_HOME/mcp/seed.json\" ]; then\n"
+            "  exit 9\n"
+            "fi\n"
+            "printf '%s' '{\"status\":\"completed\",\"summary\":\"Executed specialist from a seeded codex home.\",\"verification_notes\":[\"Execution used copied auth and config in the sidecar.\"],\"changed_files\":[],\"bounded_output_notes\":[\"Sidecar was seeded from the current host codex home before launch.\"]}' > \"$OUT\"\n"
+            "printf 'CODEX_HOME_SEEDED=1\\n'\n",
+            encoding="utf-8",
+        )
+        command_path.chmod(command_path.stat().st_mode | stat.S_IXUSR)
+    return command_path
+
+
+def set_directory_read_only(path: Path) -> None:
+    if os.name == "nt":
+        path.chmod(stat.S_IREAD | stat.S_IEXEC)
+    else:
+        path.chmod(0o555)
+
+
+def set_directory_writable(path: Path) -> None:
+    if os.name == "nt":
+        path.chmod(stat.S_IWRITE | stat.S_IREAD | stat.S_IEXEC)
+    else:
+        path.chmod(0o755)
 
 
 class PlanExecuteReceiptTests(unittest.TestCase):
@@ -242,6 +478,289 @@ class PlanExecuteReceiptTests(unittest.TestCase):
         self.assertIsNone(result["prompt_path"])
         self.assertFalse(result["prompt_injection_complete"])
         self.assertEqual([], result["missing_prompt_injection_fields"])
+
+    def test_specialist_dispatch_bypasses_codex_repo_check_for_non_git_roots(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell not available")
+
+        common_path = REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1"
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_path = Path(tempdir)
+            fake_codex = create_repo_check_fake_codex_command(temp_path)
+            non_git_root = temp_path / "non-git-workspace"
+            non_git_root.mkdir(parents=True, exist_ok=True)
+            session_root = temp_path / "session"
+            session_root.mkdir(parents=True, exist_ok=True)
+            requirement_doc = temp_path / "requirement.md"
+            execution_plan = temp_path / "plan.md"
+            skill_root = temp_path / "skills" / "systematic-debugging"
+            skill_root.mkdir(parents=True, exist_ok=True)
+            entrypoint_path = skill_root / "SKILL.runtime-mirror.md"
+            requirement_doc.write_text("# Requirement\n", encoding="utf-8")
+            execution_plan.write_text("# Plan\n", encoding="utf-8")
+            entrypoint_path.write_text("# Specialist\n", encoding="utf-8")
+
+            ps_script = (
+                "& { "
+                f". '{common_path}'; "
+                "$dispatch = [pscustomobject]@{ "
+                "skill_id = 'systematic-debugging'; "
+                "bounded_role = 'specialist_assist'; "
+                f"native_skill_entrypoint = '{entrypoint_path.as_posix()}'; "
+                f"skill_root = '{skill_root.as_posix()}'; "
+                "visibility_class = 'path_resolved'; "
+                "native_usage_required = $true; "
+                "usage_required = $true; "
+                "must_preserve_workflow = $true; "
+                "required_inputs = @('requirement_doc', 'execution_plan'); "
+                "expected_outputs = @('verification_notes', 'changed_files'); "
+                "verification_expectation = 'Return bounded execution guidance.'; "
+                "progressive_load_policy = @('Open the declared specialist entrypoint before executing.') "
+                "}; "
+                f"$result = Invoke-VibeSpecialistDispatchUnit -UnitId 'unit-{uuid.uuid4().hex[:8]}' -Dispatch $dispatch -SessionRoot '{session_root.as_posix()}' -RepoRoot '{non_git_root.as_posix()}' -RequirementDocPath '{requirement_doc.as_posix()}' -ExecutionPlanPath '{execution_plan.as_posix()}' -RunId 'run-1' -GovernanceScope 'root' -WriteScope 'read_only'; "
+                "$result.result | ConvertTo-Json -Depth 20 }"
+            )
+
+            completed = subprocess.run(
+                [powershell, "-NoLogo", "-NoProfile", "-Command", ps_script],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+                env={
+                    **os.environ,
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+
+            result = json.loads(completed.stdout)
+            self.assertEqual("completed", result["status"])
+            self.assertTrue(result["live_native_execution"])
+            self.assertEqual(non_git_root.as_posix(), result["cwd"])
+            self.assertIn("--skip-git-repo-check", list(result["arguments"]))
+            self.assertTrue(Path(result["response_json_path"]).exists())
+            self.assertEqual([], list(result["observed_changed_files"]))
+
+    def test_specialist_dispatch_falls_back_to_requirement_workspace_when_repo_root_is_read_only(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        common_path = REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1"
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_path = Path(tempdir)
+            fake_codex = create_repo_check_fake_codex_command(temp_path)
+            read_only_root = temp_path / "read-only-install-root"
+            read_only_root.mkdir(parents=True, exist_ok=True)
+            session_root = temp_path / "session"
+            session_root.mkdir(parents=True, exist_ok=True)
+            requirement_doc = temp_path / "docs" / "requirements" / "requirement.md"
+            execution_plan = temp_path / "docs" / "plans" / "plan.md"
+            requirement_doc.parent.mkdir(parents=True, exist_ok=True)
+            execution_plan.parent.mkdir(parents=True, exist_ok=True)
+            skill_root = temp_path / "skills" / "systematic-debugging"
+            skill_root.mkdir(parents=True, exist_ok=True)
+            entrypoint_path = skill_root / "SKILL.runtime-mirror.md"
+            requirement_doc.write_text("# Requirement\n", encoding="utf-8")
+            execution_plan.write_text("# Plan\n", encoding="utf-8")
+            entrypoint_path.write_text("# Specialist\n", encoding="utf-8")
+
+            try:
+                set_directory_read_only(read_only_root)
+
+                ps_script = (
+                    "& { "
+                    f". '{common_path}'; "
+                    "$dispatch = [pscustomobject]@{ "
+                    "skill_id = 'systematic-debugging'; "
+                    "bounded_role = 'specialist_assist'; "
+                    f"native_skill_entrypoint = '{entrypoint_path.as_posix()}'; "
+                    f"skill_root = '{skill_root.as_posix()}'; "
+                    "visibility_class = 'path_resolved'; "
+                    "native_usage_required = $true; "
+                    "usage_required = $true; "
+                    "must_preserve_workflow = $true; "
+                    "required_inputs = @('requirement_doc', 'execution_plan'); "
+                    "expected_outputs = @('verification_notes', 'changed_files'); "
+                    "verification_expectation = 'Return bounded execution guidance.'; "
+                    "progressive_load_policy = @('Open the declared specialist entrypoint before executing.') "
+                    "}; "
+                    f"$result = Invoke-VibeSpecialistDispatchUnit -UnitId 'unit-{uuid.uuid4().hex[:8]}' -Dispatch $dispatch -SessionRoot '{session_root.as_posix()}' -RepoRoot '{read_only_root.as_posix()}' -RequirementDocPath '{requirement_doc.as_posix()}' -ExecutionPlanPath '{execution_plan.as_posix()}' -RunId 'run-1' -GovernanceScope 'root' -WriteScope 'read_only'; "
+                    "$result.result | ConvertTo-Json -Depth 20 }"
+                )
+
+                completed = subprocess.run(
+                    [powershell, "-NoLogo", "-NoProfile", "-Command", ps_script],
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    env={
+                        **os.environ,
+                        "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                        "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                        "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                    },
+                )
+            finally:
+                set_directory_writable(read_only_root)
+
+            result = json.loads(completed.stdout)
+            self.assertEqual("completed", result["status"])
+            self.assertEqual(temp_path.as_posix(), result["cwd"])
+            self.assertIn("--skip-git-repo-check", list(result["arguments"]))
+            self.assertTrue(Path(result["response_json_path"]).exists())
+
+    def test_specialist_dispatch_uses_sidecar_codex_home_with_materialized_skill_surface(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        common_path = REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1"
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_path = Path(tempdir)
+            fake_codex = create_codex_home_verifying_fake_dispatch_command(temp_path)
+            non_git_root = temp_path / "non-git-workspace"
+            non_git_root.mkdir(parents=True, exist_ok=True)
+            session_root = temp_path / "session"
+            session_root.mkdir(parents=True, exist_ok=True)
+            requirement_doc = temp_path / "requirement.md"
+            execution_plan = temp_path / "plan.md"
+            skill_root = temp_path / "skills" / "systematic-debugging"
+            skill_root.mkdir(parents=True, exist_ok=True)
+            entrypoint_path = skill_root / "SKILL.runtime-mirror.md"
+            requirement_doc.write_text("# Requirement\n", encoding="utf-8")
+            execution_plan.write_text("# Plan\n", encoding="utf-8")
+            entrypoint_path.write_text("# Specialist\n", encoding="utf-8")
+
+            ps_script = (
+                "& { "
+                f". '{common_path}'; "
+                "$dispatch = [pscustomobject]@{ "
+                "skill_id = 'systematic-debugging'; "
+                "bounded_role = 'specialist_assist'; "
+                f"native_skill_entrypoint = '{entrypoint_path.as_posix()}'; "
+                f"skill_root = '{skill_root.as_posix()}'; "
+                "visibility_class = 'path_resolved'; "
+                "native_usage_required = $true; "
+                "usage_required = $true; "
+                "must_preserve_workflow = $true; "
+                "required_inputs = @('requirement_doc', 'execution_plan'); "
+                "expected_outputs = @('verification_notes', 'changed_files'); "
+                "verification_expectation = 'Return bounded execution guidance.'; "
+                "progressive_load_policy = @('Open the declared specialist entrypoint before executing.') "
+                "}; "
+                f"$result = Invoke-VibeSpecialistDispatchUnit -UnitId 'unit-sidecar' -Dispatch $dispatch -SessionRoot '{session_root.as_posix()}' -RepoRoot '{non_git_root.as_posix()}' -RequirementDocPath '{requirement_doc.as_posix()}' -ExecutionPlanPath '{execution_plan.as_posix()}' -RunId 'run-sidecar' -GovernanceScope 'root' -WriteScope 'read_only'; "
+                "$result.result | ConvertTo-Json -Depth 20 }"
+            )
+
+            completed = subprocess.run(
+                [powershell, "-NoLogo", "-NoProfile", "-Command", ps_script],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+                env={
+                    **os.environ,
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+
+            result = json.loads(completed.stdout)
+            self.assertEqual("completed", result["status"])
+            self.assertTrue(result["live_native_execution"])
+            self.assertEqual(non_git_root.as_posix(), result["cwd"])
+            codex_home_line = next(
+                line for line in list(result["stdout_preview"]) if str(line).startswith("CODEX_HOME=")
+            )
+            codex_home = codex_home_line.split("=", 1)[1]
+            self.assertNotIn(str(session_root), codex_home)
+            self.assertNotIn(str(temp_path), codex_home)
+            skill_surface_line = next(
+                line for line in list(result["stdout_preview"]) if str(line).startswith("SKILL_SURFACE=")
+            )
+            skill_surface = skill_surface_line.split("=", 1)[1]
+            self.assertTrue(Path(skill_surface).exists())
+            self.assertEqual("SKILL.md", Path(skill_surface).name)
+
+    def test_specialist_dispatch_seeds_sidecar_codex_home_from_current_host(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        common_path = REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1"
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_path = Path(tempdir)
+            fake_codex = create_codex_home_seed_verifying_fake_dispatch_command(temp_path)
+            source_codex_home = temp_path / "source-codex-home"
+            (source_codex_home / "config").mkdir(parents=True, exist_ok=True)
+            (source_codex_home / "mcp").mkdir(parents=True, exist_ok=True)
+            (source_codex_home / "config.toml").write_text("# config-seed-marker\n", encoding="utf-8")
+            (source_codex_home / "auth.json").write_text("{\"marker\":\"auth-seed-marker\"}\n", encoding="utf-8")
+            (source_codex_home / "config" / "seed.json").write_text("{\"marker\":\"config-dir\"}\n", encoding="utf-8")
+            (source_codex_home / "mcp" / "seed.json").write_text("{\"marker\":\"mcp-dir\"}\n", encoding="utf-8")
+            non_git_root = temp_path / "non-git-workspace"
+            non_git_root.mkdir(parents=True, exist_ok=True)
+            session_root = temp_path / "session"
+            session_root.mkdir(parents=True, exist_ok=True)
+            requirement_doc = temp_path / "requirement.md"
+            execution_plan = temp_path / "plan.md"
+            skill_root = temp_path / "skills" / "systematic-debugging"
+            skill_root.mkdir(parents=True, exist_ok=True)
+            entrypoint_path = skill_root / "SKILL.runtime-mirror.md"
+            requirement_doc.write_text("# Requirement\n", encoding="utf-8")
+            execution_plan.write_text("# Plan\n", encoding="utf-8")
+            entrypoint_path.write_text("# Specialist\n", encoding="utf-8")
+
+            ps_script = (
+                "& { "
+                f". '{common_path}'; "
+                "$dispatch = [pscustomobject]@{ "
+                "skill_id = 'systematic-debugging'; "
+                "bounded_role = 'specialist_assist'; "
+                f"native_skill_entrypoint = '{entrypoint_path.as_posix()}'; "
+                f"skill_root = '{skill_root.as_posix()}'; "
+                "visibility_class = 'path_resolved'; "
+                "native_usage_required = $true; "
+                "usage_required = $true; "
+                "must_preserve_workflow = $true; "
+                "required_inputs = @('requirement_doc', 'execution_plan'); "
+                "expected_outputs = @('verification_notes', 'changed_files'); "
+                "verification_expectation = 'Return bounded execution guidance.'; "
+                "progressive_load_policy = @('Open the declared specialist entrypoint before executing.') "
+                "}; "
+                f"$result = Invoke-VibeSpecialistDispatchUnit -UnitId 'unit-seed' -Dispatch $dispatch -SessionRoot '{session_root.as_posix()}' -RepoRoot '{non_git_root.as_posix()}' -RequirementDocPath '{requirement_doc.as_posix()}' -ExecutionPlanPath '{execution_plan.as_posix()}' -RunId 'run-seed' -GovernanceScope 'root' -WriteScope 'read_only'; "
+                "$result.result | ConvertTo-Json -Depth 20 }"
+            )
+
+            completed = subprocess.run(
+                [powershell, "-NoLogo", "-NoProfile", "-Command", ps_script],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+                env={
+                    **os.environ,
+                    "CODEX_HOME": str(source_codex_home),
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+
+            result = json.loads(completed.stdout)
+            self.assertEqual("completed", result["status"])
+            self.assertTrue(result["live_native_execution"])
+            self.assertIn("CODEX_HOME_SEEDED=1", list(result["stdout_preview"]))
 
 
 if __name__ == "__main__":

--- a/tests/runtime_neutral/test_vibe_specialist_consultation.py
+++ b/tests/runtime_neutral/test_vibe_specialist_consultation.py
@@ -43,6 +43,14 @@ def load_json(path: str | Path) -> dict[str, object]:
     return json.loads(Path(path).read_text(encoding="utf-8"))
 
 
+def require_preview_line(preview_lines: object, prefix: str) -> str:
+    normalized = [str(line) for line in list(preview_lines)]
+    line = next((line for line in normalized if line.startswith(prefix)), None)
+    if line is None:
+        raise AssertionError(f"{prefix} line not found in preview: {normalized}")
+    return line
+
+
 def freeze_runtime_packet(task: str, artifact_root: Path) -> dict[str, object]:
     shell = resolve_powershell()
     if shell is None:
@@ -301,6 +309,7 @@ def create_codex_home_seed_verifying_fake_consultation_command(directory: Path) 
             "if not exist \"%CODEX_HOME%\\config\\seed.json\" exit /b 8\r\n"
             "if not exist \"%CODEX_HOME%\\mcp\\seed.json\" exit /b 9\r\n"
             "> \"%OUT%\" echo {\"status\":\"completed\",\"summary\":\"Consulted specialist from a seeded codex home.\",\"consultation_notes\":[\"Baseline codex config was copied into the sidecar.\"],\"adoption_notes\":[\"Keep user auth and config available to native specialist subprocesses.\"],\"verification_notes\":[\"Consultation used a seeded CODEX_HOME sidecar.\"]}\r\n"
+            "echo CODEX_HOME=%CODEX_HOME%\r\n"
             "echo CODEX_HOME_SEEDED=1\r\n"
             "exit /b 0\r\n",
             encoding="utf-8",
@@ -344,6 +353,7 @@ def create_codex_home_seed_verifying_fake_consultation_command(directory: Path) 
             "  exit 9\n"
             "fi\n"
             "printf '%s' '{\"status\":\"completed\",\"summary\":\"Consulted specialist from a seeded codex home.\",\"consultation_notes\":[\"Baseline codex config was copied into the sidecar.\"],\"adoption_notes\":[\"Keep user auth and config available to native specialist subprocesses.\"],\"verification_notes\":[\"Consultation used a seeded CODEX_HOME sidecar.\"]}' > \"$OUT\"\n"
+            "printf 'CODEX_HOME=%s\\n' \"$CODEX_HOME\"\n"
             "printf 'CODEX_HOME_SEEDED=1\\n'\n",
             encoding="utf-8",
         )
@@ -466,6 +476,57 @@ def create_repo_check_fake_codex_command(directory: Path) -> Path:
             "fi\n"
             "printf '%s' '{\"status\":\"completed\",\"summary\":\"Consulted specialist from a non-git workspace.\",\"consultation_notes\":[\"Repo-check bypass was applied only for this codex exec.\"],\"adoption_notes\":[\"Keep the bypass scoped to native codex subprocesses.\"],\"verification_notes\":[\"Consultation stayed read-only and returned structured guidance.\"]}' > \"$OUT\"\n"
             "printf 'fake codex repo-check ok\\n'\n",
+            encoding="utf-8",
+        )
+        command_path.chmod(command_path.stat().st_mode | stat.S_IXUSR)
+    return command_path
+
+
+def create_write_attempt_fake_consultation_command(directory: Path) -> Path:
+    suffix = ".cmd" if os.name == "nt" else ""
+    command_path = directory / f"codex-write-attempt{suffix}"
+    if os.name == "nt":
+        command_path.write_text(
+            "@echo off\r\n"
+            "setlocal EnableDelayedExpansion\r\n"
+            "set OUT=\r\n"
+            ":loop\r\n"
+            "if \"%~1\"==\"\" goto done\r\n"
+            "if /I \"%~1\"==\"-o\" (\r\n"
+            "  set OUT=%~2\r\n"
+            "  shift\r\n"
+            "  shift\r\n"
+            "  goto loop\r\n"
+            ")\r\n"
+            "shift\r\n"
+            "goto loop\r\n"
+            ":done\r\n"
+            "if \"%OUT%\"==\"\" exit /b 2\r\n"
+            "> wrote-by-fake.txt echo hi\r\n"
+            "> \"%OUT%\" echo {\"status\":\"completed\",\"summary\":\"Consultation attempted a write.\",\"consultation_notes\":[\"A write was attempted in the working directory.\"],\"adoption_notes\":[\"Read-only verification should reject this run.\"],\"verification_notes\":[\"The fake codex created wrote-by-fake.txt.\"]}\r\n"
+            "exit /b 0\r\n",
+            encoding="utf-8",
+        )
+    else:
+        command_path.write_text(
+            "#!/usr/bin/env sh\n"
+            "OUT=''\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    -o)\n"
+            "      OUT=\"$2\"\n"
+            "      shift 2\n"
+            "      ;;\n"
+            "    *)\n"
+            "      shift\n"
+            "      ;;\n"
+            "  esac\n"
+            "done\n"
+            "if [ -z \"$OUT\" ]; then\n"
+            "  exit 2\n"
+            "fi\n"
+            "printf 'hi' > wrote-by-fake.txt\n"
+            "printf '%s' '{\"status\":\"completed\",\"summary\":\"Consultation attempted a write.\",\"consultation_notes\":[\"A write was attempted in the working directory.\"],\"adoption_notes\":[\"Read-only verification should reject this run.\"],\"verification_notes\":[\"The fake codex created wrote-by-fake.txt.\"]}' > \"$OUT\"\n",
             encoding="utf-8",
         )
         command_path.chmod(command_path.stat().st_mode | stat.S_IXUSR)
@@ -719,8 +780,68 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
             )
             self.assertEqual("completed", consulted["status"])
             self.assertTrue(bool(consulted["live_native_execution"]))
-            self.assertEqual(str(non_git_root), consulted["cwd"])
+            self.assertEqual(non_git_root.resolve(), Path(consulted["cwd"]).resolve())
             self.assertIn("--skip-git-repo-check", list(consulted["arguments"]))
+
+    def test_consultation_window_fails_verification_when_non_git_working_root_is_modified(self) -> None:
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            fake_codex = create_write_attempt_fake_consultation_command(artifact_root)
+            freeze_payload = freeze_runtime_packet(SPECIALIST_TASK, artifact_root)
+            packet_path = Path(freeze_payload["packet_path"])
+            non_git_root = artifact_root / "non-git-workspace"
+            non_git_root.mkdir(parents=True, exist_ok=True)
+            run_id = "pytest-consult-write-attempt-" + uuid.uuid4().hex[:10]
+            prompt_seed_path = artifact_root / "discussion-seed.md"
+            prompt_seed_path.write_text("# Intent\nDetect writes inside a non-git consultation workspace.\n", encoding="utf-8")
+
+            ps_script = (
+                "& { "
+                f". {_ps_single_quote(str(RUNTIME_COMMON))}; "
+                f". {_ps_single_quote(str(EXECUTION_COMMON))}; "
+                f". {_ps_single_quote(str(CONSULTATION_SCRIPT))}; "
+                f"$runtime = Get-VibeRuntimeContext -ScriptPath {_ps_single_quote(str(CONSULTATION_SCRIPT))}; "
+                f"$packet = Get-Content -LiteralPath {_ps_single_quote(str(packet_path))} -Raw -Encoding UTF8 | ConvertFrom-Json; "
+                f"$sessionRoot = Ensure-VibeSessionRoot -RepoRoot {_ps_single_quote(str(non_git_root))} -RunId {_ps_single_quote(run_id)} -Runtime $runtime -ArtifactRoot {_ps_single_quote(str(artifact_root))}; "
+                f"$result = Invoke-VibeSpecialistConsultationWindow "
+                f"-Task {_ps_single_quote(SPECIALIST_TASK)} "
+                f"-RunId {_ps_single_quote(run_id)} "
+                f"-SessionRoot $sessionRoot "
+                f"-RepoRoot {_ps_single_quote(str(non_git_root))} "
+                f"-WindowId 'discussion' "
+                f"-Stage 'deep_interview' "
+                f"-SourceArtifactPath {_ps_single_quote(str(prompt_seed_path))} "
+                f"-Recommendations @($packet.specialist_recommendations) "
+                f"-Policy $runtime.specialist_consultation_policy; "
+                "$result | ConvertTo-Json -Depth 20 }"
+            )
+            completed = subprocess.run(
+                [shell, "-NoLogo", "-NoProfile", "-Command", ps_script],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=True,
+                env={
+                    **os.environ,
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+
+            payload = json.loads(completed.stdout)
+            receipt = load_json(payload["receipt_path"])
+            degraded = next(
+                item for item in list(receipt["degraded"]) if item["skill_id"] == "systematic-debugging"
+            )
+            self.assertEqual("failed", degraded["status"])
+            self.assertFalse(bool(degraded["verification_passed"]))
+            self.assertIn("wrote-by-fake.txt", list(degraded["observed_changed_files"]))
 
     def test_consultation_window_falls_back_to_writable_artifact_root_when_repo_root_is_read_only(self) -> None:
         shell = resolve_powershell()
@@ -784,8 +905,8 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
                 item for item in list(receipt["consulted_units"]) if item["skill_id"] == "systematic-debugging"
             )
             self.assertEqual("completed", consulted["status"])
-            self.assertNotEqual(str(read_only_root.resolve()), consulted["cwd"])
-            self.assertEqual(str(artifact_root.resolve()), consulted["cwd"])
+            self.assertNotEqual(read_only_root.resolve(), Path(consulted["cwd"]).resolve())
+            self.assertEqual(artifact_root.resolve(), Path(consulted["cwd"]).resolve())
             self.assertIn("--skip-git-repo-check", list(consulted["arguments"]))
 
     def test_specialist_consultation_unit_uses_sidecar_codex_home_with_materialized_skill_surface(self) -> None:
@@ -846,17 +967,14 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
             result = json.loads(completed.stdout)
             self.assertEqual("completed", result["status"])
             self.assertTrue(bool(result["live_native_execution"]))
-            codex_home_line = next(
-                line for line in list(result["stdout_preview"]) if str(line).startswith("CODEX_HOME=")
-            )
+            codex_home_line = require_preview_line(result["stdout_preview"], "CODEX_HOME=")
             codex_home = codex_home_line.split("=", 1)[1]
             self.assertNotIn(str(session_root), codex_home)
             self.assertNotIn(str(artifact_root), codex_home)
-            skill_surface_line = next(
-                line for line in list(result["stdout_preview"]) if str(line).startswith("SKILL_SURFACE=")
-            )
+            self.assertFalse(Path(codex_home).exists())
+            skill_surface_line = require_preview_line(result["stdout_preview"], "SKILL_SURFACE=")
             skill_surface = skill_surface_line.split("=", 1)[1]
-            self.assertTrue(Path(skill_surface).exists())
+            self.assertFalse(Path(skill_surface).exists())
             self.assertEqual("SKILL.md", Path(skill_surface).name)
 
     def test_specialist_consultation_unit_seeds_sidecar_codex_home_from_current_host(self) -> None:
@@ -925,7 +1043,10 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
             result = json.loads(completed.stdout)
             self.assertEqual("completed", result["status"])
             self.assertTrue(bool(result["live_native_execution"]))
+            codex_home_line = require_preview_line(result["stdout_preview"], "CODEX_HOME=")
+            codex_home = codex_home_line.split("=", 1)[1]
             self.assertIn("CODEX_HOME_SEEDED=1", list(result["stdout_preview"]))
+            self.assertFalse(Path(codex_home).exists())
 
     def test_runtime_projects_consultation_truth_into_summary_requirement_and_plan(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/runtime_neutral/test_vibe_specialist_consultation.py
+++ b/tests/runtime_neutral/test_vibe_specialist_consultation.py
@@ -195,6 +195,162 @@ def create_fake_codex_command(directory: Path) -> Path:
     return command_path
 
 
+def create_codex_home_verifying_fake_consultation_command(directory: Path) -> Path:
+    suffix = ".cmd" if os.name == "nt" else ""
+    command_path = directory / f"codex-home-check{suffix}"
+    if os.name == "nt":
+        command_path.write_text(
+            "@echo off\r\n"
+            "setlocal EnableDelayedExpansion\r\n"
+            "set OUT=\r\n"
+            ":loop\r\n"
+            "if \"%~1\"==\"\" goto done\r\n"
+            "if /I \"%~1\"==\"-o\" (\r\n"
+            "  set OUT=%~2\r\n"
+            "  shift\r\n"
+            "  shift\r\n"
+            "  goto loop\r\n"
+            ")\r\n"
+            "shift\r\n"
+            "goto loop\r\n"
+            ":done\r\n"
+            "if \"%OUT%\"==\"\" exit /b 2\r\n"
+            "if \"%CODEX_HOME%\"==\"\" (\r\n"
+            "  >&2 echo CODEX_HOME missing\r\n"
+            "  exit /b 3\r\n"
+            ")\r\n"
+            "if not exist \"%CODEX_HOME%\\skills\\systematic-debugging\\SKILL.md\" (\r\n"
+            "  >&2 echo skill surface missing\r\n"
+            "  exit /b 4\r\n"
+            ")\r\n"
+            "> \"%OUT%\" echo {\"status\":\"completed\",\"summary\":\"Consulted specialist and produced bounded guidance.\",\"consultation_notes\":[\"Validate the failing path before proposing a fix.\"],\"adoption_notes\":[\"Use the systematic-debugging workflow to shape requirement and plan wording.\"],\"verification_notes\":[\"Consultation stayed read-only and returned structured guidance.\"]}\r\n"
+            "echo CODEX_HOME=%CODEX_HOME%\r\n"
+            "echo SKILL_SURFACE=%CODEX_HOME%\\skills\\systematic-debugging\\SKILL.md\r\n"
+            "exit /b 0\r\n",
+            encoding="utf-8",
+        )
+    else:
+        command_path.write_text(
+            "#!/usr/bin/env sh\n"
+            "OUT=''\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    -o)\n"
+            "      OUT=\"$2\"\n"
+            "      shift 2\n"
+            "      ;;\n"
+            "    *)\n"
+            "      shift\n"
+            "      ;;\n"
+            "  esac\n"
+            "done\n"
+            "if [ -z \"$OUT\" ]; then\n"
+            "  exit 2\n"
+            "fi\n"
+            "if [ -z \"$CODEX_HOME\" ]; then\n"
+            "  printf 'CODEX_HOME missing\\n' >&2\n"
+            "  exit 3\n"
+            "fi\n"
+            "if [ ! -f \"$CODEX_HOME/skills/systematic-debugging/SKILL.md\" ]; then\n"
+            "  printf 'skill surface missing\\n' >&2\n"
+            "  exit 4\n"
+            "fi\n"
+            "printf '%s' '{\"status\":\"completed\",\"summary\":\"Consulted specialist and produced bounded guidance.\",\"consultation_notes\":[\"Validate the failing path before proposing a fix.\"],\"adoption_notes\":[\"Use the systematic-debugging workflow to shape requirement and plan wording.\"],\"verification_notes\":[\"Consultation stayed read-only and returned structured guidance.\"]}' > \"$OUT\"\n"
+            "printf 'CODEX_HOME=%s\\n' \"$CODEX_HOME\"\n"
+            "printf 'SKILL_SURFACE=%s\\n' \"$CODEX_HOME/skills/systematic-debugging/SKILL.md\"\n",
+            encoding="utf-8",
+        )
+        command_path.chmod(command_path.stat().st_mode | stat.S_IXUSR)
+    return command_path
+
+
+def create_codex_home_seed_verifying_fake_consultation_command(directory: Path) -> Path:
+    suffix = ".cmd" if os.name == "nt" else ""
+    command_path = directory / f"codex-home-seed-check{suffix}"
+    if os.name == "nt":
+        command_path.write_text(
+            "@echo off\r\n"
+            "setlocal EnableDelayedExpansion\r\n"
+            "set OUT=\r\n"
+            ":loop\r\n"
+            "if \"%~1\"==\"\" goto done\r\n"
+            "if /I \"%~1\"==\"-o\" (\r\n"
+            "  set OUT=%~2\r\n"
+            "  shift\r\n"
+            "  shift\r\n"
+            "  goto loop\r\n"
+            ")\r\n"
+            "shift\r\n"
+            "goto loop\r\n"
+            ":done\r\n"
+            "if \"%OUT%\"==\"\" exit /b 2\r\n"
+            "if \"%CODEX_HOME%\"==\"\" (\r\n"
+            "  >&2 echo CODEX_HOME missing\r\n"
+            "  exit /b 3\r\n"
+            ")\r\n"
+            "if not exist \"%CODEX_HOME%\\config.toml\" (\r\n"
+            "  >&2 echo config missing\r\n"
+            "  exit /b 4\r\n"
+            ")\r\n"
+            "findstr /c:\"config-seed-marker\" \"%CODEX_HOME%\\config.toml\" >nul || exit /b 5\r\n"
+            "if not exist \"%CODEX_HOME%\\auth.json\" (\r\n"
+            "  >&2 echo auth missing\r\n"
+            "  exit /b 6\r\n"
+            ")\r\n"
+            "findstr /c:\"auth-seed-marker\" \"%CODEX_HOME%\\auth.json\" >nul || exit /b 7\r\n"
+            "if not exist \"%CODEX_HOME%\\config\\seed.json\" exit /b 8\r\n"
+            "if not exist \"%CODEX_HOME%\\mcp\\seed.json\" exit /b 9\r\n"
+            "> \"%OUT%\" echo {\"status\":\"completed\",\"summary\":\"Consulted specialist from a seeded codex home.\",\"consultation_notes\":[\"Baseline codex config was copied into the sidecar.\"],\"adoption_notes\":[\"Keep user auth and config available to native specialist subprocesses.\"],\"verification_notes\":[\"Consultation used a seeded CODEX_HOME sidecar.\"]}\r\n"
+            "echo CODEX_HOME_SEEDED=1\r\n"
+            "exit /b 0\r\n",
+            encoding="utf-8",
+        )
+    else:
+        command_path.write_text(
+            "#!/usr/bin/env sh\n"
+            "OUT=''\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    -o)\n"
+            "      OUT=\"$2\"\n"
+            "      shift 2\n"
+            "      ;;\n"
+            "    *)\n"
+            "      shift\n"
+            "      ;;\n"
+            "  esac\n"
+            "done\n"
+            "if [ -z \"$OUT\" ]; then\n"
+            "  exit 2\n"
+            "fi\n"
+            "if [ -z \"$CODEX_HOME\" ]; then\n"
+            "  printf 'CODEX_HOME missing\\n' >&2\n"
+            "  exit 3\n"
+            "fi\n"
+            "if [ ! -f \"$CODEX_HOME/config.toml\" ]; then\n"
+            "  printf 'config missing\\n' >&2\n"
+            "  exit 4\n"
+            "fi\n"
+            "grep -q 'config-seed-marker' \"$CODEX_HOME/config.toml\" || exit 5\n"
+            "if [ ! -f \"$CODEX_HOME/auth.json\" ]; then\n"
+            "  printf 'auth missing\\n' >&2\n"
+            "  exit 6\n"
+            "fi\n"
+            "grep -q 'auth-seed-marker' \"$CODEX_HOME/auth.json\" || exit 7\n"
+            "if [ ! -f \"$CODEX_HOME/config/seed.json\" ]; then\n"
+            "  exit 8\n"
+            "fi\n"
+            "if [ ! -f \"$CODEX_HOME/mcp/seed.json\" ]; then\n"
+            "  exit 9\n"
+            "fi\n"
+            "printf '%s' '{\"status\":\"completed\",\"summary\":\"Consulted specialist from a seeded codex home.\",\"consultation_notes\":[\"Baseline codex config was copied into the sidecar.\"],\"adoption_notes\":[\"Keep user auth and config available to native specialist subprocesses.\"],\"verification_notes\":[\"Consultation used a seeded CODEX_HOME sidecar.\"]}' > \"$OUT\"\n"
+            "printf 'CODEX_HOME_SEEDED=1\\n'\n",
+            encoding="utf-8",
+        )
+        command_path.chmod(command_path.stat().st_mode | stat.S_IXUSR)
+    return command_path
+
+
 def create_incomplete_fake_codex_command(directory: Path) -> Path:
     suffix = ".cmd" if os.name == "nt" else ""
     command_path = directory / f"codex-incomplete{suffix}"
@@ -244,6 +400,90 @@ def create_incomplete_fake_codex_command(directory: Path) -> Path:
         )
         command_path.chmod(command_path.stat().st_mode | stat.S_IXUSR)
     return command_path
+
+
+def create_repo_check_fake_codex_command(directory: Path) -> Path:
+    suffix = ".cmd" if os.name == "nt" else ""
+    command_path = directory / f"codex-repo-check{suffix}"
+    if os.name == "nt":
+        command_path.write_text(
+            "@echo off\r\n"
+            "setlocal EnableDelayedExpansion\r\n"
+            "set OUT=\r\n"
+            "set HAS_SKIP=0\r\n"
+            ":loop\r\n"
+            "if \"%~1\"==\"\" goto done\r\n"
+            "if /I \"%~1\"==\"-o\" (\r\n"
+            "  set OUT=%~2\r\n"
+            "  shift\r\n"
+            "  shift\r\n"
+            "  goto loop\r\n"
+            ")\r\n"
+            "if /I \"%~1\"==\"--skip-git-repo-check\" (\r\n"
+            "  set HAS_SKIP=1\r\n"
+            "  shift\r\n"
+            "  goto loop\r\n"
+            ")\r\n"
+            "shift\r\n"
+            "goto loop\r\n"
+            ":done\r\n"
+            "if \"%HAS_SKIP%\"==\"0\" (\r\n"
+            "  >&2 echo Not inside a trusted directory and --skip-git-repo-check was not specified.\r\n"
+            "  exit /b 1\r\n"
+            ")\r\n"
+            "if \"%OUT%\"==\"\" exit /b 2\r\n"
+            "> \"%OUT%\" echo {\"status\":\"completed\",\"summary\":\"Consulted specialist from a non-git workspace.\",\"consultation_notes\":[\"Repo-check bypass was applied only for this codex exec.\"],\"adoption_notes\":[\"Keep the bypass scoped to native codex subprocesses.\"],\"verification_notes\":[\"Consultation stayed read-only and returned structured guidance.\"]}\r\n"
+            "echo fake codex repo-check ok\r\n"
+            "exit /b 0\r\n",
+            encoding="utf-8",
+        )
+    else:
+        command_path.write_text(
+            "#!/usr/bin/env sh\n"
+            "OUT=''\n"
+            "HAS_SKIP=0\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    -o)\n"
+            "      OUT=\"$2\"\n"
+            "      shift 2\n"
+            "      ;;\n"
+            "    --skip-git-repo-check)\n"
+            "      HAS_SKIP=1\n"
+            "      shift\n"
+            "      ;;\n"
+            "    *)\n"
+            "      shift\n"
+            "      ;;\n"
+            "  esac\n"
+            "done\n"
+            "if [ \"$HAS_SKIP\" != \"1\" ]; then\n"
+            "  printf 'Not inside a trusted directory and --skip-git-repo-check was not specified.\\n' >&2\n"
+            "  exit 1\n"
+            "fi\n"
+            "if [ -z \"$OUT\" ]; then\n"
+            "  exit 2\n"
+            "fi\n"
+            "printf '%s' '{\"status\":\"completed\",\"summary\":\"Consulted specialist from a non-git workspace.\",\"consultation_notes\":[\"Repo-check bypass was applied only for this codex exec.\"],\"adoption_notes\":[\"Keep the bypass scoped to native codex subprocesses.\"],\"verification_notes\":[\"Consultation stayed read-only and returned structured guidance.\"]}' > \"$OUT\"\n"
+            "printf 'fake codex repo-check ok\\n'\n",
+            encoding="utf-8",
+        )
+        command_path.chmod(command_path.stat().st_mode | stat.S_IXUSR)
+    return command_path
+
+
+def set_directory_read_only(path: Path) -> None:
+    if os.name == "nt":
+        path.chmod(stat.S_IREAD | stat.S_IEXEC)
+    else:
+        path.chmod(0o555)
+
+
+def set_directory_writable(path: Path) -> None:
+    if os.name == "nt":
+        path.chmod(stat.S_IWRITE | stat.S_IREAD | stat.S_IEXEC)
+    else:
+        path.chmod(0o755)
 
 
 class VibeSpecialistConsultationTests(unittest.TestCase):
@@ -420,6 +660,272 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
             self.assertGreaterEqual(len(list(consulted["consultation_notes"])), 1)
             self.assertGreaterEqual(len(list(consulted["adoption_notes"])), 1)
             self.assertGreaterEqual(len(list(consulted["verification_notes"])), 1)
+
+    def test_consultation_window_bypasses_codex_repo_check_for_non_git_roots(self) -> None:
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            fake_codex = create_repo_check_fake_codex_command(artifact_root)
+            freeze_payload = freeze_runtime_packet(SPECIALIST_TASK, artifact_root)
+            packet_path = Path(freeze_payload["packet_path"])
+            non_git_root = artifact_root / "non-git-workspace"
+            non_git_root.mkdir(parents=True, exist_ok=True)
+            run_id = "pytest-consult-non-git-" + uuid.uuid4().hex[:10]
+            prompt_seed_path = artifact_root / "discussion-seed.md"
+            prompt_seed_path.write_text("# Intent\nNeed consultation from a non-git workspace.\n", encoding="utf-8")
+
+            ps_script = (
+                "& { "
+                f". {_ps_single_quote(str(RUNTIME_COMMON))}; "
+                f". {_ps_single_quote(str(EXECUTION_COMMON))}; "
+                f". {_ps_single_quote(str(CONSULTATION_SCRIPT))}; "
+                f"$runtime = Get-VibeRuntimeContext -ScriptPath {_ps_single_quote(str(CONSULTATION_SCRIPT))}; "
+                f"$packet = Get-Content -LiteralPath {_ps_single_quote(str(packet_path))} -Raw -Encoding UTF8 | ConvertFrom-Json; "
+                f"$sessionRoot = Ensure-VibeSessionRoot -RepoRoot {_ps_single_quote(str(non_git_root))} -RunId {_ps_single_quote(run_id)} -Runtime $runtime -ArtifactRoot {_ps_single_quote(str(artifact_root))}; "
+                f"$result = Invoke-VibeSpecialistConsultationWindow "
+                f"-Task {_ps_single_quote(SPECIALIST_TASK)} "
+                f"-RunId {_ps_single_quote(run_id)} "
+                f"-SessionRoot $sessionRoot "
+                f"-RepoRoot {_ps_single_quote(str(non_git_root))} "
+                f"-WindowId 'discussion' "
+                f"-Stage 'deep_interview' "
+                f"-SourceArtifactPath {_ps_single_quote(str(prompt_seed_path))} "
+                f"-Recommendations @($packet.specialist_recommendations) "
+                f"-Policy $runtime.specialist_consultation_policy; "
+                "$result | ConvertTo-Json -Depth 20 }"
+            )
+            completed = subprocess.run(
+                [shell, "-NoLogo", "-NoProfile", "-Command", ps_script],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=True,
+                env={
+                    **os.environ,
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+            payload = json.loads(completed.stdout)
+            receipt = load_json(payload["receipt_path"])
+
+            consulted = next(
+                item for item in list(receipt["consulted_units"]) if item["skill_id"] == "systematic-debugging"
+            )
+            self.assertEqual("completed", consulted["status"])
+            self.assertTrue(bool(consulted["live_native_execution"]))
+            self.assertEqual(str(non_git_root), consulted["cwd"])
+            self.assertIn("--skip-git-repo-check", list(consulted["arguments"]))
+
+    def test_consultation_window_falls_back_to_writable_artifact_root_when_repo_root_is_read_only(self) -> None:
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            fake_codex = create_fake_codex_command(artifact_root)
+            freeze_payload = freeze_runtime_packet(SPECIALIST_TASK, artifact_root)
+            packet_path = Path(freeze_payload["packet_path"])
+            read_only_root = artifact_root / "read-only-install-root"
+            read_only_root.mkdir(parents=True, exist_ok=True)
+            run_id = "pytest-consult-readonly-" + uuid.uuid4().hex[:10]
+            prompt_seed_path = artifact_root / "discussion-seed.md"
+            prompt_seed_path.write_text("# Intent\nNeed consultation from a writable artifact root.\n", encoding="utf-8")
+
+            try:
+                set_directory_read_only(read_only_root)
+
+                ps_script = (
+                    "& { "
+                    f". {_ps_single_quote(str(RUNTIME_COMMON))}; "
+                    f". {_ps_single_quote(str(EXECUTION_COMMON))}; "
+                    f". {_ps_single_quote(str(CONSULTATION_SCRIPT))}; "
+                    f"$runtime = Get-VibeRuntimeContext -ScriptPath {_ps_single_quote(str(CONSULTATION_SCRIPT))}; "
+                    f"$packet = Get-Content -LiteralPath {_ps_single_quote(str(packet_path))} -Raw -Encoding UTF8 | ConvertFrom-Json; "
+                    f"$sessionRoot = Ensure-VibeSessionRoot -RepoRoot {_ps_single_quote(str(read_only_root))} -RunId {_ps_single_quote(run_id)} -Runtime $runtime -ArtifactRoot {_ps_single_quote(str(artifact_root))}; "
+                    f"$result = Invoke-VibeSpecialistConsultationWindow "
+                    f"-Task {_ps_single_quote(SPECIALIST_TASK)} "
+                    f"-RunId {_ps_single_quote(run_id)} "
+                    f"-SessionRoot $sessionRoot "
+                    f"-RepoRoot {_ps_single_quote(str(read_only_root))} "
+                    f"-WindowId 'discussion' "
+                    f"-Stage 'deep_interview' "
+                    f"-SourceArtifactPath {_ps_single_quote(str(prompt_seed_path))} "
+                    f"-Recommendations @($packet.specialist_recommendations) "
+                    f"-Policy $runtime.specialist_consultation_policy; "
+                    "$result | ConvertTo-Json -Depth 20 }"
+                )
+                completed = subprocess.run(
+                    [shell, "-NoLogo", "-NoProfile", "-Command", ps_script],
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    check=True,
+                    env={
+                        **os.environ,
+                        "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                        "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                        "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                    },
+                )
+            finally:
+                set_directory_writable(read_only_root)
+
+            payload = json.loads(completed.stdout)
+            receipt = load_json(payload["receipt_path"])
+            consulted = next(
+                item for item in list(receipt["consulted_units"]) if item["skill_id"] == "systematic-debugging"
+            )
+            self.assertEqual("completed", consulted["status"])
+            self.assertNotEqual(str(read_only_root.resolve()), consulted["cwd"])
+            self.assertEqual(str(artifact_root.resolve()), consulted["cwd"])
+            self.assertIn("--skip-git-repo-check", list(consulted["arguments"]))
+
+    def test_specialist_consultation_unit_uses_sidecar_codex_home_with_materialized_skill_surface(self) -> None:
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            fake_codex = create_codex_home_verifying_fake_consultation_command(artifact_root)
+            non_git_root = artifact_root / "non-git-workspace"
+            non_git_root.mkdir(parents=True, exist_ok=True)
+            session_root = artifact_root / "session"
+            session_root.mkdir(parents=True, exist_ok=True)
+            skill_root = artifact_root / "skills" / "systematic-debugging"
+            skill_root.mkdir(parents=True, exist_ok=True)
+            entrypoint_path = skill_root / "SKILL.runtime-mirror.md"
+            source_artifact = artifact_root / "intent-contract.json"
+            entrypoint_path.write_text("# Specialist\n", encoding="utf-8")
+            source_artifact.write_text("{\"goal\":\"demo\"}\n", encoding="utf-8")
+
+            ps_script = (
+                "& { "
+                f". {_ps_single_quote(str(RUNTIME_COMMON))}; "
+                f". {_ps_single_quote(str(EXECUTION_COMMON))}; "
+                f". {_ps_single_quote(str(CONSULTATION_SCRIPT))}; "
+                "$consultation = [pscustomobject]@{ "
+                "skill_id = 'systematic-debugging'; "
+                f"native_skill_entrypoint = '{entrypoint_path.as_posix()}'; "
+                f"skill_root = '{skill_root.as_posix()}'; "
+                "consultation_reason = 'verify codex sidecar home'; "
+                "consultation_scope = 'bounded consultation'; "
+                "consultation_role = 'discussion_consultant'; "
+                "required_inputs = @('source_artifact'); "
+                "expected_outputs = @('consultation_notes'); "
+                "verification_expectation = 'Return structured consultation output.' "
+                "}; "
+                f"$runtime = Get-VibeRuntimeContext -ScriptPath {_ps_single_quote(str(CONSULTATION_SCRIPT))}; "
+                f"$result = Invoke-VibeSpecialistConsultationUnit -UnitId 'consult-unit' -Consultation $consultation -SessionRoot '{session_root.as_posix()}' -RepoRoot '{non_git_root.as_posix()}' -Task 'debug this workflow' -RunId 'run-sidecar' -WindowId 'discussion' -Stage 'deep_interview' -SourceArtifactPath '{source_artifact.as_posix()}' -Policy $runtime.specialist_consultation_policy; "
+                "$result.result | ConvertTo-Json -Depth 20 }"
+            )
+
+            completed = subprocess.run(
+                [shell, "-NoLogo", "-NoProfile", "-Command", ps_script],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=True,
+                env={
+                    **os.environ,
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+
+            result = json.loads(completed.stdout)
+            self.assertEqual("completed", result["status"])
+            self.assertTrue(bool(result["live_native_execution"]))
+            codex_home_line = next(
+                line for line in list(result["stdout_preview"]) if str(line).startswith("CODEX_HOME=")
+            )
+            codex_home = codex_home_line.split("=", 1)[1]
+            self.assertNotIn(str(session_root), codex_home)
+            self.assertNotIn(str(artifact_root), codex_home)
+            skill_surface_line = next(
+                line for line in list(result["stdout_preview"]) if str(line).startswith("SKILL_SURFACE=")
+            )
+            skill_surface = skill_surface_line.split("=", 1)[1]
+            self.assertTrue(Path(skill_surface).exists())
+            self.assertEqual("SKILL.md", Path(skill_surface).name)
+
+    def test_specialist_consultation_unit_seeds_sidecar_codex_home_from_current_host(self) -> None:
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            fake_codex = create_codex_home_seed_verifying_fake_consultation_command(artifact_root)
+            source_codex_home = artifact_root / "source-codex-home"
+            (source_codex_home / "config").mkdir(parents=True, exist_ok=True)
+            (source_codex_home / "mcp").mkdir(parents=True, exist_ok=True)
+            (source_codex_home / "config.toml").write_text("# config-seed-marker\n", encoding="utf-8")
+            (source_codex_home / "auth.json").write_text("{\"marker\":\"auth-seed-marker\"}\n", encoding="utf-8")
+            (source_codex_home / "config" / "seed.json").write_text("{\"marker\":\"config-dir\"}\n", encoding="utf-8")
+            (source_codex_home / "mcp" / "seed.json").write_text("{\"marker\":\"mcp-dir\"}\n", encoding="utf-8")
+            non_git_root = artifact_root / "non-git-workspace"
+            non_git_root.mkdir(parents=True, exist_ok=True)
+            session_root = artifact_root / "session"
+            session_root.mkdir(parents=True, exist_ok=True)
+            skill_root = artifact_root / "skills" / "systematic-debugging"
+            skill_root.mkdir(parents=True, exist_ok=True)
+            entrypoint_path = skill_root / "SKILL.runtime-mirror.md"
+            source_artifact = artifact_root / "intent-contract.json"
+            entrypoint_path.write_text("# Specialist\n", encoding="utf-8")
+            source_artifact.write_text("{\"goal\":\"demo\"}\n", encoding="utf-8")
+
+            ps_script = (
+                "& { "
+                f". {_ps_single_quote(str(RUNTIME_COMMON))}; "
+                f". {_ps_single_quote(str(EXECUTION_COMMON))}; "
+                f". {_ps_single_quote(str(CONSULTATION_SCRIPT))}; "
+                "$consultation = [pscustomobject]@{ "
+                "skill_id = 'systematic-debugging'; "
+                f"native_skill_entrypoint = '{entrypoint_path.as_posix()}'; "
+                f"skill_root = '{skill_root.as_posix()}'; "
+                "consultation_reason = 'verify codex sidecar home seed'; "
+                "consultation_scope = 'bounded consultation'; "
+                "consultation_role = 'discussion_consultant'; "
+                "required_inputs = @('source_artifact'); "
+                "expected_outputs = @('consultation_notes'); "
+                "verification_expectation = 'Return structured consultation output.' "
+                "}; "
+                f"$runtime = Get-VibeRuntimeContext -ScriptPath {_ps_single_quote(str(CONSULTATION_SCRIPT))}; "
+                f"$result = Invoke-VibeSpecialistConsultationUnit -UnitId 'consult-seed-unit' -Consultation $consultation -SessionRoot '{session_root.as_posix()}' -RepoRoot '{non_git_root.as_posix()}' -Task 'debug this workflow' -RunId 'run-seed' -WindowId 'discussion' -Stage 'deep_interview' -SourceArtifactPath '{source_artifact.as_posix()}' -Policy $runtime.specialist_consultation_policy; "
+                "$result.result | ConvertTo-Json -Depth 20 }"
+            )
+
+            completed = subprocess.run(
+                [shell, "-NoLogo", "-NoProfile", "-Command", ps_script],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=True,
+                env={
+                    **os.environ,
+                    "CODEX_HOME": str(source_codex_home),
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+
+            result = json.loads(completed.stdout)
+            self.assertEqual("completed", result["status"])
+            self.assertTrue(bool(result["live_native_execution"]))
+            self.assertIn("CODEX_HOME_SEEDED=1", list(result["stdout_preview"]))
 
     def test_runtime_projects_consultation_truth_into_summary_requirement_and_plan(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
## Summary
- frontload canonical `vibe` bootstrap instructions in `SKILL.md`, including explicit POSIX and Windows PowerShell launch paths
- make native codex specialist subprocesses seed a writable sidecar `CODEX_HOME` from the current host codex home before materializing routed skills
- stabilize specialist consultation/dispatch execution by keeping working-root fallback, repo-check bypass, stdin closure, and codex policy coverage under regression tests

## Why
Pure `$vibe` was reaching the router, but native codex specialist subprocesses were entering a half-empty codex home. That let routed experts start, but they could fail to complete or lose the host provider/config state needed to write structured output artifacts.

## What changed
- add canonical bootstrap contract text to `SKILL.md`
- remove `--json` from the native codex specialist adapter policy
- add environment override support and stdin closure in `Invoke-VibeCapturedProcess`
- seed sidecar codex homes from the current host codex home, while avoiding recursive self-copy from previous sidecars
- materialize routed skills as real `SKILL.md` surfaces in the sidecar
- resolve writable native specialist working roots from governed artifact/session paths when the vibe install root or a read-only root would be unsafe
- cover the bootstrap contract, captured process handling, sidecar skill surfacing, sidecar codex-home seeding, repo-check bypass, and writable-root fallback with regression tests

## Verification
- `pytest -q tests/integration/test_powershell_captured_process_argument_integrity.py tests/integration/test_vibe_skill_bootstrap_contract.py`
- `pytest -q tests/runtime_neutral/test_vibe_specialist_consultation.py -k 'consultation_window_bypasses_codex_repo_check_for_non_git_roots or consultation_window_falls_back_to_writable_artifact_root_when_repo_root_is_read_only or specialist_consultation_unit_uses_sidecar_codex_home_with_materialized_skill_surface or specialist_consultation_unit_seeds_sidecar_codex_home_from_current_host'`
- `pytest -q tests/runtime_neutral/test_plan_execute_receipts.py -k 'specialist_dispatch_bypasses_codex_repo_check_for_non_git_roots or specialist_dispatch_falls_back_to_requirement_workspace_when_repo_root_is_read_only or specialist_dispatch_uses_sidecar_codex_home_with_materialized_skill_surface or specialist_dispatch_seeds_sidecar_codex_home_from_current_host'`

## Fresh-run evidence
A fresh pure `$vibe` run now produced a real native specialist response for `ml-pipeline-workflow`, with the child codex subprocess preserving the host provider/config and writing its structured consultation JSON successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frontloads a canonical bootstrap workflow for invoking vibe, with explicit launch/validation and richer execution receipts (prompt injection metadata).
  * Adds managed per-run specialist environment support and temporary sidecar workspace handling.
  * Improved working-directory resolution with writable-fallback behavior.

* **Bug Fixes**
  * Ensures child processes have stdin closed to prevent hangs.
  * Bypasses git repo checks for non-git workspaces when appropriate.

* **Documentation**
  * Documents canonical bootstrap requirements and failure reporting.

* **Tests**
  * Adds integration tests covering bootstrap contract, environment overrides, sidecar workspace, and dispatch flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->