### PR TITLE
Fix canonical entry receipt lifecycle on launch failure

### DIFF
--- a/packages/runtime-core/src/vgo_runtime/canonical_entry.py
+++ b/packages/runtime-core/src/vgo_runtime/canonical_entry.py
@@ -89,6 +89,26 @@ def _normalize_requested_entry_id(entry_id: str | None) -> str:
     return requested_entry_id
 
 
+def _new_run_id() -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    suffix = os.urandom(4).hex()
+    return f"{timestamp}-{suffix}"
+
+
+def _resolve_artifact_root(repo_root: Path, artifact_root: str | Path | None) -> Path:
+    if artifact_root in (None, ""):
+        return (repo_root / ".vibeskills").resolve()
+
+    artifact_root_path = Path(str(artifact_root)).expanduser()
+    if artifact_root_path.is_absolute():
+        return artifact_root_path.resolve()
+    return (repo_root / artifact_root_path).resolve()
+
+
+def _resolve_session_root(*, repo_root: Path, run_id: str, artifact_root: str | Path | None) -> Path:
+    return (_resolve_artifact_root(repo_root, artifact_root) / "outputs" / "runtime" / "vibe-sessions" / run_id).resolve()
+
+
 def invoke_vibe_runtime_entrypoint(
     *,
     repo_root: Path,
@@ -308,25 +328,9 @@ def launch_canonical_vibe(
     if bool(contract.get("allow_skill_doc_fallback", False)):
         raise RuntimeError("unsupported fallback policy for canonical entry launcher")
 
-    payload = invoke_vibe_runtime_entrypoint(
-        repo_root=repo_root_path,
-        host_id=host_id,
-        entry_id=requested_entry_id,
-        prompt=prompt,
-        requested_stage_stop=requested_stage_stop,
-        requested_grade_floor=requested_grade_floor,
-        run_id=run_id,
-        artifact_root=artifact_root,
-        force_runtime_neutral=force_runtime_neutral,
-    )
-    session_root = Path(str(payload["session_root"])).resolve()
-    resolved_run_id = str(payload.get("run_id") or run_id or session_root.name)
-    summary_path = Path(str(payload.get("summary_path") or (session_root / "runtime-summary.json"))).resolve()
-
-    summary = dict(payload.get("summary") or {})
-    if summary_path.exists():
-        summary = _load_json_dict(summary_path, label="runtime-summary")
-
+    resolved_run_id = str(run_id or "").strip() or _new_run_id()
+    session_root = _resolve_session_root(repo_root=repo_root_path, run_id=resolved_run_id, artifact_root=artifact_root)
+    summary_path = (session_root / "runtime-summary.json").resolve()
     receipt = HostLaunchReceipt(
         host_id=host_id,
         entry_id=CANONICAL_RUNTIME_ENTRY_ID,
@@ -341,14 +345,47 @@ def launch_canonical_vibe(
     )
     receipt_path = write_host_launch_receipt(session_root, receipt)
 
-    artifacts = assert_minimum_truth_artifacts(session_root)
-    assert_minimum_truth_consistency(
-        receipt=receipt,
-        requested_entry_id=requested_entry_id,
-        runtime_packet_path=artifacts["runtime_input_packet"],
-        governance_capsule_path=artifacts["governance_capsule"],
-        stage_lineage_path=artifacts["stage_lineage"],
-    )
+    try:
+        payload = invoke_vibe_runtime_entrypoint(
+            repo_root=repo_root_path,
+            host_id=host_id,
+            entry_id=requested_entry_id,
+            prompt=prompt,
+            requested_stage_stop=requested_stage_stop,
+            requested_grade_floor=requested_grade_floor,
+            run_id=resolved_run_id,
+            artifact_root=artifact_root,
+            force_runtime_neutral=force_runtime_neutral,
+        )
+    except Exception:
+        failed_receipt = HostLaunchReceipt(**{**receipt.model_dump(), "launch_status": "failed"})
+        write_host_launch_receipt(receipt_path, failed_receipt)
+        raise
+
+    session_root = Path(str(payload["session_root"])).resolve()
+    resolved_run_id = str(payload.get("run_id") or resolved_run_id or session_root.name)
+    summary_path = Path(str(payload.get("summary_path") or summary_path)).resolve()
+
+    summary = dict(payload.get("summary") or {})
+    if summary_path.exists():
+        summary = _load_json_dict(summary_path, label="runtime-summary")
+
+    if receipt_path.parent != session_root:
+        receipt_path = write_host_launch_receipt(session_root, receipt)
+
+    try:
+        artifacts = assert_minimum_truth_artifacts(session_root)
+        assert_minimum_truth_consistency(
+            receipt=receipt,
+            requested_entry_id=requested_entry_id,
+            runtime_packet_path=artifacts["runtime_input_packet"],
+            governance_capsule_path=artifacts["governance_capsule"],
+            stage_lineage_path=artifacts["stage_lineage"],
+        )
+    except Exception:
+        failed_receipt = HostLaunchReceipt(**{**receipt.model_dump(), "launch_status": "failed"})
+        write_host_launch_receipt(receipt_path, failed_receipt)
+        raise
 
     verified_receipt = HostLaunchReceipt(**{**receipt.model_dump(), "launch_status": "verified"})
     receipt_path = write_host_launch_receipt(receipt_path, verified_receipt)

--- a/tests/unit/test_canonical_vibe_entry_launcher.py
+++ b/tests/unit/test_canonical_vibe_entry_launcher.py
@@ -123,6 +123,82 @@ def test_canonical_entry_writes_host_launch_receipt(
     assert receipt["launch_status"] == "verified"
 
 
+def test_canonical_entry_prewrites_launched_receipt_before_runtime_invocation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_id = "pytest-canonical-entry-prewrite"
+    session_root = tmp_path / "outputs" / "runtime" / "vibe-sessions" / run_id
+
+    monkeypatch.setattr(
+        canonical_entry,
+        "resolve_canonical_vibe_contract",
+        lambda repo_root, host_id: {"fallback_policy": "blocked", "allow_skill_doc_fallback": False},
+    )
+
+    def fake_invoke_runtime(**kwargs: object) -> dict[str, object]:
+        receipt_path = session_root / "host-launch-receipt.json"
+        assert receipt_path.exists()
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        assert receipt["launch_status"] == "launched"
+        assert receipt["run_id"] == run_id
+        _write_valid_truth_artifacts(session_root)
+        return {
+            "run_id": run_id,
+            "session_root": str(session_root),
+            "summary_path": str(session_root / "runtime-summary.json"),
+            "summary": {"run_id": run_id},
+        }
+
+    monkeypatch.setattr(canonical_entry, "invoke_vibe_runtime_entrypoint", fake_invoke_runtime)
+
+    result = canonical_entry.launch_canonical_vibe(
+        repo_root=tmp_path,
+        host_id="codex",
+        entry_id="vibe",
+        prompt="x",
+        requested_stage_stop="phase_cleanup",
+        run_id=run_id,
+        artifact_root=tmp_path,
+    )
+
+    receipt = json.loads(result.host_launch_receipt_path.read_text(encoding="utf-8"))
+    assert receipt["launch_status"] == "verified"
+
+
+def test_canonical_entry_marks_receipt_failed_when_runtime_invocation_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_id = "pytest-canonical-entry-runtime-failure"
+    session_root = tmp_path / "outputs" / "runtime" / "vibe-sessions" / run_id
+
+    monkeypatch.setattr(
+        canonical_entry,
+        "resolve_canonical_vibe_contract",
+        lambda repo_root, host_id: {"fallback_policy": "blocked", "allow_skill_doc_fallback": False},
+    )
+
+    def fake_invoke_runtime(**kwargs: object) -> dict[str, object]:
+        raise RuntimeError("runtime exploded")
+
+    monkeypatch.setattr(canonical_entry, "invoke_vibe_runtime_entrypoint", fake_invoke_runtime)
+
+    with pytest.raises(RuntimeError, match="runtime exploded"):
+        canonical_entry.launch_canonical_vibe(
+            repo_root=tmp_path,
+            host_id="codex",
+            entry_id="vibe",
+            prompt="x",
+            requested_stage_stop="phase_cleanup",
+            run_id=run_id,
+            artifact_root=tmp_path,
+        )
+
+    receipt = json.loads((session_root / "host-launch-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["launch_status"] == "failed"
+
+
 def test_canonical_entry_rejects_non_blocked_fallback_policy(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- prewrite `host-launch-receipt.json` before the runtime bridge returns
- mark the receipt as failed when runtime launch or truth validation fails
- keep verified receipt behavior unchanged on successful canonical entry

## Testing
- `pytest -q tests/unit/test_canonical_vibe_entry_launcher.py`
- `pytest -q tests/integration/test_real_canonical_entry_bounded_stop.py`
- `pytest -q tests/integration/test_cli_runtime_entrypoint_contract_cutover.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during runtime launching with better failure status tracking and reporting.
  * Enhanced session and receipt management to ensure consistent state tracking across operations.

* **Tests**
  * Added comprehensive unit tests for launch failure scenarios and receipt state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->