### PR TITLE
Fix Windows Python resolution in verification gates

### DIFF
--- a/scripts/common/vibe-governance-helpers.ps1
+++ b/scripts/common/vibe-governance-helpers.ps1
@@ -728,20 +728,24 @@ function Resolve-VgoPythonCandidate {
         [string[]]$PrefixArguments = @()
     )
 
-    $resolved = Get-Command $CommandName -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1
-    if ([string]::IsNullOrWhiteSpace($resolved) -or -not (Test-Path -LiteralPath $resolved)) {
-        return $null
+    $candidates = @(Get-Command $CommandName -All -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source)
+    foreach ($candidate in $candidates) {
+        if ([string]::IsNullOrWhiteSpace($candidate) -or -not (Test-Path -LiteralPath $candidate)) {
+            continue
+        }
+
+        if (Test-VgoWindowsAppsPythonStubPath -Path $candidate -CommandName $CommandName) {
+            continue
+        }
+
+        return [pscustomobject]@{
+            host_path = [System.IO.Path]::GetFullPath($candidate)
+            host_leaf = [System.IO.Path]::GetFileName($candidate).ToLowerInvariant()
+            prefix_arguments = @($PrefixArguments)
+        }
     }
 
-    if (Test-VgoWindowsAppsPythonStubPath -Path $resolved -CommandName $CommandName) {
-        return $null
-    }
-
-    return [pscustomobject]@{
-        host_path = [System.IO.Path]::GetFullPath($resolved)
-        host_leaf = [System.IO.Path]::GetFileName($resolved).ToLowerInvariant()
-        prefix_arguments = @($PrefixArguments)
-    }
+    return $null
 }
 
 function Get-VgoPythonCommand {

--- a/scripts/common/vibe-governance-helpers.ps1
+++ b/scripts/common/vibe-governance-helpers.ps1
@@ -749,14 +749,14 @@ function Resolve-VgoPythonCandidate {
 }
 
 function Get-VgoPythonCommand {
-    $python = Resolve-VgoPythonCandidate -CommandName 'python'
-    if ($null -ne $python) {
-        return $python
-    }
-
     $python3 = Resolve-VgoPythonCandidate -CommandName 'python3'
     if ($null -ne $python3) {
         return $python3
+    }
+
+    $python = Resolve-VgoPythonCandidate -CommandName 'python'
+    if ($null -ne $python) {
+        return $python
     }
 
     $pyLauncher = Resolve-VgoPythonCandidate -CommandName 'py' -PrefixArguments @('-3')

--- a/scripts/common/vibe-governance-helpers.ps1
+++ b/scripts/common/vibe-governance-helpers.ps1
@@ -703,32 +703,61 @@ function Get-VgoPowerShellCommand {
     throw 'Unable to resolve a PowerShell host for governed sub-process execution.'
 }
 
+function Test-VgoWindowsAppsPythonStubPath {
+    param(
+        [AllowEmptyString()] [string]$Path,
+        [AllowEmptyString()] [string]$CommandName = ''
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $false
+    }
+
+    $normalizedCommand = if ($null -eq $CommandName) { '' } else { ([string]$CommandName).Trim().ToLowerInvariant() }
+    if ($normalizedCommand -notin @('python', 'python3')) {
+        return $false
+    }
+
+    $normalizedPath = [string]$Path
+    return $normalizedPath -match '(^|[\\/])Microsoft[\\/]WindowsApps[\\/].*python3?(\.(exe|cmd|bat))?$'
+}
+
+function Resolve-VgoPythonCandidate {
+    param(
+        [Parameter(Mandatory)] [string]$CommandName,
+        [string[]]$PrefixArguments = @()
+    )
+
+    $resolved = Get-Command $CommandName -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1
+    if ([string]::IsNullOrWhiteSpace($resolved) -or -not (Test-Path -LiteralPath $resolved)) {
+        return $null
+    }
+
+    if (Test-VgoWindowsAppsPythonStubPath -Path $resolved -CommandName $CommandName) {
+        return $null
+    }
+
+    return [pscustomobject]@{
+        host_path = [System.IO.Path]::GetFullPath($resolved)
+        host_leaf = [System.IO.Path]::GetFileName($resolved).ToLowerInvariant()
+        prefix_arguments = @($PrefixArguments)
+    }
+}
+
 function Get-VgoPythonCommand {
-    $python = Get-Command python -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1
-    if (-not [string]::IsNullOrWhiteSpace($python) -and (Test-Path -LiteralPath $python)) {
-        return [pscustomobject]@{
-            host_path = [System.IO.Path]::GetFullPath($python)
-            host_leaf = [System.IO.Path]::GetFileName($python).ToLowerInvariant()
-            prefix_arguments = @()
-        }
+    $python = Resolve-VgoPythonCandidate -CommandName 'python'
+    if ($null -ne $python) {
+        return $python
     }
 
-    $python3 = Get-Command python3 -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1
-    if (-not [string]::IsNullOrWhiteSpace($python3) -and (Test-Path -LiteralPath $python3)) {
-        return [pscustomobject]@{
-            host_path = [System.IO.Path]::GetFullPath($python3)
-            host_leaf = [System.IO.Path]::GetFileName($python3).ToLowerInvariant()
-            prefix_arguments = @()
-        }
+    $python3 = Resolve-VgoPythonCandidate -CommandName 'python3'
+    if ($null -ne $python3) {
+        return $python3
     }
 
-    $pyLauncher = Get-Command py -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1
-    if (-not [string]::IsNullOrWhiteSpace($pyLauncher) -and (Test-Path -LiteralPath $pyLauncher)) {
-        return [pscustomobject]@{
-            host_path = [System.IO.Path]::GetFullPath($pyLauncher)
-            host_leaf = [System.IO.Path]::GetFileName($pyLauncher).ToLowerInvariant()
-            prefix_arguments = @('-3')
-        }
+    $pyLauncher = Resolve-VgoPythonCandidate -CommandName 'py' -PrefixArguments @('-3')
+    if ($null -ne $pyLauncher) {
+        return $pyLauncher
     }
 
     throw "Unable to resolve a Python host for governed execution. Tried 'python', 'python3', and 'py -3'."

--- a/scripts/verify/vibe-installed-runtime-freshness-gate.ps1
+++ b/scripts/verify/vibe-installed-runtime-freshness-gate.ps1
@@ -15,13 +15,7 @@ if (-not (Test-Path -LiteralPath $runnerPath)) {
     throw "runtime-neutral freshness gate missing: $runnerPath"
 }
 
-$pythonCommand = Get-Command python3 -ErrorAction SilentlyContinue
-if (-not $pythonCommand) {
-    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
-}
-if (-not $pythonCommand) {
-    throw 'Python is required to run vibe-installed-runtime-freshness-gate.'
-}
+$pythonInvocation = Get-VgoPythonCommand
 
 $args = @(
     $runnerPath,
@@ -34,7 +28,7 @@ if ($WriteReceipt) {
     $args += '--write-receipt'
 }
 
-& $pythonCommand.Source @args
+& $pythonInvocation.host_path @($pythonInvocation.prefix_arguments) @args
 $exitCode = $LASTEXITCODE
 if ($exitCode -ne 0) {
     throw "vibe-installed-runtime-freshness-gate failed with exit code $exitCode"

--- a/scripts/verify/vibe-release-install-runtime-coherence-gate.ps1
+++ b/scripts/verify/vibe-release-install-runtime-coherence-gate.ps1
@@ -14,13 +14,7 @@ if (-not (Test-Path -LiteralPath $runnerPath)) {
     throw "runtime-neutral coherence gate missing: $runnerPath"
 }
 
-$pythonCommand = Get-Command python3 -ErrorAction SilentlyContinue
-if (-not $pythonCommand) {
-    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
-}
-if (-not $pythonCommand) {
-    throw 'Python is required to run vibe-release-install-runtime-coherence-gate.'
-}
+$pythonInvocation = Get-VgoPythonCommand
 
 $args = @(
     $runnerPath,
@@ -30,7 +24,7 @@ if ($WriteArtifacts) {
     $args += '--write-artifacts'
 }
 
-& $pythonCommand.Source @args
+& $pythonInvocation.host_path @($pythonInvocation.prefix_arguments) @args
 $exitCode = $LASTEXITCODE
 if ($exitCode -ne 0) {
     throw "vibe-release-install-runtime-coherence-gate failed with exit code $exitCode"

--- a/scripts/verify/vibe-release-notes-quality-gate.ps1
+++ b/scripts/verify/vibe-release-notes-quality-gate.ps1
@@ -19,13 +19,8 @@ if (-not (Test-Path -LiteralPath $runnerPath)) {
     throw "release notes quality runner missing: $runnerPath"
 }
 
-$pythonCommand = Get-Command python3 -ErrorAction SilentlyContinue
-if (-not $pythonCommand) {
-    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
-}
-if (-not $pythonCommand) {
-    throw 'Python is required to run vibe-release-notes-quality-gate.'
-}
+. (Join-Path $RepoRoot 'scripts\common\vibe-governance-helpers.ps1')
+$pythonInvocation = Get-VgoPythonCommand
 
 $args = @(
     $runnerPath
@@ -42,7 +37,7 @@ if ($OutputDirectory) {
     $args += @('--output-directory', $OutputDirectory)
 }
 
-& $pythonCommand.Source @args
+& $pythonInvocation.host_path @($pythonInvocation.prefix_arguments) @args
 $exitCode = $LASTEXITCODE
 if ($exitCode -ne 0) {
     throw "vibe-release-notes-quality-gate failed with exit code $exitCode"

--- a/scripts/verify/vibe-release-truth-gate.ps1
+++ b/scripts/verify/vibe-release-truth-gate.ps1
@@ -20,13 +20,8 @@ if (-not (Test-Path -LiteralPath $runnerPath)) {
     throw "release truth runner missing: $runnerPath"
 }
 
-$pythonCommand = Get-Command python3 -ErrorAction SilentlyContinue
-if (-not $pythonCommand) {
-    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
-}
-if (-not $pythonCommand) {
-    throw 'Python is required to run vibe-release-truth-gate.'
-}
+. (Join-Path $RepoRoot 'scripts\common\vibe-governance-helpers.ps1')
+$pythonInvocation = Get-VgoPythonCommand
 
 $args = @(
     $runnerPath
@@ -40,7 +35,7 @@ if ($OutputDirectory) {
     $args += @('--output-directory', $OutputDirectory)
 }
 
-& $pythonCommand.Source @args
+& $pythonInvocation.host_path @($pythonInvocation.prefix_arguments) @args
 $exitCode = $LASTEXITCODE
 if ($exitCode -ne 0) {
     throw "vibe-release-truth-gate failed with exit code $exitCode"

--- a/scripts/verify/vibe-workflow-acceptance-gate.ps1
+++ b/scripts/verify/vibe-workflow-acceptance-gate.ps1
@@ -22,13 +22,8 @@ if (-not (Test-Path -LiteralPath $runnerPath)) {
 
 $resolvedScenario = (Resolve-Path $ScenarioPath).Path
 
-$pythonCommand = Get-Command python3 -ErrorAction SilentlyContinue
-if (-not $pythonCommand) {
-    $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
-}
-if (-not $pythonCommand) {
-    throw 'Python is required to run vibe-workflow-acceptance-gate.'
-}
+. (Join-Path $RepoRoot 'scripts\common\vibe-governance-helpers.ps1')
+$pythonInvocation = Get-VgoPythonCommand
 
 $args = @(
     $runnerPath
@@ -40,7 +35,7 @@ if ($OutputDirectory) {
     $args += @('--output-directory', $OutputDirectory)
 }
 
-& $pythonCommand.Source @args
+& $pythonInvocation.host_path @($pythonInvocation.prefix_arguments) @args
 $exitCode = $LASTEXITCODE
 if ($exitCode -ne 0) {
     throw "vibe-workflow-acceptance-gate failed with exit code $exitCode"

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -804,8 +804,31 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
 
             resolved = resolve_python_command_spec_via_powershell("${VGO_PYTHON}", [windowsapps_dir, real_dir])
 
-            self.assertEqual("python", str(resolved["host_leaf"]))
-            self.assertEqual(str((real_dir / "python").resolve()), str(Path(str(resolved["host_path"])).resolve()))
+            host_leaf = str(resolved["host_leaf"])
+            self.assertTrue(host_leaf.startswith("python"))
+            self.assertFalse(host_leaf.startswith("python3"))
+            resolved_host = Path(str(resolved["host_path"])).resolve()
+            self.assertEqual(real_dir.resolve(), resolved_host.parent)
+            self.assertEqual([], resolved["prefix_arguments"])
+
+    def test_resolve_vgo_python_command_spec_skips_windowsapps_python_stub_and_uses_real_python_later_on_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            windowsapps_dir = root / "Microsoft" / "WindowsApps"
+            real_dir = root / "real-python"
+            windowsapps_dir.mkdir(parents=True)
+            real_dir.mkdir(parents=True)
+            _create_fake_command(windowsapps_dir, "python")
+            _create_fake_command(windowsapps_dir, "python3")
+            _create_fake_command(real_dir, "python")
+
+            resolved = resolve_python_command_spec_via_powershell("${VGO_PYTHON}", [windowsapps_dir, real_dir])
+
+            host_leaf = str(resolved["host_leaf"])
+            self.assertTrue(host_leaf.startswith("python"))
+            self.assertFalse(host_leaf.startswith("python3"))
+            resolved_host = Path(str(resolved["host_path"])).resolve()
+            self.assertEqual(real_dir.resolve(), resolved_host.parent)
             self.assertEqual([], resolved["prefix_arguments"])
 
     def test_resolve_vgo_python_command_spec_skips_windowsapps_python_stub_and_uses_py_launcher(self) -> None:

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -792,6 +792,22 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertTrue(str(resolved["host_leaf"]).startswith("python3"))
             self.assertEqual([], resolved["prefix_arguments"])
 
+    def test_resolve_vgo_python_command_spec_prefers_python3_over_python(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            python3_dir = root / "python3-dir"
+            python_dir = root / "python-dir"
+            python3_dir.mkdir(parents=True)
+            python_dir.mkdir(parents=True)
+            _create_fake_command(python3_dir, "python3")
+            _create_fake_command(python_dir, "python")
+
+            resolved = resolve_python_command_spec_via_powershell("${VGO_PYTHON}", [python3_dir, python_dir])
+
+            self.assertTrue(str(resolved["host_leaf"]).startswith("python3"))
+            self.assertEqual(python3_dir.resolve(), Path(str(resolved["host_path"])).resolve().parent)
+            self.assertEqual([], resolved["prefix_arguments"])
+
     def test_resolve_vgo_python_command_spec_skips_windowsapps_python3_stub_and_uses_python(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)

--- a/tests/runtime_neutral/test_governed_runtime_bridge.py
+++ b/tests/runtime_neutral/test_governed_runtime_bridge.py
@@ -792,6 +792,37 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
             self.assertTrue(str(resolved["host_leaf"]).startswith("python3"))
             self.assertEqual([], resolved["prefix_arguments"])
 
+    def test_resolve_vgo_python_command_spec_skips_windowsapps_python3_stub_and_uses_python(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            windowsapps_dir = root / "Microsoft" / "WindowsApps"
+            real_dir = root / "real-python"
+            windowsapps_dir.mkdir(parents=True)
+            real_dir.mkdir(parents=True)
+            _create_fake_command(windowsapps_dir, "python3")
+            _create_fake_command(real_dir, "python")
+
+            resolved = resolve_python_command_spec_via_powershell("${VGO_PYTHON}", [windowsapps_dir, real_dir])
+
+            self.assertEqual("python", str(resolved["host_leaf"]))
+            self.assertEqual(str((real_dir / "python").resolve()), str(Path(str(resolved["host_path"])).resolve()))
+            self.assertEqual([], resolved["prefix_arguments"])
+
+    def test_resolve_vgo_python_command_spec_skips_windowsapps_python_stub_and_uses_py_launcher(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            windowsapps_dir = root / "Microsoft" / "WindowsApps"
+            launcher_dir = root / "launcher"
+            windowsapps_dir.mkdir(parents=True)
+            launcher_dir.mkdir(parents=True)
+            _create_fake_command(windowsapps_dir, "python")
+            _create_fake_command(launcher_dir, "py")
+
+            resolved = resolve_python_command_spec_via_powershell("${VGO_PYTHON}", [windowsapps_dir, launcher_dir])
+
+            self.assertTrue(str(resolved["host_leaf"]).startswith("py"))
+            self.assertEqual(["-3"], resolved["prefix_arguments"])
+
     def test_resolve_vgo_python_command_spec_uses_py_launcher_with_dash3_prefix(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             fake_dir = Path(tempdir)
@@ -801,6 +832,21 @@ class GovernedRuntimeBridgeTests(unittest.TestCase):
 
             self.assertTrue(str(resolved["host_leaf"]).startswith("py"))
             self.assertEqual(["-3"], resolved["prefix_arguments"])
+
+    def test_verification_gates_use_governed_python_helper(self) -> None:
+        gate_paths = [
+            REPO_ROOT / "scripts" / "verify" / "vibe-installed-runtime-freshness-gate.ps1",
+            REPO_ROOT / "scripts" / "verify" / "vibe-release-install-runtime-coherence-gate.ps1",
+            REPO_ROOT / "scripts" / "verify" / "vibe-release-notes-quality-gate.ps1",
+            REPO_ROOT / "scripts" / "verify" / "vibe-release-truth-gate.ps1",
+            REPO_ROOT / "scripts" / "verify" / "vibe-workflow-acceptance-gate.ps1",
+        ]
+
+        for gate_path in gate_paths:
+            content = gate_path.read_text(encoding="utf-8")
+            self.assertIn("Get-VgoPythonCommand", content, str(gate_path))
+            self.assertIn("prefix_arguments", content, str(gate_path))
+            self.assertNotIn("Get-Command python3 -ErrorAction SilentlyContinue", content, str(gate_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- route freshness, coherence, release notes, release truth, and workflow acceptance PowerShell gates through `Get-VgoPythonCommand`
- teach the governed Python resolver to skip WindowsApps `python`/`python3` stubs before falling back to real interpreters or `py -3`
- add regression coverage for WindowsApps stub handling and for gate wrappers staying on the governed helper path

Closes #180.

## Testing
- `python3 -m pytest tests/runtime_neutral/test_governed_runtime_bridge.py`
- simulated `pwsh -NoProfile -File scripts/verify/vibe-release-notes-quality-gate.ps1 ...` with PATH preferring a fake `Microsoft/WindowsApps/python3` stub before a real Python wrapper


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized Python discovery into a shared helper used by verification scripts, standardizing how a Python runtime is selected and invoked and avoiding problematic platform-specific launcher stubs and missing invocation prefixes.

* **Tests**
  * Added tests for multiple Python resolution scenarios (including stubbed launchers and required prefix arguments) and to verify verification scripts use the centralized discovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->