### PR TITLE
Fix Windows PowerShell JSON bridge decoding in runtime entrypoints

### DIFF
--- a/packages/runtime-core/src/vgo_runtime/canonical_entry.py
+++ b/packages/runtime-core/src/vgo_runtime/canonical_entry.py
@@ -7,7 +7,6 @@ import json
 import os
 from pathlib import Path
 import shutil
-import subprocess
 import sys
 from typing import Any
 
@@ -17,6 +16,7 @@ if str(CONTRACTS_SRC) not in sys.path:
 
 from vgo_contracts.canonical_vibe_contract import resolve_canonical_vibe_contract
 from vgo_contracts.host_launch_receipt import HostLaunchReceipt, write_host_launch_receipt
+from vgo_runtime.powershell_bridge import run_powershell_json_command
 from vgo_runtime.router import load_allowed_vibe_entry_ids
 
 RUNTIME_ENTRYPOINT_RELPATH = "scripts/runtime/invoke-vibe-runtime.ps1"
@@ -172,21 +172,12 @@ def invoke_vibe_runtime_entrypoint(
 
     env = dict(os.environ)
     env["VCO_HOST_ID"] = host_id
-    completed = subprocess.run(
+    return run_powershell_json_command(
         command,
         cwd=repo_root,
-        capture_output=True,
-        text=True,
-        check=True,
+        bridge_label="canonical entry bridge",
         env=env,
     )
-    try:
-        payload = json.loads(completed.stdout)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError("canonical entry bridge returned invalid JSON") from exc
-    if not isinstance(payload, dict):
-        raise RuntimeError("canonical entry bridge returned non-object payload")
-    return payload
 
 
 def assert_minimum_truth_artifacts(session_root: str | Path) -> dict[str, str]:

--- a/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
+++ b/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
@@ -41,18 +41,34 @@ def _preview_stream(value: bytes | str | None) -> str | None:
         elif value.startswith(b"\xfe\xff"):
             text = value.decode("utf-16-be", errors="replace")
         else:
-            preview_encodings = ["utf-8-sig", str(locale.getpreferredencoding(False) or "").strip(), "latin-1"]
-            text = ""
+            preview_encodings = ["utf-8-sig", str(locale.getpreferredencoding(False) or "").strip()]
+            text: str | None = None
             for encoding in preview_encodings:
                 normalized = encoding.strip()
                 if not normalized:
                     continue
                 try:
-                    text = value.decode(normalized, errors="replace")
-                except LookupError:
+                    candidate = value.decode(normalized)
+                except (LookupError, UnicodeDecodeError):
                     continue
+                if "\ufffd" in candidate or "\x00" in candidate:
+                    continue
+                text = candidate
                 break
-            if not text:
+            if text is None:
+                for encoding in preview_encodings:
+                    normalized = encoding.strip()
+                    if not normalized:
+                        continue
+                    try:
+                        candidate = value.decode(normalized, errors="replace")
+                    except LookupError:
+                        continue
+                    if "\ufffd" in candidate or "\x00" in candidate:
+                        continue
+                    text = candidate
+                    break
+            if text is None:
                 text = value.decode("latin-1", errors="replace")
         text = text.replace("\x00", "")
     else:

--- a/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
+++ b/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
@@ -12,10 +12,10 @@ def _preferred_bridge_encodings() -> tuple[str, ...]:
     candidates = [
         "utf-8-sig",
         "utf-8",
-        preferred,
         "utf-16",
         "utf-16-le",
         "utf-16-be",
+        preferred,
     ]
     ordered: list[str] = []
     seen: set[str] = set()
@@ -75,7 +75,7 @@ def _decode_json_object_stdout(
         raise RuntimeError(f"{bridge_label} returned empty stdout{detail}")
 
     decode_failures: list[str] = []
-    last_json_error: json.JSONDecodeError | None = None
+    last_json_error: tuple[str, json.JSONDecodeError] | None = None
     for encoding in _preferred_bridge_encodings():
         try:
             payload_text = stdout.decode(encoding)
@@ -87,7 +87,7 @@ def _decode_json_object_stdout(
         try:
             payload = json.loads(payload_text)
         except json.JSONDecodeError as exc:
-            last_json_error = exc
+            last_json_error = (encoding, exc)
             continue
         if not isinstance(payload, dict):
             raise RuntimeError(f"{bridge_label} returned non-object payload")
@@ -99,11 +99,13 @@ def _decode_json_object_stdout(
     stdout_preview = _preview_stream(stdout)
     if stdout_preview:
         detail_parts.append(f"stdout={stdout_preview}")
+    if last_json_error is not None:
+        detail_parts.append(f"decoded-as-{last_json_error[0]}")
     if stderr_preview:
         detail_parts.append(f"stderr={stderr_preview}")
     detail = f" ({'; '.join(detail_parts)})" if detail_parts else ""
     if last_json_error is not None:
-        raise RuntimeError(f"{bridge_label} returned invalid JSON stdout{detail}") from last_json_error
+        raise RuntimeError(f"{bridge_label} returned invalid JSON stdout{detail}") from last_json_error[1]
     raise RuntimeError(f"{bridge_label} returned undecodable JSON stdout{detail}")
 
 
@@ -118,9 +120,18 @@ def run_powershell_json_command(
         list(command),
         cwd=cwd,
         capture_output=True,
-        check=True,
+        check=False,
         env=dict(env) if env is not None else None,
     )
+    if completed.returncode != 0:
+        detail_parts = [f"exit={completed.returncode}"]
+        stdout_preview = _preview_stream(completed.stdout)
+        stderr_preview = _preview_stream(completed.stderr)
+        if stdout_preview:
+            detail_parts.append(f"stdout={stdout_preview}")
+        if stderr_preview:
+            detail_parts.append(f"stderr={stderr_preview}")
+        raise RuntimeError(f"{bridge_label} failed ({'; '.join(detail_parts)})")
     return _decode_json_object_stdout(
         completed.stdout,
         bridge_label=bridge_label,

--- a/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
+++ b/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+import locale
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+def _preferred_bridge_encodings() -> tuple[str, ...]:
+    preferred = str(locale.getpreferredencoding(False) or "").strip()
+    candidates = [
+        "utf-8-sig",
+        "utf-8",
+        preferred,
+        "utf-16",
+        "utf-16-le",
+        "utf-16-be",
+    ]
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        normalized = candidate.strip()
+        if not normalized:
+            continue
+        dedupe_key = normalized.casefold()
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        ordered.append(normalized)
+    return tuple(ordered)
+
+
+def _preview_stream(value: bytes | str | None) -> str | None:
+    if value in (None, b"", ""):
+        return None
+    if isinstance(value, bytes):
+        text = value.decode("utf-8", errors="replace")
+    else:
+        text = value
+    flattened = " ".join(text.split())
+    if not flattened:
+        return None
+    if len(flattened) > 160:
+        return flattened[:157] + "..."
+    return flattened
+
+
+def _decode_json_object_stdout(
+    stdout: bytes | str | None,
+    *,
+    bridge_label: str,
+    stderr: bytes | str | None = None,
+) -> dict[str, Any]:
+    stderr_preview = _preview_stream(stderr)
+    if stdout is None:
+        detail = f"; stderr={stderr_preview}" if stderr_preview else ""
+        raise RuntimeError(f"{bridge_label} returned no stdout{detail}")
+
+    if isinstance(stdout, str):
+        payload_text = stdout.strip()
+        if not payload_text:
+            detail = f"; stderr={stderr_preview}" if stderr_preview else ""
+            raise RuntimeError(f"{bridge_label} returned empty stdout{detail}")
+        try:
+            payload = json.loads(payload_text)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"{bridge_label} returned invalid JSON stdout") from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"{bridge_label} returned non-object payload")
+        return payload
+
+    if not stdout.strip():
+        detail = f"; stderr={stderr_preview}" if stderr_preview else ""
+        raise RuntimeError(f"{bridge_label} returned empty stdout{detail}")
+
+    decode_failures: list[str] = []
+    last_json_error: json.JSONDecodeError | None = None
+    for encoding in _preferred_bridge_encodings():
+        try:
+            payload_text = stdout.decode(encoding)
+        except UnicodeDecodeError:
+            decode_failures.append(encoding)
+            continue
+        if not payload_text.strip():
+            continue
+        try:
+            payload = json.loads(payload_text)
+        except json.JSONDecodeError as exc:
+            last_json_error = exc
+            continue
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"{bridge_label} returned non-object payload")
+        return payload
+
+    detail_parts: list[str] = []
+    if decode_failures:
+        detail_parts.append("decode failed for " + ", ".join(decode_failures))
+    stdout_preview = _preview_stream(stdout)
+    if stdout_preview:
+        detail_parts.append(f"stdout={stdout_preview}")
+    if stderr_preview:
+        detail_parts.append(f"stderr={stderr_preview}")
+    detail = f" ({'; '.join(detail_parts)})" if detail_parts else ""
+    if last_json_error is not None:
+        raise RuntimeError(f"{bridge_label} returned invalid JSON stdout{detail}") from last_json_error
+    raise RuntimeError(f"{bridge_label} returned undecodable JSON stdout{detail}")
+
+
+def run_powershell_json_command(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    bridge_label: str,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    completed = subprocess.run(
+        list(command),
+        cwd=cwd,
+        capture_output=True,
+        check=True,
+        env=dict(env) if env is not None else None,
+    )
+    return _decode_json_object_stdout(
+        completed.stdout,
+        bridge_label=bridge_label,
+        stderr=completed.stderr,
+    )

--- a/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
+++ b/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import json
 import locale
+import logging
 import os
 import subprocess
 from pathlib import Path
 from typing import Any, Mapping, Sequence
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _preferred_bridge_encodings() -> tuple[str, ...]:
@@ -90,6 +94,10 @@ def _resolve_bridge_timeout(timeout: float | None) -> float | None:
     try:
         resolved = float(raw)
     except ValueError:
+        LOGGER.warning(
+            "Invalid VGO_POWERSHELL_BRIDGE_TIMEOUT_SECONDS=%r; using default timeout 300.0s",
+            raw,
+        )
         return 300.0
     if resolved <= 0:
         return None
@@ -101,6 +109,27 @@ def _command_preview(command: Sequence[str]) -> str:
     if len(command) > 8:
         preview += " ..."
     return preview
+
+
+def _build_stream_detail(
+    *,
+    stdout: bytes | str | None,
+    stderr: bytes | str | None,
+    decoded_as: str | None = None,
+    extra_parts: Sequence[str] | None = None,
+) -> str:
+    detail_parts: list[str] = list(extra_parts or [])
+    stdout_preview = _preview_stream(stdout)
+    stderr_preview = _preview_stream(stderr)
+    if stdout_preview:
+        detail_parts.append(f"stdout={stdout_preview}")
+    if decoded_as:
+        detail_parts.append(f"decoded-as-{decoded_as}")
+    if stderr_preview:
+        detail_parts.append(f"stderr={stderr_preview}")
+    if not detail_parts:
+        return ""
+    return f" ({'; '.join(detail_parts)})"
 
 
 def _decode_json_object_stdout(
@@ -122,9 +151,11 @@ def _decode_json_object_stdout(
         try:
             payload = json.loads(payload_text)
         except json.JSONDecodeError as exc:
-            raise RuntimeError(f"{bridge_label} returned invalid JSON stdout") from exc
+            detail = _build_stream_detail(stdout=stdout, stderr=stderr)
+            raise RuntimeError(f"{bridge_label} returned invalid JSON stdout{detail}") from exc
         if not isinstance(payload, dict):
-            raise RuntimeError(f"{bridge_label} returned non-object payload")
+            detail = _build_stream_detail(stdout=stdout, stderr=stderr)
+            raise RuntimeError(f"{bridge_label} returned non-object payload{detail}")
         return payload
 
     if not stdout.strip():
@@ -133,6 +164,7 @@ def _decode_json_object_stdout(
 
     decode_failures: list[str] = []
     last_json_error: tuple[str, json.JSONDecodeError] | None = None
+    last_non_object: tuple[str, Any] | None = None
     for encoding in _preferred_bridge_encodings():
         try:
             payload_text = stdout.decode(encoding)
@@ -147,22 +179,28 @@ def _decode_json_object_stdout(
             last_json_error = (encoding, exc)
             continue
         if not isinstance(payload, dict):
-            raise RuntimeError(f"{bridge_label} returned non-object payload")
+            last_non_object = (encoding, payload)
+            continue
         return payload
 
-    detail_parts: list[str] = []
-    if decode_failures:
-        detail_parts.append("decode failed for " + ", ".join(decode_failures))
-    stdout_preview = _preview_stream(stdout)
-    if stdout_preview:
-        detail_parts.append(f"stdout={stdout_preview}")
+    extra_parts = ["decode failed for " + ", ".join(decode_failures)] if decode_failures else []
     if last_json_error is not None:
-        detail_parts.append(f"decoded-as-{last_json_error[0]}")
-    if stderr_preview:
-        detail_parts.append(f"stderr={stderr_preview}")
-    detail = f" ({'; '.join(detail_parts)})" if detail_parts else ""
-    if last_json_error is not None:
+        detail = _build_stream_detail(
+            stdout=stdout,
+            stderr=stderr,
+            decoded_as=last_json_error[0],
+            extra_parts=extra_parts,
+        )
         raise RuntimeError(f"{bridge_label} returned invalid JSON stdout{detail}") from last_json_error[1]
+    if last_non_object is not None:
+        detail = _build_stream_detail(
+            stdout=stdout,
+            stderr=stderr,
+            decoded_as=last_non_object[0],
+            extra_parts=extra_parts,
+        )
+        raise RuntimeError(f"{bridge_label} returned non-object payload{detail}")
+    detail = _build_stream_detail(stdout=stdout, stderr=stderr, extra_parts=extra_parts)
     raise RuntimeError(f"{bridge_label} returned undecodable JSON stdout{detail}")
 
 

--- a/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
+++ b/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
@@ -10,6 +10,14 @@ from typing import Any, Mapping, Sequence
 
 
 LOGGER = logging.getLogger(__name__)
+SENSITIVE_COMMAND_FLAGS = frozenset(
+    {
+        "-task",
+        "-prompt",
+        "--task",
+        "--prompt",
+    }
+)
 
 
 def _preferred_bridge_encodings() -> tuple[str, ...]:
@@ -105,10 +113,39 @@ def _resolve_bridge_timeout(timeout: float | None) -> float | None:
 
 
 def _command_preview(command: Sequence[str]) -> str:
-    preview = " ".join(str(part) for part in command[:8]).strip()
-    if len(command) > 8:
-        preview += " ..."
-    return preview
+    parts = [str(part) for part in command]
+    if not parts:
+        return ""
+
+    executable = Path(parts[0]).name or parts[0]
+    script_name: str | None = None
+    for index, part in enumerate(parts[1:], start=1):
+        lowered = part.lower()
+        if lowered in {"-file", "--file"} and index + 1 < len(parts):
+            script_name = Path(parts[index + 1]).name or parts[index + 1]
+            break
+        if lowered.endswith((".ps1", ".py", ".sh", ".cmd", ".bat")):
+            script_name = Path(part).name or part
+            break
+
+    arg_count = max(len(parts) - 1, 0)
+    if script_name:
+        return f"{executable} ... {script_name} ({arg_count} args)"
+    if len(parts) > 2:
+        return f"{executable} ({arg_count} args)"
+
+    redacted: list[str] = []
+    redact_next = False
+    for part in parts:
+        lowered = part.lower()
+        if redact_next:
+            redacted.append("<redacted>")
+            redact_next = False
+            continue
+        redacted.append(part)
+        if lowered in SENSITIVE_COMMAND_FLAGS:
+            redact_next = True
+    return " ".join(redacted)
 
 
 def _build_stream_detail(

--- a/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
+++ b/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import locale
+import os
 import subprocess
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -35,7 +36,25 @@ def _preview_stream(value: bytes | str | None) -> str | None:
     if value in (None, b"", ""):
         return None
     if isinstance(value, bytes):
-        text = value.decode("utf-8", errors="replace")
+        if value.startswith(b"\xff\xfe"):
+            text = value.decode("utf-16", errors="replace")
+        elif value.startswith(b"\xfe\xff"):
+            text = value.decode("utf-16-be", errors="replace")
+        else:
+            preview_encodings = ["utf-8-sig", str(locale.getpreferredencoding(False) or "").strip(), "latin-1"]
+            text = ""
+            for encoding in preview_encodings:
+                normalized = encoding.strip()
+                if not normalized:
+                    continue
+                try:
+                    text = value.decode(normalized, errors="replace")
+                except LookupError:
+                    continue
+                break
+            if not text:
+                text = value.decode("latin-1", errors="replace")
+        text = text.replace("\x00", "")
     else:
         text = value
     flattened = " ".join(text.split())
@@ -44,6 +63,28 @@ def _preview_stream(value: bytes | str | None) -> str | None:
     if len(flattened) > 160:
         return flattened[:157] + "..."
     return flattened
+
+
+def _resolve_bridge_timeout(timeout: float | None) -> float | None:
+    if timeout is not None:
+        return timeout
+    raw = str(os.environ.get("VGO_POWERSHELL_BRIDGE_TIMEOUT_SECONDS") or "").strip()
+    if not raw:
+        return 300.0
+    try:
+        resolved = float(raw)
+    except ValueError:
+        return 300.0
+    if resolved <= 0:
+        return None
+    return resolved
+
+
+def _command_preview(command: Sequence[str]) -> str:
+    preview = " ".join(str(part) for part in command[:8]).strip()
+    if len(command) > 8:
+        preview += " ..."
+    return preview
 
 
 def _decode_json_object_stdout(
@@ -115,16 +156,29 @@ def run_powershell_json_command(
     cwd: Path,
     bridge_label: str,
     env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
 ) -> dict[str, Any]:
-    completed = subprocess.run(
-        list(command),
-        cwd=cwd,
-        capture_output=True,
-        check=False,
-        env=dict(env) if env is not None else None,
-    )
+    resolved_timeout = _resolve_bridge_timeout(timeout)
+    try:
+        completed = subprocess.run(
+            list(command),
+            cwd=cwd,
+            capture_output=True,
+            check=False,
+            env=dict(env) if env is not None else None,
+            timeout=resolved_timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        detail_parts = [f"timeout={resolved_timeout}s", f"cwd={cwd}", f"command={_command_preview(command)}"]
+        stdout_preview = _preview_stream(exc.stdout)
+        stderr_preview = _preview_stream(exc.stderr)
+        if stdout_preview:
+            detail_parts.append(f"stdout={stdout_preview}")
+        if stderr_preview:
+            detail_parts.append(f"stderr={stderr_preview}")
+        raise RuntimeError(f"{bridge_label} timed out ({'; '.join(detail_parts)})") from exc
     if completed.returncode != 0:
-        detail_parts = [f"exit={completed.returncode}"]
+        detail_parts = [f"exit={completed.returncode}", f"cwd={cwd}", f"command={_command_preview(command)}"]
         stdout_preview = _preview_stream(completed.stdout)
         stderr_preview = _preview_stream(completed.stderr)
         if stdout_preview:

--- a/packages/runtime-core/src/vgo_runtime/router_bridge.py
+++ b/packages/runtime-core/src/vgo_runtime/router_bridge.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 
+from .powershell_bridge import run_powershell_json_command
 from .router_contract_runtime import route_prompt
 from .router_contract_support import resolve_repo_root
 
@@ -53,8 +53,7 @@ def invoke_canonical_router(args: argparse.Namespace, shell: str) -> dict:
         command.extend(['-HostId', args.host_id])
     if args.target_root:
         command.extend(['-TargetRoot', args.target_root])
-    completed = subprocess.run(command, cwd=repo_root, capture_output=True, text=True, check=True)
-    return json.loads(completed.stdout)
+    return run_powershell_json_command(command, cwd=repo_root, bridge_label="canonical router bridge")
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- add a shared PowerShell JSON bridge helper in runtime-core
- capture PowerShell stdout as bytes instead of locale-decoded text
- decode bridge payloads with UTF-aware fallbacks before parsing JSON
- switch both canonical-entry and router bridge production paths to the shared helper
- keep this PR production-only and do not include new test files

## Why
On Windows systems with non-UTF-8 locale settings, the current PowerShell JSON bridge can fail before routing/runtime payloads reach the UI because Python decodes stdout using the local default text encoding. That makes machine-to-machine JSON output brittle for UTF-8 BOM and UTF-16 cases.

## What changed
- `packages/runtime-core/src/vgo_runtime/powershell_bridge.py`
  - new shared helper for PowerShell JSON subprocess execution and decoding
- `packages/runtime-core/src/vgo_runtime/canonical_entry.py`
  - use the shared helper for canonical entry bridge payloads
- `packages/runtime-core/src/vgo_runtime/router_bridge.py`
  - use the shared helper for canonical router bridge payloads

## Verification
- syntax-checked the changed Python files with `python3 -m py_compile`
- performed installed-runtime simulation against a real temporary `CODEX_HOME` deployment
- simulated user-facing route/canonical-entry calls with PowerShell bridge outputs encoded as UTF-8 BOM and UTF-16
- confirmed the installed route entry returned specialist selections and canonical-entry returned receipt-backed JSON plus runtime artifacts

Fixes #182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized external-command handling into a shared bridge used by runtime components for consistent execution and result handling.

* **New**
  * Introduced a dedicated bridge for running external commands and returning validated structured results.

* **Bug Fixes / Reliability**
  * Improved output decoding and validation, added timeout handling, clearer truncated error previews, and stricter payload validation for more robust behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->