### PR TITLE
Fix upgrade truth source for target installs

### DIFF
--- a/apps/vgo-cli/src/vgo_cli/upgrade_service.py
+++ b/apps/vgo-cli/src/vgo_cli/upgrade_service.py
@@ -24,6 +24,35 @@ def resolve_upgrade_repo_root(repo_root: Path) -> Path | None:
     return resolve_canonical_repo_root(repo_root)
 
 
+def load_recorded_install_status(repo_root: Path, target_root: Path, host_id: str) -> dict[str, object]:
+    existing = load_upgrade_status(target_root)
+    repo_remote = str(existing.get('repo_remote') or '').strip()
+    repo_default_branch = str(existing.get('repo_default_branch') or '').strip()
+    if not repo_remote or not repo_default_branch:
+        official_repo = get_official_self_repo_metadata(repo_root)
+        repo_remote = repo_remote or str(official_repo.get('repo_url') or '').strip()
+        repo_default_branch = repo_default_branch or str(official_repo.get('default_branch') or '').strip()
+    return merge_upgrade_status(
+        existing,
+        installed={
+            'host_id': host_id,
+            'target_root': target_root,
+            'repo_remote': repo_remote,
+            'repo_default_branch': repo_default_branch,
+            'installed_version': existing.get('installed_version'),
+            'installed_commit': existing.get('installed_commit'),
+            'installed_recorded_at': existing.get('installed_recorded_at'),
+        },
+    )
+
+
+def has_recorded_install_truth(status: dict[str, object] | None) -> bool:
+    return bool(
+        str((status or {}).get('installed_version') or '').strip()
+        or str((status or {}).get('installed_commit') or '').strip()
+    )
+
+
 def refresh_installed_status(
     repo_root: Path,
     target_root: Path,
@@ -208,9 +237,10 @@ def upgrade_runtime(
             'Pass --repo-root pointing at a Vibe-Skills git checkout before invoking the upgrade runtime.'
         )
 
-    before = refresh_installed_status(resolved_repo_root, target_root, host_id, persist=False)
+    before = load_recorded_install_status(resolved_repo_root, target_root, host_id)
+    install_truth_present = has_recorded_install_truth(before)
     status = refresh_upstream_status(resolved_repo_root, target_root, before, force_refresh=True)
-    if not bool(status.get('update_available')):
+    if install_truth_present and not bool(status.get('update_available')):
         print(
             'Vibe-Skills already current: '
             f"local={status.get('installed_version') or 'unknown'}@{status.get('installed_commit') or 'unknown'}"

--- a/apps/vgo-cli/src/vgo_cli/upgrade_service.py
+++ b/apps/vgo-cli/src/vgo_cli/upgrade_service.py
@@ -49,7 +49,7 @@ def load_recorded_install_status(repo_root: Path, target_root: Path, host_id: st
 def has_recorded_install_truth(status: dict[str, object] | None) -> bool:
     return bool(
         str((status or {}).get('installed_version') or '').strip()
-        or str((status or {}).get('installed_commit') or '').strip()
+        and str((status or {}).get('installed_commit') or '').strip()
     )
 
 

--- a/apps/vgo-cli/src/vgo_cli/version_reminder.py
+++ b/apps/vgo-cli/src/vgo_cli/version_reminder.py
@@ -8,18 +8,20 @@ import sys
 if __package__ in {None, ''}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from vgo_cli.upgrade_service import refresh_installed_status, refresh_upstream_status
+from vgo_cli.upgrade_service import has_recorded_install_truth, load_recorded_install_status, refresh_upstream_status
 from vgo_cli.upgrade_state import is_upstream_cache_stale
 
 
 def build_update_reminder(repo_root: Path, target_root: Path, host_id: str) -> str | None:
     try:
-        status = refresh_installed_status(repo_root, target_root, host_id)
+        status = load_recorded_install_status(repo_root, target_root, host_id)
         if is_upstream_cache_stale(status):
             status = refresh_upstream_status(repo_root, target_root, status)
     except Exception:
         return None
 
+    if not has_recorded_install_truth(status):
+        return None
     if not bool(status.get('update_available')):
         return None
 

--- a/apps/vgo-cli/src/vgo_cli/version_reminder.py
+++ b/apps/vgo-cli/src/vgo_cli/version_reminder.py
@@ -15,13 +15,13 @@ from vgo_cli.upgrade_state import is_upstream_cache_stale
 def build_update_reminder(repo_root: Path, target_root: Path, host_id: str) -> str | None:
     try:
         status = load_recorded_install_status(repo_root, target_root, host_id)
+        if not has_recorded_install_truth(status):
+            return None
         if is_upstream_cache_stale(status):
             status = refresh_upstream_status(repo_root, target_root, status)
     except Exception:
         return None
 
-    if not has_recorded_install_truth(status):
-        return None
     if not bool(status.get('update_available')):
         return None
 

--- a/tests/runtime_neutral/test_vibe_upgrade_reminder.py
+++ b/tests/runtime_neutral/test_vibe_upgrade_reminder.py
@@ -117,11 +117,11 @@ def test_build_update_reminder_returns_none_when_target_install_truth_is_missing
             'installed_commit': '',
             'remote_latest_version': '3.0.3',
             'remote_latest_commit': 'new',
-            'update_available': False,
+            'update_available': True,
         },
     )
     monkeypatch.setattr('vgo_cli.version_reminder.has_recorded_install_truth', lambda status: False)
-    monkeypatch.setattr('vgo_cli.version_reminder.is_upstream_cache_stale', lambda status: False)
+    monkeypatch.setattr('vgo_cli.version_reminder.is_upstream_cache_stale', lambda status: True)
     monkeypatch.setattr(
         'vgo_cli.version_reminder.refresh_upstream_status',
         lambda repo_root, target_root, current_status: (_ for _ in ()).throw(AssertionError('should not refresh')),

--- a/tests/runtime_neutral/test_vibe_upgrade_reminder.py
+++ b/tests/runtime_neutral/test_vibe_upgrade_reminder.py
@@ -20,13 +20,14 @@ def test_build_update_reminder_refreshes_stale_cache_and_emits_advisory(monkeypa
     calls: list[str] = []
 
     monkeypatch.setattr(
-        'vgo_cli.version_reminder.refresh_installed_status',
+        'vgo_cli.version_reminder.load_recorded_install_status',
         lambda repo_root, target_root, host_id: {
             'installed_version': '3.0.0',
             'installed_commit': 'old',
             'repo_default_branch': 'main',
         },
     )
+    monkeypatch.setattr('vgo_cli.version_reminder.has_recorded_install_truth', lambda status: True)
     monkeypatch.setattr('vgo_cli.version_reminder.is_upstream_cache_stale', lambda status: True)
 
     def fake_refresh(repo_root, target_root, current_status):
@@ -50,7 +51,7 @@ def test_build_update_reminder_refreshes_stale_cache_and_emits_advisory(monkeypa
 
 def test_build_update_reminder_uses_fresh_cache_without_refresh(monkeypatch) -> None:
     monkeypatch.setattr(
-        'vgo_cli.version_reminder.refresh_installed_status',
+        'vgo_cli.version_reminder.load_recorded_install_status',
         lambda repo_root, target_root, host_id: {
             'installed_version': '3.0.0',
             'installed_commit': 'old',
@@ -60,6 +61,7 @@ def test_build_update_reminder_uses_fresh_cache_without_refresh(monkeypatch) -> 
             'update_available': True,
         },
     )
+    monkeypatch.setattr('vgo_cli.version_reminder.has_recorded_install_truth', lambda status: True)
     monkeypatch.setattr('vgo_cli.version_reminder.is_upstream_cache_stale', lambda status: False)
     monkeypatch.setattr(
         'vgo_cli.version_reminder.refresh_upstream_status',
@@ -73,7 +75,7 @@ def test_build_update_reminder_uses_fresh_cache_without_refresh(monkeypatch) -> 
 
 def test_build_update_reminder_returns_none_when_no_update_is_available(monkeypatch) -> None:
     monkeypatch.setattr(
-        'vgo_cli.version_reminder.refresh_installed_status',
+        'vgo_cli.version_reminder.load_recorded_install_status',
         lambda repo_root, target_root, host_id: {
             'installed_version': '3.0.1',
             'installed_commit': 'same',
@@ -82,6 +84,7 @@ def test_build_update_reminder_returns_none_when_no_update_is_available(monkeypa
             'update_available': False,
         },
     )
+    monkeypatch.setattr('vgo_cli.version_reminder.has_recorded_install_truth', lambda status: True)
     monkeypatch.setattr('vgo_cli.version_reminder.is_upstream_cache_stale', lambda status: False)
 
     assert build_update_reminder(REPO_ROOT, REPO_ROOT / '.tmp-target', 'codex') is None
@@ -89,17 +92,39 @@ def test_build_update_reminder_returns_none_when_no_update_is_available(monkeypa
 
 def test_build_update_reminder_swallows_refresh_failures(monkeypatch) -> None:
     monkeypatch.setattr(
-        'vgo_cli.version_reminder.refresh_installed_status',
+        'vgo_cli.version_reminder.load_recorded_install_status',
         lambda repo_root, target_root, host_id: {
             'installed_version': '3.0.0',
             'installed_commit': 'old',
             'repo_default_branch': 'main',
         },
     )
+    monkeypatch.setattr('vgo_cli.version_reminder.has_recorded_install_truth', lambda status: True)
     monkeypatch.setattr('vgo_cli.version_reminder.is_upstream_cache_stale', lambda status: True)
     monkeypatch.setattr(
         'vgo_cli.version_reminder.refresh_upstream_status',
         lambda repo_root, target_root, current_status: (_ for _ in ()).throw(RuntimeError('network down')),
+    )
+
+    assert build_update_reminder(REPO_ROOT, REPO_ROOT / '.tmp-target', 'codex') is None
+
+
+def test_build_update_reminder_returns_none_when_target_install_truth_is_missing(monkeypatch) -> None:
+    monkeypatch.setattr(
+        'vgo_cli.version_reminder.load_recorded_install_status',
+        lambda repo_root, target_root, host_id: {
+            'installed_version': '',
+            'installed_commit': '',
+            'remote_latest_version': '3.0.3',
+            'remote_latest_commit': 'new',
+            'update_available': False,
+        },
+    )
+    monkeypatch.setattr('vgo_cli.version_reminder.has_recorded_install_truth', lambda status: False)
+    monkeypatch.setattr('vgo_cli.version_reminder.is_upstream_cache_stale', lambda status: False)
+    monkeypatch.setattr(
+        'vgo_cli.version_reminder.refresh_upstream_status',
+        lambda repo_root, target_root, current_status: (_ for _ in ()).throw(AssertionError('should not refresh')),
     )
 
     assert build_update_reminder(REPO_ROOT, REPO_ROOT / '.tmp-target', 'codex') is None

--- a/tests/unit/test_vgo_cli_upgrade_service.py
+++ b/tests/unit/test_vgo_cli_upgrade_service.py
@@ -298,6 +298,93 @@ def test_upgrade_runtime_reinstalls_when_target_root_has_no_recorded_install_tru
     assert result["after"]["installed_commit"] == "new-source-head"
 
 
+def test_upgrade_runtime_reinstalls_when_recorded_install_version_has_no_commit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "fresh-clone"
+    repo_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    steps: list[str] = []
+
+    upgrade_service.save_upgrade_status(
+        target_root,
+        {
+            "host_id": "codex",
+            "target_root": str(target_root.resolve()),
+            "repo_remote": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+            "repo_default_branch": "main",
+            "installed_version": "3.0.3",
+            "installed_commit": "",
+            "installed_recorded_at": "2026-04-10T00:00:00Z",
+        },
+    )
+
+    monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
+    monkeypatch.setattr(
+        upgrade_service,
+        "get_official_self_repo_metadata",
+        lambda repo_root_arg: {
+            "repo_url": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+            "default_branch": "main",
+            "canonical_root": ".",
+        },
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_upstream_status",
+        lambda repo_root_arg, target_root_arg, current_status, **kwargs: {
+            **current_status,
+            "remote_latest_version": "3.0.3",
+            "remote_latest_commit": "new-source-head",
+            "update_available": False,
+            "repo_default_branch": "main",
+        },
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "reset_repo_to_official_head",
+        lambda repo_root_arg, branch, target_commit=None: steps.append(f"reset:{branch}:{target_commit}"),
+    )
+    monkeypatch.setattr(upgrade_service, "reinstall_runtime", lambda **kwargs: steps.append("reinstall"))
+    monkeypatch.setattr(
+        upgrade_service,
+        "run_upgrade_check",
+        lambda **kwargs: (steps.append("check") or subprocess.CompletedProcess(args=["check"], returncode=0, stdout="", stderr="")),
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_installed_status",
+        lambda repo_root_arg, target_root_arg, host_id, **kwargs: {
+            "installed_version": "3.0.3",
+            "installed_commit": "new-source-head",
+            "remote_latest_version": "3.0.3",
+            "remote_latest_commit": "new-source-head",
+            "update_available": False,
+        },
+    )
+
+    result = upgrade_service.upgrade_runtime(
+        repo_root=repo_root,
+        target_root=target_root,
+        host_id="codex",
+        profile="full",
+        frontend="shell",
+        install_external=False,
+        strict_offline=False,
+        require_closed_ready=False,
+        allow_external_skill_fallback=False,
+        skip_runtime_freshness_gate=False,
+    )
+
+    assert steps == ["reset:main:new-source-head", "reinstall", "check"]
+    assert result["changed"] is True
+    assert result["before"]["installed_version"] == "3.0.3"
+    assert result["before"]["installed_commit"] == ""
+
+
 def test_resolve_upgrade_repo_root_does_not_fall_back_to_unrelated_cwd_repo(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_vgo_cli_upgrade_service.py
+++ b/tests/unit/test_vgo_cli_upgrade_service.py
@@ -28,17 +28,14 @@ def test_upgrade_runtime_resolves_canonical_git_root_before_refresh(monkeypatch:
 
     monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: canonical_root)
 
-    def fake_refresh_installed_status(
+    def fake_load_recorded_install_status(
         repo_root_arg: Path,
         target_root_arg: Path,
         host_id: str,
-        *,
-        persist: bool = True,
     ) -> dict[str, object]:
         recorded["repo_root"] = repo_root_arg
         recorded["target_root"] = target_root_arg
         recorded["host_id"] = host_id
-        recorded["persist"] = persist
         return {
             "installed_version": "3.0.1",
             "installed_commit": "same",
@@ -47,7 +44,8 @@ def test_upgrade_runtime_resolves_canonical_git_root_before_refresh(monkeypatch:
             "update_available": False,
         }
 
-    monkeypatch.setattr(upgrade_service, "refresh_installed_status", fake_refresh_installed_status)
+    monkeypatch.setattr(upgrade_service, "load_recorded_install_status", fake_load_recorded_install_status)
+    monkeypatch.setattr(upgrade_service, "has_recorded_install_truth", lambda status: True)
     monkeypatch.setattr(
         upgrade_service,
         "refresh_upstream_status",
@@ -71,7 +69,6 @@ def test_upgrade_runtime_resolves_canonical_git_root_before_refresh(monkeypatch:
     assert recorded["repo_root"] == canonical_root
     assert recorded["target_root"] == target_root
     assert recorded["host_id"] == "codex"
-    assert recorded["persist"] is False
 
 
 def test_upgrade_runtime_noops_when_install_is_already_current(
@@ -85,15 +82,13 @@ def test_upgrade_runtime_noops_when_install_is_already_current(
     target_root.mkdir()
 
     monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
-    monkeypatch.setattr(
-        upgrade_service,
-        "refresh_installed_status",
-        lambda repo_root_arg, target_root_arg, host_id, **kwargs: {
+    upgrade_service.save_upgrade_status(
+        target_root,
+        {
             "installed_version": "3.0.1",
             "installed_commit": "same",
-            "remote_latest_version": "3.0.1",
-            "remote_latest_commit": "same",
-            "update_available": False,
+            "repo_remote": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+            "repo_default_branch": "main",
         },
     )
     monkeypatch.setattr(
@@ -101,6 +96,7 @@ def test_upgrade_runtime_noops_when_install_is_already_current(
         "refresh_upstream_status",
         lambda repo_root_arg, target_root_arg, status, **kwargs: status,
     )
+    monkeypatch.setattr(upgrade_service, "has_recorded_install_truth", lambda status: True)
     monkeypatch.setattr(
         upgrade_service,
         "reset_repo_to_official_head",
@@ -132,6 +128,174 @@ def test_upgrade_runtime_noops_when_install_is_already_current(
 
     assert result["changed"] is False
     assert "already current" in capsys.readouterr().out.lower()
+
+
+def test_upgrade_runtime_uses_recorded_target_install_truth_instead_of_fresh_repo_checkout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "fresh-clone"
+    repo_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    steps: list[str] = []
+
+    upgrade_service.save_upgrade_status(
+        target_root,
+        {
+            "host_id": "codex",
+            "target_root": str(target_root.resolve()),
+            "repo_remote": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+            "repo_default_branch": "main",
+            "installed_version": "3.0.2",
+            "installed_commit": "old-install",
+            "installed_recorded_at": "2026-04-10T00:00:00Z",
+        },
+    )
+
+    monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
+    monkeypatch.setattr(
+        upgrade_service,
+        "get_official_self_repo_metadata",
+        lambda repo_root_arg: {
+            "repo_url": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+            "default_branch": "main",
+            "canonical_root": ".",
+        },
+    )
+
+    def fake_refresh_upstream(
+        repo_root_arg: Path,
+        target_root_arg: Path,
+        current_status: dict[str, object],
+        **kwargs: object,
+    ) -> dict[str, object]:
+        assert current_status["installed_version"] == "3.0.2"
+        assert current_status["installed_commit"] == "old-install"
+        return {
+            **current_status,
+            "remote_latest_version": "3.0.3",
+            "remote_latest_commit": "new-source-head",
+            "update_available": True,
+            "repo_default_branch": "main",
+        }
+
+    monkeypatch.setattr(upgrade_service, "refresh_upstream_status", fake_refresh_upstream)
+    monkeypatch.setattr(
+        upgrade_service,
+        "reset_repo_to_official_head",
+        lambda repo_root_arg, branch, target_commit=None: steps.append(f"reset:{branch}:{target_commit}"),
+    )
+    monkeypatch.setattr(upgrade_service, "reinstall_runtime", lambda **kwargs: steps.append("reinstall"))
+    monkeypatch.setattr(
+        upgrade_service,
+        "run_upgrade_check",
+        lambda **kwargs: (steps.append("check") or subprocess.CompletedProcess(args=["check"], returncode=0, stdout="", stderr="")),
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_installed_status",
+        lambda repo_root_arg, target_root_arg, host_id, **kwargs: {
+            "installed_version": "3.0.3",
+            "installed_commit": "new-source-head",
+            "remote_latest_version": "3.0.3",
+            "remote_latest_commit": "new-source-head",
+            "update_available": False,
+        },
+    )
+
+    result = upgrade_service.upgrade_runtime(
+        repo_root=repo_root,
+        target_root=target_root,
+        host_id="codex",
+        profile="full",
+        frontend="shell",
+        install_external=False,
+        strict_offline=False,
+        require_closed_ready=False,
+        allow_external_skill_fallback=False,
+        skip_runtime_freshness_gate=False,
+    )
+
+    assert steps == ["reset:main:new-source-head", "reinstall", "check"]
+    assert result["changed"] is True
+    assert result["before"]["installed_commit"] == "old-install"
+    assert result["after"]["installed_commit"] == "new-source-head"
+
+
+def test_upgrade_runtime_reinstalls_when_target_root_has_no_recorded_install_truth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    repo_root = tmp_path / "fresh-clone"
+    repo_root.mkdir()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    steps: list[str] = []
+
+    monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
+    monkeypatch.setattr(
+        upgrade_service,
+        "get_official_self_repo_metadata",
+        lambda repo_root_arg: {
+            "repo_url": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+            "default_branch": "main",
+            "canonical_root": ".",
+        },
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_upstream_status",
+        lambda repo_root_arg, target_root_arg, current_status, **kwargs: {
+            **current_status,
+            "remote_latest_version": "3.0.3",
+            "remote_latest_commit": "new-source-head",
+            "update_available": False,
+            "repo_default_branch": "main",
+        },
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "reset_repo_to_official_head",
+        lambda repo_root_arg, branch, target_commit=None: steps.append(f"reset:{branch}:{target_commit}"),
+    )
+    monkeypatch.setattr(upgrade_service, "reinstall_runtime", lambda **kwargs: steps.append("reinstall"))
+    monkeypatch.setattr(
+        upgrade_service,
+        "run_upgrade_check",
+        lambda **kwargs: (steps.append("check") or subprocess.CompletedProcess(args=["check"], returncode=0, stdout="", stderr="")),
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_installed_status",
+        lambda repo_root_arg, target_root_arg, host_id, **kwargs: {
+            "installed_version": "3.0.3",
+            "installed_commit": "new-source-head",
+            "remote_latest_version": "3.0.3",
+            "remote_latest_commit": "new-source-head",
+            "update_available": False,
+        },
+    )
+
+    result = upgrade_service.upgrade_runtime(
+        repo_root=repo_root,
+        target_root=target_root,
+        host_id="codex",
+        profile="full",
+        frontend="shell",
+        install_external=False,
+        strict_offline=False,
+        require_closed_ready=False,
+        allow_external_skill_fallback=False,
+        skip_runtime_freshness_gate=False,
+    )
+
+    assert steps == ["reset:main:new-source-head", "reinstall", "check"]
+    assert result["changed"] is True
+    assert result["before"]["installed_commit"] == ""
+    assert result["after"]["installed_commit"] == "new-source-head"
 
 
 def test_resolve_upgrade_repo_root_does_not_fall_back_to_unrelated_cwd_repo(
@@ -187,29 +351,17 @@ def test_upgrade_runtime_refreshes_repo_reinstalls_and_checks_when_update_is_ava
     target_root = tmp_path / "target"
     target_root.mkdir()
     steps: list[str] = []
-    statuses = iter(
-        [
-            {
-                "installed_version": "3.0.0",
-                "installed_commit": "old",
-                "repo_default_branch": "main",
-            },
-            {
-                "installed_version": "3.0.1",
-                "installed_commit": "new",
-                "remote_latest_version": "3.0.1",
-                "remote_latest_commit": "new",
-                "update_available": False,
-            },
-        ]
-    )
-
     monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
     monkeypatch.setattr(
         upgrade_service,
-        "refresh_installed_status",
-        lambda repo_root_arg, target_root_arg, host_id, **kwargs: next(statuses),
+        "load_recorded_install_status",
+        lambda repo_root_arg, target_root_arg, host_id: {
+            "installed_version": "3.0.0",
+            "installed_commit": "old",
+            "repo_default_branch": "main",
+        },
     )
+    monkeypatch.setattr(upgrade_service, "has_recorded_install_truth", lambda status: True)
 
     def fake_refresh_upstream(
         repo_root_arg: Path,
@@ -240,6 +392,17 @@ def test_upgrade_runtime_refreshes_repo_reinstalls_and_checks_when_update_is_ava
         upgrade_service,
         "run_upgrade_check",
         lambda **kwargs: (steps.append("check") or subprocess.CompletedProcess(args=["check"], returncode=0, stdout="", stderr="")),
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_installed_status",
+        lambda repo_root_arg, target_root_arg, host_id, **kwargs: {
+            "installed_version": "3.0.1",
+            "installed_commit": "new",
+            "remote_latest_version": "3.0.1",
+            "remote_latest_commit": "new",
+            "update_available": False,
+        },
     )
 
     result = upgrade_service.upgrade_runtime(
@@ -274,8 +437,8 @@ def test_upgrade_runtime_forces_fresh_upstream_refresh_before_deciding_update(
     monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
     monkeypatch.setattr(
         upgrade_service,
-        "refresh_installed_status",
-        lambda repo_root_arg, target_root_arg, host_id, **kwargs: {
+        "load_recorded_install_status",
+        lambda repo_root_arg, target_root_arg, host_id: {
             "installed_version": "3.0.0",
             "installed_commit": "local",
             "remote_latest_version": "3.0.1",
@@ -284,6 +447,7 @@ def test_upgrade_runtime_forces_fresh_upstream_refresh_before_deciding_update(
             "update_available": True,
         },
     )
+    monkeypatch.setattr(upgrade_service, "has_recorded_install_truth", lambda status: True)
 
     recorded: dict[str, object] = {}
 
@@ -532,9 +696,10 @@ def test_upgrade_runtime_propagates_refresh_failures(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
     monkeypatch.setattr(
         upgrade_service,
-        "refresh_installed_status",
-        lambda repo_root_arg, target_root_arg, host_id, **kwargs: {"installed_version": "3.0.0", "installed_commit": "old"},
+        "load_recorded_install_status",
+        lambda repo_root_arg, target_root_arg, host_id: {"installed_version": "3.0.0", "installed_commit": "old"},
     )
+    monkeypatch.setattr(upgrade_service, "has_recorded_install_truth", lambda status: True)
     monkeypatch.setattr(
         upgrade_service,
         "refresh_upstream_status",
@@ -563,19 +728,17 @@ def test_upgrade_runtime_propagates_check_failures(monkeypatch: pytest.MonkeyPat
     repo_root.mkdir()
     target_root = tmp_path / "target"
     target_root.mkdir()
-    statuses = iter(
-        [
-            {"installed_version": "3.0.0", "installed_commit": "old", "repo_default_branch": "main"},
-            {"installed_version": "3.0.1", "installed_commit": "new"},
-        ]
-    )
-
     monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: repo_root)
     monkeypatch.setattr(
         upgrade_service,
-        "refresh_installed_status",
-        lambda repo_root_arg, target_root_arg, host_id, **kwargs: next(statuses),
+        "load_recorded_install_status",
+        lambda repo_root_arg, target_root_arg, host_id: {
+            "installed_version": "3.0.0",
+            "installed_commit": "old",
+            "repo_default_branch": "main",
+        },
     )
+    monkeypatch.setattr(upgrade_service, "has_recorded_install_truth", lambda status: True)
     monkeypatch.setattr(
         upgrade_service,
         "refresh_upstream_status",


### PR DESCRIPTION
## Summary
- make upgrade preflight read installed truth from `target_root` instead of treating the source checkout as the install state
- prevent fresh GitHub clones passed as `--repo-root` from falsely no-oping as `already current`
- align `version_reminder` with the same target-root truth source and stay quiet when install truth is missing

## Testing
- `pytest -q tests/unit/test_vgo_cli_upgrade_service.py`
- `pytest -q tests/runtime_neutral/test_vibe_upgrade_reminder.py -k 'not powershell_upgrade_reminder_uses_python_command_spec'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Upgrade checks now rely on recorded installation history rather than freshly recomputing installed state.
  * Version reminder notifications are suppressed unless a recorded install truth (recorded version and commit) exists.
  * Upgrade runtime honors recorded install truth when deciding whether an update is available, reducing false "already current" exits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->