### PR TITLE
Fix empty /vibe-upgrade requests in canonical entry

### DIFF
--- a/bundled/skills/vibe-upgrade/SKILL.md
+++ b/bundled/skills/vibe-upgrade/SKILL.md
@@ -26,5 +26,7 @@ When this wrapper is chosen, bias canonical `vibe` toward:
 - overwrite-style upgrade for the selected supported host
 - post-upgrade verification and concise before/after reporting
 
+If invoked with no arguments, default the request to upgrading the current host installation through shared `vgo-cli upgrade` and verifying the result.
+
 Request:
 $ARGUMENTS

--- a/packages/installer-core/src/vgo_installer/discoverable_wrappers.py
+++ b/packages/installer-core/src/vgo_installer/discoverable_wrappers.py
@@ -67,6 +67,11 @@ def _body_lines(host_id: str, entry: DiscoverableEntry, *, contract: dict[str, o
         "proof_required": bool(contract.get("proof_required", True)),
     }
     trampoline_json = json.dumps(trampoline_payload, ensure_ascii=False, indent=2)
+    empty_request_line = (
+        "If the request is empty, default to upgrading the current host installation through shared `vgo-cli upgrade` and verify the result."
+        if entry.id == "vibe-upgrade"
+        else None
+    )
     return [
         "Canonical runtime trampoline contract (installer-managed wrapper):",
         "```json",
@@ -79,6 +84,7 @@ def _body_lines(host_id: str, entry: DiscoverableEntry, *, contract: dict[str, o
         bounded_warning,
         "Dispatch through canonical-entry runtime bridge. Do not treat this file as ordinary SKILL.md prose.",
         "If canonical runtime cannot be launched, report blocked instead of silently falling back.",
+        *([empty_request_line] if empty_request_line else []),
         "",
         "Request:",
         "$ARGUMENTS",

--- a/packages/runtime-core/src/vgo_runtime/canonical_entry.py
+++ b/packages/runtime-core/src/vgo_runtime/canonical_entry.py
@@ -89,6 +89,20 @@ def _normalize_requested_entry_id(entry_id: str | None) -> str:
     return requested_entry_id
 
 
+def _resolve_effective_prompt(*, host_id: str, entry_id: str, prompt: str) -> str:
+    prompt_text = str(prompt or "")
+    if prompt_text.strip():
+        return prompt_text
+    if entry_id != "vibe-upgrade":
+        return prompt_text
+    resolved_host_id = str(host_id or "").strip() or "current-host"
+    return (
+        f"Upgrade the local Vibe-Skills installation for host {resolved_host_id} "
+        "using the shared vgo-cli upgrade flow against the official default branch. "
+        "Reinstall the supported host surface, verify the result, and report concise before-and-after status."
+    )
+
+
 def _new_run_id() -> str:
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     suffix = os.urandom(4).hex()
@@ -322,6 +336,7 @@ def launch_canonical_vibe(
 ) -> CanonicalLaunchResult:
     repo_root_path = Path(repo_root).resolve()
     requested_entry_id = _normalize_requested_entry_id(entry_id)
+    effective_prompt = _resolve_effective_prompt(host_id=host_id, entry_id=requested_entry_id, prompt=prompt)
     contract = resolve_canonical_vibe_contract(repo_root_path, host_id)
     if str(contract.get("fallback_policy") or "").strip() != "blocked":
         raise RuntimeError("unsupported fallback policy for canonical entry launcher")
@@ -350,7 +365,7 @@ def launch_canonical_vibe(
             repo_root=repo_root_path,
             host_id=host_id,
             entry_id=requested_entry_id,
-            prompt=prompt,
+            prompt=effective_prompt,
             requested_stage_stop=requested_stage_stop,
             requested_grade_floor=requested_grade_floor,
             run_id=resolved_run_id,

--- a/tests/unit/test_canonical_vibe_entry_launcher.py
+++ b/tests/unit/test_canonical_vibe_entry_launcher.py
@@ -166,6 +166,48 @@ def test_canonical_entry_prewrites_launched_receipt_before_runtime_invocation(
     assert receipt["launch_status"] == "verified"
 
 
+def test_canonical_entry_synthesizes_default_prompt_for_empty_vibe_upgrade_request(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_id = "pytest-canonical-entry-upgrade-default-prompt"
+    session_root = tmp_path / "outputs" / "runtime" / "vibe-sessions" / run_id
+
+    monkeypatch.setattr(
+        canonical_entry,
+        "resolve_canonical_vibe_contract",
+        lambda repo_root, host_id: {"fallback_policy": "blocked", "allow_skill_doc_fallback": False},
+    )
+
+    def fake_invoke_runtime(**kwargs: object) -> dict[str, object]:
+        prompt = str(kwargs["prompt"])
+        assert "Upgrade the local Vibe-Skills installation" in prompt
+        assert "host codex" in prompt
+        assert "shared vgo-cli upgrade flow" in prompt
+        _write_valid_truth_artifacts(session_root, entry_intent_id="vibe-upgrade")
+        return {
+            "run_id": run_id,
+            "session_root": str(session_root),
+            "summary_path": str(session_root / "runtime-summary.json"),
+            "summary": {"run_id": run_id},
+        }
+
+    monkeypatch.setattr(canonical_entry, "invoke_vibe_runtime_entrypoint", fake_invoke_runtime)
+
+    result = canonical_entry.launch_canonical_vibe(
+        repo_root=tmp_path,
+        host_id="codex",
+        entry_id="vibe-upgrade",
+        prompt="   ",
+        requested_stage_stop="phase_cleanup",
+        run_id=run_id,
+        artifact_root=tmp_path,
+    )
+
+    receipt = json.loads(result.host_launch_receipt_path.read_text(encoding="utf-8"))
+    assert receipt["launch_status"] == "verified"
+
+
 def test_canonical_entry_marks_receipt_failed_when_runtime_invocation_raises(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/test_discoverable_wrappers.py
+++ b/tests/unit/test_discoverable_wrappers.py
@@ -41,6 +41,7 @@ def test_build_wrapper_descriptors_renders_all_discoverable_entries_for_codex() 
     assert 'Default stop target: `xl_plan`' in rendered['vibe-how'].content
     assert 'Default stop target: `requirement_doc`' in rendered['vibe-want'].content
     assert 'Public grade flags allowed: no' in rendered['vibe-upgrade'].content
+    assert 'If the request is empty, default to upgrading the current host installation through shared `vgo-cli upgrade` and verify the result.' in rendered['vibe-upgrade'].content
 
 
 def test_build_wrapper_descriptors_renders_skill_wrappers_for_skill_only_hosts() -> None:
@@ -66,6 +67,7 @@ def test_build_wrapper_descriptors_renders_skill_wrappers_for_skill_only_hosts()
     assert 'Use the `vibe` skill' not in rendered['vibe-how'].content
     assert 'Default stop target: `xl_plan`' in rendered['vibe-how'].content
     assert '$ARGUMENTS' in rendered['vibe-how'].content
+    assert 'If the request is empty, default to upgrading the current host installation through shared `vgo-cli upgrade` and verify the result.' in rendered['vibe-upgrade'].content
 
 
 def test_build_wrapper_descriptors_fails_closed_when_canonical_contract_is_unresolved(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- synthesize a default upgrade intent when `vibe-upgrade` is invoked with an empty request
- make generated host wrappers and the bundled `vibe-upgrade` skill explicitly document the no-argument default behavior
- add regression tests covering canonical entry prompt synthesis and wrapper rendering

## Problem
Calling `/vibe-upgrade` with no arguments entered canonical `vibe` with an empty prompt. The runtime then treated it as a missing request and asked the user what should be upgraded, instead of executing the shared upgrade flow for the current host.

## Verification
- `python3 -m pytest tests/unit/test_canonical_vibe_entry_launcher.py tests/unit/test_discoverable_wrappers.py tests/unit/test_vgo_cli_commands.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The vibe-upgrade skill now defaults to upgrading the current host installation when invoked with an empty request, executing the shared upgrade flow and verifying the result.

* **Documentation**
  * Updated vibe-upgrade skill documentation to clarify default behavior for empty requests.

* **Tests**
  * Added and updated tests to verify synthesized prompt behavior and wrapper instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->