### PR TITLE
Default specialist routing to current session

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -160,6 +160,7 @@ Use this when the system should still ask the user high-value questions, confirm
 That means:
 
 - governed `vibe` runs must surface bounded specialist recommendations and must treat router-selected specialist skills as route truth or executable recommendation candidates
+- direct specialist handling should stay in the current host session by default; do not create hidden specialist sub-sessions unless policy explicitly opts back into that bridge path
 - runtime-selected skill remains `vibe` for governed entry
 - eligible specialist help must auto-promote into bounded native-mode assistance by default
 - specialist help must preserve the specialist skill's own workflow, inputs, outputs, and validation style

--- a/config/native-specialist-execution-policy.json
+++ b/config/native-specialist-execution-policy.json
@@ -2,6 +2,7 @@
   "version": 2,
   "updated_at": "2026-03-29",
   "enabled": true,
+  "mode": "direct_current_session_route",
   "default_adapter_id": "codex",
   "enable_env": "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION",
   "disable_env": "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION",

--- a/config/specialist-consultation-policy.json
+++ b/config/specialist-consultation-policy.json
@@ -3,6 +3,7 @@
   "policy_id": "specialist-consultation-v1",
   "updated_at": "2026-04-12",
   "enabled": true,
+  "mode": "direct_current_session_route",
   "max_consults_per_window": 2,
   "allowed_windows": [
     "discussion",

--- a/scripts/runtime/Invoke-DelegatedLaneUnit.ps1
+++ b/scripts/runtime/Invoke-DelegatedLaneUnit.ps1
@@ -97,6 +97,7 @@ switch ($laneKind) {
     }
     'specialist_dispatch' {
         $dispatch = $laneSpec.dispatch
+        $usageRequirementState = Get-VibeDispatchUsageRequirementState -Dispatch $dispatch
         $executed = Invoke-VibeSpecialistDispatchUnit `
             -UnitId ("{0}-specialist" -f [string]$laneSpec.lane_id) `
             -Dispatch $dispatch `
@@ -134,7 +135,8 @@ switch ($laneKind) {
             dispatch_phase = if ($dispatch.PSObject.Properties.Name -contains 'dispatch_phase') { [string]$dispatch.dispatch_phase } else { 'in_execution' }
             binding_profile = if ($dispatch.PSObject.Properties.Name -contains 'binding_profile') { [string]$dispatch.binding_profile } else { 'default' }
             lane_policy = if ($dispatch.PSObject.Properties.Name -contains 'lane_policy') { [string]$dispatch.lane_policy } else { 'inherit_grade' }
-            native_usage_required = [bool]$dispatch.native_usage_required
+            native_usage_required = [bool]$usageRequirementState.native_usage_required
+            usage_required = [bool]$usageRequirementState.usage_required
             must_preserve_workflow = [bool]$dispatch.must_preserve_workflow
             result_path = $resultPath
             started_at = [string]$executed.result.started_at
@@ -151,7 +153,8 @@ switch ($laneKind) {
             "- binding_profile: $(if ($dispatch.PSObject.Properties.Name -contains 'binding_profile') { [string]$dispatch.binding_profile } else { 'default' })",
             "- lane_policy: $(if ($dispatch.PSObject.Properties.Name -contains 'lane_policy') { [string]$dispatch.lane_policy } else { 'inherit_grade' })",
             "- parallelizable: $([bool]$laneSpec.parallelizable)",
-            "- native_usage_required: $([bool]$dispatch.native_usage_required)",
+            "- native_usage_required: $([bool]$usageRequirementState.native_usage_required)",
+            "- usage_required: $([bool]$usageRequirementState.usage_required)",
             "- verification_expectation: $([string]$dispatch.verification_expectation)",
             "- required_inputs: $([string]::Join(', ', @($dispatch.required_inputs)))",
             "- expected_outputs: $([string]::Join(', ', @($dispatch.expected_outputs)))",

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -1154,19 +1154,64 @@ $directRoutedSpecialistUnits = @($executedSpecialistUnits | Where-Object {
 })
 $verifiedSpecialistUnits = @($liveSpecialistUnits)
 
+function Get-VibeSpecialistDispatchResolutionKey {
+    param(
+        [AllowNull()] [object]$Entry = $null
+    )
+
+    if ($null -eq $Entry) {
+        return $null
+    }
+
+    $skillId = if (
+        $Entry.PSObject.Properties.Name -contains 'skill_id' -and
+        -not [string]::IsNullOrWhiteSpace([string]$Entry.skill_id)
+    ) {
+        [string]$Entry.skill_id
+    } elseif (
+        $Entry.PSObject.Properties.Name -contains 'specialist_skill_id' -and
+        -not [string]::IsNullOrWhiteSpace([string]$Entry.specialist_skill_id)
+    ) {
+        [string]$Entry.specialist_skill_id
+    } else {
+        $null
+    }
+    if ([string]::IsNullOrWhiteSpace($skillId)) {
+        return $null
+    }
+
+    $dispatchPhase = if (
+        $Entry.PSObject.Properties.Name -contains 'dispatch_phase' -and
+        -not [string]::IsNullOrWhiteSpace([string]$Entry.dispatch_phase)
+    ) {
+        [string]$Entry.dispatch_phase
+    } else {
+        'in_execution'
+    }
+
+    return ('{0}|{1}' -f $dispatchPhase, $skillId)
+}
+
 $recommendationSkillIds = @($specialistRecommendations | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
 $approvedDispatchSkillIds = @($approvedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
 $localSuggestionSkillIds = @($localSuggestions | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
 $executedSpecialistSkillIds = @($verifiedSpecialistUnits | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
 $directRoutedSpecialistSkillIds = @($directRoutedSpecialistUnits | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
 $resolvedSpecialistSkillIds = @((@($executedSpecialistSkillIds) + @($directRoutedSpecialistSkillIds)) | Select-Object -Unique)
+$recommendationResolutionKeys = @($specialistRecommendations | ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$approvedDispatchResolutionKeys = @($approvedDispatch | ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$localSuggestionResolutionKeys = @($localSuggestions | ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$executedSpecialistResolutionKeys = @($verifiedSpecialistUnits | ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$directRoutedSpecialistResolutionKeys = @($directRoutedSpecialistUnits | ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$resolvedSpecialistResolutionKeys = @((@($executedSpecialistResolutionKeys) + @($directRoutedSpecialistResolutionKeys)) | Select-Object -Unique)
 
 $approvedDispatchMissingFromRecommendations = @($approvedDispatchSkillIds | Where-Object { $_ -notin $recommendationSkillIds })
-$approvedDispatchNotExecuted = @($approvedDispatchSkillIds | Where-Object { $_ -notin $executedSpecialistSkillIds })
-$approvedDispatchNotResolved = @($approvedDispatchSkillIds | Where-Object { $_ -notin $resolvedSpecialistSkillIds })
-$executedWithoutApproval = @($executedSpecialistSkillIds | Where-Object { $_ -notin $approvedDispatchSkillIds })
-$routedWithoutApproval = @($directRoutedSpecialistSkillIds | Where-Object { $_ -notin $approvedDispatchSkillIds })
-$localSuggestionsExecutedWithoutApproval = @($localSuggestionSkillIds | Where-Object { $_ -in $executedSpecialistSkillIds })
+$approvedDispatchMissingFromRecommendationsResolutionKeys = @($approvedDispatchResolutionKeys | Where-Object { $_ -notin $recommendationResolutionKeys })
+$approvedDispatchNotExecuted = @($approvedDispatchResolutionKeys | Where-Object { $_ -notin $executedSpecialistResolutionKeys })
+$approvedDispatchNotResolved = @($approvedDispatchResolutionKeys | Where-Object { $_ -notin $resolvedSpecialistResolutionKeys })
+$executedWithoutApproval = @($executedSpecialistResolutionKeys | Where-Object { $_ -notin $approvedDispatchResolutionKeys })
+$routedWithoutApproval = @($directRoutedSpecialistResolutionKeys | Where-Object { $_ -notin $approvedDispatchResolutionKeys })
+$localSuggestionsExecutedWithoutApproval = @($localSuggestionResolutionKeys | Where-Object { $_ -in $executedSpecialistResolutionKeys })
 $dispatchContractIncompleteSkillIds = @(
     $approvedDispatch | Where-Object {
         $hasNativeUsageRequired = $_.PSObject.Properties.Name -contains 'native_usage_required'
@@ -1204,20 +1249,26 @@ $dispatchContractIncompleteSkillIds = @(
 
 $dispatchIntegrity = [pscustomobject]@{
     recommendation_skill_ids = @($recommendationSkillIds)
+    recommendation_resolution_keys = @($recommendationResolutionKeys)
     matched_skill_ids = @($matchedSkillIds)
     surfaced_skill_ids = @($surfacedSkillIds)
     approved_dispatch_skill_ids = @($approvedDispatchSkillIds)
+    approved_dispatch_resolution_keys = @($approvedDispatchResolutionKeys)
     local_suggestion_skill_ids = @($localSuggestionSkillIds)
+    local_suggestion_resolution_keys = @($localSuggestionResolutionKeys)
     blocked_skill_ids = @($blockedSkillIds)
     degraded_skill_ids = @($degradedSkillIds)
     ghost_match_skill_ids = @($ghostMatchSkillIds)
     executed_specialist_skill_ids = @($executedSpecialistSkillIds)
+    executed_specialist_resolution_keys = @($executedSpecialistResolutionKeys)
     direct_routed_specialist_skill_ids = @($directRoutedSpecialistSkillIds)
+    direct_routed_specialist_resolution_keys = @($directRoutedSpecialistResolutionKeys)
     resolved_specialist_skill_ids = @($resolvedSpecialistSkillIds)
-    approved_dispatch_subset_of_recommendations = [bool](@($approvedDispatchMissingFromRecommendations).Count -eq 0)
+    resolved_specialist_resolution_keys = @($resolvedSpecialistResolutionKeys)
+    approved_dispatch_subset_of_recommendations = [bool](@($approvedDispatchMissingFromRecommendationsResolutionKeys).Count -eq 0)
     inherited_root_approval_allowed = [bool]([string]$hierarchyState.governance_scope -eq 'child')
     approved_dispatch_supported_by_recommendation_or_inherited_approval = [bool](
-        (@($approvedDispatchMissingFromRecommendations).Count -eq 0) -or
+        (@($approvedDispatchMissingFromRecommendationsResolutionKeys).Count -eq 0) -or
         ([string]$hierarchyState.governance_scope -eq 'child')
     )
     approved_dispatch_fully_executed = [bool](@($approvedDispatchNotExecuted).Count -eq 0)
@@ -1228,6 +1279,7 @@ $dispatchIntegrity = [pscustomobject]@{
     native_contract_complete_for_approved_dispatch = [bool](@($dispatchContractIncompleteSkillIds).Count -eq 0)
     matched_skills_resolved = [bool](@($ghostMatchSkillIds).Count -eq 0)
     approved_dispatch_missing_from_recommendations = @($approvedDispatchMissingFromRecommendations)
+    approved_dispatch_missing_from_recommendations_resolution_keys = @($approvedDispatchMissingFromRecommendationsResolutionKeys)
     approved_dispatch_not_executed = @($approvedDispatchNotExecuted)
     approved_dispatch_not_resolved = @($approvedDispatchNotResolved)
     executed_without_approval = @($executedWithoutApproval)

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -1296,6 +1296,11 @@ $dispatchIntegrity | Add-Member -NotePropertyName 'proof_passed' -NotePropertyVa
     $dispatchIntegrity.native_contract_complete_for_approved_dispatch -and
     $dispatchIntegrity.matched_skills_resolved
 ))
+$topLevelProofPassed = [bool](
+    ($failedUnitCount -eq 0) -and
+    ($executedUnitCount -ge [int]$profile.expected_minimum_units) -and
+    $dispatchIntegrity.proof_passed
+)
 
 $baseStatus = if ($failedUnitCount -eq 0 -and $executedUnitCount -ge [int]$profile.expected_minimum_units) { 'completed' } elseif ($executedUnitCount -eq 0) { 'failed' } else { 'completed_with_failures' }
 $degradedSpecialistUnits = @(@($executedSpecialistUnits | Where-Object { [bool]$_.degraded }) + @($preDispatchDegradedUnits))
@@ -1501,7 +1506,7 @@ $proofManifest = [pscustomobject]@{
     review_receipt_count = [int]$reviewReceiptCount
     governance_scope = [string]$hierarchyState.governance_scope
     escalation_required = [bool]$escalationRequired
-    proof_passed = [bool](($failedUnitCount -eq 0) -and ($executedUnitCount -ge [int]$profile.expected_minimum_units))
+    proof_passed = [bool]$topLevelProofPassed
 }
 $proofManifestPath = Join-Path $proofRoot 'manifest.json'
 Write-VibeJsonArtifact -Path $proofManifestPath -Value $proofManifest

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -1143,14 +1143,29 @@ $effectiveUnitExecution = if ($parallelUnitsExecutedCount -gt 0 -and ($executedU
     'sequential'
 }
 
+$liveAttemptedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live_native_execution })
+$liveSpecialistUnits = @($liveAttemptedSpecialistUnits | Where-Object { [bool]$_.verification_passed })
+$failedLiveSpecialistUnits = @($liveAttemptedSpecialistUnits | Where-Object { -not [bool]$_.verification_passed })
+$directRoutedSpecialistUnits = @($executedSpecialistUnits | Where-Object {
+    -not [bool]$(if ($_.PSObject.Properties.Name -contains 'live_native_execution') { $_.live_native_execution } else { $false }) -and
+    -not [bool]$(if ($_.PSObject.Properties.Name -contains 'degraded') { $_.degraded } else { $false }) -and
+    -not [bool]$(if ($_.PSObject.Properties.Name -contains 'blocked') { $_.blocked } else { $false }) -and
+    [string]$_.execution_driver -eq 'direct_current_session_route'
+})
+$verifiedSpecialistUnits = @($liveSpecialistUnits)
+
 $recommendationSkillIds = @($specialistRecommendations | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
 $approvedDispatchSkillIds = @($approvedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
 $localSuggestionSkillIds = @($localSuggestions | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-$executedSpecialistSkillIds = @($executedSpecialistUnits | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$executedSpecialistSkillIds = @($verifiedSpecialistUnits | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$directRoutedSpecialistSkillIds = @($directRoutedSpecialistUnits | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$resolvedSpecialistSkillIds = @((@($executedSpecialistSkillIds) + @($directRoutedSpecialistSkillIds)) | Select-Object -Unique)
 
 $approvedDispatchMissingFromRecommendations = @($approvedDispatchSkillIds | Where-Object { $_ -notin $recommendationSkillIds })
 $approvedDispatchNotExecuted = @($approvedDispatchSkillIds | Where-Object { $_ -notin $executedSpecialistSkillIds })
+$approvedDispatchNotResolved = @($approvedDispatchSkillIds | Where-Object { $_ -notin $resolvedSpecialistSkillIds })
 $executedWithoutApproval = @($executedSpecialistSkillIds | Where-Object { $_ -notin $approvedDispatchSkillIds })
+$routedWithoutApproval = @($directRoutedSpecialistSkillIds | Where-Object { $_ -notin $approvedDispatchSkillIds })
 $localSuggestionsExecutedWithoutApproval = @($localSuggestionSkillIds | Where-Object { $_ -in $executedSpecialistSkillIds })
 $dispatchContractIncompleteSkillIds = @(
     $approvedDispatch | Where-Object {
@@ -1197,6 +1212,8 @@ $dispatchIntegrity = [pscustomobject]@{
     degraded_skill_ids = @($degradedSkillIds)
     ghost_match_skill_ids = @($ghostMatchSkillIds)
     executed_specialist_skill_ids = @($executedSpecialistSkillIds)
+    direct_routed_specialist_skill_ids = @($directRoutedSpecialistSkillIds)
+    resolved_specialist_skill_ids = @($resolvedSpecialistSkillIds)
     approved_dispatch_subset_of_recommendations = [bool](@($approvedDispatchMissingFromRecommendations).Count -eq 0)
     inherited_root_approval_allowed = [bool]([string]$hierarchyState.governance_scope -eq 'child')
     approved_dispatch_supported_by_recommendation_or_inherited_approval = [bool](
@@ -1204,36 +1221,31 @@ $dispatchIntegrity = [pscustomobject]@{
         ([string]$hierarchyState.governance_scope -eq 'child')
     )
     approved_dispatch_fully_executed = [bool](@($approvedDispatchNotExecuted).Count -eq 0)
+    approved_dispatch_fully_resolved = [bool](@($approvedDispatchNotResolved).Count -eq 0)
     executed_specialists_subset_of_approved_dispatch = [bool](@($executedWithoutApproval).Count -eq 0)
+    routed_specialists_subset_of_approved_dispatch = [bool](@($routedWithoutApproval).Count -eq 0)
     local_suggestions_contained = [bool](@($localSuggestionsExecutedWithoutApproval).Count -eq 0)
     native_contract_complete_for_approved_dispatch = [bool](@($dispatchContractIncompleteSkillIds).Count -eq 0)
     matched_skills_resolved = [bool](@($ghostMatchSkillIds).Count -eq 0)
     approved_dispatch_missing_from_recommendations = @($approvedDispatchMissingFromRecommendations)
     approved_dispatch_not_executed = @($approvedDispatchNotExecuted)
+    approved_dispatch_not_resolved = @($approvedDispatchNotResolved)
     executed_without_approval = @($executedWithoutApproval)
+    routed_without_approval = @($routedWithoutApproval)
     local_suggestions_executed_without_approval = @($localSuggestionsExecutedWithoutApproval)
     dispatch_contract_incomplete_skill_ids = @($dispatchContractIncompleteSkillIds)
 }
 $dispatchIntegrity | Add-Member -NotePropertyName 'proof_passed' -NotePropertyValue ([bool](
     $dispatchIntegrity.approved_dispatch_supported_by_recommendation_or_inherited_approval -and
-    $dispatchIntegrity.approved_dispatch_fully_executed -and
+    $dispatchIntegrity.approved_dispatch_fully_resolved -and
     $dispatchIntegrity.executed_specialists_subset_of_approved_dispatch -and
+    $dispatchIntegrity.routed_specialists_subset_of_approved_dispatch -and
     $dispatchIntegrity.local_suggestions_contained -and
     $dispatchIntegrity.native_contract_complete_for_approved_dispatch -and
     $dispatchIntegrity.matched_skills_resolved
 ))
 
 $baseStatus = if ($failedUnitCount -eq 0 -and $executedUnitCount -ge [int]$profile.expected_minimum_units) { 'completed' } elseif ($executedUnitCount -eq 0) { 'failed' } else { 'completed_with_failures' }
-$liveAttemptedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live_native_execution })
-$liveSpecialistUnits = @($liveAttemptedSpecialistUnits | Where-Object { [bool]$_.verification_passed })
-$failedLiveSpecialistUnits = @($liveAttemptedSpecialistUnits | Where-Object { -not [bool]$_.verification_passed })
-$directRoutedSpecialistUnits = @($executedSpecialistUnits | Where-Object {
-    -not [bool]$(if ($_.PSObject.Properties.Name -contains 'live_native_execution') { $_.live_native_execution } else { $false }) -and
-    -not [bool]$(if ($_.PSObject.Properties.Name -contains 'degraded') { $_.degraded } else { $false }) -and
-    -not [bool]$(if ($_.PSObject.Properties.Name -contains 'blocked') { $_.blocked } else { $false }) -and
-    [string]$_.execution_driver -eq 'direct_current_session_route'
-})
-$verifiedSpecialistUnits = @(@($liveSpecialistUnits) + @($directRoutedSpecialistUnits))
 $degradedSpecialistUnits = @(@($executedSpecialistUnits | Where-Object { [bool]$_.degraded }) + @($preDispatchDegradedUnits))
 $nonDegradedExecutedSpecialistUnits = @($executedSpecialistUnits | Where-Object { -not [bool]$_.degraded })
 $totalSpecialistDispatchOutcomeCount = @($nonDegradedExecutedSpecialistUnits).Count + @($blockedSpecialistUnits).Count + @($degradedSpecialistUnits).Count
@@ -1377,6 +1389,7 @@ $executionManifest = [pscustomobject]@{
             surfaced = @($surfacedSkillIds).Count
             dispatched = @($approvedDispatch).Count
             executed = @($verifiedSpecialistUnits).Count
+            routed = @($directRoutedSpecialistUnits).Count
             blocked_due_to_destructive = @($blockedSkillIds).Count
             degraded_due_to_missing_contract = @($degradedSkillIds).Count
             ghost_match = @($ghostMatchSkillIds).Count

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -1192,6 +1192,86 @@ function Get-VibeSpecialistDispatchResolutionKey {
     return ('{0}|{1}' -f $dispatchPhase, $skillId)
 }
 
+function Get-VibeSpecialistDispatchExplicitPhase {
+    param(
+        [AllowNull()] [object]$Entry = $null
+    )
+
+    if (
+        $null -ne $Entry -and
+        $Entry.PSObject.Properties.Name -contains 'dispatch_phase' -and
+        -not [string]::IsNullOrWhiteSpace([string]$Entry.dispatch_phase)
+    ) {
+        return [string]$Entry.dispatch_phase
+    }
+
+    return $null
+}
+
+function Test-VibeSpecialistEntrySupportedByCandidates {
+    param(
+        [AllowNull()] [object]$Entry = $null,
+        [object[]]$Candidates = @()
+    )
+
+    if ($null -eq $Entry) {
+        return $false
+    }
+
+    $entrySkillId = if (
+        $Entry.PSObject.Properties.Name -contains 'skill_id' -and
+        -not [string]::IsNullOrWhiteSpace([string]$Entry.skill_id)
+    ) {
+        [string]$Entry.skill_id
+    } elseif (
+        $Entry.PSObject.Properties.Name -contains 'specialist_skill_id' -and
+        -not [string]::IsNullOrWhiteSpace([string]$Entry.specialist_skill_id)
+    ) {
+        [string]$Entry.specialist_skill_id
+    } else {
+        $null
+    }
+    if ([string]::IsNullOrWhiteSpace($entrySkillId)) {
+        return $false
+    }
+
+    $entryPhase = Get-VibeSpecialistDispatchExplicitPhase -Entry $Entry
+    foreach ($candidate in @($Candidates)) {
+        if ($null -eq $candidate) {
+            continue
+        }
+
+        $candidateSkillId = if (
+            $candidate.PSObject.Properties.Name -contains 'skill_id' -and
+            -not [string]::IsNullOrWhiteSpace([string]$candidate.skill_id)
+        ) {
+            [string]$candidate.skill_id
+        } elseif (
+            $candidate.PSObject.Properties.Name -contains 'specialist_skill_id' -and
+            -not [string]::IsNullOrWhiteSpace([string]$candidate.specialist_skill_id)
+        ) {
+            [string]$candidate.specialist_skill_id
+        } else {
+            $null
+        }
+        if ([string]::IsNullOrWhiteSpace($candidateSkillId) -or $candidateSkillId -ne $entrySkillId) {
+            continue
+        }
+
+        $candidatePhase = Get-VibeSpecialistDispatchExplicitPhase -Entry $candidate
+        if ($null -ne $entryPhase -and $null -ne $candidatePhase) {
+            if ($candidatePhase -eq $entryPhase) {
+                return $true
+            }
+            continue
+        }
+
+        return $true
+    }
+
+    return $false
+}
+
 $recommendationSkillIds = @($specialistRecommendations | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
 $approvedDispatchSkillIds = @($approvedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
 $localSuggestionSkillIds = @($localSuggestions | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
@@ -1206,12 +1286,48 @@ $directRoutedSpecialistResolutionKeys = @($directRoutedSpecialistUnits | ForEach
 $resolvedSpecialistResolutionKeys = @((@($executedSpecialistResolutionKeys) + @($directRoutedSpecialistResolutionKeys)) | Select-Object -Unique)
 
 $approvedDispatchMissingFromRecommendations = @($approvedDispatchSkillIds | Where-Object { $_ -notin $recommendationSkillIds })
-$approvedDispatchMissingFromRecommendationsResolutionKeys = @($approvedDispatchResolutionKeys | Where-Object { $_ -notin $recommendationResolutionKeys })
-$approvedDispatchNotExecuted = @($approvedDispatchResolutionKeys | Where-Object { $_ -notin $executedSpecialistResolutionKeys })
-$approvedDispatchNotResolved = @($approvedDispatchResolutionKeys | Where-Object { $_ -notin $resolvedSpecialistResolutionKeys })
-$executedWithoutApproval = @($executedSpecialistResolutionKeys | Where-Object { $_ -notin $approvedDispatchResolutionKeys })
-$routedWithoutApproval = @($directRoutedSpecialistResolutionKeys | Where-Object { $_ -notin $approvedDispatchResolutionKeys })
-$localSuggestionsExecutedWithoutApproval = @($localSuggestionResolutionKeys | Where-Object { $_ -in $executedSpecialistResolutionKeys })
+$approvedDispatchMissingFromRecommendationsResolutionKeys = @(
+    $approvedDispatch |
+        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @($specialistRecommendations)) } |
+        ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -Unique
+)
+$approvedDispatchNotExecuted = @(
+    $approvedDispatch |
+        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @($verifiedSpecialistUnits)) } |
+        ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -Unique
+)
+$approvedDispatchNotResolved = @(
+    $approvedDispatch |
+        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @(@($verifiedSpecialistUnits) + @($directRoutedSpecialistUnits))) } |
+        ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -Unique
+)
+$executedWithoutApproval = @(
+    $verifiedSpecialistUnits |
+        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @($approvedDispatch)) } |
+        ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -Unique
+)
+$routedWithoutApproval = @(
+    $directRoutedSpecialistUnits |
+        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @($approvedDispatch)) } |
+        ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -Unique
+)
+$localSuggestionsExecutedWithoutApproval = @(
+    $localSuggestions |
+        Where-Object { Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @($verifiedSpecialistUnits) } |
+        ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -Unique
+)
 $dispatchContractIncompleteSkillIds = @(
     $approvedDispatch | Where-Object {
         $hasNativeUsageRequired = $_.PSObject.Properties.Name -contains 'native_usage_required'

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -1154,9 +1154,36 @@ $executedWithoutApproval = @($executedSpecialistSkillIds | Where-Object { $_ -no
 $localSuggestionsExecutedWithoutApproval = @($localSuggestionSkillIds | Where-Object { $_ -in $executedSpecialistSkillIds })
 $dispatchContractIncompleteSkillIds = @(
     $approvedDispatch | Where-Object {
-        -not [bool]$_.native_usage_required -or
-        -not [bool]$_.must_preserve_workflow -or
-        [string]::IsNullOrWhiteSpace([string]$_.native_skill_entrypoint)
+        $hasNativeUsageRequired = $_.PSObject.Properties.Name -contains 'native_usage_required'
+        $hasUsageRequired = $_.PSObject.Properties.Name -contains 'usage_required'
+        $effectiveUsageRequired = if ($hasUsageRequired) {
+            [bool]$_.usage_required
+        } elseif ($hasNativeUsageRequired) {
+            [bool]$_.native_usage_required
+        } else {
+            $false
+        }
+        $mustPreserveWorkflow = if ($_.PSObject.Properties.Name -contains 'must_preserve_workflow') {
+            [bool]$_.must_preserve_workflow
+        } else {
+            $false
+        }
+        $nativeEntrypoint = if ($_.PSObject.Properties.Name -contains 'native_skill_entrypoint') {
+            [string]$_.native_skill_entrypoint
+        } else {
+            ''
+        }
+        $skillRoot = if ($_.PSObject.Properties.Name -contains 'skill_root') {
+            [string]$_.skill_root
+        } else {
+            ''
+        }
+
+        (-not $hasNativeUsageRequired -and -not $hasUsageRequired) -or
+        -not $effectiveUsageRequired -or
+        -not $mustPreserveWorkflow -or
+        [string]::IsNullOrWhiteSpace($nativeEntrypoint) -or
+        [string]::IsNullOrWhiteSpace($skillRoot)
     } | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
 )
 
@@ -1200,6 +1227,13 @@ $baseStatus = if ($failedUnitCount -eq 0 -and $executedUnitCount -ge [int]$profi
 $liveAttemptedSpecialistUnits = @($executedSpecialistUnits | Where-Object { [bool]$_.live_native_execution })
 $liveSpecialistUnits = @($liveAttemptedSpecialistUnits | Where-Object { [bool]$_.verification_passed })
 $failedLiveSpecialistUnits = @($liveAttemptedSpecialistUnits | Where-Object { -not [bool]$_.verification_passed })
+$directRoutedSpecialistUnits = @($executedSpecialistUnits | Where-Object {
+    -not [bool]$(if ($_.PSObject.Properties.Name -contains 'live_native_execution') { $_.live_native_execution } else { $false }) -and
+    -not [bool]$(if ($_.PSObject.Properties.Name -contains 'degraded') { $_.degraded } else { $false }) -and
+    -not [bool]$(if ($_.PSObject.Properties.Name -contains 'blocked') { $_.blocked } else { $false }) -and
+    [string]$_.execution_driver -eq 'direct_current_session_route'
+})
+$verifiedSpecialistUnits = @(@($liveSpecialistUnits) + @($directRoutedSpecialistUnits))
 $degradedSpecialistUnits = @(@($executedSpecialistUnits | Where-Object { [bool]$_.degraded }) + @($preDispatchDegradedUnits))
 $nonDegradedExecutedSpecialistUnits = @($executedSpecialistUnits | Where-Object { -not [bool]$_.degraded })
 $totalSpecialistDispatchOutcomeCount = @($nonDegradedExecutedSpecialistUnits).Count + @($blockedSpecialistUnits).Count + @($degradedSpecialistUnits).Count
@@ -1209,6 +1243,8 @@ $effectiveSpecialistExecutionStatus = if (@($liveSpecialistUnits).Count -gt 0 -a
     'live_native_partial_failures'
 } elseif (@($failedLiveSpecialistUnits).Count -gt 0) {
     'live_native_failed'
+} elseif (@($directRoutedSpecialistUnits).Count -gt 0) {
+    'direct_current_session_routed'
 } elseif (@($degradedSpecialistUnits).Count -gt 0) {
     'explicitly_degraded'
 } elseif (@($blockedSpecialistUnits).Count -gt 0) {
@@ -1322,9 +1358,11 @@ $executionManifest = [pscustomobject]@{
         }
         parallelizable_dispatch_count = @($approvedDispatch | Where-Object { [bool]$_.parallelizable_in_root_xl }).Count
         attempted_specialist_unit_count = @($liveAttemptedSpecialistUnits).Count
-        executed_specialist_unit_count = @($liveSpecialistUnits).Count
+        executed_specialist_unit_count = @($verifiedSpecialistUnits).Count
         failed_specialist_unit_count = @($failedLiveSpecialistUnits).Count
-        executed_specialist_units = @($liveSpecialistUnits)
+        direct_routed_specialist_unit_count = @($directRoutedSpecialistUnits).Count
+        direct_routed_specialist_units = @($directRoutedSpecialistUnits)
+        executed_specialist_units = @($verifiedSpecialistUnits)
         failed_specialist_units = @($failedLiveSpecialistUnits)
         blocked_specialist_unit_count = @($blockedSpecialistUnits).Count
         blocked_specialist_units = @($blockedSpecialistUnits)
@@ -1338,12 +1376,12 @@ $executionManifest = [pscustomobject]@{
             matched = @($matchedSkillIds).Count
             surfaced = @($surfacedSkillIds).Count
             dispatched = @($approvedDispatch).Count
-            executed = @($liveSpecialistUnits).Count
+            executed = @($verifiedSpecialistUnits).Count
             blocked_due_to_destructive = @($blockedSkillIds).Count
             degraded_due_to_missing_contract = @($degradedSkillIds).Count
             ghost_match = @($ghostMatchSkillIds).Count
-            executed_per_matched = if (@($matchedSkillIds).Count -gt 0) { [Math]::Round((@($liveSpecialistUnits).Count / [double]@($matchedSkillIds).Count), 4) } else { 0.0 }
-            executed_rate = if (@($approvedDispatch).Count -gt 0) { [Math]::Round((@($liveSpecialistUnits).Count / [double]@($approvedDispatch).Count), 4) } else { 0.0 }
+            executed_per_matched = if (@($matchedSkillIds).Count -gt 0) { [Math]::Round((@($verifiedSpecialistUnits).Count / [double]@($matchedSkillIds).Count), 4) } else { 0.0 }
+            executed_rate = if (@($approvedDispatch).Count -gt 0) { [Math]::Round((@($verifiedSpecialistUnits).Count / [double]@($approvedDispatch).Count), 4) } else { 0.0 }
         }
         original_local_suggestion_count = @($frozenLocalSuggestions).Count
         original_local_specialist_suggestions = @($frozenLocalSuggestions)
@@ -1383,8 +1421,9 @@ $proofManifest = [pscustomobject]@{
     specialist_recommendation_count = @($specialistRecommendations).Count
     specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
     attempted_specialist_unit_count = @($liveAttemptedSpecialistUnits).Count
-    executed_specialist_unit_count = @($liveSpecialistUnits).Count
+    executed_specialist_unit_count = @($verifiedSpecialistUnits).Count
     failed_specialist_unit_count = @($failedLiveSpecialistUnits).Count
+    direct_routed_specialist_unit_count = @($directRoutedSpecialistUnits).Count
     blocked_specialist_unit_count = @($blockedSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount
@@ -1417,8 +1456,9 @@ $proofLines = @(
     ('- specialist_recommendation_count: `{0}`' -f @($specialistRecommendations).Count),
     ('- specialist_dispatch_unit_count: `{0}`' -f [int]$specialistDispatchUnitCount),
     ('- attempted_specialist_unit_count: `{0}`' -f @($liveAttemptedSpecialistUnits).Count),
-    ('- executed_specialist_unit_count: `{0}`' -f @($liveSpecialistUnits).Count),
+    ('- executed_specialist_unit_count: `{0}`' -f @($verifiedSpecialistUnits).Count),
     ('- failed_specialist_unit_count: `{0}`' -f @($failedLiveSpecialistUnits).Count),
+    ('- direct_routed_specialist_unit_count: `{0}`' -f @($directRoutedSpecialistUnits).Count),
     ('- blocked_specialist_unit_count: `{0}`' -f @($blockedSpecialistUnits).Count),
     ('- degraded_specialist_unit_count: `{0}`' -f @($degradedSpecialistUnits).Count),
     ('- auto_approved_specialist_unit_count: `{0}`' -f @($autoApprovedDispatch).Count),
@@ -1474,8 +1514,9 @@ $receipt = [pscustomobject]@{
     specialist_recommendation_count = @($specialistRecommendations).Count
     specialist_dispatch_unit_count = [int]$specialistDispatchUnitCount
     attempted_specialist_unit_count = @($liveAttemptedSpecialistUnits).Count
-    executed_specialist_unit_count = @($liveSpecialistUnits).Count
+    executed_specialist_unit_count = @($verifiedSpecialistUnits).Count
     failed_specialist_unit_count = @($failedLiveSpecialistUnits).Count
+    direct_routed_specialist_unit_count = @($directRoutedSpecialistUnits).Count
     blocked_specialist_unit_count = @($blockedSpecialistUnits).Count
     degraded_specialist_unit_count = @($degradedSpecialistUnits).Count
     specialist_dispatch_outcome_count = $totalSpecialistDispatchOutcomeCount

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -1154,6 +1154,31 @@ $directRoutedSpecialistUnits = @($executedSpecialistUnits | Where-Object {
 })
 $verifiedSpecialistUnits = @($liveSpecialistUnits)
 
+function Get-VibeSpecialistEntrySkillId {
+    param(
+        [AllowNull()] [object]$Entry = $null
+    )
+
+    if ($null -eq $Entry) {
+        return $null
+    }
+
+    if (
+        $Entry.PSObject.Properties.Name -contains 'skill_id' -and
+        -not [string]::IsNullOrWhiteSpace([string]$Entry.skill_id)
+    ) {
+        return [string]$Entry.skill_id
+    }
+    if (
+        $Entry.PSObject.Properties.Name -contains 'specialist_skill_id' -and
+        -not [string]::IsNullOrWhiteSpace([string]$Entry.specialist_skill_id)
+    ) {
+        return [string]$Entry.specialist_skill_id
+    }
+
+    return $null
+}
+
 function Get-VibeSpecialistDispatchResolutionKey {
     param(
         [AllowNull()] [object]$Entry = $null
@@ -1163,19 +1188,7 @@ function Get-VibeSpecialistDispatchResolutionKey {
         return $null
     }
 
-    $skillId = if (
-        $Entry.PSObject.Properties.Name -contains 'skill_id' -and
-        -not [string]::IsNullOrWhiteSpace([string]$Entry.skill_id)
-    ) {
-        [string]$Entry.skill_id
-    } elseif (
-        $Entry.PSObject.Properties.Name -contains 'specialist_skill_id' -and
-        -not [string]::IsNullOrWhiteSpace([string]$Entry.specialist_skill_id)
-    ) {
-        [string]$Entry.specialist_skill_id
-    } else {
-        $null
-    }
+    $skillId = Get-VibeSpecialistEntrySkillId -Entry $Entry
     if ([string]::IsNullOrWhiteSpace($skillId)) {
         return $null
     }
@@ -1208,7 +1221,7 @@ function Get-VibeSpecialistDispatchExplicitPhase {
     return $null
 }
 
-function Test-VibeSpecialistEntrySupportedByCandidates {
+function Test-VibeSpecialistEntrySupportedByCandidate {
     param(
         [AllowNull()] [object]$Entry = $null,
         [object[]]$Candidates = @()
@@ -1218,19 +1231,7 @@ function Test-VibeSpecialistEntrySupportedByCandidates {
         return $false
     }
 
-    $entrySkillId = if (
-        $Entry.PSObject.Properties.Name -contains 'skill_id' -and
-        -not [string]::IsNullOrWhiteSpace([string]$Entry.skill_id)
-    ) {
-        [string]$Entry.skill_id
-    } elseif (
-        $Entry.PSObject.Properties.Name -contains 'specialist_skill_id' -and
-        -not [string]::IsNullOrWhiteSpace([string]$Entry.specialist_skill_id)
-    ) {
-        [string]$Entry.specialist_skill_id
-    } else {
-        $null
-    }
+    $entrySkillId = Get-VibeSpecialistEntrySkillId -Entry $Entry
     if ([string]::IsNullOrWhiteSpace($entrySkillId)) {
         return $false
     }
@@ -1241,19 +1242,7 @@ function Test-VibeSpecialistEntrySupportedByCandidates {
             continue
         }
 
-        $candidateSkillId = if (
-            $candidate.PSObject.Properties.Name -contains 'skill_id' -and
-            -not [string]::IsNullOrWhiteSpace([string]$candidate.skill_id)
-        ) {
-            [string]$candidate.skill_id
-        } elseif (
-            $candidate.PSObject.Properties.Name -contains 'specialist_skill_id' -and
-            -not [string]::IsNullOrWhiteSpace([string]$candidate.specialist_skill_id)
-        ) {
-            [string]$candidate.specialist_skill_id
-        } else {
-            $null
-        }
+        $candidateSkillId = Get-VibeSpecialistEntrySkillId -Entry $candidate
         if ([string]::IsNullOrWhiteSpace($candidateSkillId) -or $candidateSkillId -ne $entrySkillId) {
             continue
         }
@@ -1288,42 +1277,42 @@ $resolvedSpecialistResolutionKeys = @((@($executedSpecialistResolutionKeys) + @(
 $approvedDispatchMissingFromRecommendations = @($approvedDispatchSkillIds | Where-Object { $_ -notin $recommendationSkillIds })
 $approvedDispatchMissingFromRecommendationsResolutionKeys = @(
     $approvedDispatch |
-        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @($specialistRecommendations)) } |
+        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidate -Entry $_ -Candidates @($specialistRecommendations)) } |
         ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } |
         Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
         Select-Object -Unique
 )
 $approvedDispatchNotExecuted = @(
     $approvedDispatch |
-        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @($verifiedSpecialistUnits)) } |
+        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidate -Entry $_ -Candidates @($verifiedSpecialistUnits)) } |
         ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } |
         Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
         Select-Object -Unique
 )
 $approvedDispatchNotResolved = @(
     $approvedDispatch |
-        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @(@($verifiedSpecialistUnits) + @($directRoutedSpecialistUnits))) } |
+        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidate -Entry $_ -Candidates @(@($verifiedSpecialistUnits) + @($directRoutedSpecialistUnits))) } |
         ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } |
         Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
         Select-Object -Unique
 )
 $executedWithoutApproval = @(
     $verifiedSpecialistUnits |
-        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @($approvedDispatch)) } |
+        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidate -Entry $_ -Candidates @($approvedDispatch)) } |
         ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } |
         Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
         Select-Object -Unique
 )
 $routedWithoutApproval = @(
     $directRoutedSpecialistUnits |
-        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @($approvedDispatch)) } |
+        Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidate -Entry $_ -Candidates @($approvedDispatch)) } |
         ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } |
         Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
         Select-Object -Unique
 )
 $localSuggestionsExecutedWithoutApproval = @(
     $localSuggestions |
-        Where-Object { Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @($verifiedSpecialistUnits) } |
+        Where-Object { Test-VibeSpecialistEntrySupportedByCandidate -Entry $_ -Candidates @($verifiedSpecialistUnits) } |
         ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } |
         Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
         Select-Object -Unique

--- a/scripts/runtime/VibeConsultation.Common.ps1
+++ b/scripts/runtime/VibeConsultation.Common.ps1
@@ -1067,7 +1067,10 @@ function Invoke-VibeSpecialistConsultationWindow {
             $consultedUnits.Add($entry) | Out-Null
         } elseif ([string]$outcome.category -eq 'routed') {
             $routedUnits.Add($entry) | Out-Null
+        } elseif ([string]$outcome.category -eq 'degraded') {
+            $degraded.Add($entry) | Out-Null
         } else {
+            Write-Warning ("Unexpected specialist consultation outcome category '{0}' for window '{1}' skill '{2}'; treating as degraded." -f [string]$outcome.category, [string]$WindowId, [string]$consultation.skill_id)
             $degraded.Add($entry) | Out-Null
         }
     }

--- a/scripts/runtime/VibeConsultation.Common.ps1
+++ b/scripts/runtime/VibeConsultation.Common.ps1
@@ -41,6 +41,11 @@ function Get-VibeSpecialistConsultationPolicy {
     if (-not [string]::IsNullOrWhiteSpace($modeOverride)) {
         $consultationMode = [string]$modeOverride
     }
+    $consultationMode = $consultationMode.Trim().ToLowerInvariant()
+    $allowedConsultationModes = @('direct_current_session_route', 'host_subprocess')
+    if ($consultationMode -notin $allowedConsultationModes) {
+        throw ("Unsupported specialist consultation mode: {0}" -f $consultationMode)
+    }
 
     return [pscustomobject]@{
         enabled = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'enabled')) { [bool]$resolvedPolicy.enabled } else { $false }
@@ -144,7 +149,7 @@ function New-VibeSpecialistConsultationCandidate {
         required_inputs = if (Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'required_inputs') { [object[]]@($Recommendation.required_inputs) } else { @() }
         expected_outputs = if (Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'expected_outputs') { [object[]]@($Recommendation.expected_outputs) } else { @() }
         verification_expectation = if ((Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'verification_expectation') -and -not [string]::IsNullOrWhiteSpace([string]$Recommendation.verification_expectation)) { [string]$Recommendation.verification_expectation } else { 'Return bounded structured specialist guidance only.' }
-        native_usage_required = if (Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'native_usage_required') { [bool]$Recommendation.native_usage_required } else { $true }
+        native_usage_required = if (Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'native_usage_required') { [bool]$Recommendation.native_usage_required } elseif (Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'usage_required') { [bool]$Recommendation.usage_required } else { $true }
         must_preserve_workflow = if (Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'must_preserve_workflow') { [bool]$Recommendation.must_preserve_workflow } else { $true }
         contract_complete = if (Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'contract_complete') { [bool]$Recommendation.contract_complete } else { $false }
         contract_missing_fields = if (Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'contract_missing_fields') { [object[]]@($Recommendation.contract_missing_fields) } else { @() }

--- a/scripts/runtime/VibeConsultation.Common.ps1
+++ b/scripts/runtime/VibeConsultation.Common.ps1
@@ -597,8 +597,8 @@ function New-VibeDirectRoutedSpecialistConsultationResult {
     $result = [pscustomobject]@{
         unit_id = $UnitId
         kind = 'specialist_consultation'
-        status = 'completed'
-        verification_passed = $true
+        status = 'routed_pending_current_session'
+        verification_passed = $false
         skill_id = [string]$Consultation.skill_id
         consultation_window_id = [string]$WindowId
         consultation_stage = [string]$Stage
@@ -626,13 +626,13 @@ function New-VibeDirectRoutedSpecialistConsultationResult {
         response_json_path = $null
         prompt_path = $null
         schema_path = $null
-        result_reason = 'direct_current_session_route'
+        result_reason = 'pending_direct_current_session_route'
     }
     $resultPath = Join-Path $resultsRoot ("{0}.json" -f $UnitId)
     Write-VibeJsonArtifact -Path $resultPath -Value $result
 
     return [pscustomobject]@{
-        category = 'consulted'
+        category = 'routed'
         result = $result
         result_path = $resultPath
     }
@@ -842,6 +842,7 @@ function New-VibeSpecialistConsultationWindowSummary {
         [AllowEmptyCollection()] [AllowNull()] [object[]]$Blocked = @(),
         [AllowEmptyCollection()] [AllowNull()] [object[]]$Degraded = @(),
         [AllowEmptyCollection()] [AllowNull()] [object[]]$ConsultedUnits = @(),
+        [AllowEmptyCollection()] [AllowNull()] [object[]]$RoutedUnits = @(),
         [AllowEmptyCollection()] [AllowNull()] [object[]]$UserDisclosures = @()
     )
 
@@ -853,12 +854,14 @@ function New-VibeSpecialistConsultationWindowSummary {
         blocked_count = @($Blocked).Count
         degraded_count = @($Degraded).Count
         consulted_unit_count = @($ConsultedUnits).Count
+        routed_unit_count = @($RoutedUnits).Count
         user_disclosure_count = @($UserDisclosures).Count
         approved_skill_ids = @($ApprovedConsultation | ForEach-Object { [string]$_.skill_id } | Select-Object -Unique)
         deferred_skill_ids = @($DeferredToExecution | ForEach-Object { [string]$_.skill_id } | Select-Object -Unique)
         blocked_skill_ids = @($Blocked | ForEach-Object { [string]$_.skill_id } | Select-Object -Unique)
         degraded_skill_ids = @($Degraded | ForEach-Object { [string]$_.skill_id } | Select-Object -Unique)
         consulted_skill_ids = @($ConsultedUnits | ForEach-Object { [string]$_.skill_id } | Select-Object -Unique)
+        routed_skill_ids = @($RoutedUnits | ForEach-Object { [string]$_.skill_id } | Select-Object -Unique)
     }
 }
 
@@ -875,6 +878,7 @@ function Test-VibeSpecialistConsultationFreezeGate {
             errors = @()
             approved_skill_ids = @()
             consulted_skill_ids = @()
+            routed_skill_ids = @()
             degraded_skill_ids = @()
             deferred_skill_ids = @()
             blocked_skill_ids = @()
@@ -884,6 +888,7 @@ function Test-VibeSpecialistConsultationFreezeGate {
 
     $approvedSkillIds = @($Receipt.approved_consultation | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
     $consultedSkillIds = @($Receipt.consulted_units | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $routedSkillIds = @($Receipt.routed_units | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
     $degradedSkillIds = @($Receipt.degraded | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
     $deferredSkillIds = @($Receipt.deferred_to_execution | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
     $blockedSkillIds = @($Receipt.blocked | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
@@ -893,6 +898,12 @@ function Test-VibeSpecialistConsultationFreezeGate {
     foreach ($entry in @($Receipt.consulted_units)) {
         if ($null -ne $entry -and -not [string]::IsNullOrWhiteSpace([string]$entry.skill_id)) {
             $consultedIndex[[string]$entry.skill_id] = $entry
+        }
+    }
+    $routedIndex = @{}
+    foreach ($entry in @($Receipt.routed_units)) {
+        if ($null -ne $entry -and -not [string]::IsNullOrWhiteSpace([string]$entry.skill_id)) {
+            $routedIndex[[string]$entry.skill_id] = $entry
         }
     }
     $degradedIndex = @{}
@@ -906,6 +917,7 @@ function Test-VibeSpecialistConsultationFreezeGate {
     foreach ($skillId in @($approvedSkillIds)) {
         $outcomeCount = 0
         if ($consultedIndex.ContainsKey($skillId)) { $outcomeCount += 1 }
+        if ($routedIndex.ContainsKey($skillId)) { $outcomeCount += 1 }
         if ($degradedIndex.ContainsKey($skillId)) { $outcomeCount += 1 }
         if ($deferredSkillIds -contains $skillId) { $outcomeCount += 1 }
         if ($blockedSkillIds -contains $skillId) { $outcomeCount += 1 }
@@ -950,6 +962,7 @@ function Test-VibeSpecialistConsultationFreezeGate {
         errors = [string[]]$errors.ToArray()
         approved_skill_ids = @($approvedSkillIds)
         consulted_skill_ids = @($consultedSkillIds)
+        routed_skill_ids = @($routedSkillIds)
         degraded_skill_ids = @($degradedSkillIds)
         deferred_skill_ids = @($deferredSkillIds)
         blocked_skill_ids = @($blockedSkillIds)
@@ -1007,6 +1020,7 @@ function Invoke-VibeSpecialistConsultationWindow {
             blocked = @()
             degraded = @()
             consulted_units = @()
+            routed_units = @()
             user_disclosures = @()
             summary = New-VibeSpecialistConsultationWindowSummary -WindowId $WindowId -Stage $defaultStage
         }
@@ -1033,6 +1047,7 @@ function Invoke-VibeSpecialistConsultationWindow {
         -Policy $resolvedPolicy
 
     $consultedUnits = New-Object System.Collections.Generic.List[object]
+    $routedUnits = New-Object System.Collections.Generic.List[object]
     $degraded = New-Object System.Collections.Generic.List[object]
     foreach ($consultation in @($approvedConsultation)) {
         $unitId = ('consult-{0}-{1}' -f [string]$WindowId, [string]$consultation.skill_id)
@@ -1050,6 +1065,8 @@ function Invoke-VibeSpecialistConsultationWindow {
         $entry = $outcome.result | Select-Object *, @{ Name = 'result_path'; Expression = { [string]$outcome.result_path } }
         if ([string]$outcome.category -eq 'consulted') {
             $consultedUnits.Add($entry) | Out-Null
+        } elseif ([string]$outcome.category -eq 'routed') {
+            $routedUnits.Add($entry) | Out-Null
         } else {
             $degraded.Add($entry) | Out-Null
         }
@@ -1067,6 +1084,7 @@ function Invoke-VibeSpecialistConsultationWindow {
         blocked = @($blocked)
         degraded = [object[]]$degraded.ToArray()
         consulted_units = [object[]]$consultedUnits.ToArray()
+        routed_units = [object[]]$routedUnits.ToArray()
         user_disclosures = @($userDisclosures)
         summary = New-VibeSpecialistConsultationWindowSummary `
             -WindowId $WindowId `
@@ -1076,6 +1094,7 @@ function Invoke-VibeSpecialistConsultationWindow {
             -Blocked @($blocked) `
             -Degraded @($degraded.ToArray()) `
             -ConsultedUnits @($consultedUnits.ToArray()) `
+            -RoutedUnits @($routedUnits.ToArray()) `
             -UserDisclosures @($userDisclosures)
     }
     $receipt | Add-Member -NotePropertyName freeze_gate -NotePropertyValue (Test-VibeSpecialistConsultationFreezeGate -Receipt $receipt -Policy $resolvedPolicy)
@@ -1103,9 +1122,11 @@ function New-VibeSpecialistConsultationRuntimeProjection {
                 stage = [string]$receipt.stage
                 approved_consultation_count = if ($receipt.summary) { [int]$receipt.summary.approved_consultation_count } else { 0 }
                 consulted_unit_count = if ($receipt.summary) { [int]$receipt.summary.consulted_unit_count } else { 0 }
+                routed_unit_count = if ($receipt.summary) { [int]$receipt.summary.routed_unit_count } else { 0 }
                 user_disclosure_count = if ($receipt.summary) { [int]$receipt.summary.user_disclosure_count } else { 0 }
                 approved_skill_ids = if ($receipt.summary) { [object[]]@($receipt.summary.approved_skill_ids) } else { @() }
                 consulted_skill_ids = if ($receipt.summary) { [object[]]@($receipt.summary.consulted_skill_ids) } else { @() }
+                routed_skill_ids = if ($receipt.summary) { [object[]]@($receipt.summary.routed_skill_ids) } else { @() }
                 deferred_skill_ids = if ($receipt.summary) { [object[]]@($receipt.summary.deferred_skill_ids) } else { @() }
                 degraded_skill_ids = if ($receipt.summary) { [object[]]@($receipt.summary.degraded_skill_ids) } else { @() }
                 freeze_gate_passed = if ($receipt.PSObject.Properties.Name -contains 'freeze_gate') { [bool]$receipt.freeze_gate.passed } else { $true }
@@ -1120,6 +1141,7 @@ function New-VibeSpecialistConsultationRuntimeProjection {
         window_count = @($windowArray).Count
         approved_consultation_count = [int]((@($windowArray | ForEach-Object { [int]$_.approved_consultation_count }) | Measure-Object -Sum).Sum)
         consulted_unit_count = [int]((@($windowArray | ForEach-Object { [int]$_.consulted_unit_count }) | Measure-Object -Sum).Sum)
+        routed_unit_count = [int]((@($windowArray | ForEach-Object { [int]$_.routed_unit_count }) | Measure-Object -Sum).Sum)
         user_disclosure_count = [int]((@($windowArray | ForEach-Object { [int]$_.user_disclosure_count }) | Measure-Object -Sum).Sum)
         freeze_gate_passed = [bool](@($windowArray | Where-Object { -not [bool]$_.freeze_gate_passed }).Count -eq 0)
         freeze_gate_error_count = [int]((@($windowArray | ForEach-Object { [int]$_.freeze_gate_error_count }) | Measure-Object -Sum).Sum)

--- a/scripts/runtime/VibeConsultation.Common.ps1
+++ b/scripts/runtime/VibeConsultation.Common.ps1
@@ -32,10 +32,21 @@ function Get-VibeSpecialistConsultationPolicy {
         }
     }
 
+    $consultationMode = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'mode') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedPolicy.mode)) {
+        [string]$resolvedPolicy.mode
+    } else {
+        'direct_current_session_route'
+    }
+    $modeOverride = [Environment]::GetEnvironmentVariable('VGO_SPECIALIST_CONSULTATION_MODE')
+    if (-not [string]::IsNullOrWhiteSpace($modeOverride)) {
+        $consultationMode = [string]$modeOverride
+    }
+
     return [pscustomobject]@{
         enabled = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'enabled')) { [bool]$resolvedPolicy.enabled } else { $false }
         version = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'version')) { [int]$resolvedPolicy.version } else { 1 }
         policy_id = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'policy_id') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedPolicy.policy_id)) { [string]$resolvedPolicy.policy_id } else { 'specialist-consultation-v1' }
+        mode = $consultationMode
         max_consults_per_window = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'max_consults_per_window')) { [int]$resolvedPolicy.max_consults_per_window } else { 2 }
         allowed_windows = @($allowedWindows)
         require_contract_complete = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'require_contract_complete')) { [bool]$resolvedPolicy.require_contract_complete } else { $true }
@@ -556,6 +567,77 @@ function New-VibeDegradedSpecialistConsultationResult {
     }
 }
 
+function New-VibeDirectRoutedSpecialistConsultationResult {
+    param(
+        [Parameter(Mandatory)] [string]$UnitId,
+        [Parameter(Mandatory)] [object]$Consultation,
+        [Parameter(Mandatory)] [string]$SessionRoot,
+        [Parameter(Mandatory)] [ValidateSet('discussion', 'planning')] [string]$WindowId,
+        [Parameter(Mandatory)] [string]$Stage
+    )
+
+    $resultsRoot = Join-Path $SessionRoot 'consultation-results'
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+
+    $entrypoint = if (
+        (Test-VibeObjectHasProperty -InputObject $Consultation -PropertyName 'native_skill_entrypoint') -and
+        -not [string]::IsNullOrWhiteSpace([string]$Consultation.native_skill_entrypoint)
+    ) {
+        [string]$Consultation.native_skill_entrypoint
+    } else {
+        $null
+    }
+
+    $summary = if (-not [string]::IsNullOrWhiteSpace($entrypoint)) {
+        ('Specialist was routed for direct current-session consultation. Load {0} in the current host session instead of launching a hidden host subprocess.' -f $entrypoint)
+    } else {
+        'Specialist was routed for direct current-session consultation instead of launching a hidden host subprocess.'
+    }
+
+    $result = [pscustomobject]@{
+        unit_id = $UnitId
+        kind = 'specialist_consultation'
+        status = 'completed'
+        verification_passed = $true
+        skill_id = [string]$Consultation.skill_id
+        consultation_window_id = [string]$WindowId
+        consultation_stage = [string]$Stage
+        live_native_execution = $false
+        degraded = $false
+        blocked = $false
+        direct_route = $true
+        consultation_mode = 'direct_current_session_route'
+        native_skill_entrypoint = $entrypoint
+        summary = $summary
+        consultation_notes = @(
+            'No hidden host subprocess was launched for this specialist.',
+            'The current host session should load the specialist entrypoint directly and keep vibe as the only runtime authority.'
+        )
+        adoption_notes = @(
+            'Use the specialist path already frozen in native_skill_entrypoint for same-session loading.',
+            'Do not replace vibe governance; absorb specialist guidance back into the governed artifact flow.'
+        )
+        verification_notes = @(
+            'consultation_mode:direct_current_session_route',
+            'hidden_host_subprocess:false',
+            ('native_skill_entrypoint:{0}' -f $(if ([string]::IsNullOrWhiteSpace($entrypoint)) { 'missing' } else { $entrypoint }))
+        )
+        observed_changed_files = @()
+        response_json_path = $null
+        prompt_path = $null
+        schema_path = $null
+        result_reason = 'direct_current_session_route'
+    }
+    $resultPath = Join-Path $resultsRoot ("{0}.json" -f $UnitId)
+    Write-VibeJsonArtifact -Path $resultPath -Value $result
+
+    return [pscustomobject]@{
+        category = 'consulted'
+        result = $result
+        result_path = $resultPath
+    }
+}
+
 function Invoke-VibeSpecialistConsultationUnit {
     param(
         [Parameter(Mandatory)] [string]$UnitId,
@@ -571,6 +653,15 @@ function Invoke-VibeSpecialistConsultationUnit {
     )
 
     $resolvedPolicy = Get-VibeSpecialistConsultationPolicy -Policy $Policy
+    if ([string]$resolvedPolicy.mode -eq 'direct_current_session_route') {
+        return New-VibeDirectRoutedSpecialistConsultationResult `
+            -UnitId $UnitId `
+            -Consultation $Consultation `
+            -SessionRoot $SessionRoot `
+            -WindowId $WindowId `
+            -Stage $Stage
+    }
+
     $adapterResolution = Resolve-VibeNativeSpecialistAdapter -ScriptPath $PSCommandPath
     if (-not [bool]$adapterResolution.live_execution_allowed -or $null -eq $adapterResolution.adapter) {
         return New-VibeDegradedSpecialistConsultationResult `

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -1505,6 +1505,18 @@ function New-VibeDirectRoutedSpecialistDispatchResult {
     } else {
         $null
     }
+    $effectiveUsageRequired = if ($Dispatch.PSObject.Properties.Name -contains 'usage_required') {
+        [bool]$Dispatch.usage_required
+    } elseif ($Dispatch.PSObject.Properties.Name -contains 'native_usage_required') {
+        [bool]$Dispatch.native_usage_required
+    } else {
+        $false
+    }
+    $nativeUsageRequired = if ($Dispatch.PSObject.Properties.Name -contains 'native_usage_required') {
+        [bool]$Dispatch.native_usage_required
+    } else {
+        [bool]$effectiveUsageRequired
+    }
 
     $unitResult = [pscustomobject]@{
         unit_id = $UnitId
@@ -1528,8 +1540,12 @@ function New-VibeDirectRoutedSpecialistDispatchResult {
         verification_passed = $true
         specialist_skill_id = [string]$Dispatch.skill_id
         bounded_role = [string]$Dispatch.bounded_role
-        native_usage_required = [bool]$Dispatch.native_usage_required
+        native_usage_required = [bool]$nativeUsageRequired
+        usage_required = [bool]$effectiveUsageRequired
         must_preserve_workflow = [bool]$Dispatch.must_preserve_workflow
+        native_skill_entrypoint = $entrypoint
+        skill_root = if ($Dispatch.PSObject.Properties.Name -contains 'skill_root') { [string]$Dispatch.skill_root } else { $null }
+        visibility_class = if ($Dispatch.PSObject.Properties.Name -contains 'visibility_class') { [string]$Dispatch.visibility_class } else { $null }
         write_scope = $WriteScope
         review_mode = $ReviewMode
         execution_driver = 'direct_current_session_route'

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -672,6 +672,21 @@ function Resolve-VibeNativeSpecialistAdapter {
     if (-not [string]::IsNullOrWhiteSpace($modeOverride)) {
         $executionMode = [string]$modeOverride
     }
+    $allowedExecutionModes = @('direct_current_session_route', 'host_subprocess')
+    if ($executionMode -notin $allowedExecutionModes) {
+        return [pscustomobject]@{
+            enabled = $true
+            live_execution_allowed = $false
+            reason = ("native_specialist_execution_mode_invalid:{0}" -f $executionMode)
+            runtime = $runtime
+            policy = $policy
+            adapter = $null
+            requested_host_adapter_id = [string]$runtimeHostAdapterIdentity.requested_host_id
+            effective_host_adapter_id = [string]$runtimeHostAdapterIdentity.effective_host_id
+            command_path = $null
+            invocation_arguments_prefix = @()
+        }
+    }
     if ($null -eq $policy -or -not [bool]$policy.enabled) {
         return [pscustomobject]@{
             enabled = $false

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -17,6 +17,30 @@ function Expand-VibeExecutionTemplate {
     return $value
 }
 
+function Get-VibeDispatchUsageRequirementState {
+    param(
+        [Parameter(Mandatory)] [object]$Dispatch
+    )
+
+    $effectiveUsageRequired = if ($Dispatch.PSObject.Properties.Name -contains 'usage_required') {
+        [bool]$Dispatch.usage_required
+    } elseif ($Dispatch.PSObject.Properties.Name -contains 'native_usage_required') {
+        [bool]$Dispatch.native_usage_required
+    } else {
+        $false
+    }
+    $nativeUsageRequired = if ($Dispatch.PSObject.Properties.Name -contains 'native_usage_required') {
+        [bool]$Dispatch.native_usage_required
+    } else {
+        [bool]$effectiveUsageRequired
+    }
+
+    return [pscustomobject]@{
+        native_usage_required = [bool]$nativeUsageRequired
+        usage_required = [bool]$effectiveUsageRequired
+    }
+}
+
 function New-VibeExecutedSpecialistUnitSummary {
     param(
         [Parameter(Mandatory)] [object]$UnitReceipt,
@@ -1308,6 +1332,7 @@ function New-VibeNativeSpecialistPrompt {
         [AllowEmptyString()] [string]$ParentUnitId = ''
     )
 
+    $usageRequirementState = Get-VibeDispatchUsageRequirementState -Dispatch $Dispatch
     $lines = @(
         ('$' + [string]$Dispatch.skill_id),
         '',
@@ -1319,7 +1344,7 @@ function New-VibeNativeSpecialistPrompt {
         ('native_skill_entrypoint: {0}' -f [string]$(if ($Dispatch.PSObject.Properties.Name -contains 'native_skill_entrypoint') { $Dispatch.native_skill_entrypoint } else { '' })),
         ('skill_root: {0}' -f [string]$(if ($Dispatch.PSObject.Properties.Name -contains 'skill_root') { $Dispatch.skill_root } else { '' })),
         ('visibility_class: {0}' -f [string]$(if ($Dispatch.PSObject.Properties.Name -contains 'visibility_class') { $Dispatch.visibility_class } else { '' })),
-        ('usage_required: {0}' -f [string]([bool]$(if ($Dispatch.PSObject.Properties.Name -contains 'usage_required') { $Dispatch.usage_required } else { $Dispatch.native_usage_required })).ToString().ToLowerInvariant()),
+        ('usage_required: {0}' -f [string]([bool]$usageRequirementState.usage_required).ToString().ToLowerInvariant()),
         ('must_preserve_workflow: {0}' -f [string]([bool]$Dispatch.must_preserve_workflow).ToString().ToLowerInvariant()),
         ('governance_scope: {0}' -f $GovernanceScope),
         ('run_id: {0}' -f $RunId)
@@ -1381,10 +1406,11 @@ function Get-VibeSpecialistPromptInjectionAssessment {
         [Parameter(Mandatory)] [string]$Prompt
     )
 
+    $usageRequirementState = Get-VibeDispatchUsageRequirementState -Dispatch $Dispatch
     $requiredPairs = @()
     $requiredPairs += [pscustomobject]@{ name = 'native_skill_entrypoint'; value = [string]$(if ($Dispatch.PSObject.Properties.Name -contains 'native_skill_entrypoint') { $Dispatch.native_skill_entrypoint } else { '' }) }
     $requiredPairs += [pscustomobject]@{ name = 'skill_root'; value = [string]$(if ($Dispatch.PSObject.Properties.Name -contains 'skill_root') { $Dispatch.skill_root } else { '' }) }
-    $requiredPairs += [pscustomobject]@{ name = 'usage_required'; value = [string]([bool]$(if ($Dispatch.PSObject.Properties.Name -contains 'usage_required') { $Dispatch.usage_required } else { $Dispatch.native_usage_required })).ToString().ToLowerInvariant() }
+    $requiredPairs += [pscustomobject]@{ name = 'usage_required'; value = [string]([bool]$usageRequirementState.usage_required).ToString().ToLowerInvariant() }
     $requiredPairs += [pscustomobject]@{ name = 'must_preserve_workflow'; value = [string]([bool]$Dispatch.must_preserve_workflow).ToString().ToLowerInvariant() }
 
     $missingFields = @()
@@ -1437,6 +1463,7 @@ function New-VibeDegradedSpecialistDispatchResult {
     Write-VgoUtf8NoBomText -Path $stderrPath -Content ''
 
     $finishedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.ffffffZ')
+    $usageRequirementState = Get-VibeDispatchUsageRequirementState -Dispatch $Dispatch
     $unitResult = [pscustomobject]@{
         unit_id = $UnitId
         kind = 'specialist_dispatch'
@@ -1461,8 +1488,8 @@ function New-VibeDegradedSpecialistDispatchResult {
         verification_passed = [bool]$Policy.degrade_contract.verification_passed
         specialist_skill_id = [string]$Dispatch.skill_id
         bounded_role = [string]$Dispatch.bounded_role
-        native_usage_required = [bool]$Dispatch.native_usage_required
-        usage_required = [bool]$(if ($Dispatch.PSObject.Properties.Name -contains 'usage_required') { $Dispatch.usage_required } else { $Dispatch.native_usage_required })
+        native_usage_required = [bool]$usageRequirementState.native_usage_required
+        usage_required = [bool]$usageRequirementState.usage_required
         must_preserve_workflow = [bool]$Dispatch.must_preserve_workflow
         native_skill_entrypoint = if ($Dispatch.PSObject.Properties.Name -contains 'native_skill_entrypoint') { [string]$Dispatch.native_skill_entrypoint } else { $null }
         skill_root = if ($Dispatch.PSObject.Properties.Name -contains 'skill_root') { [string]$Dispatch.skill_root } else { $null }
@@ -1520,18 +1547,7 @@ function New-VibeDirectRoutedSpecialistDispatchResult {
     } else {
         $null
     }
-    $effectiveUsageRequired = if ($Dispatch.PSObject.Properties.Name -contains 'usage_required') {
-        [bool]$Dispatch.usage_required
-    } elseif ($Dispatch.PSObject.Properties.Name -contains 'native_usage_required') {
-        [bool]$Dispatch.native_usage_required
-    } else {
-        $false
-    }
-    $nativeUsageRequired = if ($Dispatch.PSObject.Properties.Name -contains 'native_usage_required') {
-        [bool]$Dispatch.native_usage_required
-    } else {
-        [bool]$effectiveUsageRequired
-    }
+    $usageRequirementState = Get-VibeDispatchUsageRequirementState -Dispatch $Dispatch
 
     $unitResult = [pscustomobject]@{
         unit_id = $UnitId
@@ -1555,8 +1571,8 @@ function New-VibeDirectRoutedSpecialistDispatchResult {
         verification_passed = $true
         specialist_skill_id = [string]$Dispatch.skill_id
         bounded_role = [string]$Dispatch.bounded_role
-        native_usage_required = [bool]$nativeUsageRequired
-        usage_required = [bool]$effectiveUsageRequired
+        native_usage_required = [bool]$usageRequirementState.native_usage_required
+        usage_required = [bool]$usageRequirementState.usage_required
         must_preserve_workflow = [bool]$Dispatch.must_preserve_workflow
         native_skill_entrypoint = $entrypoint
         skill_root = if ($Dispatch.PSObject.Properties.Name -contains 'skill_root') { [string]$Dispatch.skill_root } else { $null }
@@ -1619,6 +1635,7 @@ function New-VibeBlockedSpecialistDispatchResult {
     Write-VgoUtf8NoBomText -Path $stderrPath -Content ''
 
     $finishedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.ffffffZ')
+    $usageRequirementState = Get-VibeDispatchUsageRequirementState -Dispatch $Dispatch
     $unitResult = [pscustomobject]@{
         unit_id = $UnitId
         kind = 'specialist_dispatch'
@@ -1641,7 +1658,8 @@ function New-VibeBlockedSpecialistDispatchResult {
         verification_passed = $false
         specialist_skill_id = [string]$Dispatch.skill_id
         bounded_role = [string]$Dispatch.bounded_role
-        native_usage_required = [bool]$Dispatch.native_usage_required
+        native_usage_required = [bool]$usageRequirementState.native_usage_required
+        usage_required = [bool]$usageRequirementState.usage_required
         must_preserve_workflow = [bool]$Dispatch.must_preserve_workflow
         write_scope = $WriteScope
         review_mode = $ReviewMode
@@ -1862,6 +1880,7 @@ function Invoke-VibeSpecialistDispatchUnit {
     }
 
     $finishedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.ffffffZ')
+    $usageRequirementState = Get-VibeDispatchUsageRequirementState -Dispatch $Dispatch
     $unitResult = [pscustomobject]@{
         unit_id = $UnitId
         kind = 'specialist_dispatch'
@@ -1889,8 +1908,8 @@ function Invoke-VibeSpecialistDispatchUnit {
         verification_passed = [bool]$verificationPassed
         specialist_skill_id = [string]$Dispatch.skill_id
         bounded_role = [string]$Dispatch.bounded_role
-        native_usage_required = [bool]$Dispatch.native_usage_required
-        usage_required = [bool]$(if ($Dispatch.PSObject.Properties.Name -contains 'usage_required') { $Dispatch.usage_required } else { $Dispatch.native_usage_required })
+        native_usage_required = [bool]$usageRequirementState.native_usage_required
+        usage_required = [bool]$usageRequirementState.usage_required
         must_preserve_workflow = [bool]$Dispatch.must_preserve_workflow
         native_skill_entrypoint = if ($Dispatch.PSObject.Properties.Name -contains 'native_skill_entrypoint') { [string]$Dispatch.native_skill_entrypoint } else { $null }
         skill_root = if ($Dispatch.PSObject.Properties.Name -contains 'skill_root') { [string]$Dispatch.skill_root } else { $null }

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -659,11 +659,39 @@ function Resolve-VibeNativeSpecialistAdapter {
         -HostAdapter $runtime.host_adapter `
         -RequestedPropertyName 'requested_id' `
         -EffectivePropertyName 'id'
+    $executionMode = if (
+        $null -ne $policy -and
+        $policy.PSObject.Properties.Name -contains 'mode' -and
+        -not [string]::IsNullOrWhiteSpace([string]$policy.mode)
+    ) {
+        [string]$policy.mode
+    } else {
+        'direct_current_session_route'
+    }
+    $modeOverride = [Environment]::GetEnvironmentVariable('VGO_NATIVE_SPECIALIST_EXECUTION_MODE')
+    if (-not [string]::IsNullOrWhiteSpace($modeOverride)) {
+        $executionMode = [string]$modeOverride
+    }
     if ($null -eq $policy -or -not [bool]$policy.enabled) {
         return [pscustomobject]@{
             enabled = $false
             live_execution_allowed = $false
             reason = 'native_specialist_execution_policy_disabled'
+            runtime = $runtime
+            policy = $policy
+            adapter = $null
+            requested_host_adapter_id = [string]$runtimeHostAdapterIdentity.requested_host_id
+            effective_host_adapter_id = [string]$runtimeHostAdapterIdentity.effective_host_id
+            command_path = $null
+            invocation_arguments_prefix = @()
+        }
+    }
+
+    if ($executionMode -eq 'direct_current_session_route') {
+        return [pscustomobject]@{
+            enabled = $true
+            live_execution_allowed = $false
+            reason = 'direct_current_session_route'
             runtime = $runtime
             policy = $policy
             adapter = $null
@@ -1450,6 +1478,87 @@ function New-VibeDegradedSpecialistDispatchResult {
     }
 }
 
+function New-VibeDirectRoutedSpecialistDispatchResult {
+    param(
+        [Parameter(Mandatory)] [string]$UnitId,
+        [Parameter(Mandatory)] [object]$Dispatch,
+        [Parameter(Mandatory)] [string]$SessionRoot,
+        [AllowEmptyString()] [string]$WriteScope = '',
+        [AllowEmptyString()] [string]$ReviewMode = 'native_contract'
+    )
+
+    $logsRoot = Join-Path $SessionRoot 'execution-logs'
+    $resultsRoot = Join-Path $SessionRoot 'execution-results'
+    New-Item -ItemType Directory -Path $logsRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+
+    $stdoutPath = Join-Path $logsRoot ("{0}.stdout.log" -f $UnitId)
+    $stderrPath = Join-Path $logsRoot ("{0}.stderr.log" -f $UnitId)
+    Write-VgoUtf8NoBomText -Path $stdoutPath -Content ''
+    Write-VgoUtf8NoBomText -Path $stderrPath -Content ''
+
+    $entrypoint = if (
+        $Dispatch.PSObject.Properties.Name -contains 'native_skill_entrypoint' -and
+        -not [string]::IsNullOrWhiteSpace([string]$Dispatch.native_skill_entrypoint)
+    ) {
+        [string]$Dispatch.native_skill_entrypoint
+    } else {
+        $null
+    }
+
+    $unitResult = [pscustomobject]@{
+        unit_id = $UnitId
+        kind = 'specialist_dispatch'
+        status = 'completed'
+        started_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.ffffffZ')
+        finished_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.ffffffZ')
+        command = ("specialist:{0}" -f [string]$Dispatch.skill_id)
+        arguments = @()
+        display_command = ("specialist:{0}" -f [string]$Dispatch.skill_id)
+        cwd = $SessionRoot
+        timeout_seconds = 0
+        expected_exit_code = 0
+        exit_code = 0
+        timed_out = $false
+        stdout_path = $stdoutPath
+        stderr_path = $stderrPath
+        stdout_preview = @()
+        stderr_preview = @()
+        expected_artifacts = @()
+        verification_passed = $true
+        specialist_skill_id = [string]$Dispatch.skill_id
+        bounded_role = [string]$Dispatch.bounded_role
+        native_usage_required = [bool]$Dispatch.native_usage_required
+        must_preserve_workflow = [bool]$Dispatch.must_preserve_workflow
+        write_scope = $WriteScope
+        review_mode = $ReviewMode
+        execution_driver = 'direct_current_session_route'
+        live_native_execution = $false
+        degraded = $false
+        blocked = $false
+        direct_route = $true
+        direct_route_entrypoint = $entrypoint
+        changed_files = @()
+        verification_notes = @(
+            'execution_mode:direct_current_session_route',
+            'hidden_host_subprocess:false',
+            ('native_skill_entrypoint:{0}' -f $(if ([string]::IsNullOrWhiteSpace($entrypoint)) { 'missing' } else { $entrypoint }))
+        )
+        bounded_output_notes = @(
+            'Load and execute the specialist in the current host session instead of launching a hidden host subprocess.',
+            'Keep vibe as the only runtime authority and absorb any specialist result back into the governed flow.'
+        )
+    }
+
+    $resultPath = Join-Path $resultsRoot ("{0}.json" -f $UnitId)
+    Write-VibeJsonArtifact -Path $resultPath -Value $unitResult
+
+    return [pscustomobject]@{
+        result = $unitResult
+        result_path = $resultPath
+    }
+}
+
 function New-VibeBlockedSpecialistDispatchResult {
     param(
         [Parameter(Mandatory)] [string]$UnitId,
@@ -1544,6 +1653,15 @@ function Invoke-VibeSpecialistDispatchUnit {
 
     $adapterResolution = Resolve-VibeNativeSpecialistAdapter -ScriptPath $PSCommandPath
     $policy = $adapterResolution.policy
+    if ([string]$adapterResolution.reason -eq 'direct_current_session_route') {
+        return New-VibeDirectRoutedSpecialistDispatchResult `
+            -UnitId $UnitId `
+            -Dispatch $Dispatch `
+            -SessionRoot $SessionRoot `
+            -WriteScope $WriteScope `
+            -ReviewMode $ReviewMode
+    }
+
     if (-not $adapterResolution.live_execution_allowed -or $null -eq $adapterResolution.adapter) {
         return New-VibeDegradedSpecialistDispatchResult `
             -UnitId $UnitId `

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -1947,8 +1947,31 @@ function New-VibeSpecialistConsultationLifecycleLayerProjection {
     if ($windowId -notin @('discussion', 'planning')) {
         throw 'Enabled specialist consultation receipts must declare window_id as discussion or planning.'
     }
+    $consultedCount = if (
+        (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'summary') -and
+        $null -ne $ConsultationReceipt.summary -and
+        (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt.summary -PropertyName 'consulted_unit_count')
+    ) {
+        [int]$ConsultationReceipt.summary.consulted_unit_count
+    } else {
+        @($ConsultationReceipt.consulted_units).Count
+    }
+    $routedCount = if (
+        (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'summary') -and
+        $null -ne $ConsultationReceipt.summary -and
+        (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt.summary -PropertyName 'routed_unit_count')
+    ) {
+        [int]$ConsultationReceipt.summary.routed_unit_count
+    } else {
+        @($ConsultationReceipt.routed_units).Count
+    }
+
     $skills = New-Object System.Collections.Generic.List[object]
-    $renderedLines = @(('Specialist consultation during {0}:' -f $windowId))
+    $renderedLines = @(if ($routedCount -gt 0 -and $consultedCount -eq 0) {
+        ('Specialist consultation routing during {0}:' -f $windowId)
+    } else {
+        ('Specialist consultation during {0}:' -f $windowId)
+    })
     foreach ($disclosure in @($ConsultationReceipt.user_disclosures)) {
         if ($null -eq $disclosure) {
             continue
@@ -1961,6 +1984,13 @@ function New-VibeSpecialistConsultationLifecycleLayerProjection {
                 break
             }
         }
+        $routedUnit = $null
+        foreach ($candidate in @($ConsultationReceipt.routed_units)) {
+            if ($null -ne $candidate -and [string]$candidate.skill_id -eq [string]$disclosure.skill_id) {
+                $routedUnit = $candidate
+                break
+            }
+        }
 
         $skills.Add(
             [pscustomobject]@{
@@ -1968,8 +1998,20 @@ function New-VibeSpecialistConsultationLifecycleLayerProjection {
                 why_now = if ((Test-VibeObjectHasProperty -InputObject $disclosure -PropertyName 'why_now') -and -not [string]::IsNullOrWhiteSpace([string]$disclosure.why_now)) { [string]$disclosure.why_now } else { $null }
                 native_skill_entrypoint = if ((Test-VibeObjectHasProperty -InputObject $disclosure -PropertyName 'native_skill_entrypoint') -and -not [string]::IsNullOrWhiteSpace([string]$disclosure.native_skill_entrypoint)) { [string]$disclosure.native_skill_entrypoint } else { $null }
                 native_skill_description = if ((Test-VibeObjectHasProperty -InputObject $disclosure -PropertyName 'native_skill_description') -and -not [string]::IsNullOrWhiteSpace([string]$disclosure.native_skill_description)) { [string]$disclosure.native_skill_description } else { $null }
-                state = if ($consultedUnit -and (Test-VibeObjectHasProperty -InputObject $consultedUnit -PropertyName 'status')) { [string]$consultedUnit.status } else { 'consulted' }
-                summary = if ($consultedUnit -and (Test-VibeObjectHasProperty -InputObject $consultedUnit -PropertyName 'summary')) { [string]$consultedUnit.summary } else { $null }
+                state = if ($consultedUnit -and (Test-VibeObjectHasProperty -InputObject $consultedUnit -PropertyName 'status')) {
+                    [string]$consultedUnit.status
+                } elseif ($routedUnit -and (Test-VibeObjectHasProperty -InputObject $routedUnit -PropertyName 'status')) {
+                    [string]$routedUnit.status
+                } else {
+                    'consultation_disclosed'
+                }
+                summary = if ($consultedUnit -and (Test-VibeObjectHasProperty -InputObject $consultedUnit -PropertyName 'summary')) {
+                    [string]$consultedUnit.summary
+                } elseif ($routedUnit -and (Test-VibeObjectHasProperty -InputObject $routedUnit -PropertyName 'summary')) {
+                    [string]$routedUnit.summary
+                } else {
+                    $null
+                }
             }
         ) | Out-Null
         $renderedLines += ('- {0}: {1} ({2})' -f [string]$disclosure.skill_id, [string]$disclosure.why_now, (Get-VibeSpecialistEntrypointDisplayText -SkillRecord $disclosure))
@@ -2199,7 +2241,33 @@ function New-VibeHostUserBriefingSegmentProjection {
                     $status = 'gate_unknown'
                 }
                 $category = 'consultation'
-                $segmentLines += ('Vibe consulted these Skills during {0}; freeze gate: {1}.' -f $windowId, $gateStatus)
+                $consultedCount = if (
+                    $ConsultationReceipt -and
+                    (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'summary') -and
+                    $null -ne $ConsultationReceipt.summary -and
+                    (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt.summary -PropertyName 'consulted_unit_count')
+                ) {
+                    [int]$ConsultationReceipt.summary.consulted_unit_count
+                } else {
+                    @($ConsultationReceipt.consulted_units).Count
+                }
+                $routedCount = if (
+                    $ConsultationReceipt -and
+                    (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'summary') -and
+                    $null -ne $ConsultationReceipt.summary -and
+                    (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt.summary -PropertyName 'routed_unit_count')
+                ) {
+                    [int]$ConsultationReceipt.summary.routed_unit_count
+                } else {
+                    @($ConsultationReceipt.routed_units).Count
+                }
+                if ($routedCount -gt 0 -and $consultedCount -eq 0) {
+                    $segmentLines += ('Vibe routed these Skills for direct current-session consultation during {0}; freeze gate: {1}.' -f $windowId, $gateStatus)
+                } elseif ($consultedCount -gt 0 -and $routedCount -eq 0) {
+                    $segmentLines += ('Vibe consulted these Skills during {0}; freeze gate: {1}.' -f $windowId, $gateStatus)
+                } else {
+                    $segmentLines += ('Vibe recorded these Skills in the {0} consultation chain; freeze gate: {1}.' -f $windowId, $gateStatus)
+                }
             } else {
                 $segmentLines += ('Vibe reported specialist activity for {0}:' -f $segmentId)
             }
@@ -2254,10 +2322,41 @@ function New-VibeHostStageDisclosureEventProjection {
         return $null
     }
 
+    $hasRoutedConsultation = $false
+    $hasCompletedConsultation = $false
+    foreach ($skill in @($Segment.skills)) {
+        if ($null -eq $skill -or -not (Test-VibeObjectHasProperty -InputObject $skill -PropertyName 'state')) {
+            continue
+        }
+        $state = [string]$skill.state
+        if ($state -match '^routed') {
+            $hasRoutedConsultation = $true
+        }
+        if ($state -in @('completed', 'completed_with_notes', 'consulted')) {
+            $hasCompletedConsultation = $true
+        }
+    }
+
     $eventId = switch ($segmentId) {
         'discussion_routing' { 'discussion_routing_frozen' }
-        'discussion_consultation' { 'discussion_consultation_completed' }
-        'planning_consultation' { 'planning_consultation_completed' }
+        'discussion_consultation' {
+            if ($hasCompletedConsultation -and -not $hasRoutedConsultation) {
+                'discussion_consultation_completed'
+            } elseif ($hasRoutedConsultation -and -not $hasCompletedConsultation) {
+                'discussion_consultation_routed'
+            } else {
+                'discussion_consultation_reported'
+            }
+        }
+        'planning_consultation' {
+            if ($hasCompletedConsultation -and -not $hasRoutedConsultation) {
+                'planning_consultation_completed'
+            } elseif ($hasRoutedConsultation -and -not $hasCompletedConsultation) {
+                'planning_consultation_routed'
+            } else {
+                'planning_consultation_reported'
+            }
+        }
         'execution_dispatch' { 'execution_dispatch_confirmed' }
         default { ('{0}_reported' -f $segmentId) }
     }

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -1947,6 +1947,22 @@ function New-VibeSpecialistConsultationLifecycleLayerProjection {
     if ($windowId -notin @('discussion', 'planning')) {
         throw 'Enabled specialist consultation receipts must declare window_id as discussion or planning.'
     }
+    $consultedUnits = if (
+        (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'consulted_units') -and
+        $null -ne $ConsultationReceipt.consulted_units
+    ) {
+        @($ConsultationReceipt.consulted_units)
+    } else {
+        @()
+    }
+    $routedUnits = if (
+        (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'routed_units') -and
+        $null -ne $ConsultationReceipt.routed_units
+    ) {
+        @($ConsultationReceipt.routed_units)
+    } else {
+        @()
+    }
     $consultedCount = if (
         (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'summary') -and
         $null -ne $ConsultationReceipt.summary -and
@@ -1954,7 +1970,7 @@ function New-VibeSpecialistConsultationLifecycleLayerProjection {
     ) {
         [int]$ConsultationReceipt.summary.consulted_unit_count
     } else {
-        @($ConsultationReceipt.consulted_units).Count
+        @($consultedUnits).Count
     }
     $routedCount = if (
         (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'summary') -and
@@ -1963,7 +1979,7 @@ function New-VibeSpecialistConsultationLifecycleLayerProjection {
     ) {
         [int]$ConsultationReceipt.summary.routed_unit_count
     } else {
-        @($ConsultationReceipt.routed_units).Count
+        @($routedUnits).Count
     }
 
     $skills = New-Object System.Collections.Generic.List[object]
@@ -1978,14 +1994,14 @@ function New-VibeSpecialistConsultationLifecycleLayerProjection {
         }
 
         $consultedUnit = $null
-        foreach ($candidate in @($ConsultationReceipt.consulted_units)) {
+        foreach ($candidate in @($consultedUnits)) {
             if ($null -ne $candidate -and [string]$candidate.skill_id -eq [string]$disclosure.skill_id) {
                 $consultedUnit = $candidate
                 break
             }
         }
         $routedUnit = $null
-        foreach ($candidate in @($ConsultationReceipt.routed_units)) {
+        foreach ($candidate in @($routedUnits)) {
             if ($null -ne $candidate -and [string]$candidate.skill_id -eq [string]$disclosure.skill_id) {
                 $routedUnit = $candidate
                 break
@@ -2241,6 +2257,24 @@ function New-VibeHostUserBriefingSegmentProjection {
                     $status = 'gate_unknown'
                 }
                 $category = 'consultation'
+                $consultedUnits = if (
+                    $ConsultationReceipt -and
+                    (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'consulted_units') -and
+                    $null -ne $ConsultationReceipt.consulted_units
+                ) {
+                    @($ConsultationReceipt.consulted_units)
+                } else {
+                    @()
+                }
+                $routedUnits = if (
+                    $ConsultationReceipt -and
+                    (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'routed_units') -and
+                    $null -ne $ConsultationReceipt.routed_units
+                ) {
+                    @($ConsultationReceipt.routed_units)
+                } else {
+                    @()
+                }
                 $consultedCount = if (
                     $ConsultationReceipt -and
                     (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'summary') -and
@@ -2248,13 +2282,8 @@ function New-VibeHostUserBriefingSegmentProjection {
                     (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt.summary -PropertyName 'consulted_unit_count')
                 ) {
                     [int]$ConsultationReceipt.summary.consulted_unit_count
-                } elseif (
-                    $ConsultationReceipt -and
-                    (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'consulted_units')
-                ) {
-                    @($ConsultationReceipt.consulted_units).Count
                 } else {
-                    0
+                    @($consultedUnits).Count
                 }
                 $routedCount = if (
                     $ConsultationReceipt -and
@@ -2263,13 +2292,8 @@ function New-VibeHostUserBriefingSegmentProjection {
                     (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt.summary -PropertyName 'routed_unit_count')
                 ) {
                     [int]$ConsultationReceipt.summary.routed_unit_count
-                } elseif (
-                    $ConsultationReceipt -and
-                    (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'routed_units')
-                ) {
-                    @($ConsultationReceipt.routed_units).Count
                 } else {
-                    0
+                    @($routedUnits).Count
                 }
                 if ($routedCount -gt 0 -and $consultedCount -eq 0) {
                     $segmentLines += ('Vibe routed these Skills for direct current-session consultation during {0}; freeze gate: {1}.' -f $windowId, $gateStatus)

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -2329,7 +2329,7 @@ function New-VibeHostStageDisclosureEventProjection {
             continue
         }
         $state = [string]$skill.state
-        if ($state -match '^routed') {
+        if ($state -match '(^|_)routed($|_)') {
             $hasRoutedConsultation = $true
         }
         if ($state -in @('completed', 'completed_with_notes', 'consulted')) {

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -2248,8 +2248,13 @@ function New-VibeHostUserBriefingSegmentProjection {
                     (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt.summary -PropertyName 'consulted_unit_count')
                 ) {
                     [int]$ConsultationReceipt.summary.consulted_unit_count
-                } else {
+                } elseif (
+                    $ConsultationReceipt -and
+                    (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'consulted_units')
+                ) {
                     @($ConsultationReceipt.consulted_units).Count
+                } else {
+                    0
                 }
                 $routedCount = if (
                     $ConsultationReceipt -and
@@ -2258,8 +2263,13 @@ function New-VibeHostUserBriefingSegmentProjection {
                     (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt.summary -PropertyName 'routed_unit_count')
                 ) {
                     [int]$ConsultationReceipt.summary.routed_unit_count
-                } else {
+                } elseif (
+                    $ConsultationReceipt -and
+                    (Test-VibeObjectHasProperty -InputObject $ConsultationReceipt -PropertyName 'routed_units')
+                ) {
                     @($ConsultationReceipt.routed_units).Count
+                } else {
+                    0
                 }
                 if ($routedCount -gt 0 -and $consultedCount -eq 0) {
                     $segmentLines += ('Vibe routed these Skills for direct current-session consultation during {0}; freeze gate: {1}.' -f $windowId, $gateStatus)

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -1985,8 +1985,10 @@ function New-VibeSpecialistConsultationLifecycleLayerProjection {
     $skills = New-Object System.Collections.Generic.List[object]
     $renderedLines = @(if ($routedCount -gt 0 -and $consultedCount -eq 0) {
         ('Specialist consultation routing during {0}:' -f $windowId)
-    } else {
+    } elseif ($consultedCount -gt 0 -and $routedCount -eq 0) {
         ('Specialist consultation during {0}:' -f $windowId)
+    } else {
+        ('Recorded specialist consultation chain during {0}:' -f $windowId)
     })
     foreach ($disclosure in @($ConsultationReceipt.user_disclosures)) {
         if ($null -eq $disclosure) {

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -518,7 +518,7 @@ if ($discussionConsultation -and [bool]$discussionConsultation.enabled) {
     $lines += @(
         '',
         '## Specialist Consultation',
-        'These are specialists actually consulted during discussion-time under governed `vibe` before this requirement doc was frozen.'
+        'These are specialists resolved for discussion-time handling under governed `vibe` before this requirement doc was frozen. Depending on policy, they may be consulted live or routed for direct current-session loading.'
     )
     foreach ($disclosure in @($discussionConsultation.user_disclosures)) {
         $lines += @(

--- a/scripts/runtime/Write-XlPlan.ps1
+++ b/scripts/runtime/Write-XlPlan.ps1
@@ -348,7 +348,7 @@ if ($planningConsultation -and [bool]$planningConsultation.enabled) {
     $lines += @(
         '',
         '## Specialist Consultation',
-        'These are specialists actually consulted during plan-time under governed `vibe` before this execution plan was frozen.'
+        'These are specialists resolved for plan-time handling under governed `vibe` before this execution plan was frozen. Depending on policy, they may be consulted live or routed for direct current-session loading.'
     )
     foreach ($disclosure in @($planningConsultation.user_disclosures)) {
         $lines += @(

--- a/tests/runtime_neutral/test_custom_admission_bridge.py
+++ b/tests/runtime_neutral/test_custom_admission_bridge.py
@@ -381,7 +381,8 @@ class CustomAdmissionBridgeTests(unittest.TestCase):
                 [str(skill_id) for skill_id in execution_manifest["specialist_accounting"]["specialist_skills"]],
             )
             self.assertTrue(bool(execution_manifest["dispatch_integrity"]["proof_passed"]))
-            self.assertTrue(bool(execution_manifest["dispatch_integrity"]["approved_dispatch_fully_executed"]))
+            self.assertFalse(bool(execution_manifest["dispatch_integrity"]["approved_dispatch_fully_executed"]))
+            self.assertTrue(bool(execution_manifest["dispatch_integrity"]["approved_dispatch_fully_resolved"]))
             self.assertNotIn(
                 "prompt_injection_complete_for_executed_specialists",
                 execution_manifest["dispatch_integrity"],
@@ -392,7 +393,7 @@ class CustomAdmissionBridgeTests(unittest.TestCase):
             )
             self.assertIn(
                 "genomics-qc-flow",
-                [str(skill_id) for skill_id in execution_manifest["dispatch_integrity"]["executed_specialist_skill_ids"]],
+                [str(skill_id) for skill_id in execution_manifest["dispatch_integrity"]["direct_routed_specialist_skill_ids"]],
             )
 
 

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -463,8 +463,10 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertEqual(host_stage_disclosure, summary["host_stage_disclosure"])
 
             self.assertTrue(bool(execution_manifest["dispatch_integrity"]["proof_passed"]))
-            self.assertTrue(bool(execution_manifest["dispatch_integrity"]["approved_dispatch_fully_executed"]))
+            self.assertFalse(bool(execution_manifest["dispatch_integrity"]["approved_dispatch_fully_executed"]))
+            self.assertTrue(bool(execution_manifest["dispatch_integrity"]["approved_dispatch_fully_resolved"]))
             self.assertTrue(bool(execution_manifest["dispatch_integrity"]["executed_specialists_subset_of_approved_dispatch"]))
+            self.assertTrue(bool(execution_manifest["dispatch_integrity"]["routed_specialists_subset_of_approved_dispatch"]))
             self.assertTrue(bool(execution_manifest["dispatch_integrity"]["local_suggestions_contained"]))
             self.assertTrue(execution_proof["proof_passed"])
             self.assertGreaterEqual(execution_proof["executed_unit_count"], 2)

--- a/tests/runtime_neutral/test_installed_host_runtime_simulation.py
+++ b/tests/runtime_neutral/test_installed_host_runtime_simulation.py
@@ -369,9 +369,14 @@ class InstalledHostRuntimeSimulationTests(unittest.TestCase):
                     host_id,
                 )
                 execution_status = debug_state["execution_manifest"]["specialist_accounting"]["effective_execution_status"]
-                self.assertEqual("live_native_executed", execution_status, host_id)
-                self.assertGreaterEqual(
+                self.assertEqual("direct_current_session_routed", execution_status, host_id)
+                self.assertEqual(
+                    0,
                     int(debug_state["execution_manifest"]["specialist_accounting"]["executed_specialist_unit_count"]),
+                    host_id,
+                )
+                self.assertGreaterEqual(
+                    int(debug_state["execution_manifest"]["specialist_accounting"]["direct_routed_specialist_unit_count"]),
                     1,
                     host_id,
                 )

--- a/tests/runtime_neutral/test_installed_host_runtime_simulation.py
+++ b/tests/runtime_neutral/test_installed_host_runtime_simulation.py
@@ -333,6 +333,8 @@ class InstalledHostRuntimeSimulationTests(unittest.TestCase):
                 runtime_env = {
                     **base_env,
                     "VCO_HOST_ID": host_id,
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "",
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
                 }

--- a/tests/runtime_neutral/test_l_xl_native_execution_topology.py
+++ b/tests/runtime_neutral/test_l_xl_native_execution_topology.py
@@ -887,6 +887,8 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                 artifact_root=temp_path,
                 governance_scope="root",
                 extra_env={
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "",
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
                 },

--- a/tests/runtime_neutral/test_l_xl_native_execution_topology.py
+++ b/tests/runtime_neutral/test_l_xl_native_execution_topology.py
@@ -586,11 +586,75 @@ class NativeExecutionTopologyTests(unittest.TestCase):
             )
             execution_receipt = load_json(execution_payload["receipt_path"])
             execution_manifest = load_json(execution_receipt["execution_manifest_path"])
+            execution_proof = load_json(execution_receipt["execution_proof_manifest_path"])
 
             self.assertIn(
                 legacy_skill_id,
                 list(execution_manifest["dispatch_integrity"]["dispatch_contract_incomplete_skill_ids"]),
             )
+            self.assertFalse(bool(execution_manifest["dispatch_integrity"]["proof_passed"]))
+            self.assertFalse(bool(execution_proof["dispatch_integrity_proof_passed"]))
+            self.assertFalse(bool(execution_proof["proof_passed"]))
+
+    def test_plan_execute_accepts_legacy_usage_required_only_dispatch_packets(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir)
+            fake_codex = create_fake_codex_command(
+                artifact_root,
+                required_prompt_markers=[
+                    "native_skill_entrypoint:",
+                    "skill_root:",
+                    "usage_required: true",
+                    "must_preserve_workflow: true",
+                ],
+            )
+            initial_payload = run_runtime(
+                task="I have a failing test and a stack trace. Help me debug systematically before proposing fixes.",
+                artifact_root=artifact_root,
+                governance_scope="root",
+            )
+            initial_summary = initial_payload["summary"]
+            requirement_doc_path = Path(initial_summary["artifacts"]["requirement_doc"])
+            execution_plan_path = Path(initial_summary["artifacts"]["execution_plan"])
+            runtime_input_packet_path = Path(initial_summary["artifacts"]["runtime_input_packet"])
+            runtime_input_packet = load_json(runtime_input_packet_path)
+
+            approved_dispatch = list((runtime_input_packet.get("specialist_dispatch") or {}).get("approved_dispatch") or [])
+            self.assertGreaterEqual(len(approved_dispatch), 1)
+            legacy_skill_id = str(approved_dispatch[0]["skill_id"])
+            approved_dispatch[0].pop("native_usage_required", None)
+            approved_dispatch[0]["usage_required"] = True
+            runtime_input_packet_path.write_text(
+                json.dumps(runtime_input_packet, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
+            execution_payload = run_plan_execute(
+                task="I have a failing test and a stack trace. Help me debug systematically before proposing fixes.",
+                artifact_root=artifact_root,
+                requirement_doc_path=requirement_doc_path,
+                execution_plan_path=execution_plan_path,
+                runtime_input_packet_path=runtime_input_packet_path,
+                extra_env={
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+            execution_receipt = load_json(execution_payload["receipt_path"])
+            execution_manifest = load_json(execution_receipt["execution_manifest_path"])
+
+            self.assertGreaterEqual(int(execution_manifest["specialist_accounting"]["executed_specialist_unit_count"]), 1)
+            executed_units = list(execution_manifest["specialist_accounting"]["executed_specialist_units"])
+            legacy_units = [unit for unit in executed_units if str(unit.get("skill_id")) == legacy_skill_id]
+            self.assertGreaterEqual(len(legacy_units), 1)
+
+            result = load_json(legacy_units[0]["result_path"])
+            self.assertTrue(bool(result["live_native_execution"]))
+            self.assertTrue(bool(result["verification_passed"]))
+            self.assertTrue(bool(result["native_usage_required"]))
+            self.assertTrue(bool(result["usage_required"]))
 
     def test_specialist_binding_metadata_is_frozen_into_runtime_requirement_and_plan(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/runtime_neutral/test_l_xl_native_execution_topology.py
+++ b/tests/runtime_neutral/test_l_xl_native_execution_topology.py
@@ -882,7 +882,6 @@ class NativeExecutionTopologyTests(unittest.TestCase):
     def test_approved_specialist_dispatch_routes_directly_in_current_session_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             temp_path = Path(tempdir)
-            fake_codex = create_fake_codex_command(temp_path)
             payload = run_runtime(
                 task="I have a failing test and stack trace. Debug systematically and execute specialist workflow.",
                 artifact_root=temp_path,
@@ -890,7 +889,6 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                 extra_env={
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
-                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )
             summary = payload["summary"]
@@ -900,7 +898,7 @@ class NativeExecutionTopologyTests(unittest.TestCase):
             self.assertEqual("native_bounded_units", specialist_accounting["execution_mode"])
             self.assertEqual("direct_current_session_routed", specialist_accounting["effective_execution_status"])
             self.assertGreaterEqual(int(specialist_accounting["direct_routed_specialist_unit_count"]), 1)
-            self.assertGreaterEqual(int(specialist_accounting["executed_specialist_unit_count"]), 1)
+            self.assertEqual(0, int(specialist_accounting["executed_specialist_unit_count"]))
             self.assertEqual(0, int(specialist_accounting["degraded_specialist_unit_count"]))
             self.assertEqual("completed", execution_manifest["status"])
 
@@ -918,6 +916,7 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                     self.assertTrue(bool(result["direct_route"]))
                     self.assertEqual("direct_current_session_route", result["execution_driver"])
                     self.assertFalse(bool(result["live_native_execution"]))
+                    self.assertFalse(bool(result.get("host_adapter_id")))
                     self.assertFalse(bool(result["degraded"]))
                     self.assertFalse(bool(result["blocked"]))
                     self.assertFalse(bool(result.get("prompt_path")))

--- a/tests/runtime_neutral/test_l_xl_native_execution_topology.py
+++ b/tests/runtime_neutral/test_l_xl_native_execution_topology.py
@@ -745,13 +745,19 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                     self.assertTrue(Path(result["stdout_path"]).exists())
                     self.assertTrue(Path(result["stderr_path"]).exists())
                     if result["kind"] == "specialist_dispatch":
-                        self.assertEqual("degraded_non_authoritative", result["status"])
-                        self.assertFalse(bool(result["verification_passed"]))
-                        self.assertTrue(bool(result["degraded"]))
+                        self.assertEqual("completed", result["status"])
+                        self.assertTrue(bool(result["verification_passed"]))
+                        self.assertFalse(bool(result["degraded"]))
                         self.assertFalse(bool(result["live_native_execution"]))
+                        self.assertEqual("direct_current_session_route", result["execution_driver"])
+                        self.assertTrue(bool(result["direct_route"]))
                     else:
                         self.assertEqual("completed", result["status"])
                         self.assertTrue(bool(result["verification_passed"]))
+
+            specialist_accounting = execution_manifest["specialist_accounting"]
+            self.assertEqual("direct_current_session_routed", specialist_accounting["effective_execution_status"])
+            self.assertGreaterEqual(int(specialist_accounting["direct_routed_specialist_unit_count"]), 1)
 
             serial_order = list(topology.get("serial_execution_order") or [])
             self.assertEqual(
@@ -831,6 +837,9 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                 task="I have a failing test and stack trace. Debug systematically and execute specialist workflow.",
                 artifact_root=Path(tempdir),
                 governance_scope="root",
+                extra_env={
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
+                },
             )
             summary = payload["summary"]
             execution_manifest = load_json(summary["artifacts"]["execution_manifest"])
@@ -870,6 +879,49 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                     self.assertTrue(Path(result["stdout_path"]).exists())
                     self.assertTrue(Path(result["stderr_path"]).exists())
 
+    def test_approved_specialist_dispatch_routes_directly_in_current_session_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_path = Path(tempdir)
+            fake_codex = create_fake_codex_command(temp_path)
+            payload = run_runtime(
+                task="I have a failing test and stack trace. Debug systematically and execute specialist workflow.",
+                artifact_root=temp_path,
+                governance_scope="root",
+                extra_env={
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+            summary = payload["summary"]
+            execution_manifest = load_json(summary["artifacts"]["execution_manifest"])
+
+            specialist_accounting = execution_manifest["specialist_accounting"]
+            self.assertEqual("native_bounded_units", specialist_accounting["execution_mode"])
+            self.assertEqual("direct_current_session_routed", specialist_accounting["effective_execution_status"])
+            self.assertGreaterEqual(int(specialist_accounting["direct_routed_specialist_unit_count"]), 1)
+            self.assertGreaterEqual(int(specialist_accounting["executed_specialist_unit_count"]), 1)
+            self.assertEqual(0, int(specialist_accounting["degraded_specialist_unit_count"]))
+            self.assertEqual("completed", execution_manifest["status"])
+
+            routed_units = list(specialist_accounting["direct_routed_specialist_units"])
+            self.assertGreaterEqual(len(routed_units), 1)
+            for unit in routed_units:
+                with self.subTest(unit_id=unit.get("unit_id", "")):
+                    self.assertTrue(bool(unit["verification_passed"]))
+                    self.assertFalse(bool(unit["degraded"]))
+                    self.assertFalse(bool(unit["live_native_execution"]))
+                    self.assertEqual("direct_current_session_route", unit["execution_driver"])
+                    result = load_json(unit["result_path"])
+                    self.assertEqual("completed", result["status"])
+                    self.assertTrue(bool(result["verification_passed"]))
+                    self.assertTrue(bool(result["direct_route"]))
+                    self.assertEqual("direct_current_session_route", result["execution_driver"])
+                    self.assertFalse(bool(result["live_native_execution"]))
+                    self.assertFalse(bool(result["degraded"]))
+                    self.assertFalse(bool(result["blocked"]))
+                    self.assertFalse(bool(result.get("prompt_path")))
+
     def test_approved_specialist_dispatch_can_execute_live_native_lane_when_adapter_enabled(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             temp_path = Path(tempdir)
@@ -889,6 +941,7 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                 extra_env={
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )
@@ -946,6 +999,7 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                 extra_env={
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )
@@ -1184,6 +1238,7 @@ class NativeExecutionTopologyTests(unittest.TestCase):
                 extra_env={
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )

--- a/tests/runtime_neutral/test_multi_host_specialist_execution.py
+++ b/tests/runtime_neutral/test_multi_host_specialist_execution.py
@@ -167,6 +167,8 @@ class MultiHostSpecialistExecutionTests(unittest.TestCase):
                         artifact_root=temp_path,
                         extra_env={
                             "VCO_HOST_ID": host_id,
+                            "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "",
+                            "VGO_SPECIALIST_CONSULTATION_MODE": "",
                             "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                             "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
                             env_name: str(wrapper),
@@ -189,6 +191,33 @@ class MultiHostSpecialistExecutionTests(unittest.TestCase):
                         self.assertFalse(bool(result["live_native_execution"]))
                         self.assertFalse(bool(result["degraded"]))
                         self.assertFalse(bool(result["blocked"]))
+
+    def test_invalid_specialist_execution_mode_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            payload = run_runtime(
+                TASK,
+                artifact_root=Path(tempdir),
+                extra_env={
+                    "VCO_HOST_ID": "openclaw",
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "typo-mode",
+                },
+            )
+            summary = payload["summary"]
+            execution_manifest = load_json(summary["artifacts"]["execution_manifest"])
+            specialist_accounting = execution_manifest["specialist_accounting"]
+
+            self.assertEqual("explicitly_degraded", specialist_accounting["effective_execution_status"])
+            self.assertEqual(0, int(specialist_accounting["executed_specialist_unit_count"]))
+            self.assertEqual(0, int(specialist_accounting["direct_routed_specialist_unit_count"]))
+            degraded_units = list(specialist_accounting["degraded_specialist_units"])
+            self.assertGreaterEqual(len(degraded_units), 1)
+            first = load_json(degraded_units[0]["result_path"])
+            self.assertEqual(
+                "native_specialist_execution_mode_invalid:typo-mode",
+                first["degradation_reason"],
+            )
 
     def test_non_codex_hosts_can_execute_live_specialist_lane_when_wrapper_is_configured(self) -> None:
         for host_id, env_name, command_name in HOST_CASES:

--- a/tests/runtime_neutral/test_multi_host_specialist_execution.py
+++ b/tests/runtime_neutral/test_multi_host_specialist_execution.py
@@ -156,6 +156,40 @@ class MultiHostSpecialistExecutionTests(unittest.TestCase):
                 execution_manifest["route_runtime_alignment"]["effective_host_adapter_id"],
             )
 
+    def test_non_codex_hosts_route_directly_by_default_even_when_wrapper_is_configured(self) -> None:
+        for host_id, env_name, command_name in HOST_CASES:
+            with self.subTest(host_id=host_id):
+                with tempfile.TemporaryDirectory() as tempdir:
+                    temp_path = Path(tempdir)
+                    wrapper = create_fake_wrapper(temp_path, command_name, host_id)
+                    payload = run_runtime(
+                        TASK,
+                        artifact_root=temp_path,
+                        extra_env={
+                            "VCO_HOST_ID": host_id,
+                            "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                            "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                            env_name: str(wrapper),
+                        },
+                    )
+                    summary = payload["summary"]
+                    execution_manifest = load_json(summary["artifacts"]["execution_manifest"])
+                    specialist_accounting = execution_manifest["specialist_accounting"]
+
+                    self.assertEqual("direct_current_session_routed", specialist_accounting["effective_execution_status"])
+                    self.assertGreaterEqual(int(specialist_accounting["direct_routed_specialist_unit_count"]), 1)
+                    self.assertEqual(host_id, specialist_accounting["effective_host_adapter_id"])
+
+                    routed_units = list(specialist_accounting["direct_routed_specialist_units"])
+                    self.assertGreaterEqual(len(routed_units), 1)
+                    for unit in routed_units:
+                        result = load_json(unit["result_path"])
+                        self.assertEqual("direct_current_session_route", result["execution_driver"])
+                        self.assertTrue(bool(result["direct_route"]))
+                        self.assertFalse(bool(result["live_native_execution"]))
+                        self.assertFalse(bool(result["degraded"]))
+                        self.assertFalse(bool(result["blocked"]))
+
     def test_non_codex_hosts_can_execute_live_specialist_lane_when_wrapper_is_configured(self) -> None:
         for host_id, env_name, command_name in HOST_CASES:
             with self.subTest(host_id=host_id):
@@ -169,6 +203,7 @@ class MultiHostSpecialistExecutionTests(unittest.TestCase):
                             "VCO_HOST_ID": host_id,
                             "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                             "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                            "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                             env_name: str(wrapper),
                         },
                     )
@@ -199,6 +234,7 @@ class MultiHostSpecialistExecutionTests(unittest.TestCase):
                     "VCO_HOST_ID": "windsurf",
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                 },
             )
             summary = payload["summary"]
@@ -257,6 +293,7 @@ class MultiHostSpecialistExecutionTests(unittest.TestCase):
                     "OPENCLAW_HOME": str(target_root),
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                 },
             )
             summary = payload["summary"]

--- a/tests/runtime_neutral/test_plan_execute_receipts.py
+++ b/tests/runtime_neutral/test_plan_execute_receipts.py
@@ -543,6 +543,7 @@ class PlanExecuteReceiptTests(unittest.TestCase):
                     **os.environ,
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )
@@ -614,6 +615,7 @@ class PlanExecuteReceiptTests(unittest.TestCase):
                         **os.environ,
                         "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                         "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                        "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                         "VGO_CODEX_EXECUTABLE": str(fake_codex),
                     },
                 )
@@ -680,6 +682,7 @@ class PlanExecuteReceiptTests(unittest.TestCase):
                     **os.environ,
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )
@@ -760,6 +763,7 @@ class PlanExecuteReceiptTests(unittest.TestCase):
                     "CODEX_HOME": str(source_codex_home),
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )

--- a/tests/runtime_neutral/test_plan_execute_receipts.py
+++ b/tests/runtime_neutral/test_plan_execute_receipts.py
@@ -556,6 +556,125 @@ class PlanExecuteReceiptTests(unittest.TestCase):
             self.assertTrue(Path(result["response_json_path"]).exists())
             self.assertEqual([], list(result["observed_changed_files"]))
 
+    def test_delegated_lane_receipt_normalizes_legacy_usage_required_dispatch(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell not available")
+
+        script_path = REPO_ROOT / "scripts" / "runtime" / "Invoke-DelegatedLaneUnit.ps1"
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_path = Path(tempdir)
+            fake_codex = create_repo_check_fake_codex_command(temp_path)
+            non_git_root = temp_path / "non-git-workspace"
+            non_git_root.mkdir(parents=True, exist_ok=True)
+            lane_root = temp_path / "lane-root"
+            requirement_doc = temp_path / "requirement.md"
+            execution_plan = temp_path / "plan.md"
+            skill_root = temp_path / "skills" / "systematic-debugging"
+            skill_root.mkdir(parents=True, exist_ok=True)
+            entrypoint_path = skill_root / "SKILL.runtime-mirror.md"
+            requirement_doc.write_text("# Requirement\n", encoding="utf-8")
+            execution_plan.write_text("# Plan\n", encoding="utf-8")
+            entrypoint_path.write_text("# Specialist\n", encoding="utf-8")
+
+            lane_id = "lane-" + uuid.uuid4().hex[:8]
+            envelope_path = temp_path / "delegation-envelope.json"
+            envelope_path.write_text(
+                json.dumps(
+                    {
+                        "root_run_id": "root-run-1",
+                        "parent_run_id": "parent-run-1",
+                        "parent_unit_id": "parent-unit-1",
+                        "child_run_id": lane_id,
+                        "governance_scope": "child_governed",
+                        "requirement_doc_path": str(requirement_doc.resolve()),
+                        "execution_plan_path": str(execution_plan.resolve()),
+                        "write_scope": "read_only",
+                        "approved_specialists": ["systematic-debugging"],
+                        "review_mode": "native_contract",
+                        "prompt_tail_required": "$vibe",
+                        "allow_requirement_freeze": False,
+                        "allow_plan_freeze": False,
+                        "allow_root_completion_claim": False,
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+            lane_spec_path = temp_path / "lane-spec.json"
+            lane_spec_path.write_text(
+                json.dumps(
+                    {
+                        "lane_id": lane_id,
+                        "lane_kind": "specialist_dispatch",
+                        "lane_root": str(lane_root.resolve()),
+                        "run_id": lane_id,
+                        "mode": "interactive_governed",
+                        "governance_scope": "child",
+                        "root_run_id": "root-run-1",
+                        "parent_run_id": "parent-run-1",
+                        "parent_unit_id": "parent-unit-1",
+                        "requirement_doc_path": str(requirement_doc.resolve()),
+                        "execution_plan_path": str(execution_plan.resolve()),
+                        "repo_root": str(non_git_root.resolve()),
+                        "default_timeout_seconds": 120,
+                        "parallelizable": False,
+                        "write_scope": "read_only",
+                        "review_mode": "native_contract",
+                        "delegation_envelope_path": str(envelope_path.resolve()),
+                        "tokens": {},
+                        "dispatch": {
+                            "skill_id": "systematic-debugging",
+                            "bounded_role": "specialist_assist",
+                            "native_skill_entrypoint": str(entrypoint_path.resolve()),
+                            "skill_root": str(skill_root.resolve()),
+                            "visibility_class": "path_resolved",
+                            "usage_required": True,
+                            "must_preserve_workflow": True,
+                            "required_inputs": ["requirement_doc", "execution_plan"],
+                            "expected_outputs": ["verification_notes", "changed_files"],
+                            "verification_expectation": "Return bounded execution guidance.",
+                            "progressive_load_policy": [
+                                "Open the declared specialist entrypoint before executing."
+                            ],
+                        },
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+            completed = subprocess.run(
+                [
+                    powershell,
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-Command",
+                    f"& '{script_path.as_posix()}' -LaneSpecPath '{lane_spec_path.as_posix()}'",
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+                env={
+                    **os.environ,
+                    "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
+                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
+                },
+            )
+
+            payload = json.loads(completed.stdout)
+            receipt = payload["receipt"]
+            self.assertTrue(bool(receipt["native_usage_required"]))
+            self.assertTrue(bool(receipt["usage_required"]))
+            notes = Path(payload["lane_notes_path"]).read_text(encoding="utf-8")
+            self.assertIn("native_usage_required: True", notes)
+            self.assertIn("usage_required: True", notes)
+
     def test_specialist_dispatch_falls_back_to_requirement_workspace_when_repo_root_is_read_only(self) -> None:
         powershell = resolve_powershell()
         if powershell is None:

--- a/tests/runtime_neutral/test_runtime_contract_schema.py
+++ b/tests/runtime_neutral/test_runtime_contract_schema.py
@@ -714,6 +714,7 @@ class RuntimeContractSchemaTests(unittest.TestCase):
                 "surfaced",
                 "dispatched",
                 "executed",
+                "routed",
                 "blocked_due_to_destructive",
                 "degraded_due_to_missing_contract",
                 "ghost_match",

--- a/tests/runtime_neutral/test_skill_promotion_destructive_gate.py
+++ b/tests/runtime_neutral/test_skill_promotion_destructive_gate.py
@@ -163,6 +163,8 @@ class SkillPromotionDestructiveGateTests(unittest.TestCase):
                 ML_PROMPT,
                 temp_path,
                 extra_env={
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },

--- a/tests/runtime_neutral/test_skill_promotion_destructive_gate.py
+++ b/tests/runtime_neutral/test_skill_promotion_destructive_gate.py
@@ -172,5 +172,6 @@ class SkillPromotionDestructiveGateTests(unittest.TestCase):
             specialist_accounting = execution_manifest["specialist_accounting"]
 
             self.assertGreaterEqual(int(specialist_accounting["approved_dispatch_count"]), 1)
-            self.assertGreaterEqual(int(specialist_accounting["executed_specialist_unit_count"]), 1)
-            self.assertEqual("live_native_executed", specialist_accounting["effective_execution_status"])
+            self.assertEqual(0, int(specialist_accounting["executed_specialist_unit_count"]))
+            self.assertGreaterEqual(int(specialist_accounting["direct_routed_specialist_unit_count"]), 1)
+            self.assertEqual("direct_current_session_routed", specialist_accounting["effective_execution_status"])

--- a/tests/runtime_neutral/test_skill_promotion_metrics.py
+++ b/tests/runtime_neutral/test_skill_promotion_metrics.py
@@ -161,14 +161,12 @@ class SkillPromotionMetricsTests(unittest.TestCase):
     def test_metrics_capture_match_surface_dispatch_and_execute(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             temp_path = Path(tempdir)
-            fake_codex = create_fake_codex_command(temp_path)
             payload = run_runtime(
                 ML_PROMPT,
                 temp_path,
                 extra_env={
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
-                    "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )
             summary = payload["summary"]
@@ -178,7 +176,8 @@ class SkillPromotionMetricsTests(unittest.TestCase):
             self.assertGreaterEqual(int(funnel["matched"]), 1)
             self.assertGreaterEqual(int(funnel["surfaced"]), int(funnel["matched"]))
             self.assertGreaterEqual(int(funnel["dispatched"]), 1)
-            self.assertGreaterEqual(int(funnel["executed"]), 1)
+            self.assertEqual(0, int(funnel["executed"]))
+            self.assertGreaterEqual(int(funnel["routed"]), 1)
             self.assertEqual(0, int(funnel["ghost_match"]))
 
     def test_metrics_record_destructive_block_instead_of_ghost_match(self) -> None:

--- a/tests/runtime_neutral/test_skill_promotion_metrics.py
+++ b/tests/runtime_neutral/test_skill_promotion_metrics.py
@@ -157,6 +157,14 @@ def extract_expression(pattern: str) -> str:
     return match.group(1).strip()
 
 
+def extract_block(pattern: str) -> str:
+    content = PLAN_EXECUTE_SCRIPT.read_text(encoding="utf-8")
+    match = re.search(pattern, content, re.MULTILINE | re.DOTALL)
+    if not match:
+        raise AssertionError(f"Unable to extract block with pattern: {pattern}")
+    return match.group(0).strip()
+
+
 class SkillPromotionMetricsTests(unittest.TestCase):
     def test_metrics_capture_match_surface_dispatch_and_execute(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -165,6 +173,8 @@ class SkillPromotionMetricsTests(unittest.TestCase):
                 ML_PROMPT,
                 temp_path,
                 extra_env={
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "",
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
                 },
@@ -179,6 +189,48 @@ class SkillPromotionMetricsTests(unittest.TestCase):
             self.assertEqual(0, int(funnel["executed"]))
             self.assertGreaterEqual(int(funnel["routed"]), 1)
             self.assertEqual(0, int(funnel["ghost_match"]))
+
+    def test_phase_qualified_resolution_keys_do_not_collapse_duplicate_skill_ids(self) -> None:
+        resolution_key_block = extract_block(
+            r"^function Get-VibeSpecialistDispatchResolutionKey \{.*?^}\s*$"
+        )
+        approved_keys_expr = extract_expression(r"^\$approvedDispatchResolutionKeys = (.+)$")
+        executed_keys_expr = extract_expression(r"^\$executedSpecialistResolutionKeys = (.+)$")
+        routed_keys_expr = extract_expression(r"^\$directRoutedSpecialistResolutionKeys = (.+)$")
+        resolved_keys_expr = extract_expression(r"^\$resolvedSpecialistResolutionKeys = (.+)$")
+        approved_not_resolved_expr = extract_expression(r"^\$approvedDispatchNotResolved = (.+)$")
+
+        payload = run_powershell_json(
+            (
+                "& { "
+                f"{resolution_key_block} "
+                "$approvedDispatch = @("
+                "[pscustomobject]@{ skill_id = 'demo-skill'; dispatch_phase = 'pre_execution' },"
+                "[pscustomobject]@{ skill_id = 'demo-skill'; dispatch_phase = 'verification' }"
+                "); "
+                "$verifiedSpecialistUnits = @("
+                "[pscustomobject]@{ skill_id = 'demo-skill'; dispatch_phase = 'pre_execution' }"
+                "); "
+                "$directRoutedSpecialistUnits = @(); "
+                f"$approvedDispatchResolutionKeys = {approved_keys_expr}; "
+                f"$executedSpecialistResolutionKeys = {executed_keys_expr}; "
+                f"$directRoutedSpecialistResolutionKeys = {routed_keys_expr}; "
+                f"$resolvedSpecialistResolutionKeys = {resolved_keys_expr}; "
+                f"$approvedDispatchNotResolved = {approved_not_resolved_expr}; "
+                "[pscustomobject]@{ "
+                "approved = @($approvedDispatchResolutionKeys | Sort-Object); "
+                "resolved = @($resolvedSpecialistResolutionKeys | Sort-Object); "
+                "not_resolved = @($approvedDispatchNotResolved | Sort-Object) "
+                "} | ConvertTo-Json -Depth 20 }"
+            )
+        )
+
+        self.assertEqual(
+            ["pre_execution|demo-skill", "verification|demo-skill"],
+            list(payload["approved"]),
+        )
+        self.assertEqual(["pre_execution|demo-skill"], list(payload["resolved"]))
+        self.assertEqual(["verification|demo-skill"], list(payload["not_resolved"]))
 
     def test_metrics_record_destructive_block_instead_of_ghost_match(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/runtime_neutral/test_skill_promotion_metrics.py
+++ b/tests/runtime_neutral/test_skill_promotion_metrics.py
@@ -194,16 +194,23 @@ class SkillPromotionMetricsTests(unittest.TestCase):
         resolution_key_block = extract_block(
             r"^function Get-VibeSpecialistDispatchResolutionKey \{.*?^}\s*$"
         )
+        explicit_phase_block = extract_block(
+            r"^function Get-VibeSpecialistDispatchExplicitPhase \{.*?^}\s*$"
+        )
+        support_block = extract_block(
+            r"^function Test-VibeSpecialistEntrySupportedByCandidates \{.*?^}\s*$"
+        )
         approved_keys_expr = extract_expression(r"^\$approvedDispatchResolutionKeys = (.+)$")
         executed_keys_expr = extract_expression(r"^\$executedSpecialistResolutionKeys = (.+)$")
         routed_keys_expr = extract_expression(r"^\$directRoutedSpecialistResolutionKeys = (.+)$")
         resolved_keys_expr = extract_expression(r"^\$resolvedSpecialistResolutionKeys = (.+)$")
-        approved_not_resolved_expr = extract_expression(r"^\$approvedDispatchNotResolved = (.+)$")
 
         payload = run_powershell_json(
             (
                 "& { "
                 f"{resolution_key_block} "
+                f"{explicit_phase_block} "
+                f"{support_block} "
                 "$approvedDispatch = @("
                 "[pscustomobject]@{ skill_id = 'demo-skill'; dispatch_phase = 'pre_execution' },"
                 "[pscustomobject]@{ skill_id = 'demo-skill'; dispatch_phase = 'verification' }"
@@ -216,7 +223,13 @@ class SkillPromotionMetricsTests(unittest.TestCase):
                 f"$executedSpecialistResolutionKeys = {executed_keys_expr}; "
                 f"$directRoutedSpecialistResolutionKeys = {routed_keys_expr}; "
                 f"$resolvedSpecialistResolutionKeys = {resolved_keys_expr}; "
-                f"$approvedDispatchNotResolved = {approved_not_resolved_expr}; "
+                "$approvedDispatchNotResolved = @("
+                "$approvedDispatch | "
+                "Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @(@($verifiedSpecialistUnits) + @($directRoutedSpecialistUnits))) } | "
+                "ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } | "
+                "Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | "
+                "Select-Object -Unique"
+                "); "
                 "[pscustomobject]@{ "
                 "approved = @($approvedDispatchResolutionKeys | Sort-Object); "
                 "resolved = @($resolvedSpecialistResolutionKeys | Sort-Object); "
@@ -231,6 +244,45 @@ class SkillPromotionMetricsTests(unittest.TestCase):
         )
         self.assertEqual(["pre_execution|demo-skill"], list(payload["resolved"]))
         self.assertEqual(["verification|demo-skill"], list(payload["not_resolved"]))
+
+    def test_unphased_recommendations_support_phase_bound_dispatch(self) -> None:
+        resolution_key_block = extract_block(
+            r"^function Get-VibeSpecialistDispatchResolutionKey \{.*?^}\s*$"
+        )
+        explicit_phase_block = extract_block(
+            r"^function Get-VibeSpecialistDispatchExplicitPhase \{.*?^}\s*$"
+        )
+        support_block = extract_block(
+            r"^function Test-VibeSpecialistEntrySupportedByCandidates \{.*?^}\s*$"
+        )
+
+        payload = run_powershell_json(
+            (
+                "& { "
+                f"{resolution_key_block} "
+                f"{explicit_phase_block} "
+                f"{support_block} "
+                "$specialistRecommendations = @("
+                "[pscustomobject]@{ skill_id = 'demo-skill' }"
+                "); "
+                "$approvedDispatch = @("
+                "[pscustomobject]@{ skill_id = 'demo-skill'; dispatch_phase = 'pre_execution' },"
+                "[pscustomobject]@{ skill_id = 'demo-skill'; dispatch_phase = 'verification' }"
+                "); "
+                "$approvedDispatchMissingFromRecommendationsResolutionKeys = @("
+                "$approvedDispatch | "
+                "Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @($specialistRecommendations)) } | "
+                "ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } | "
+                "Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | "
+                "Select-Object -Unique"
+                "); "
+                "[pscustomobject]@{ "
+                "missing = @($approvedDispatchMissingFromRecommendationsResolutionKeys | Sort-Object) "
+                "} | ConvertTo-Json -Depth 20 }"
+            )
+        )
+
+        self.assertEqual([], list(payload["missing"]))
 
     def test_metrics_record_destructive_block_instead_of_ghost_match(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/runtime_neutral/test_skill_promotion_metrics.py
+++ b/tests/runtime_neutral/test_skill_promotion_metrics.py
@@ -191,6 +191,9 @@ class SkillPromotionMetricsTests(unittest.TestCase):
             self.assertEqual(0, int(funnel["ghost_match"]))
 
     def test_phase_qualified_resolution_keys_do_not_collapse_duplicate_skill_ids(self) -> None:
+        skill_id_block = extract_block(
+            r"^function Get-VibeSpecialistEntrySkillId \{.*?^}\s*$"
+        )
         resolution_key_block = extract_block(
             r"^function Get-VibeSpecialistDispatchResolutionKey \{.*?^}\s*$"
         )
@@ -198,7 +201,7 @@ class SkillPromotionMetricsTests(unittest.TestCase):
             r"^function Get-VibeSpecialistDispatchExplicitPhase \{.*?^}\s*$"
         )
         support_block = extract_block(
-            r"^function Test-VibeSpecialistEntrySupportedByCandidates \{.*?^}\s*$"
+            r"^function Test-VibeSpecialistEntrySupportedByCandidate \{.*?^}\s*$"
         )
         approved_keys_expr = extract_expression(r"^\$approvedDispatchResolutionKeys = (.+)$")
         executed_keys_expr = extract_expression(r"^\$executedSpecialistResolutionKeys = (.+)$")
@@ -208,6 +211,7 @@ class SkillPromotionMetricsTests(unittest.TestCase):
         payload = run_powershell_json(
             (
                 "& { "
+                f"{skill_id_block} "
                 f"{resolution_key_block} "
                 f"{explicit_phase_block} "
                 f"{support_block} "
@@ -225,7 +229,7 @@ class SkillPromotionMetricsTests(unittest.TestCase):
                 f"$resolvedSpecialistResolutionKeys = {resolved_keys_expr}; "
                 "$approvedDispatchNotResolved = @("
                 "$approvedDispatch | "
-                "Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @(@($verifiedSpecialistUnits) + @($directRoutedSpecialistUnits))) } | "
+                "Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidate -Entry $_ -Candidates @(@($verifiedSpecialistUnits) + @($directRoutedSpecialistUnits))) } | "
                 "ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } | "
                 "Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | "
                 "Select-Object -Unique"
@@ -246,6 +250,9 @@ class SkillPromotionMetricsTests(unittest.TestCase):
         self.assertEqual(["verification|demo-skill"], list(payload["not_resolved"]))
 
     def test_unphased_recommendations_support_phase_bound_dispatch(self) -> None:
+        skill_id_block = extract_block(
+            r"^function Get-VibeSpecialistEntrySkillId \{.*?^}\s*$"
+        )
         resolution_key_block = extract_block(
             r"^function Get-VibeSpecialistDispatchResolutionKey \{.*?^}\s*$"
         )
@@ -253,12 +260,13 @@ class SkillPromotionMetricsTests(unittest.TestCase):
             r"^function Get-VibeSpecialistDispatchExplicitPhase \{.*?^}\s*$"
         )
         support_block = extract_block(
-            r"^function Test-VibeSpecialistEntrySupportedByCandidates \{.*?^}\s*$"
+            r"^function Test-VibeSpecialistEntrySupportedByCandidate \{.*?^}\s*$"
         )
 
         payload = run_powershell_json(
             (
                 "& { "
+                f"{skill_id_block} "
                 f"{resolution_key_block} "
                 f"{explicit_phase_block} "
                 f"{support_block} "
@@ -271,7 +279,7 @@ class SkillPromotionMetricsTests(unittest.TestCase):
                 "); "
                 "$approvedDispatchMissingFromRecommendationsResolutionKeys = @("
                 "$approvedDispatch | "
-                "Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidates -Entry $_ -Candidates @($specialistRecommendations)) } | "
+                "Where-Object { -not (Test-VibeSpecialistEntrySupportedByCandidate -Entry $_ -Candidates @($specialistRecommendations)) } | "
                 "ForEach-Object { Get-VibeSpecialistDispatchResolutionKey -Entry $_ } | "
                 "Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | "
                 "Select-Object -Unique"

--- a/tests/runtime_neutral/test_vibe_specialist_consultation.py
+++ b/tests/runtime_neutral/test_vibe_specialist_consultation.py
@@ -1086,6 +1086,8 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
             for receipt in (discussion_receipt, planning_receipt):
                 self.assertTrue(bool(receipt["enabled"]))
                 self.assertGreaterEqual(len(list(receipt["approved_consultation"])), 1)
+                self.assertEqual([], list(receipt["consulted_units"]))
+                self.assertGreaterEqual(len(list(receipt["routed_units"])), 1)
                 self.assertGreaterEqual(len(list(receipt["user_disclosures"])), 1)
                 disclosure = next(
                     item for item in list(receipt["user_disclosures"]) if item["skill_id"] == "systematic-debugging"
@@ -1101,6 +1103,8 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
                 ["discussion", "planning"],
                 [str(window["window_id"]) for window in list(specialist_consultation["windows"])],
             )
+            self.assertEqual(0, int(specialist_consultation["consulted_unit_count"]))
+            self.assertGreaterEqual(int(specialist_consultation["routed_unit_count"]), 2)
             self.assertGreaterEqual(int(specialist_consultation["user_disclosure_count"]), 2)
             self.assertNotIn("specialist_consultation", summary["specialist_user_disclosure"])
 
@@ -1137,8 +1141,8 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
             self.assertEqual(
                 [
                     "discussion_routing_frozen",
-                    "discussion_consultation_completed",
-                    "planning_consultation_completed",
+                    "discussion_consultation_routed",
+                    "planning_consultation_routed",
                     "execution_dispatch_confirmed",
                 ],
                 [str(event["event_id"]) for event in list(host_stage_disclosure["events"])],
@@ -1167,7 +1171,10 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
                 [str(segment["segment_id"]) for segment in list(host_user_briefing["segments"])],
             )
             self.assertIn("Vibe routed these Skills", host_user_briefing["rendered_text"])
-            self.assertIn("Vibe consulted these Skills during discussion", host_user_briefing["rendered_text"])
+            self.assertIn(
+                "Vibe routed these Skills for direct current-session consultation during discussion",
+                host_user_briefing["rendered_text"],
+            )
             self.assertIn("freeze gate: passed", host_user_briefing["rendered_text"])
             self.assertIn("Vibe approved these Skills for execution", host_user_briefing["rendered_text"])
             self.assertIn("systematic-debugging", host_user_briefing["rendered_text"])

--- a/tests/runtime_neutral/test_vibe_specialist_consultation.py
+++ b/tests/runtime_neutral/test_vibe_specialist_consultation.py
@@ -663,6 +663,54 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
 
         self.assertEqual("discussion_consultation_routed", result["event_id"])
 
+    def test_invalid_specialist_consultation_mode_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            completed = run_runtime(
+                SPECIALIST_TASK,
+                Path(tempdir),
+                extra_env={
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "typo-mode",
+                },
+                check=False,
+            )
+
+        assert isinstance(completed, subprocess.CompletedProcess)
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn(
+            "Unsupported specialist consultation mode: typo-mode",
+            "\n".join([completed.stdout, completed.stderr]),
+        )
+
+    def test_host_user_briefing_segment_handles_missing_consultation_receipt(self) -> None:
+        result = run_runtime_common_json(
+            """
+            $layer = [pscustomobject]@{
+                layer_id = 'discussion_consultation'
+                stage = 'deep_interview'
+                truth_layer = 'consultation'
+                skills = @(
+                    [pscustomobject]@{
+                        skill_id = 'systematic-debugging'
+                        state = 'direct_current_session_routed'
+                        why_now = 'need debugging guidance before requirement freeze'
+                        native_skill_entrypoint = 'scripts/runtime/systematic-debugging/SKILL.md'
+                    }
+                )
+            }
+            $result = New-VibeHostUserBriefingSegmentProjection -LifecycleLayer $layer -ConsultationReceipt $null
+            $result | ConvertTo-Json -Depth 20
+            """
+        )
+
+        self.assertEqual("consultation", result["category"])
+        self.assertEqual("gate_unknown", result["status"])
+        self.assertIn(
+            "Vibe recorded these Skills in the discussion consultation chain; freeze gate: not_applicable.",
+            result["rendered_text"],
+        )
+
     def test_consultation_window_invokes_specialist_and_emits_progressive_disclosure(self) -> None:
         shell = resolve_powershell()
         if shell is None:
@@ -1086,7 +1134,11 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
             payload = run_runtime(
                 SPECIALIST_TASK,
                 artifact_root,
-                extra_env={"VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "1"},
+                extra_env={
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "",
+                    "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "1",
+                },
             )
             summary = payload["summary"]
             artifacts = summary["artifacts"]

--- a/tests/runtime_neutral/test_vibe_specialist_consultation.py
+++ b/tests/runtime_neutral/test_vibe_specialist_consultation.py
@@ -643,6 +643,26 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
             completed.stderr,
         )
 
+    def test_host_stage_disclosure_treats_suffix_routed_states_as_routed(self) -> None:
+        result = run_runtime_common_json(
+            """
+            $segment = [pscustomobject]@{
+                segment_id = 'discussion_consultation'
+                stage = 'deep_interview'
+                skills = @(
+                    [pscustomobject]@{
+                        skill_id = 'systematic-debugging'
+                        state = 'direct_current_session_routed'
+                    }
+                )
+            }
+            $result = New-VibeHostStageDisclosureEventProjection -Segment $segment
+            $result | ConvertTo-Json -Depth 20
+            """
+        )
+
+        self.assertEqual("discussion_consultation_routed", result["event_id"])
+
     def test_consultation_window_invokes_specialist_and_emits_progressive_disclosure(self) -> None:
         shell = resolve_powershell()
         if shell is None:

--- a/tests/runtime_neutral/test_vibe_specialist_consultation.py
+++ b/tests/runtime_neutral/test_vibe_specialist_consultation.py
@@ -643,6 +643,37 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
             completed.stderr,
         )
 
+    def test_consultation_lifecycle_projection_handles_summary_only_receipt(self) -> None:
+        result = run_runtime_common_json(
+            """
+            $receipt = [pscustomobject]@{
+                enabled = $true
+                window_id = 'discussion'
+                stage = 'requirement_doc'
+                summary = [pscustomobject]@{
+                    consulted_unit_count = 0
+                    routed_unit_count = 1
+                }
+                user_disclosures = @(
+                    [pscustomobject]@{
+                        skill_id = 'systematic-debugging'
+                        why_now = 'need debugging guidance before requirement freeze'
+                        native_skill_entrypoint = 'scripts/runtime/systematic-debugging/SKILL.md'
+                    }
+                )
+            }
+            $result = New-VibeSpecialistConsultationLifecycleLayerProjection -ConsultationReceipt $receipt
+            $result | ConvertTo-Json -Depth 20
+            """
+        )
+
+        self.assertEqual("discussion_consultation", result["layer_id"])
+        self.assertEqual(1, int(result["skill_count"]))
+        self.assertIn("Specialist consultation routing during discussion:", result["rendered_text"])
+        skill = list(result["skills"])[0]
+        self.assertEqual("systematic-debugging", skill["skill_id"])
+        self.assertEqual("consultation_disclosed", skill["state"])
+
     def test_host_stage_disclosure_treats_suffix_routed_states_as_routed(self) -> None:
         result = run_runtime_common_json(
             """

--- a/tests/runtime_neutral/test_vibe_specialist_consultation.py
+++ b/tests/runtime_neutral/test_vibe_specialist_consultation.py
@@ -688,6 +688,8 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
                     **os.environ,
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "host_subprocess",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )
@@ -769,6 +771,8 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
                     **os.environ,
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "host_subprocess",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )
@@ -830,6 +834,8 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
                     **os.environ,
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "host_subprocess",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )
@@ -893,6 +899,8 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
                         **os.environ,
                         "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                         "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                        "VGO_SPECIALIST_CONSULTATION_MODE": "host_subprocess",
+                        "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                         "VGO_CODEX_EXECUTABLE": str(fake_codex),
                     },
                 )
@@ -960,6 +968,8 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
                     **os.environ,
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "host_subprocess",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )
@@ -1036,6 +1046,8 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
                     "CODEX_HOME": str(source_codex_home),
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "host_subprocess",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )
@@ -1214,6 +1226,8 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
                     **os.environ,
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "host_subprocess",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
             )
@@ -1244,6 +1258,8 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
                 extra_env={
                     "VGO_ENABLE_NATIVE_SPECIALIST_EXECUTION": "1",
                     "VGO_DISABLE_NATIVE_SPECIALIST_EXECUTION": "0",
+                    "VGO_SPECIALIST_CONSULTATION_MODE": "host_subprocess",
+                    "VGO_NATIVE_SPECIALIST_EXECUTION_MODE": "host_subprocess",
                     "VGO_CODEX_EXECUTABLE": str(fake_codex),
                 },
                 check=False,

--- a/tests/runtime_neutral/test_vibe_specialist_consultation.py
+++ b/tests/runtime_neutral/test_vibe_specialist_consultation.py
@@ -674,6 +674,32 @@ class VibeSpecialistConsultationTests(unittest.TestCase):
         self.assertEqual("systematic-debugging", skill["skill_id"])
         self.assertEqual("consultation_disclosed", skill["state"])
 
+    def test_consultation_lifecycle_projection_uses_chain_header_for_mixed_consultation_state(self) -> None:
+        result = run_runtime_common_json(
+            """
+            $receipt = [pscustomobject]@{
+                enabled = $true
+                window_id = 'discussion'
+                stage = 'requirement_doc'
+                summary = [pscustomobject]@{
+                    consulted_unit_count = 1
+                    routed_unit_count = 1
+                }
+                user_disclosures = @(
+                    [pscustomobject]@{
+                        skill_id = 'systematic-debugging'
+                        why_now = 'need debugging guidance before requirement freeze'
+                        native_skill_entrypoint = 'scripts/runtime/systematic-debugging/SKILL.md'
+                    }
+                )
+            }
+            $result = New-VibeSpecialistConsultationLifecycleLayerProjection -ConsultationReceipt $receipt
+            $result | ConvertTo-Json -Depth 20
+            """
+        )
+
+        self.assertIn("Recorded specialist consultation chain during discussion:", result["rendered_text"])
+
     def test_host_stage_disclosure_treats_suffix_routed_states_as_routed(self) -> None:
         result = run_runtime_common_json(
             """


### PR DESCRIPTION
## Summary
- make specialist consultation and specialist execution default to direct current-session routing instead of hidden host subprocess launches
- keep the old host wrapper/native bridge path behind explicit compatibility env overrides
- account for direct-routed specialist units in execution manifests and restore stricter dispatch contract completeness checks

## Details
- add `mode: direct_current_session_route` to both specialist consultation and native specialist execution policies
- return direct-route specialist consultation and dispatch receipts by default, with no hidden subprocess/session launch
- preserve explicit fallback paths via `VGO_SPECIALIST_CONSULTATION_MODE=host_subprocess` and `VGO_NATIVE_SPECIALIST_EXECUTION_MODE=host_subprocess`
- update docs wording so governed artifacts describe direct current-session specialist handling honestly
- split tests into two lanes: default direct-route expectations and explicit host-subprocess regression coverage

## Verification
- `pytest -q tests/runtime_neutral/test_multi_host_specialist_execution.py`
- `pytest -q tests/runtime_neutral/test_l_xl_native_execution_topology.py`
- `pytest -q tests/runtime_neutral/test_plan_execute_receipts.py tests/runtime_neutral/test_governed_runtime_bridge.py`
- `pytest -q tests/runtime_neutral/test_vibe_specialist_consultation.py tests/runtime_neutral/test_runtime_delivery_acceptance.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Specialist units now route directly into the current session by default; routed outcomes are reported alongside executed ones.

* **Configuration**
  * New top-level mode for specialist execution and consultation policies; defaults to direct current-session routing and can be overridden via environment.

* **Documentation**
  * Consultation/planning text updated to describe routed (direct current-session) handling.

* **Metrics & Reporting**
  * Receipts, promotion funnel, and UI summaries include routed counts/IDs and routing-aware messaging.

* **Tests**
  * Added/updated tests covering direct routing, accounting, and mode validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->