### PR TITLE
Fix Codex readiness to require live direct runtime

### DIFF
--- a/apps/vgo-cli/src/vgo_cli/installer_bridge.py
+++ b/apps/vgo-cli/src/vgo_cli/installer_bridge.py
@@ -7,6 +7,7 @@ from .workspace import extend_workspace_package_path
 
 
 def refresh_install_ledger_payload(repo_root: Path, target_root: Path) -> dict[str, object]:
+    """Refresh the install ledger and attach current runtime diagnostics."""
     extend_workspace_package_path(repo_root)
     from vgo_installer.ledger_service import refresh_install_ledger
     from vgo_verify.bootstrap_doctor_runtime import collect_host_runtime

--- a/apps/vgo-cli/src/vgo_cli/installer_bridge.py
+++ b/apps/vgo-cli/src/vgo_cli/installer_bridge.py
@@ -15,5 +15,5 @@ def refresh_install_ledger_payload(repo_root: Path, target_root: Path) -> dict[s
         payload = refresh_install_ledger(target_root)
     except SystemExit as exc:
         raise CliError(str(exc)) from exc
-    payload['host_runtime'] = collect_host_runtime(target_root)
+    payload['host_runtime'] = collect_host_runtime(repo_root, target_root)
     return payload

--- a/check.ps1
+++ b/check.ps1
@@ -131,7 +131,7 @@ function Resolve-DirectRuntimeExecutableForCheck {
     if ($candidate) {
       $resolvedPath = [string]$candidate.Source
       $source = "env:$envName"
-    } elseif (Test-Path -LiteralPath $envValue) {
+    } elseif (Test-Path -LiteralPath $envValue -PathType Leaf) {
       $resolvedPath = [System.IO.Path]::GetFullPath($envValue)
       $source = "env:$envName"
     }
@@ -699,7 +699,11 @@ function Invoke-AdapterSpecificChecks {
       $closureState = if ($hostClosure.PSObject.Properties.Name -contains 'host_closure_state') { [string]$hostClosure.host_closure_state } else { '' }
       if (-not [string]::IsNullOrWhiteSpace($closureState)) {
         if ($closureState -eq 'closed_ready') {
-          Check-Condition -Label 'host closure state' -Condition $true
+          if ([string]$HostId -eq 'codex' -and -not $directRuntime.ready) {
+            Write-WarnNote -Message ("host closure receipt stale -> {0} (live direct runtime unavailable for {1})" -f $closureState, [string]$HostId)
+          } else {
+            Check-Condition -Label 'host closure state' -Condition $true
+          }
         } elseif ([string]$HostId -eq 'codex' -and $directRuntime.ready) {
           Write-WarnNote -Message ("host closure receipt stale -> {0} (live direct runtime ready via {1})" -f $closureState, (Format-OptionalValue -Value ([string]$directRuntime.source)))
         } else {

--- a/check.ps1
+++ b/check.ps1
@@ -101,6 +101,57 @@ function Get-InstalledRuntimeTargetRelpath {
   return $targetRel
 }
 
+function Resolve-DirectRuntimeExecutableForCheck {
+  param([string]$HostId)
+
+  $envName = $null
+  $defaultCommand = $null
+  switch ([string]$HostId) {
+    'codex' {
+      $envName = 'VGO_CODEX_EXECUTABLE'
+      $defaultCommand = 'codex'
+    }
+    default {
+      return [pscustomobject]@{
+        command = $null
+        resolved_path = $null
+        source = $null
+        ready = $false
+      }
+    }
+  }
+
+  $command = $defaultCommand
+  $resolvedPath = $null
+  $source = $null
+  $envValue = if (-not [string]::IsNullOrWhiteSpace($envName)) { [Environment]::GetEnvironmentVariable($envName) } else { $null }
+  if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+    $command = [string]$envValue
+    $candidate = Get-Command $envValue -ErrorAction SilentlyContinue
+    if ($candidate) {
+      $resolvedPath = [string]$candidate.Source
+      $source = "env:$envName"
+    } elseif (Test-Path -LiteralPath $envValue) {
+      $resolvedPath = [System.IO.Path]::GetFullPath($envValue)
+      $source = "env:$envName"
+    }
+  }
+  if ([string]::IsNullOrWhiteSpace($resolvedPath) -and -not [string]::IsNullOrWhiteSpace($defaultCommand)) {
+    $candidate = Get-Command $defaultCommand -ErrorAction SilentlyContinue
+    if ($candidate) {
+      $resolvedPath = [string]$candidate.Source
+      $source = "path:$defaultCommand"
+    }
+  }
+
+  return [pscustomobject]@{
+    command = $command
+    resolved_path = $resolvedPath
+    source = $source
+    ready = [bool](-not [string]::IsNullOrWhiteSpace($resolvedPath))
+  }
+}
+
 function Resolve-CheckTargetContext {
   param(
     [Parameter(Mandatory)] [string]$InputRoot,
@@ -637,11 +688,19 @@ function Invoke-AdapterSpecificChecks {
   Check-Path -Label "host closure manifest" -Path $hostClosurePath
   if (Test-Path -LiteralPath $hostClosurePath) {
     $hostClosure = Get-JsonObject -Path $hostClosurePath -Label 'host closure manifest'
+    $directRuntime = Resolve-DirectRuntimeExecutableForCheck -HostId $HostId
+    if ($directRuntime.ready) {
+      Check-Condition -Label ("direct runtime executable -> {0}" -f [string]$directRuntime.resolved_path) -Condition $true
+    } elseif ([string]$HostId -eq 'codex') {
+      Write-WarnNote -Message ("direct runtime executable unavailable for {0} ({1})" -f [string]$HostId, (Format-OptionalValue -Value ([string]$directRuntime.command)))
+    }
     if ($null -ne $hostClosure) {
       $closureState = if ($hostClosure.PSObject.Properties.Name -contains 'host_closure_state') { [string]$hostClosure.host_closure_state } else { '' }
       if (-not [string]::IsNullOrWhiteSpace($closureState)) {
         if ($closureState -eq 'closed_ready') {
           Check-Condition -Label 'host closure state' -Condition $true
+        } elseif ([string]$HostId -eq 'codex' -and $directRuntime.ready) {
+          Write-WarnNote -Message ("host closure receipt stale -> {0} (live direct runtime ready via {1})" -f $closureState, (Format-OptionalValue -Value ([string]$directRuntime.source)))
         } else {
           Write-WarnNote -Message ("host closure state -> {0}" -f $closureState)
         }

--- a/check.ps1
+++ b/check.ps1
@@ -656,6 +656,7 @@ function Invoke-AdapterSpecificChecks {
   param(
     [psobject]$Adapter,
     [string]$TargetRoot,
+    [string]$HostId,
     [string]$RuntimeSkillRoot,
     [string]$RuntimeNestedSkillRoot,
     [bool]$NestedBundledRequired,
@@ -862,7 +863,7 @@ if ($null -ne $startupGovernance -and $startupGovernance.PSObject.Properties.Nam
   }
 }
 
-Invoke-AdapterSpecificChecks -Adapter $Adapter -TargetRoot $TargetRoot -RuntimeSkillRoot $runtimeSkillRoot -RuntimeNestedSkillRoot $runtimeNestedSkillRoot -NestedBundledRequired:$nestedBundledRequired -NestedBundledPresencePolicy $nestedBundledPresencePolicy
+Invoke-AdapterSpecificChecks -Adapter $Adapter -TargetRoot $TargetRoot -HostId $HostId -RuntimeSkillRoot $runtimeSkillRoot -RuntimeNestedSkillRoot $runtimeNestedSkillRoot -NestedBundledRequired:$nestedBundledRequired -NestedBundledPresencePolicy $nestedBundledPresencePolicy
 Check-CodexDuplicateSkillSurface -TargetRoot $TargetRoot -HostId $HostId
 
 Invoke-RuntimeFreshnessCheck -RepoRoot $RepoRoot -TargetRoot $TargetRoot -SkipGate:$SkipRuntimeFreshnessGate

--- a/check.sh
+++ b/check.sh
@@ -86,7 +86,7 @@ resolve_executable_candidate() {
       return 0
     fi
   fi
-  if [[ -e "${candidate}" ]]; then
+  if [[ -f "${candidate}" ]]; then
     if [[ "${candidate}" == /* ]]; then
       printf '%s' "${candidate}"
     else
@@ -852,8 +852,12 @@ if [[ -f "${TARGET_ROOT}/.vibeskills/host-closure.json" ]]; then
   closure_state="$(json_query_scalar_from_file "${TARGET_ROOT}/.vibeskills/host-closure.json" 'host_closure_state' 2>/dev/null || true)"
   if [[ -n "${closure_state}" ]]; then
     if [[ "${closure_state}" == "closed_ready" ]]; then
-      echo "[OK] host closure state -> ${closure_state}"
-      PASS=$((PASS+1))
+      if [[ "${HOST_ID}" == "codex" && -z "${direct_runtime_resolved}" ]]; then
+        warn_note "host closure receipt stale -> ${closure_state} (live direct runtime unavailable for ${HOST_ID})"
+      else
+        echo "[OK] host closure state -> ${closure_state}"
+        PASS=$((PASS+1))
+      fi
     elif [[ "${HOST_ID}" == "codex" && -n "${direct_runtime_resolved}" ]]; then
       warn_note "host closure receipt stale -> ${closure_state} (live direct runtime ready via ${direct_runtime_source:-path})"
     else

--- a/check.sh
+++ b/check.sh
@@ -76,6 +76,59 @@ run_powershell_file() {
   "${cmd[@]}" "$@"
 }
 
+resolve_executable_candidate() {
+  local candidate="${1:-}"
+  [[ -n "${candidate}" ]] || return 1
+  local resolved=""
+  if resolved="$(command -v "${candidate}" 2>/dev/null)"; then
+    if [[ -n "${resolved}" ]]; then
+      printf '%s' "${resolved}"
+      return 0
+    fi
+  fi
+  if [[ -e "${candidate}" ]]; then
+    if [[ "${candidate}" == /* ]]; then
+      printf '%s' "${candidate}"
+    else
+      printf '%s/%s' "$(cd "$(dirname "${candidate}")" 2>/dev/null && pwd)" "$(basename "${candidate}")"
+    fi
+    return 0
+  fi
+  return 1
+}
+
+probe_direct_runtime_executable() {
+  local host_id="$1"
+  local env_name="" default_command=""
+  case "${host_id}" in
+    codex)
+      env_name="VGO_CODEX_EXECUTABLE"
+      default_command="codex"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  local env_value="" resolved="" source="" command_name="${default_command}"
+  if [[ -n "${env_name}" ]]; then
+    env_value="${!env_name:-}"
+  fi
+  if [[ -n "${env_value}" ]]; then
+    command_name="${env_value}"
+    if resolved="$(resolve_executable_candidate "${env_value}" 2>/dev/null)"; then
+      source="env:${env_name}"
+    fi
+  fi
+  if [[ -z "${resolved}" && -n "${default_command}" ]]; then
+    if resolved="$(resolve_executable_candidate "${default_command}" 2>/dev/null)"; then
+      source="path:${default_command}"
+    fi
+  fi
+
+  printf '%s\t%s\t%s\n' "${command_name}" "${resolved}" "${source}"
+}
+
 adapter_query_for_host() {
   local host_id="$1"
   local property="$2"
@@ -784,11 +837,25 @@ if [[ "${HOST_ID}" == "claude-code" ]]; then
 fi
 check_path "host closure manifest" "${TARGET_ROOT}/.vibeskills/host-closure.json"
 if [[ -f "${TARGET_ROOT}/.vibeskills/host-closure.json" ]]; then
+  direct_runtime_command=""
+  direct_runtime_resolved=""
+  direct_runtime_source=""
+  if [[ "${HOST_ID}" == "codex" ]]; then
+    IFS=$'\t' read -r direct_runtime_command direct_runtime_resolved direct_runtime_source < <(probe_direct_runtime_executable "${HOST_ID}" || printf '\t\t\n')
+    if [[ -n "${direct_runtime_resolved}" ]]; then
+      echo "[OK] direct runtime executable -> ${direct_runtime_resolved}"
+      PASS=$((PASS+1))
+    else
+      warn_note "direct runtime executable unavailable for ${HOST_ID} (${direct_runtime_command:-codex})"
+    fi
+  fi
   closure_state="$(json_query_scalar_from_file "${TARGET_ROOT}/.vibeskills/host-closure.json" 'host_closure_state' 2>/dev/null || true)"
   if [[ -n "${closure_state}" ]]; then
     if [[ "${closure_state}" == "closed_ready" ]]; then
       echo "[OK] host closure state -> ${closure_state}"
       PASS=$((PASS+1))
+    elif [[ "${HOST_ID}" == "codex" && -n "${direct_runtime_resolved}" ]]; then
+      warn_note "host closure receipt stale -> ${closure_state} (live direct runtime ready via ${direct_runtime_source:-path})"
     else
       warn_note "host closure state -> ${closure_state}"
     fi

--- a/packages/contracts/src/vgo_contracts/host_runtime_readiness.py
+++ b/packages/contracts/src/vgo_contracts/host_runtime_readiness.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+from .adapter_registry_support import load_adapter_registry
+from .canonical_vibe_contract import resolve_canonical_vibe_contract
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _resolve_repo_root(repo_root: str | Path | None) -> Path:
+    if repo_root is None:
+        return REPO_ROOT
+    return Path(repo_root).resolve()
+
+
+def _load_native_specialist_execution_policy(repo_root: str | Path | None) -> dict[str, Any]:
+    repo_candidates = [_resolve_repo_root(repo_root)]
+    if REPO_ROOT not in repo_candidates:
+        repo_candidates.append(REPO_ROOT)
+    for candidate_root in repo_candidates:
+        policy_path = candidate_root / "config" / "native-specialist-execution-policy.json"
+        if policy_path.exists():
+            return json.loads(policy_path.read_text(encoding="utf-8-sig"))
+    raise RuntimeError("native-specialist-execution-policy.json not found")
+
+
+def _resolve_direct_runtime_policy(repo_root: str | Path | None, host_id: str) -> dict[str, Any] | None:
+    policy = _load_native_specialist_execution_policy(repo_root)
+    for adapter in policy.get("adapters") or []:
+        if isinstance(adapter, dict) and str(adapter.get("id") or "").strip().lower() == host_id:
+            return dict(adapter)
+    return None
+
+
+def _resolve_executable_candidate(raw: str) -> str | None:
+    candidate = str(raw or "").strip()
+    if not candidate:
+        return None
+    resolved = shutil.which(candidate)
+    if resolved:
+        return str(Path(resolved).resolve())
+    path_candidate = Path(candidate).expanduser()
+    if path_candidate.exists():
+        return str(path_candidate.resolve())
+    return None
+
+
+def evaluate_host_runtime_readiness(
+    repo_root: str | Path | None,
+    host_id: str | None,
+    *,
+    specialist_wrapper_ready: bool | None = None,
+) -> dict[str, Any]:
+    resolved_repo_root = _resolve_repo_root(repo_root)
+    try:
+        load_adapter_registry(resolved_repo_root)
+        contract_repo_root: str | Path | None = resolved_repo_root
+    except RuntimeError:
+        contract_repo_root = REPO_ROOT
+    contract = resolve_canonical_vibe_contract(contract_repo_root, host_id)
+    normalized_host_id = str(contract.get("host_id") or "").strip().lower()
+    readiness_driver = "direct_runtime" if contract["entry_mode"] == "direct_runtime" else "specialist_wrapper"
+    wrapper_ready = bool(specialist_wrapper_ready)
+    direct_runtime: dict[str, Any] = {
+        "required": readiness_driver == "direct_runtime",
+        "ready": False,
+        "invocation_kind": None,
+        "executable_env": None,
+        "command": None,
+        "resolved_path": None,
+        "source": None,
+        "reason": "not_applicable",
+    }
+
+    if readiness_driver == "direct_runtime":
+        policy_adapter = _resolve_direct_runtime_policy(contract_repo_root, normalized_host_id)
+        if policy_adapter is None:
+            direct_runtime["reason"] = "native_specialist_policy_missing"
+        else:
+            invocation_kind = str(policy_adapter.get("invocation_kind") or "").strip()
+            env_name = str(policy_adapter.get("executable_env") or "").strip()
+            configured_command = str(policy_adapter.get("command") or "").strip()
+            env_value = str(os.environ.get(env_name) or "").strip() if env_name else ""
+            resolved_path = None
+            source = None
+            command = configured_command
+
+            if env_value:
+                resolved_path = _resolve_executable_candidate(env_value)
+                command = env_value
+                if resolved_path:
+                    source = f"env:{env_name}"
+            if resolved_path is None and configured_command:
+                resolved_path = _resolve_executable_candidate(configured_command)
+                if resolved_path:
+                    source = f"path:{configured_command}"
+
+            direct_runtime.update(
+                {
+                    "invocation_kind": invocation_kind or None,
+                    "executable_env": env_name or None,
+                    "command": command or None,
+                    "resolved_path": resolved_path,
+                    "source": source,
+                    "ready": resolved_path is not None,
+                    "reason": (
+                        "native_specialist_execution_ready"
+                        if resolved_path is not None and invocation_kind == "direct"
+                        else f"native_specialist_adapter_command_unavailable:{configured_command or normalized_host_id}"
+                    ),
+                }
+            )
+
+    effective_runtime_ready = direct_runtime["ready"] if readiness_driver == "direct_runtime" else wrapper_ready
+    return {
+        "host_id": normalized_host_id,
+        "entry_mode": str(contract["entry_mode"]),
+        "launcher_kind": str(contract["launcher_kind"]),
+        "readiness_driver": readiness_driver,
+        "specialist_wrapper_required": readiness_driver != "direct_runtime",
+        "specialist_wrapper_ready": wrapper_ready,
+        "effective_runtime_ready": bool(effective_runtime_ready),
+        "recommended_host_closure_state": "closed_ready" if effective_runtime_ready else "configured_offline_unready",
+        "direct_runtime": direct_runtime,
+    }

--- a/packages/contracts/src/vgo_contracts/host_runtime_readiness.py
+++ b/packages/contracts/src/vgo_contracts/host_runtime_readiness.py
@@ -13,12 +13,14 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
 def _resolve_repo_root(repo_root: str | Path | None) -> Path:
+    """Resolve the repo root used for registry and policy lookups."""
     if repo_root is None:
         return REPO_ROOT
     return Path(repo_root).resolve()
 
 
 def _load_native_specialist_execution_policy(repo_root: str | Path | None) -> dict[str, Any]:
+    """Load native specialist execution policy data from the active repo tree."""
     repo_candidates = [_resolve_repo_root(repo_root)]
     if REPO_ROOT not in repo_candidates:
         repo_candidates.append(REPO_ROOT)
@@ -30,6 +32,7 @@ def _load_native_specialist_execution_policy(repo_root: str | Path | None) -> di
 
 
 def _resolve_direct_runtime_policy(repo_root: str | Path | None, host_id: str) -> dict[str, Any] | None:
+    """Return the native direct-runtime policy entry for a given host."""
     policy = _load_native_specialist_execution_policy(repo_root)
     for adapter in policy.get("adapters") or []:
         if isinstance(adapter, dict) and str(adapter.get("id") or "").strip().lower() == host_id:
@@ -38,6 +41,7 @@ def _resolve_direct_runtime_policy(repo_root: str | Path | None, host_id: str) -
 
 
 def _resolve_executable_candidate(raw: str) -> str | None:
+    """Resolve a command or file path to an executable file path."""
     candidate = str(raw or "").strip()
     if not candidate:
         return None
@@ -45,12 +49,13 @@ def _resolve_executable_candidate(raw: str) -> str | None:
     if resolved:
         return str(Path(resolved).resolve())
     path_candidate = Path(candidate).expanduser()
-    if path_candidate.exists():
+    if path_candidate.is_file():
         return str(path_candidate.resolve())
     return None
 
 
 def _fallback_canonical_vibe_contract(host_id: str | None) -> dict[str, Any]:
+    """Return a safe bridged contract when canonical contract lookup fails."""
     normalized_host_id = str(host_id or "").strip().lower()
     return {
         "host_id": normalized_host_id,
@@ -69,6 +74,7 @@ def evaluate_host_runtime_readiness(
     *,
     specialist_wrapper_ready: bool | None = None,
 ) -> dict[str, Any]:
+    """Evaluate whether a host is truly ready for canonical vibe execution."""
     resolved_repo_root = _resolve_repo_root(repo_root)
     try:
         load_adapter_registry(resolved_repo_root)

--- a/packages/contracts/src/vgo_contracts/host_runtime_readiness.py
+++ b/packages/contracts/src/vgo_contracts/host_runtime_readiness.py
@@ -50,6 +50,19 @@ def _resolve_executable_candidate(raw: str) -> str | None:
     return None
 
 
+def _fallback_canonical_vibe_contract(host_id: str | None) -> dict[str, Any]:
+    normalized_host_id = str(host_id or "").strip().lower()
+    return {
+        "host_id": normalized_host_id,
+        "entry_mode": "bridged_runtime",
+        "fallback_policy": "blocked",
+        "proof_required": True,
+        "allow_skill_doc_fallback": False,
+        "launcher_kind": "managed_bridge",
+        "supports_bounded_stop": True,
+    }
+
+
 def evaluate_host_runtime_readiness(
     repo_root: str | Path | None,
     host_id: str | None,
@@ -62,7 +75,10 @@ def evaluate_host_runtime_readiness(
         contract_repo_root: str | Path | None = resolved_repo_root
     except RuntimeError:
         contract_repo_root = REPO_ROOT
-    contract = resolve_canonical_vibe_contract(contract_repo_root, host_id)
+    try:
+        contract = resolve_canonical_vibe_contract(contract_repo_root, host_id)
+    except ValueError:
+        contract = _fallback_canonical_vibe_contract(host_id)
     normalized_host_id = str(contract.get("host_id") or "").strip().lower()
     readiness_driver = "direct_runtime" if contract["entry_mode"] == "direct_runtime" else "specialist_wrapper"
     wrapper_ready = bool(specialist_wrapper_ready)
@@ -78,7 +94,10 @@ def evaluate_host_runtime_readiness(
     }
 
     if readiness_driver == "direct_runtime":
-        policy_adapter = _resolve_direct_runtime_policy(contract_repo_root, normalized_host_id)
+        try:
+            policy_adapter = _resolve_direct_runtime_policy(contract_repo_root, normalized_host_id)
+        except RuntimeError:
+            policy_adapter = None
         if policy_adapter is None:
             direct_runtime["reason"] = "native_specialist_policy_missing"
         else:

--- a/packages/installer-core/src/vgo_installer/host_closure.py
+++ b/packages/installer-core/src/vgo_installer/host_closure.py
@@ -330,6 +330,7 @@ def materialize_host_closure(
     record_managed_json: RecordManagedJson,
     record_bridge_launcher: RecordBridgeLauncher,
 ) -> tuple[Path, dict[str, Any]]:
+    """Materialize host-closure metadata using live runtime readiness checks."""
     host_id = adapter["id"]
     bridge_command, bridge_source = resolve_bridge_command(host_id)
     wrapper_info = materialize_host_specialist_wrapper(

--- a/packages/installer-core/src/vgo_installer/host_closure.py
+++ b/packages/installer-core/src/vgo_installer/host_closure.py
@@ -12,6 +12,7 @@ from ._bootstrap import ensure_contracts_src_on_path
 ensure_contracts_src_on_path()
 
 from vgo_contracts.canonical_vibe_contract import uses_skill_only_activation
+from vgo_contracts.host_runtime_readiness import evaluate_host_runtime_readiness
 
 HOST_BRIDGE_COMMAND_CANDIDATES = {
     "claude-code": ["claude", "claude-code"],
@@ -321,6 +322,7 @@ def materialize_host_settings(
 
 
 def materialize_host_closure(
+    repo_root: Path,
     target_root: Path,
     adapter: dict[str, Any],
     *,
@@ -345,13 +347,21 @@ def materialize_host_closure(
         record_managed_json=record_managed_json,
     )
     commands_root = target_root / "commands"
-    closure_state = "closed_ready" if wrapper_info["ready"] else "configured_offline_unready"
+    runtime_readiness = evaluate_host_runtime_readiness(
+        repo_root,
+        host_id,
+        specialist_wrapper_ready=bool(wrapper_info["ready"]),
+    )
+    closure_state = str(runtime_readiness["recommended_host_closure_state"])
     closure = {
         "schema_version": 1,
         "host_id": host_id,
         "platform": detect_platform_tag(),
         "target_root": str(target_root.resolve()),
         "install_mode": adapter["install_mode"],
+        "entry_mode": runtime_readiness["entry_mode"],
+        "host_closure_driver": runtime_readiness["readiness_driver"],
+        "effective_runtime_ready": bool(runtime_readiness["effective_runtime_ready"]),
         "skills_root": str((target_root / "skills").resolve()),
         "runtime_skill_entry": str((target_root / "skills" / "vibe" / "SKILL.md").resolve()),
         "commands_root": str(commands_root.resolve()),
@@ -360,6 +370,7 @@ def materialize_host_closure(
         "host_closure_state": closure_state,
         "commands_materialized": commands_root.exists(),
         "settings_materialized": settings_materialized,
+        "direct_runtime": dict(runtime_readiness["direct_runtime"]),
         "specialist_wrapper": {
             "launcher_path": wrapper_info["launcher_path"],
             "script_path": wrapper_info["script_path"],

--- a/packages/installer-core/src/vgo_installer/install_runtime.py
+++ b/packages/installer-core/src/vgo_installer/install_runtime.py
@@ -85,6 +85,31 @@ ledger_state = {
 }
 
 
+def build_closed_ready_failure_message(adapter: dict[str, object], closure: dict[str, object]) -> str:
+    """Describe why a host closure failed the closed_ready requirement."""
+    adapter_id = str(adapter.get("id") or "")
+    closure_state = str(closure.get("host_closure_state") or "")
+    readiness_driver = str(closure.get("host_closure_driver") or "")
+    if readiness_driver == "direct_runtime":
+        direct_runtime = closure.get("direct_runtime")
+        command = adapter_id
+        if isinstance(direct_runtime, dict):
+            command = str(direct_runtime.get("command") or adapter_id)
+        return (
+            "Host closure for "
+            f"'{adapter_id}' is not closed_ready "
+            f"(got '{closure_state}'). "
+            f"Required direct runtime executable '{command}' is not ready; "
+            "verify the executable path or install the runtime, then retry install."
+        )
+    return (
+        "Host closure for "
+        f"'{adapter_id}' is not closed_ready "
+        f"(got '{closure_state}'). "
+        "Configure the host specialist bridge command first, then retry install."
+    )
+
+
 def reset_ledger_state() -> None:
     for key, value in ledger_state.items():
         if isinstance(value, set):
@@ -608,12 +633,7 @@ def main(argv: list[str] | None = None):
     record_sidecar_root(target_root / ".vibeskills")
     require_closed_ready_effective = bool(args.require_closed_ready and is_closed_ready_required(adapter))
     if require_closed_ready_effective and closure["host_closure_state"] != "closed_ready":
-        raise SystemExit(
-            "Host closure for "
-            f"'{adapter['id']}' is not closed_ready "
-            f"(got '{closure['host_closure_state']}'). "
-            "Configure the host specialist bridge command first, then retry install."
-        )
+        raise SystemExit(build_closed_ready_failure_message(adapter, closure))
 
     canonical_vibe_rel = canonical_vibe_target_relpath(packaging)
     install_plan = build_install_plan(

--- a/packages/installer-core/src/vgo_installer/install_runtime.py
+++ b/packages/installer-core/src/vgo_installer/install_runtime.py
@@ -591,6 +591,7 @@ def main(argv: list[str] | None = None):
         record_specialist_wrapper(wrapper_path)
 
     closure_path, closure = materialize_host_closure(
+        repo_root,
         target_root,
         adapter,
         track_created_path=track_created_path,

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
@@ -380,7 +380,12 @@ def build_summary(
                     "Direct runtime is available, but the local install surfaces are incomplete. Re-run installation to refresh host closure, commands, and managed settings."
                 )
         else:
-            manual_actions.append("Host runtime is not fully ready; complete the specialist bridge setup and re-run check.")
+            if effective_runtime_ready:
+                manual_actions.append(
+                    "Bridged host wrapper is available, but the local install surfaces are incomplete. Re-run installation to refresh host closure, commands, and managed settings."
+                )
+            else:
+                manual_actions.append("Host runtime is not fully ready; complete the specialist bridge setup and re-run check.")
     intent_advice_api_key_state, intent_advice_api_key_source = resolved_setting_state(settings, "VCO_INTENT_ADVICE_API_KEY")
     intent_advice_model_state, intent_advice_model_source = resolved_setting_state(settings, "VCO_INTENT_ADVICE_MODEL")
     vector_diff_api_key_state, vector_diff_api_key_source = resolved_setting_state(settings, "VCO_VECTOR_DIFF_API_KEY")

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
@@ -165,6 +165,7 @@ def reconcile_mcp_servers_with_active_surface(
 
 
 def collect_host_runtime(repo_root: Path, target_root: Path) -> dict[str, Any]:
+    """Collect the host runtime state surfaced by bootstrap doctor."""
     runtime_skill_entry = target_root / "skills" / "vibe" / "SKILL.md"
     commands_root = target_root / "commands"
     host_closure_path = target_root / ".vibeskills" / "host-closure.json"
@@ -342,6 +343,7 @@ def build_summary(
     external_tools: list[dict[str, Any]],
     global_instruction_bootstrap: dict[str, Any] | None,
 ) -> dict[str, Any]:
+    """Build the user-facing summary for bootstrap doctor results."""
     blocking_issues: list[str] = []
     manual_actions: list[str] = []
     warnings: list[str] = []

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from vgo_contracts.host_runtime_readiness import evaluate_host_runtime_readiness
+
 from .bootstrap_doctor_support import (
     command_present,
     inspect_global_instruction_bootstrap,
@@ -162,7 +164,7 @@ def reconcile_mcp_servers_with_active_surface(
     return reconciled
 
 
-def collect_host_runtime(target_root: Path) -> dict[str, Any]:
+def collect_host_runtime(repo_root: Path, target_root: Path) -> dict[str, Any]:
     runtime_skill_entry = target_root / "skills" / "vibe" / "SKILL.md"
     commands_root = target_root / "commands"
     host_closure_path = target_root / ".vibeskills" / "host-closure.json"
@@ -190,6 +192,13 @@ def collect_host_runtime(target_root: Path) -> dict[str, Any]:
             host_closure_payload = loaded
             host_closure_valid = True
             host_id = str(host_closure_payload.get("host_id") or "").strip()
+    specialist_wrapper = host_closure_payload.get("specialist_wrapper") if host_closure_valid else None
+    specialist_wrapper_ready = bool(specialist_wrapper.get("ready")) if isinstance(specialist_wrapper, dict) else False
+    runtime_readiness = evaluate_host_runtime_readiness(
+        repo_root,
+        host_id or None,
+        specialist_wrapper_ready=specialist_wrapper_ready,
+    )
 
     runtime_skill_entry_path = str(runtime_skill_entry.resolve())
     commands_root_path = str(commands_root.resolve())
@@ -202,6 +211,7 @@ def collect_host_runtime(target_root: Path) -> dict[str, Any]:
         and str(host_closure_payload.get("commands_root") or "").strip() == commands_root_path
     )
     host_closure_commands_materialized = bool(host_closure_payload.get("commands_materialized")) if host_closure_valid else False
+    host_closure_state = str(host_closure_payload.get("host_closure_state") or "").strip() if host_closure_valid else ""
     vibe_host_ready = (
         runtime_skill_entry.exists()
         and commands_root.exists()
@@ -210,12 +220,18 @@ def collect_host_runtime(target_root: Path) -> dict[str, Any]:
         and host_closure_runtime_matches
         and host_closure_commands_match
         and host_closure_commands_materialized
+        and bool(runtime_readiness["effective_runtime_ready"])
     )
     global_instruction_bootstrap = inspect_global_instruction_bootstrap(
         target_root,
-        host_id=host_id or None,
+        host_id=str(runtime_readiness.get("host_id") or host_id or "").strip() or None,
     )
     return {
+        "host_id": str(runtime_readiness.get("host_id") or host_id or "").strip() or None,
+        "entry_mode": str(runtime_readiness["entry_mode"]),
+        "readiness_driver": str(runtime_readiness["readiness_driver"]),
+        "effective_runtime_ready": bool(runtime_readiness["effective_runtime_ready"]),
+        "host_closure_state": host_closure_state,
         "runtime_skill_entry_path": runtime_skill_entry_path,
         "runtime_skill_entry_exists": runtime_skill_entry.exists(),
         "commands_root_path": commands_root_path,
@@ -226,10 +242,12 @@ def collect_host_runtime(target_root: Path) -> dict[str, Any]:
         "host_closure_runtime_matches": host_closure_runtime_matches,
         "host_closure_commands_match": host_closure_commands_match,
         "host_closure_commands_materialized": host_closure_commands_materialized,
+        "specialist_wrapper_ready": specialist_wrapper_ready,
         "settings_surface_path": str(settings_surface_path),
         "settings_surface_exists": settings_surface_exists,
         "settings_surface_kind": settings_surface_kind,
         "vibe_host_ready": vibe_host_ready,
+        "direct_runtime": dict(runtime_readiness["direct_runtime"]),
         "global_instruction_bootstrap": global_instruction_bootstrap,
     }
 
@@ -318,6 +336,7 @@ def build_summary(
     active_mcp_path: Path,
     settings: dict[str, Any] | None,
     install_state: str,
+    host_runtime: dict[str, Any],
     plugins: list[dict[str, Any]],
     mcp_servers: list[dict[str, Any]],
     external_tools: list[dict[str, Any]],
@@ -337,6 +356,23 @@ def build_summary(
             )
     if install_state != "installed_locally":
         warnings.append(f"Install state is '{install_state}'; verify the local install receipt.")
+    if isinstance(host_runtime, dict) and not bool(host_runtime.get("vibe_host_ready")):
+        readiness_driver = str(host_runtime.get("readiness_driver") or "")
+        if readiness_driver == "direct_runtime":
+            direct_runtime = host_runtime.get("direct_runtime")
+            if isinstance(direct_runtime, dict):
+                env_name = str(direct_runtime.get("executable_env") or "").strip()
+                command = str(direct_runtime.get("command") or "codex").strip()
+                if env_name:
+                    manual_actions.append(
+                        f"Direct runtime executable is not ready. Resolve '{command}' on PATH or via {env_name}."
+                    )
+                else:
+                    manual_actions.append(
+                        f"Direct runtime executable is not ready. Resolve '{command}' on PATH and re-run check."
+                    )
+        else:
+            manual_actions.append("Host runtime is not fully ready; complete the specialist bridge setup and re-run check.")
     intent_advice_api_key_state, intent_advice_api_key_source = resolved_setting_state(settings, "VCO_INTENT_ADVICE_API_KEY")
     intent_advice_model_state, intent_advice_model_source = resolved_setting_state(settings, "VCO_INTENT_ADVICE_MODEL")
     vector_diff_api_key_state, vector_diff_api_key_source = resolved_setting_state(settings, "VCO_VECTOR_DIFF_API_KEY")
@@ -422,12 +458,13 @@ def build_bootstrap_artifact(
     secret_status_by_name = {item["name"]: item["status"] for item in secret_surfaces}
     enhancement_surfaces = collect_enhancement_surfaces(memory_governance)
     integration_surfaces = collect_integration_surfaces(tool_registry, secret_status_by_name)
-    host_runtime = collect_host_runtime(target_root)
+    host_runtime = collect_host_runtime(repo_root, target_root)
     summary = build_summary(
         settings_path=settings_path,
         active_mcp_path=active_mcp_path,
         settings=settings,
         install_state=install_state,
+        host_runtime=host_runtime,
         plugins=plugins,
         mcp_servers=mcp_servers,
         external_tools=external_tools,

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
@@ -360,19 +360,25 @@ def build_summary(
         warnings.append(f"Install state is '{install_state}'; verify the local install receipt.")
     if isinstance(host_runtime, dict) and not bool(host_runtime.get("vibe_host_ready")):
         readiness_driver = str(host_runtime.get("readiness_driver") or "")
+        effective_runtime_ready = bool(host_runtime.get("effective_runtime_ready"))
         if readiness_driver == "direct_runtime":
-            direct_runtime = host_runtime.get("direct_runtime")
-            if isinstance(direct_runtime, dict):
-                env_name = str(direct_runtime.get("executable_env") or "").strip()
-                command = str(direct_runtime.get("command") or "codex").strip()
-                if env_name:
-                    manual_actions.append(
-                        f"Direct runtime executable is not ready. Resolve '{command}' on PATH or via {env_name}."
-                    )
-                else:
-                    manual_actions.append(
-                        f"Direct runtime executable is not ready. Resolve '{command}' on PATH and re-run check."
-                    )
+            if not effective_runtime_ready:
+                direct_runtime = host_runtime.get("direct_runtime")
+                if isinstance(direct_runtime, dict):
+                    env_name = str(direct_runtime.get("executable_env") or "").strip()
+                    command = str(direct_runtime.get("command") or "codex").strip()
+                    if env_name:
+                        manual_actions.append(
+                            f"Direct runtime executable is not ready. Resolve '{command}' on PATH or via {env_name}."
+                        )
+                    else:
+                        manual_actions.append(
+                            f"Direct runtime executable is not ready. Resolve '{command}' on PATH and re-run check."
+                        )
+            else:
+                manual_actions.append(
+                    "Direct runtime is available, but the local install surfaces are incomplete. Re-run installation to refresh host closure, commands, and managed settings."
+                )
         else:
             manual_actions.append("Host runtime is not fully ready; complete the specialist bridge setup and re-run check.")
     intent_advice_api_key_state, intent_advice_api_key_source = resolved_setting_state(settings, "VCO_INTENT_ADVICE_API_KEY")

--- a/scripts/install/Install-VgoAdapter.ps1
+++ b/scripts/install/Install-VgoAdapter.ps1
@@ -534,7 +534,7 @@ function Resolve-VgoDirectRuntimeExecutable {
         }
     }
 
-    $invocationKind = if ($policyAdapter.PSObject.Properties.Name -contains 'invocation_kind') { [string]$policyAdapter.invocation_kind } else { 'direct' }
+    $invocationKind = if ($policyAdapter.PSObject.Properties.Name -contains 'invocation_kind' -and -not [string]::IsNullOrWhiteSpace([string]$policyAdapter.invocation_kind)) { [string]$policyAdapter.invocation_kind } else { $null }
     $envName = if ($policyAdapter.PSObject.Properties.Name -contains 'executable_env') { [string]$policyAdapter.executable_env } else { '' }
     $configuredCommand = if ($policyAdapter.PSObject.Properties.Name -contains 'command') { [string]$policyAdapter.command } else { '' }
     $command = $configuredCommand
@@ -806,12 +806,12 @@ function Write-VgoHostClosure {
         direct_runtime = [ordered]@{
             required = [bool]$runtimeReadiness.direct_runtime.required
             ready = [bool]$runtimeReadiness.direct_runtime.ready
-            invocation_kind = [string]$runtimeReadiness.direct_runtime.invocation_kind
-            executable_env = [string]$runtimeReadiness.direct_runtime.executable_env
-            command = [string]$runtimeReadiness.direct_runtime.command
-            resolved_path = [string]$runtimeReadiness.direct_runtime.resolved_path
-            source = [string]$runtimeReadiness.direct_runtime.source
-            reason = [string]$runtimeReadiness.direct_runtime.reason
+            invocation_kind = if ($null -eq $runtimeReadiness.direct_runtime.invocation_kind) { $null } else { [string]$runtimeReadiness.direct_runtime.invocation_kind }
+            executable_env = if ($null -eq $runtimeReadiness.direct_runtime.executable_env) { $null } else { [string]$runtimeReadiness.direct_runtime.executable_env }
+            command = if ($null -eq $runtimeReadiness.direct_runtime.command) { $null } else { [string]$runtimeReadiness.direct_runtime.command }
+            resolved_path = if ($null -eq $runtimeReadiness.direct_runtime.resolved_path) { $null } else { [string]$runtimeReadiness.direct_runtime.resolved_path }
+            source = if ($null -eq $runtimeReadiness.direct_runtime.source) { $null } else { [string]$runtimeReadiness.direct_runtime.source }
+            reason = if ($null -eq $runtimeReadiness.direct_runtime.reason) { $null } else { [string]$runtimeReadiness.direct_runtime.reason }
         }
         specialist_wrapper = [ordered]@{
             launcher_path = [string]$wrapperInfo.launcher_path

--- a/scripts/install/Install-VgoAdapter.ps1
+++ b/scripts/install/Install-VgoAdapter.ps1
@@ -549,7 +549,7 @@ function Resolve-VgoDirectRuntimeExecutable {
             if ($candidate) {
                 $resolvedPath = [string]$candidate.Source
                 $source = "env:$envName"
-            } elseif (Test-Path -LiteralPath $envValue) {
+            } elseif (Test-Path -LiteralPath $envValue -PathType Leaf) {
                 $resolvedPath = [System.IO.Path]::GetFullPath($envValue)
                 $source = "env:$envName"
             }
@@ -1279,6 +1279,12 @@ switch ([string]$adapter.install_mode) {
 $closureReceipt = Write-VgoHostClosure -TargetRoot $TargetRoot -Adapter $adapter
 $requireClosedReadyEffective = [bool]($RequireClosedReady -and (Test-VgoClosedReadyRequiredForAdapter -Adapter $adapter))
 if ($requireClosedReadyEffective -and [string]$closureReceipt.data.host_closure_state -ne 'closed_ready') {
+    $hostClosureDriver = if ($closureReceipt.data.PSObject.Properties.Name -contains 'host_closure_driver') { [string]$closureReceipt.data.host_closure_driver } else { '' }
+    if ($hostClosureDriver -eq 'direct_runtime') {
+        $directRuntime = if ($closureReceipt.data.PSObject.Properties.Name -contains 'direct_runtime') { $closureReceipt.data.direct_runtime } else { $null }
+        $runtimeCommand = if ($null -ne $directRuntime -and $directRuntime.PSObject.Properties.Name -contains 'command' -and -not [string]::IsNullOrWhiteSpace([string]$directRuntime.command)) { [string]$directRuntime.command } else { [string]$adapter.id }
+        throw ("Host closure for '{0}' is not closed_ready (got '{1}'). Required direct runtime executable '{2}' is not ready; verify the executable path or install the runtime, then retry install." -f [string]$adapter.id, [string]$closureReceipt.data.host_closure_state, $runtimeCommand)
+    }
     throw ("Host closure for '{0}' is not closed_ready (got '{1}'). Configure the host specialist bridge command first, then retry install." -f [string]$adapter.id, [string]$closureReceipt.data.host_closure_state)
 }
 $installLedgerPath = Write-VgoInstallLedger -Adapter $adapter -Profile $Profile -ExternalFallbackUsed @($result.external_fallback_used)

--- a/scripts/install/Install-VgoAdapter.ps1
+++ b/scripts/install/Install-VgoAdapter.ps1
@@ -561,6 +561,9 @@ function Resolve-VgoDirectRuntimeExecutable {
         if ($candidate) {
             $resolvedPath = [string]$candidate.Source
             $source = "path:$configuredCommand"
+        } elseif (Test-Path -LiteralPath $configuredCommand -PathType Leaf) {
+            $resolvedPath = [System.IO.Path]::GetFullPath($configuredCommand)
+            $source = "path:$configuredCommand"
         }
     }
 

--- a/scripts/install/Install-VgoAdapter.ps1
+++ b/scripts/install/Install-VgoAdapter.ps1
@@ -494,6 +494,136 @@ function Resolve-VgoHostBridgeCommand {
     }
 }
 
+function Get-VgoNativeSpecialistPolicyAdapter {
+    param([string]$HostId)
+
+    $policyPath = Join-Path $RepoRoot 'config\native-specialist-execution-policy.json'
+    if (-not (Test-Path -LiteralPath $policyPath)) {
+        return $null
+    }
+
+    try {
+        $policy = Get-Content -LiteralPath $policyPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+
+    foreach ($candidate in @($policy.adapters)) {
+        if ($null -ne $candidate -and [string]$candidate.id -eq [string]$HostId) {
+            return $candidate
+        }
+    }
+    return $null
+}
+
+function Resolve-VgoDirectRuntimeExecutable {
+    param([string]$HostId)
+
+    $policyAdapter = Get-VgoNativeSpecialistPolicyAdapter -HostId $HostId
+    if ($null -eq $policyAdapter) {
+        return [pscustomobject]@{
+            required = $true
+            ready = $false
+            invocation_kind = $null
+            executable_env = $null
+            command = $null
+            resolved_path = $null
+            source = $null
+            reason = 'native_specialist_policy_missing'
+        }
+    }
+
+    $invocationKind = if ($policyAdapter.PSObject.Properties.Name -contains 'invocation_kind') { [string]$policyAdapter.invocation_kind } else { 'direct' }
+    $envName = if ($policyAdapter.PSObject.Properties.Name -contains 'executable_env') { [string]$policyAdapter.executable_env } else { '' }
+    $configuredCommand = if ($policyAdapter.PSObject.Properties.Name -contains 'command') { [string]$policyAdapter.command } else { '' }
+    $command = $configuredCommand
+    $resolvedPath = $null
+    $source = $null
+
+    if (-not [string]::IsNullOrWhiteSpace($envName)) {
+        $envValue = [Environment]::GetEnvironmentVariable($envName)
+        if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+            $command = [string]$envValue
+            $candidate = Get-Command $envValue -ErrorAction SilentlyContinue
+            if ($candidate) {
+                $resolvedPath = [string]$candidate.Source
+                $source = "env:$envName"
+            } elseif (Test-Path -LiteralPath $envValue) {
+                $resolvedPath = [System.IO.Path]::GetFullPath($envValue)
+                $source = "env:$envName"
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($resolvedPath) -and -not [string]::IsNullOrWhiteSpace($configuredCommand)) {
+        $candidate = Get-Command $configuredCommand -ErrorAction SilentlyContinue
+        if ($candidate) {
+            $resolvedPath = [string]$candidate.Source
+            $source = "path:$configuredCommand"
+        }
+    }
+
+    return [pscustomobject]@{
+        required = $true
+        ready = [bool](-not [string]::IsNullOrWhiteSpace($resolvedPath) -and $invocationKind -eq 'direct')
+        invocation_kind = if (-not [string]::IsNullOrWhiteSpace($invocationKind)) { $invocationKind } else { $null }
+        executable_env = if (-not [string]::IsNullOrWhiteSpace($envName)) { $envName } else { $null }
+        command = if (-not [string]::IsNullOrWhiteSpace($command)) { $command } else { $null }
+        resolved_path = if (-not [string]::IsNullOrWhiteSpace($resolvedPath)) { $resolvedPath } else { $null }
+        source = if (-not [string]::IsNullOrWhiteSpace($source)) { $source } else { $null }
+        reason = if (-not [string]::IsNullOrWhiteSpace($resolvedPath) -and $invocationKind -eq 'direct') {
+            'native_specialist_execution_ready'
+        } else {
+            ("native_specialist_adapter_command_unavailable:{0}" -f $(if (-not [string]::IsNullOrWhiteSpace($configuredCommand)) { $configuredCommand } else { [string]$HostId }))
+        }
+    }
+}
+
+function Get-VgoHostRuntimeReadiness {
+    param(
+        [Parameter(Mandatory)] [psobject]$Adapter,
+        [bool]$SpecialistWrapperReady
+    )
+
+    $entryMode = if (
+        $Adapter.PSObject.Properties.Name -contains 'canonical_vibe' -and
+        $null -ne $Adapter.canonical_vibe -and
+        $Adapter.canonical_vibe.PSObject.Properties.Name -contains 'entry_mode' -and
+        -not [string]::IsNullOrWhiteSpace([string]$Adapter.canonical_vibe.entry_mode)
+    ) {
+        [string]$Adapter.canonical_vibe.entry_mode
+    } else {
+        'bridged_runtime'
+    }
+
+    $readinessDriver = if ($entryMode -eq 'direct_runtime') { 'direct_runtime' } else { 'specialist_wrapper' }
+    $directRuntime = if ($readinessDriver -eq 'direct_runtime') {
+        Resolve-VgoDirectRuntimeExecutable -HostId ([string]$Adapter.id)
+    } else {
+        [pscustomobject]@{
+            required = $false
+            ready = $false
+            invocation_kind = $null
+            executable_env = $null
+            command = $null
+            resolved_path = $null
+            source = $null
+            reason = 'not_applicable'
+        }
+    }
+    $effectiveRuntimeReady = if ($readinessDriver -eq 'direct_runtime') { [bool]$directRuntime.ready } else { [bool]$SpecialistWrapperReady }
+
+    return [pscustomobject]@{
+        entry_mode = $entryMode
+        readiness_driver = $readinessDriver
+        specialist_wrapper_required = [bool]($readinessDriver -ne 'direct_runtime')
+        specialist_wrapper_ready = [bool]$SpecialistWrapperReady
+        effective_runtime_ready = [bool]$effectiveRuntimeReady
+        recommended_host_closure_state = if ($effectiveRuntimeReady) { 'closed_ready' } else { 'configured_offline_unready' }
+        direct_runtime = $directRuntime
+    }
+}
+
 function New-VgoHostSpecialistWrapper {
     param(
         [Parameter(Mandatory)] [string]$TargetRoot,
@@ -650,13 +780,17 @@ function Write-VgoHostClosure {
     $wrapperInfo = New-VgoHostSpecialistWrapper -TargetRoot $TargetRoot -HostId ([string]$Adapter.id) -BridgeCommand ([string]$bridgeResolution.command) -BridgeEnvName ([string]$bridgeResolution.env_name)
     $settingsMaterialized = Set-VgoManagedHostSettings -TargetRoot $TargetRoot -HostId ([string]$Adapter.id) -WrapperInfo $wrapperInfo
     $commandsRoot = Join-Path $TargetRoot 'commands'
-    $closureState = if ($wrapperInfo.ready) { 'closed_ready' } else { 'configured_offline_unready' }
+    $runtimeReadiness = Get-VgoHostRuntimeReadiness -Adapter $Adapter -SpecialistWrapperReady ([bool]$wrapperInfo.ready)
+    $closureState = [string]$runtimeReadiness.recommended_host_closure_state
     $closure = [ordered]@{
         schema_version = 1
         host_id = [string]$Adapter.id
         platform = Get-VgoPlatformTag
         target_root = [System.IO.Path]::GetFullPath($TargetRoot)
         install_mode = [string]$Adapter.install_mode
+        entry_mode = [string]$runtimeReadiness.entry_mode
+        host_closure_driver = [string]$runtimeReadiness.readiness_driver
+        effective_runtime_ready = [bool]$runtimeReadiness.effective_runtime_ready
         skills_root = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'skills'))
         runtime_skill_entry = [System.IO.Path]::GetFullPath((Join-Path $TargetRoot 'skills\vibe\SKILL.md'))
         commands_root = [System.IO.Path]::GetFullPath($commandsRoot)
@@ -665,6 +799,16 @@ function Write-VgoHostClosure {
         host_closure_state = $closureState
         commands_materialized = (Test-Path -LiteralPath $commandsRoot -PathType Container)
         settings_materialized = @($settingsMaterialized)
+        direct_runtime = [ordered]@{
+            required = [bool]$runtimeReadiness.direct_runtime.required
+            ready = [bool]$runtimeReadiness.direct_runtime.ready
+            invocation_kind = [string]$runtimeReadiness.direct_runtime.invocation_kind
+            executable_env = [string]$runtimeReadiness.direct_runtime.executable_env
+            command = [string]$runtimeReadiness.direct_runtime.command
+            resolved_path = [string]$runtimeReadiness.direct_runtime.resolved_path
+            source = [string]$runtimeReadiness.direct_runtime.source
+            reason = [string]$runtimeReadiness.direct_runtime.reason
+        }
         specialist_wrapper = [ordered]@{
             launcher_path = [string]$wrapperInfo.launcher_path
             script_path = [string]$wrapperInfo.script_path

--- a/scripts/install/Install-VgoAdapter.ps1
+++ b/scripts/install/Install-VgoAdapter.ps1
@@ -73,6 +73,7 @@ function Resolve-InstallAdapterDescriptor {
     return [pscustomobject]@{
         id = [string]$entry.id
         install_mode = [string]$entry.install_mode
+        canonical_vibe = if ($entry.PSObject.Properties.Name -contains 'canonical_vibe') { $entry.canonical_vibe } else { $null }
     }
 }
 
@@ -565,7 +566,7 @@ function Resolve-VgoDirectRuntimeExecutable {
 
     return [pscustomobject]@{
         required = $true
-        ready = [bool](-not [string]::IsNullOrWhiteSpace($resolvedPath) -and $invocationKind -eq 'direct')
+        ready = [bool](-not [string]::IsNullOrWhiteSpace($resolvedPath))
         invocation_kind = if (-not [string]::IsNullOrWhiteSpace($invocationKind)) { $invocationKind } else { $null }
         executable_env = if (-not [string]::IsNullOrWhiteSpace($envName)) { $envName } else { $null }
         command = if (-not [string]::IsNullOrWhiteSpace($command)) { $command } else { $null }


### PR DESCRIPTION
## Summary
- evaluate Codex host readiness from the live direct runtime contract instead of wrapper-only closure state
- propagate effective runtime readiness through host closure generation, bootstrap doctor summaries, and the installer bridge
- surface direct runtime availability and stale-receipt warnings in `check.sh` and `check.ps1`
- mirror the same readiness logic in the PowerShell installer path

## User-visible behavior
- when `codex` is actually available, install/check report the host as ready
- when `codex` is missing, install/check report the host as not ready and explain that the direct runtime executable is unavailable
- when an old closure receipt says unready but the live direct runtime is available, check surfaces a stale-receipt warning instead of a misleading hard failure

## Verification
- manually simulated install with a fake `VGO_CODEX_EXECUTABLE` and confirmed `vibe_host_ready: True` plus `closed_ready`
- manually simulated install without `codex` on `PATH` and confirmed `vibe_host_ready: False`, `configured_offline_unready`, and the direct-runtime warning in `check.sh`

## Notes
- no test file changes are included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified runtime readiness evaluator with direct-runtime probing (env or PATH) and richer runtime metadata in host-closure payloads.
  * Installer, CLI, verification, and install scripts/reporting now surface detailed direct-runtime info and use it in bootstrap summaries and checks.

* **Bug Fixes / UX**
  * Clearer OK/warning checks across shells/PowerShell; improved failure messages that name the missing direct runtime or recommend specialist actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->