### PR TITLE
release: v3.0.4

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -381,7 +381,7 @@ The governed runtime should leave behind:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 3.0.3
-- Updated: 2026-04-15
+- Version: 3.0.4
+- Updated: 2026-04-18
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/config/version-governance.json
+++ b/config/version-governance.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
   "release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15",
+    "version": "3.0.4",
+    "updated": "2026-04-18",
     "channel": "stable",
-    "notes": "host-global bootstrap lifecycle / specialist decision truth / upgrade metadata hardening / installed runtime payload coverage repair"
+    "notes": "direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair"
   },
   "source_of_truth": {
     "canonical_root": ".",

--- a/config/wave40-63-execution-board.json
+++ b/config/wave40-63-execution-board.json
@@ -180,7 +180,7 @@
       "status": "completed",
       "required_assets": [
         "references/eval-replay-ledger-contract.md",
-        "outputs/telemetry"
+        "scripts/verify/vibe-observability-gate.ps1"
       ],
       "verify_gate": "vibe-adaptive-routing-readiness-gate"
     },

--- a/dist/core/manifest.json
+++ b/dist/core/manifest.json
@@ -4,8 +4,8 @@
   "lane_kind": "universal-core",
   "stability": "preview",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "summary": "Universal contracts only. No install/check runtime closure is promised by this lane.",
   "runtime_ownership": {

--- a/dist/host-claude-code/manifest.json
+++ b/dist/host-claude-code/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "claude-code",
   "stability": "supported-with-constraints",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "summary": "Claude Code host adapter lane with bounded managed closure. The repo can write and verify a managed Claude settings surface, while still keeping broader host behavior outside repo ownership.",
   "runtime_ownership": {

--- a/dist/host-codex/manifest.json
+++ b/dist/host-codex/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "codex",
   "stability": "supported-with-constraints",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "summary": "Codex host adapter lane. Uses the official runtime entrypoints, but remains honest about host-managed plugin and credential surfaces.",
   "runtime_ownership": {

--- a/dist/host-cursor/manifest.json
+++ b/dist/host-cursor/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "cursor",
   "stability": "preview",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "summary": "Cursor host adapter preview. The repository can expose runtime-core payload and preview health checks, but does not claim full governed closure yet.",
   "runtime_ownership": {

--- a/dist/host-openclaw/manifest.json
+++ b/dist/host-openclaw/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "openclaw",
   "stability": "preview",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "summary": "OpenClaw host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/host-opencode/manifest.json
+++ b/dist/host-opencode/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "opencode",
   "stability": "preview",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "summary": "OpenCode host adapter preview. The repo can install runtime-core plus OpenCode-native command and agent wrapper payload into OpenCode roots, but final host config and platform closure remain incomplete.",
   "runtime_ownership": {

--- a/dist/host-windsurf/manifest.json
+++ b/dist/host-windsurf/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "windsurf",
   "stability": "preview",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "summary": "Windsurf host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/manifests/vibeskills-claude-code.json
+++ b/dist/manifests/vibeskills-claude-code.json
@@ -48,8 +48,8 @@
   },
   "summary": "Claude Code now has a bounded managed install/check lane that writes and verifies a Claude settings surface, but it still does not become the Codex official runtime or full platform-parity lane.",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-codex.json
+++ b/dist/manifests/vibeskills-codex.json
@@ -53,8 +53,8 @@
   },
   "summary": "Codex is the current strongest practical reference lane for the governed runtime payload, but some key surfaces remain host-managed and certain platforms are degraded.",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-core.json
+++ b/dist/manifests/vibeskills-core.json
@@ -46,8 +46,8 @@
   },
   "summary": "Host-agnostic contracts and schemas that stabilize skill metadata without claiming a governed runtime on any host.",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "truth_sources": [
     "docs/universalization/core-contract.md",

--- a/dist/manifests/vibeskills-cursor.json
+++ b/dist/manifests/vibeskills-cursor.json
@@ -50,8 +50,8 @@
   },
   "summary": "Cursor exposes preview adapter entrypoints and truthful readiness boundaries, but this repository does not claim governed or host-native closure for it.",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-generic.json
+++ b/dist/manifests/vibeskills-generic.json
@@ -45,8 +45,8 @@
   },
   "summary": "Generic hosts may consume canonical contracts and a repo-provided runtime-core payload in a neutral target root, but the repository still makes no host closure claim.",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-openclaw.json
+++ b/dist/manifests/vibeskills-openclaw.json
@@ -50,8 +50,8 @@
   },
   "summary": "OpenClaw may consume the shared runtime-core payload through a documented host root, but this repository does not claim host-native governed closure for it.",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-opencode.json
+++ b/dist/manifests/vibeskills-opencode.json
@@ -53,8 +53,8 @@
   },
   "summary": "OpenCode now has a truthful preview adapter lane with bounded install/check entrypoints, skills payload, and wrapper scaffolds, but the repository still avoids claiming full host closure or platform parity.",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-windsurf.json
+++ b/dist/manifests/vibeskills-windsurf.json
@@ -50,8 +50,8 @@
   },
   "summary": "Windsurf may consume the shared runtime-core payload through a documented host root, but this repository does not claim host-native governed closure for it.",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/official-runtime/manifest.json
+++ b/dist/official-runtime/manifest.json
@@ -4,8 +4,8 @@
   "lane_kind": "tier-1-official-runtime",
   "stability": "tier-1",
   "source_release": {
-    "version": "3.0.3",
-    "updated": "2026-04-15"
+    "version": "3.0.4",
+    "updated": "2026-04-18"
   },
   "summary": "Reference lane for the current governed official runtime. This dist pack points to it and must not rewrite it.",
   "runtime_ownership": {

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -10,7 +10,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ### Current Release Surface
 
-- [`v3.0.3.md`](v3.0.3.md): host-global bootstrap lifecycle / specialist decision truth / upgrade metadata hardening / installed runtime payload coverage repair
+- [`v3.0.4.md`](v3.0.4.md): direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair
 
 ### Release Runtime / Proof Handoff
 
@@ -24,6 +24,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ## Recent Governed Releases
 
+- [`v3.0.4.md`](v3.0.4.md) - 2026-04-18 - direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair
 - [`v3.0.3.md`](v3.0.3.md) - 2026-04-15 - host-global bootstrap lifecycle / specialist decision truth / upgrade metadata hardening / installed runtime payload coverage repair
 - [`v3.0.2.md`](v3.0.2.md) - 2026-04-13 - mainline upgrade flow / workspace memory plane / document artifact governance / specialist lifecycle disclosure / release truth refresh
 - [`v3.0.0.md`](v3.0.0.md) - 2026-04-07 - major public baseline / architecture closure / host-safe install-uninstall / governed execution proof / native MCP-first readiness

--- a/docs/releases/v3.0.4.md
+++ b/docs/releases/v3.0.4.md
@@ -1,0 +1,49 @@
+# VCO Release v3.0.4
+
+- Date: 2026-04-18
+- Commit(base): c0618d0
+- Previous public release: `v3.0.3`
+- Previous public release commit: `48743c5`
+
+## Highlights
+
+- Promoted the latest maintained `main` state after `v3.0.3` instead of leaving the direct-routing and canonical-entry hardening work stranded behind the public line. This cut packages the current maintained source at `c0618d0`.
+- Replaced the odd "open a Codex child session to ask a specialist" behavior with direct in-session specialist routing. The governed runtime now routes specialists to the current session by default, keeps the accounting and proof surfaces explicit, and preserves reviewable fallback truth instead of hiding specialist decisions behind extra host-specific conversation launches.
+- Hardened canonical `vibe` entry truth end to end. Runtime packet coverage, host launch receipts, launch-failure receipt state, and canonical truth-artifact checks now line up more tightly with what the governed runtime actually emits.
+- Repaired a release-train contradiction around adaptive-routing evidence. The adaptive readiness gate now self-seeds route telemetry through the observability gate when a clean checkout has no prior `outputs/telemetry` evidence, so governed release cuts no longer depend on forbidden tracked outputs or a manually primed working tree.
+- Tightened upgrade correctness around installed-target truth and request defaults. Target-root upgrade checks now read the right truth source, specialist snapshot-ignore handling no longer misclassifies consultation state, and empty `/vibe-upgrade` invocations now default to the shared upgrade path for the current host instead of stopping to ask the user what should be upgraded.
+
+## What Changed Since v3.0.3
+
+- `v3.0.3` moved the public line forward to the then-latest maintained source at `537db3f`, focusing on host-global bootstrap lifecycle, specialist decision truth, upgrade metadata hardening, and installed-runtime payload completeness.
+- `v3.0.4` continues that `3.0.x` line with the next maintained source after the `v3.0.3` cut:
+  - PR `#170` hardened canonical `vibe` runtime entry behavior and proof expectations.
+  - PR `#171` restored canonical entry runtime payload coverage so the shipped runtime carries the files the governed entry actually depends on.
+  - PR `#172` repaired native specialist Codex home seeding and sidecar cleanup so direct specialist execution could stabilize without host-specific bootstrapping regressions.
+  - PR `#174` moved specialist routing to the current session by default, followed by review fixes around accounting, recommendation-phase matching, and degraded consultation proof.
+  - PR `#175` fixed host-launch receipt lifecycle so launch failures mark the receipt as failed instead of leaving a misleading launched-only state behind.
+  - PR `#176` corrected target-install upgrade truth so upgrade verification reads the selected target root instead of drifting back to the wrong source.
+  - PR `#177` fixed specialist consultation snapshot-ignore handling for issue `#173`, closing a runtime truth bug around consultation artifacts.
+  - PR `#178` fixed empty `/vibe-upgrade` requests so they resolve to the shared upgrade intent for the current host instead of degenerating into an empty governed request.
+- The release cut itself also closes a stop-ship gap that existed on latest `main`: adaptive-routing readiness no longer assumes pre-tracked telemetry under `outputs/telemetry`, and instead generates bounded replay evidence through the governed observability path during verification.
+- The practical result is a more believable governed runtime surface: specialists route directly, canonical entry proof is stricter and more honest, release gating is reproducible from a clean checkout, and upgrade behavior is less likely to ask the user unnecessary clarifying questions when the intended action is already obvious.
+
+## Release Positioning
+
+- This is a `3.0.x` continuation release, not a new major baseline.
+- The release is centered on behavior correctness and runtime truth rather than on opening a brand-new product lane. It closes gaps that were especially visible in real use: specialist routing semantics, canonical launch proof lifecycle, target-root upgrade verification, and empty upgrade invocation behavior.
+- As with `v3.0.3`, package metadata remains on the repository's current `3.0.0` package line. The meaningful public version signal for this cut is the governed release surface at `v3.0.4`.
+
+## Validation Notes
+
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/governance/release-cut.ps1 -Version 3.0.4 -Updated 2026-04-18 -Preview -RunGates` -> preview succeeded.
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/governance/release-cut.ps1 -Version 3.0.4 -Updated 2026-04-18 -RunGates` -> release cut complete.
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/verify/vibe-adaptive-routing-readiness-gate.ps1 -WriteArtifacts` -> PASS from a clean state by auto-seeding replay telemetry through `vibe-observability-gate.ps1`.
+- `python3 -m pytest tests/integration/test_release_cut_gate_contract_cutover.py` -> `3 passed`.
+- `git diff --check` -> PASS.
+
+## Migration Notes
+
+- Operators upgrading from `v3.0.3` should expect direct in-session specialist routing to be the normal path. The governed runtime should no longer need a host-specific Codex child conversation just to route a specialist during ordinary execution.
+- If you rely on canonical-entry truth artifacts, this release is stricter about host-launch receipt lifecycle and runtime payload completeness. Failure states and proof expectations should now be easier to audit.
+- If you use `/vibe-upgrade` or similar host-visible upgrade wrappers, this is the first public cut where an empty invocation defaults cleanly to the shared current-host upgrade path instead of collapsing into an empty governed request.

--- a/references/changelog.md
+++ b/references/changelog.md
@@ -1,5 +1,12 @@
 # VCO Changelog
 
+## v3.0.4 (2026-04-18)
+
+- Moved specialist routing onto the current session by default, strengthened canonical-entry truth artifacts and launch-failure receipt handling, and repaired upgrade intent/truth handling across target installs and empty `/vibe-upgrade` invocations.
+- Removed a release-train stop-ship contradiction by letting adaptive-routing readiness self-seed replay telemetry through the governed observability path instead of assuming tracked `outputs/telemetry` evidence in a clean checkout.
+- Detailed release notes: `docs/releases/v3.0.4.md`.
+
+
 ## v3.0.3 (2026-04-15)
 
 - Added host-global bootstrap lifecycle support so supported instruction-file hosts can carry an install-safe, idempotent, and uninstall-safe managed `$vibe` / `/vibe` bootstrap block.

--- a/references/release-ledger.jsonl
+++ b/references/release-ledger.jsonl
@@ -31,3 +31,4 @@
 {"recorded_at":"2026-04-07T21:51:51","version":"3.0.0","updated":"2026-04-07","git_head":"9bea31e","actor":null}
 {"recorded_at":"2026-04-13T19:03:43","version":"3.0.2","updated":"2026-04-13","git_head":"c2f98b5","actor":null}
 {"recorded_at":"2026-04-15T23:01:43","version":"3.0.3","updated":"2026-04-15","git_head":"537db3f","actor":null}
+{"recorded_at":"2026-04-18T13:34:12","version":"3.0.4","updated":"2026-04-18","git_head":"c0618d0","actor":null}

--- a/scripts/verify/vibe-adaptive-routing-readiness-gate.ps1
+++ b/scripts/verify/vibe-adaptive-routing-readiness-gate.ps1
@@ -49,6 +49,38 @@ function Write-GateArtifacts {
     Write-VgoUtf8NoBomText -Path $mdPath -Content ($lines -join "`n")
 }
 
+function Get-RouteEventFiles {
+    param([string]$RepoRoot)
+
+    $telemetryDir = Join-Path $RepoRoot 'outputs\telemetry'
+    if (-not (Test-Path -LiteralPath $telemetryDir)) {
+        return @()
+    }
+
+    return @(Get-ChildItem -LiteralPath $telemetryDir -Filter 'route-events-*.jsonl' -File -ErrorAction SilentlyContinue)
+}
+
+function Ensure-RouteEventTelemetry {
+    param([string]$RepoRoot)
+
+    $existing = @(Get-RouteEventFiles -RepoRoot $RepoRoot)
+    if ($existing.Count -gt 0) {
+        return $existing
+    }
+
+    $observabilityGate = Join-Path $RepoRoot 'scripts\verify\vibe-observability-gate.ps1'
+    if (-not (Test-Path -LiteralPath $observabilityGate)) {
+        return @()
+    }
+
+    & $observabilityGate -TelemetryOutputRel 'outputs/telemetry' -KeepTelemetry
+    if ($LASTEXITCODE -ne 0) {
+        throw 'failed to seed route event telemetry via vibe-observability-gate.ps1'
+    }
+
+    return @(Get-RouteEventFiles -RepoRoot $RepoRoot)
+}
+
 $context = Get-VgoGovernanceContext -ScriptPath $PSCommandPath -EnforceExecutionContext
 $configPath = Join-Path $context.repoRoot 'config\adaptive-routing-eval-governance.json'
 $docPath = Join-Path $context.repoRoot 'docs\governance\adaptive-routing-eval-governance.md'
@@ -58,6 +90,7 @@ $requiredScripts = @(
     'scripts/verify/vibe-routing-stability-gate.ps1',
     'scripts/verify/vibe-pack-regression-matrix.ps1',
     'scripts/verify/vibe-keyword-precision-audit.ps1',
+    'scripts/verify/vibe-observability-gate.ps1',
     'scripts/verify/vibe-pilot-scenarios.ps1',
     'scripts/research/vibe-adaptive-train.ps1'
 )
@@ -74,8 +107,7 @@ if (-not (Test-Path -LiteralPath $configPath)) { exit 1 }
 
 $config = Get-Content -LiteralPath $configPath -Raw -Encoding UTF8 | ConvertFrom-Json
 $allowedStages = @('off', 'shadow_ready', 'soft_candidate', 'strict_candidate')
-$telemetryDir = Join-Path $context.repoRoot 'outputs\telemetry'
-$routeEvents = if (Test-Path -LiteralPath $telemetryDir) { @(Get-ChildItem -LiteralPath $telemetryDir -Filter 'route-events-*.jsonl' -File -ErrorAction SilentlyContinue) } else { @() }
+$routeEvents = @(Ensure-RouteEventTelemetry -RepoRoot $context.repoRoot)
 $routeEventCount = @($routeEvents).Count
 
 Add-Assertion -Assertions $assertions -Pass ($allowedStages -contains [string]$config.stage) -Message 'adaptive routing stage is in allowed readiness set' -Details $config.stage

--- a/scripts/verify/vibe-observability-gate.ps1
+++ b/scripts/verify/vibe-observability-gate.ps1
@@ -1,4 +1,7 @@
-param()
+param(
+    [string]$TelemetryOutputRel = '',
+    [switch]$KeepTelemetry
+)
 
 $ErrorActionPreference = "Stop"
 
@@ -32,7 +35,7 @@ function Invoke-Route {
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 $policyPath = Join-Path $repoRoot "config\observability-policy.json"
-$tmpRel = "outputs/verify/tmp-telemetry"
+$tmpRel = if ([string]::IsNullOrWhiteSpace($TelemetryOutputRel)) { "outputs/verify/tmp-telemetry" } else { $TelemetryOutputRel }
 $tmpDir = Join-Path $repoRoot $tmpRel
 $originalRaw = Get-Content -LiteralPath $policyPath -Raw -Encoding UTF8
 $results = @()
@@ -82,23 +85,23 @@ try {
     $results += Assert-True -Condition ($events.Count -ge 3) -Message "telemetry event count >= routed samples"
 
     if ($events.Count -gt 0) {
-        $results += Assert-True -Condition (($events | Where-Object { -not $_.prompt_hash }).Count -eq 0) -Message "events include prompt_hash"
-        $results += Assert-True -Condition (($events | Where-Object { $_.prompt_excerpt }).Count -eq 0) -Message "raw prompt excerpt is disabled"
-        $results += Assert-True -Condition (($events | Where-Object { -not $_.environment_profile_id }).Count -eq 0) -Message "events include environment_profile_id"
-        $results += Assert-True -Condition (($events | Where-Object { -not $_.user_profile_id }).Count -eq 0) -Message "events include user_profile_id"
-        $results += Assert-True -Condition (($events | Where-Object { -not $_.scenario_key }).Count -eq 0) -Message "events include scenario_key"
-        $results += Assert-True -Condition (($events | Where-Object { -not $_.route.route_mode }).Count -eq 0) -Message "events include route core fields"
+        $results += Assert-True -Condition (@($events | Where-Object { -not $_.prompt_hash }).Count -eq 0) -Message "events include prompt_hash"
+        $results += Assert-True -Condition (@($events | Where-Object { $_.prompt_excerpt }).Count -eq 0) -Message "raw prompt excerpt is disabled"
+        $results += Assert-True -Condition (@($events | Where-Object { -not $_.environment_profile_id }).Count -eq 0) -Message "events include environment_profile_id"
+        $results += Assert-True -Condition (@($events | Where-Object { -not $_.user_profile_id }).Count -eq 0) -Message "events include user_profile_id"
+        $results += Assert-True -Condition (@($events | Where-Object { -not $_.scenario_key }).Count -eq 0) -Message "events include scenario_key"
+        $results += Assert-True -Condition (@($events | Where-Object { -not $_.route.route_mode }).Count -eq 0) -Message "events include route core fields"
     }
 } finally {
     Set-Content -LiteralPath $policyPath -Value $originalRaw -Encoding UTF8
-    if (Test-Path -LiteralPath $tmpDir) {
+    if (-not $KeepTelemetry -and (Test-Path -LiteralPath $tmpDir)) {
         Remove-Item -LiteralPath $tmpDir -Recurse -Force
     }
     Write-Host "Restored observability policy to original content."
 }
 
-$passCount = ($results | Where-Object { $_ }).Count
-$failCount = ($results | Where-Object { -not $_ }).Count
+$passCount = @($results | Where-Object { $_ }).Count
+$failCount = @($results | Where-Object { -not $_ }).Count
 $total = $results.Count
 
 Write-Host ""

--- a/tests/integration/test_release_cut_gate_contract_cutover.py
+++ b/tests/integration/test_release_cut_gate_contract_cutover.py
@@ -38,3 +38,20 @@ def test_release_closure_gates_consume_contract_backed_apply_inventory() -> None
     assert "Get-VgoOperatorPreviewStringListProperty -RepoRoot $repoRoot -OperatorId 'release-cut' -PropertyName 'apply_gates'" in wave64_gate
     assert "Get-VgoOperatorPreviewStringListProperty -RepoRoot $repoRoot -OperatorId 'release-cut' -PropertyName 'apply_gates'" in wave83_gate
     assert 'release-cut contract preserves wave63-to-wave64 gate boundary' in wave83_gate
+
+
+def test_adaptive_routing_readiness_gate_can_seed_telemetry_without_tracked_outputs() -> None:
+    adaptive_gate = (REPO_ROOT / 'scripts' / 'verify' / 'vibe-adaptive-routing-readiness-gate.ps1').read_text(encoding='utf-8')
+    observability_gate = (REPO_ROOT / 'scripts' / 'verify' / 'vibe-observability-gate.ps1').read_text(encoding='utf-8')
+    gitignore = (REPO_ROOT / '.gitignore').read_text(encoding='utf-8')
+    wave_board = json.loads((REPO_ROOT / 'config' / 'wave40-63-execution-board.json').read_text(encoding='utf-8'))
+    wave54 = next(item for item in wave_board['waves'] if item['wave'] == 54)
+
+    assert 'Ensure-RouteEventTelemetry' in adaptive_gate
+    assert "vibe-observability-gate.ps1" in adaptive_gate
+    assert "outputs/telemetry" in adaptive_gate
+    assert '[string]$TelemetryOutputRel = \'\'' in observability_gate
+    assert '[switch]$KeepTelemetry' in observability_gate
+    assert '**/telemetry/' in gitignore
+    assert 'outputs/telemetry' not in wave54['required_assets']
+    assert 'scripts/verify/vibe-observability-gate.ps1' in wave54['required_assets']


### PR DESCRIPTION
## Summary
- cut governed release `v3.0.4` from the latest `main` state
- publish the new release note, changelog entry, ledger row, and synced dist manifests
- fix release-train telemetry seeding so `release-cut` can pass from a clean checkout without relying on tracked `outputs/telemetry`

## Release highlights
- direct in-session specialist routing instead of odd Codex child-session routing
- stronger canonical-entry truth artifacts and launch-failure receipt handling
- correct target-root upgrade truth and empty `/vibe-upgrade` default behavior
- adaptive-routing readiness now seeds replay telemetry through the observability gate during governed verification

## Verification
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/governance/release-cut.ps1 -Version 3.0.4 -Updated 2026-04-18 -Preview -RunGates`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/governance/release-cut.ps1 -Version 3.0.4 -Updated 2026-04-18 -RunGates`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/verify/vibe-wave40-63-board-gate.ps1 -WriteArtifacts`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/verify/vibe-adaptive-routing-readiness-gate.ps1 -WriteArtifacts`
- `python3 -m pytest tests/integration/test_release_cut_gate_contract_cutover.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released v3.0.4 with enhanced routing behavior, improved canonical entry validation, and strengthened upgrade handling.
  * Adaptive routing now operates within the current session by default.
  * Automatic telemetry seeding for clean-checkout reproducibility.

* **Bug Fixes**
  * Corrected upgrade verification to use proper target truth source.
  * Fixed specialist snapshot-ignore state classification.
  * Improved empty upgrade request handling.

* **Documentation**
  * Added v3.0.4 release notes with migration guidance.
  * Updated changelog and release navigator.

* **Tests**
  * Added integration test for telemetry seeding validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->