### PR TITLE
Fix installed runtime verification and UI gating

### DIFF
--- a/config/execution-runtime-policy.json
+++ b/config/execution-runtime-policy.json
@@ -28,14 +28,20 @@
           "description": "Execute governed runtime proof units against repo-safe local commands.",
           "units": [
             {
-              "unit_id": "installed-runtime-freshness-gate",
-              "kind": "powershell_file",
+              "unit_id": "runtime-neutral-freshness-gate-tests",
+              "kind": "python_command",
               "parallelizable": true,
-              "write_scope": "scripts/verify",
-              "script_path": "scripts/verify/vibe-installed-runtime-freshness-gate.ps1",
+              "write_scope": "tests/runtime_neutral",
+              "command": "${VGO_PYTHON}",
               "arguments": [
-                "-TargetRoot",
-                "${TARGET_ROOT}"
+                "-m",
+                "unittest",
+                "discover",
+                "-s",
+                "tests/runtime_neutral",
+                "-p",
+                "test_freshness_gate.py",
+                "-v"
               ],
               "cwd": "${REPO_ROOT}",
               "timeout_seconds": 240,
@@ -43,15 +49,12 @@
               "expected_artifacts": []
             },
             {
-              "unit_id": "release-install-runtime-coherence-gate",
+              "unit_id": "version-consistency-gate",
               "kind": "powershell_file",
               "parallelizable": true,
               "write_scope": "scripts/verify",
-              "script_path": "scripts/verify/vibe-release-install-runtime-coherence-gate.ps1",
-              "arguments": [
-                "-TargetRoot",
-                "${TARGET_ROOT}"
-              ],
+              "script_path": "scripts/verify/vibe-version-consistency-gate.ps1",
+              "arguments": [],
               "cwd": "${REPO_ROOT}",
               "timeout_seconds": 240,
               "expected_exit_code": 0,

--- a/config/execution-runtime-policy.json
+++ b/config/execution-runtime-policy.json
@@ -28,20 +28,14 @@
           "description": "Execute governed runtime proof units against repo-safe local commands.",
           "units": [
             {
-              "unit_id": "runtime-neutral-freshness-gate-tests",
-              "kind": "python_command",
+              "unit_id": "installed-runtime-freshness-gate",
+              "kind": "powershell_file",
               "parallelizable": true,
-              "write_scope": "tests/runtime_neutral",
-              "command": "${VGO_PYTHON}",
+              "write_scope": "scripts/verify",
+              "script_path": "scripts/verify/vibe-installed-runtime-freshness-gate.ps1",
               "arguments": [
-                "-m",
-                "unittest",
-                "discover",
-                "-s",
-                "tests/runtime_neutral",
-                "-p",
-                "test_freshness_gate.py",
-                "-v"
+                "-TargetRoot",
+                "${TARGET_ROOT}"
               ],
               "cwd": "${REPO_ROOT}",
               "timeout_seconds": 240,
@@ -49,12 +43,15 @@
               "expected_artifacts": []
             },
             {
-              "unit_id": "version-consistency-gate",
+              "unit_id": "release-install-runtime-coherence-gate",
               "kind": "powershell_file",
               "parallelizable": true,
               "write_scope": "scripts/verify",
-              "script_path": "scripts/verify/vibe-version-consistency-gate.ps1",
-              "arguments": [],
+              "script_path": "scripts/verify/vibe-release-install-runtime-coherence-gate.ps1",
+              "arguments": [
+                "-TargetRoot",
+                "${TARGET_ROOT}"
+              ],
               "cwd": "${REPO_ROOT}",
               "timeout_seconds": 240,
               "expected_exit_code": 0,

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -794,6 +794,80 @@ function Resolve-VibeExecutionTargetRoot {
     return Resolve-VgoTargetRoot -HostId (Resolve-VgoHostId -HostId $env:VCO_HOST_ID)
 }
 
+function Test-VibeInstalledRuntimeExecutionContext {
+    param(
+        [Parameter(Mandatory)] [string]$RepoRoot,
+        [AllowEmptyString()] [string]$TargetRoot = ''
+    )
+
+    if ([string]::IsNullOrWhiteSpace($TargetRoot)) {
+        return $false
+    }
+
+    $installedSkillRoot = [System.IO.Path]::GetFullPath((Join-Path (Join-Path $TargetRoot 'skills') 'vibe'))
+    return (Test-VgoPathWithin -ParentPath $installedSkillRoot -ChildPath $RepoRoot)
+}
+
+function New-VibeInstalledRuntimeVerificationUnit {
+    param(
+        [Parameter(Mandatory)] [string]$UnitId,
+        [Parameter(Mandatory)] [string]$ScriptPath
+    )
+
+    return [pscustomobject]@{
+        unit_id = $UnitId
+        kind = 'powershell_file'
+        parallelizable = $true
+        write_scope = 'scripts/verify'
+        script_path = $ScriptPath
+        arguments = @('-TargetRoot', '${TARGET_ROOT}')
+        cwd = '${REPO_ROOT}'
+        timeout_seconds = 240
+        expected_exit_code = 0
+        expected_artifacts = @()
+    }
+}
+
+function Get-VibeEffectiveExecutionPolicy {
+    param(
+        [Parameter(Mandatory)] [object]$ExecutionPolicy,
+        [Parameter(Mandatory)] [string]$RepoRoot,
+        [AllowEmptyString()] [string]$TargetRoot = ''
+    )
+
+    if (-not (Test-VibeInstalledRuntimeExecutionContext -RepoRoot $RepoRoot -TargetRoot $TargetRoot)) {
+        return $ExecutionPolicy
+    }
+
+    $policyCopy = $ExecutionPolicy | ConvertTo-Json -Depth 100 | ConvertFrom-Json
+    foreach ($profileCandidate in @($policyCopy.profiles)) {
+        foreach ($wave in @($profileCandidate.waves)) {
+            $mappedUnits = foreach ($unit in @($wave.units)) {
+                switch ([string]$unit.unit_id) {
+                    'runtime-neutral-freshness-gate-tests' {
+                        New-VibeInstalledRuntimeVerificationUnit `
+                            -UnitId 'installed-runtime-freshness-gate' `
+                            -ScriptPath 'scripts/verify/vibe-installed-runtime-freshness-gate.ps1'
+                        continue
+                    }
+                    'version-consistency-gate' {
+                        New-VibeInstalledRuntimeVerificationUnit `
+                            -UnitId 'release-install-runtime-coherence-gate' `
+                            -ScriptPath 'scripts/verify/vibe-release-install-runtime-coherence-gate.ps1'
+                        continue
+                    }
+                    default {
+                        $unit
+                    }
+                }
+            }
+            $wave.units = @($mappedUnits)
+        }
+    }
+
+    return $policyCopy
+}
+
 $runtime = Get-VibeRuntimeContext -ScriptPath $PSCommandPath
 if ([string]::IsNullOrWhiteSpace($RunId)) {
     $RunId = New-VibeRunId
@@ -834,7 +908,11 @@ $hierarchyState = Get-VibeHierarchyState `
     -DelegationEnvelopePath $(if ($runtimeInputPacket -and $runtimeInputPacket.hierarchy) { [string]$runtimeInputPacket.hierarchy.delegation_envelope_path } else { '' }) `
     -HierarchyContract $runtime.runtime_input_packet_policy.hierarchy_contract
 
-$policy = $runtime.execution_runtime_policy
+$executionTargetRoot = Resolve-VibeExecutionTargetRoot -RuntimeInputPacket $runtimeInputPacket -Runtime $runtime
+$policy = Get-VibeEffectiveExecutionPolicy `
+    -ExecutionPolicy $runtime.execution_runtime_policy `
+    -RepoRoot ([System.IO.Path]::GetFullPath($runtime.repo_root)) `
+    -TargetRoot $executionTargetRoot
 $proofRegistry = $runtime.proof_class_registry
 $profile = Get-VibeExecutionProfileById -ExecutionPolicy $policy -ProfileId ([string]$policy.default_profile_id)
 
@@ -845,7 +923,6 @@ New-Item -ItemType Directory -Path $logsRoot -Force | Out-Null
 New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
 New-Item -ItemType Directory -Path $proofRoot -Force | Out-Null
 
-$executionTargetRoot = Resolve-VibeExecutionTargetRoot -RuntimeInputPacket $runtimeInputPacket -Runtime $runtime
 $tokens = @{
     '${REPO_ROOT}' = [System.IO.Path]::GetFullPath($runtime.repo_root)
     '${SESSION_ROOT}' = [System.IO.Path]::GetFullPath($sessionRoot)

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -729,6 +729,71 @@ function Get-VibePlanDerivedExecutionShadow {
     }
 }
 
+function Resolve-VibeExecutionTargetRoot {
+    param(
+        [AllowNull()] [object]$RuntimeInputPacket = $null,
+        [AllowNull()] [object]$Runtime = $null
+    )
+
+    $candidates = New-Object System.Collections.Generic.List[string]
+    if ($null -ne $RuntimeInputPacket) {
+        if (
+            (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket -PropertyName 'canonical_router') -and
+            $null -ne $RuntimeInputPacket.canonical_router -and
+            (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket.canonical_router -PropertyName 'target_root') -and
+            -not [string]::IsNullOrWhiteSpace([string]$RuntimeInputPacket.canonical_router.target_root)
+        ) {
+            [void]$candidates.Add([string]$RuntimeInputPacket.canonical_router.target_root)
+        }
+
+        if (
+            (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket -PropertyName 'host_adapter') -and
+            $null -ne $RuntimeInputPacket.host_adapter -and
+            (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket.host_adapter -PropertyName 'target_root') -and
+            -not [string]::IsNullOrWhiteSpace([string]$RuntimeInputPacket.host_adapter.target_root)
+        ) {
+            [void]$candidates.Add([string]$RuntimeInputPacket.host_adapter.target_root)
+        }
+
+        if (
+            (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket -PropertyName 'custom_admission') -and
+            $null -ne $RuntimeInputPacket.custom_admission -and
+            (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket.custom_admission -PropertyName 'target_root') -and
+            -not [string]::IsNullOrWhiteSpace([string]$RuntimeInputPacket.custom_admission.target_root)
+        ) {
+            [void]$candidates.Add([string]$RuntimeInputPacket.custom_admission.target_root)
+        }
+    }
+
+    if ($null -ne $Runtime) {
+        if (
+            (Test-VibeObjectHasProperty -InputObject $Runtime -PropertyName 'host_settings') -and
+            $null -ne $Runtime.host_settings -and
+            (Test-VibeObjectHasProperty -InputObject $Runtime.host_settings -PropertyName 'target_root') -and
+            -not [string]::IsNullOrWhiteSpace([string]$Runtime.host_settings.target_root)
+        ) {
+            [void]$candidates.Add([string]$Runtime.host_settings.target_root)
+        }
+
+        if (
+            (Test-VibeObjectHasProperty -InputObject $Runtime -PropertyName 'host_closure') -and
+            $null -ne $Runtime.host_closure -and
+            (Test-VibeObjectHasProperty -InputObject $Runtime.host_closure -PropertyName 'target_root') -and
+            -not [string]::IsNullOrWhiteSpace([string]$Runtime.host_closure.target_root)
+        ) {
+            [void]$candidates.Add([string]$Runtime.host_closure.target_root)
+        }
+    }
+
+    foreach ($candidate in @($candidates)) {
+        if (-not [string]::IsNullOrWhiteSpace([string]$candidate)) {
+            return [System.IO.Path]::GetFullPath([string]$candidate)
+        }
+    }
+
+    return Resolve-VgoTargetRoot -HostId (Resolve-VgoHostId -HostId $env:VCO_HOST_ID)
+}
+
 $runtime = Get-VibeRuntimeContext -ScriptPath $PSCommandPath
 if ([string]::IsNullOrWhiteSpace($RunId)) {
     $RunId = New-VibeRunId
@@ -780,11 +845,13 @@ New-Item -ItemType Directory -Path $logsRoot -Force | Out-Null
 New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
 New-Item -ItemType Directory -Path $proofRoot -Force | Out-Null
 
+$executionTargetRoot = Resolve-VibeExecutionTargetRoot -RuntimeInputPacket $runtimeInputPacket -Runtime $runtime
 $tokens = @{
     '${REPO_ROOT}' = [System.IO.Path]::GetFullPath($runtime.repo_root)
     '${SESSION_ROOT}' = [System.IO.Path]::GetFullPath($sessionRoot)
     '${REQUIREMENT_DOC}' = [System.IO.Path]::GetFullPath($requirementPath)
     '${EXECUTION_PLAN}' = [System.IO.Path]::GetFullPath($planPath)
+    '${TARGET_ROOT}' = [string]$executionTargetRoot
     '${RUN_ID}' = [string]$RunId
     '${ROOT_RUN_ID}' = [string]$hierarchyState.root_run_id
 }

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -23,11 +23,19 @@ $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'VibeConsultation.Common.ps1')
 . (Join-Path $PSScriptRoot '..\common\AntiProxyGoalDrift.ps1')
 
+function Get-VibeExplicitNonUiSignalRegex {
+    return 'non[- ]?ui|non[- ]?interactive|without ui|without user interface|headless|runtime[- ]?only|pure runtime|infrastructure( fix| repair| task| change)?|infra[- ]?(fix|repair|task|change)?|backend[- ]?only|cli[- ]?only|automation[- ]?only|非\s*ui|非交互|无界面|纯运行时|基础设施(修复|任务|改动)?|仅自动化|纯后端|命令行'
+}
+
 function Test-VibeTaskNeedsManualSpotChecks {
     param(
         [Parameter(Mandatory)] [string]$Task,
         [AllowEmptyString()] [string]$Deliverable = ''
     )
+
+    if (Test-VibeTaskNeedsDocumentArtifactBaseline -Task $Task -Deliverable $Deliverable) {
+        return $false
+    }
 
     if (-not (Test-VibeTaskHasUiArtifactSignals -Task $Task -Deliverable $Deliverable)) {
         return $false
@@ -56,7 +64,17 @@ function Test-VibeTaskHasExplicitNonUiSignals {
     )
 
     $text = Get-VibeTaskSignalText -Task $Task -Deliverable $Deliverable
-    return $text -match 'non[- ]?ui|non[- ]?interactive|without ui|without user interface|headless|runtime[- ]?only|pure runtime|infrastructure( fix| repair| task| change)?|infra[- ]?(fix|repair|task|change)?|backend[- ]?only|cli[- ]?only|automation[- ]?only|非\s*ui|非交互|无界面|纯运行时|基础设施(修复|任务|改动)?|仅自动化|纯后端|命令行'
+    return $text -match (Get-VibeExplicitNonUiSignalRegex)
+}
+
+function Get-VibeTaskSignalTextWithoutExplicitNonUiPhrases {
+    param(
+        [Parameter(Mandatory)] [string]$Task,
+        [AllowEmptyString()] [string]$Deliverable = ''
+    )
+
+    $text = Get-VibeTaskSignalText -Task $Task -Deliverable $Deliverable
+    return ($text -replace (Get-VibeExplicitNonUiSignalRegex), ' ')
 }
 
 function Test-VibeTaskHasUiArtifactSignals {
@@ -75,7 +93,7 @@ function Test-VibeTaskHasStrongInteractiveUiSignals {
         [AllowEmptyString()] [string]$Deliverable = ''
     )
 
-    $text = Get-VibeTaskSignalText -Task $Task -Deliverable $Deliverable
+    $text = Get-VibeTaskSignalTextWithoutExplicitNonUiPhrases -Task $Task -Deliverable $Deliverable
     return $text -match '(?<!non[-\s])\bui\b|(?<!non[-\s])\bux\b|frontend|page|screen|dashboard|dialog|modal|layout|responsive|user[- ]?facing|visual|interface|click|tap|form|navigation|用户|界面|交互|可视化|体验'
 }
 

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -29,8 +29,63 @@ function Test-VibeTaskNeedsManualSpotChecks {
         [AllowEmptyString()] [string]$Deliverable = ''
     )
 
-    $text = ('{0} {1}' -f $Task, $Deliverable).ToLowerInvariant()
-    return $text -match 'ui|ux|frontend|browser|page|screen|openclaw|cursor|windsurf|codex|用户|界面|交互|可视化|体验'
+    if (-not (Test-VibeTaskHasUiArtifactSignals -Task $Task -Deliverable $Deliverable)) {
+        return $false
+    }
+
+    if (-not (Test-VibeTaskHasExplicitNonUiSignals -Task $Task -Deliverable $Deliverable)) {
+        return $true
+    }
+
+    return (Test-VibeTaskHasStrongInteractiveUiSignals -Task $Task -Deliverable $Deliverable)
+}
+
+function Get-VibeTaskSignalText {
+    param(
+        [Parameter(Mandatory)] [string]$Task,
+        [AllowEmptyString()] [string]$Deliverable = ''
+    )
+
+    return ('{0} {1}' -f $Task, $Deliverable).ToLowerInvariant()
+}
+
+function Test-VibeTaskHasExplicitNonUiSignals {
+    param(
+        [Parameter(Mandatory)] [string]$Task,
+        [AllowEmptyString()] [string]$Deliverable = ''
+    )
+
+    $text = Get-VibeTaskSignalText -Task $Task -Deliverable $Deliverable
+    return $text -match 'non[- ]?ui|non[- ]?interactive|without ui|without user interface|headless|runtime[- ]?only|pure runtime|infrastructure( fix| repair| task| change)?|infra[- ]?(fix|repair|task|change)?|backend[- ]?only|cli[- ]?only|automation[- ]?only|非\s*ui|非交互|无界面|纯运行时|基础设施(修复|任务|改动)?|仅自动化|纯后端|命令行'
+}
+
+function Test-VibeTaskHasUiArtifactSignals {
+    param(
+        [Parameter(Mandatory)] [string]$Task,
+        [AllowEmptyString()] [string]$Deliverable = ''
+    )
+
+    $text = Get-VibeTaskSignalText -Task $Task -Deliverable $Deliverable
+    return $text -match '(?<!non[-\s])\bui\b|(?<!non[-\s])\bux\b|frontend|browser|page|screen|dashboard|dialog|modal|layout|responsive|user[- ]?facing|visual|interface|用户|界面|交互|可视化|体验'
+}
+
+function Test-VibeTaskHasStrongInteractiveUiSignals {
+    param(
+        [Parameter(Mandatory)] [string]$Task,
+        [AllowEmptyString()] [string]$Deliverable = ''
+    )
+
+    $text = Get-VibeTaskSignalText -Task $Task -Deliverable $Deliverable
+    return $text -match '(?<!non[-\s])\bui\b|(?<!non[-\s])\bux\b|frontend|page|screen|dashboard|dialog|modal|layout|responsive|user[- ]?facing|visual|interface|click|tap|form|navigation|用户|界面|交互|可视化|体验'
+}
+
+function Test-VibeTaskNeedsBaselineUiQualityDimensions {
+    param(
+        [Parameter(Mandatory)] [string]$Task,
+        [AllowEmptyString()] [string]$Deliverable = ''
+    )
+
+    return (Test-VibeTaskNeedsManualSpotChecks -Task $Task -Deliverable $Deliverable)
 }
 
 function Test-VibeTaskNeedsDocumentArtifactBaseline {
@@ -248,7 +303,7 @@ if (@($baselineDocumentQualityDimensions).Count -eq 0 -and (Test-VibeTaskNeedsDo
 if (@($artifactReviewRequirements).Count -eq 0 -and @($baselineDocumentQualityDimensions).Count -gt 0) {
     $artifactReviewRequirements = Get-VibeDefaultDocumentArtifactReviewRequirements
 }
-if (@($baselineUiQualityDimensions).Count -eq 0 -and (Test-VibeTaskNeedsManualSpotChecks -Task $Task -Deliverable ([string]$intentContract.deliverable))) {
+if (@($baselineUiQualityDimensions).Count -eq 0 -and (Test-VibeTaskNeedsBaselineUiQualityDimensions -Task $Task -Deliverable ([string]$intentContract.deliverable))) {
     $baselineUiQualityDimensions = Get-VibeDefaultBaselineUiQualityDimensions
 }
 $runtimeInputPath = if (-not [string]::IsNullOrWhiteSpace($RuntimeInputPacketPath)) {


### PR DESCRIPTION
## Summary
- replace stale governed verification units with installed-runtime freshness/coherence gates and pass `TARGET_ROOT`
- resolve execution `TARGET_ROOT` from runtime packet and host runtime context before plan execution dispatch
- tighten requirement-doc UI/manual-review heuristics so runtime or document tasks are not misclassified as UI work

## Notes
- this PR intentionally includes only source changes
- test file changes were kept out of the PR

## Scope
- `config/execution-runtime-policy.json`
- `scripts/runtime/Invoke-PlanExecute.ps1`
- `scripts/runtime/Write-RequirementDoc.ps1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced execution target root resolution to scan multiple configuration sources and determine the appropriate runtime context.
  * Improved runtime execution policy handling for installed runtime environments with dynamic verification unit mapping.
  * Refactored task analysis logic for requirement documentation generation, with more granular UI signal detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->