### PR TITLE
Refresh v3.0.4 release surface from latest main

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -382,6 +382,6 @@ The governed runtime should leave behind:
 
 - Runtime family: governed-runtime-first
 - Version: 3.0.4
-- Updated: 2026-04-18
+- Updated: 2026-04-19
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/config/version-governance.json
+++ b/config/version-governance.json
@@ -2,9 +2,9 @@
   "schema_version": 2,
   "release": {
     "version": "3.0.4",
-    "updated": "2026-04-18",
+    "updated": "2026-04-19",
     "channel": "stable",
-    "notes": "direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair"
+    "notes": "Windows verification gate Python resolution / direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair"
   },
   "source_of_truth": {
     "canonical_root": ".",

--- a/dist/core/manifest.json
+++ b/dist/core/manifest.json
@@ -5,7 +5,7 @@
   "stability": "preview",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "summary": "Universal contracts only. No install/check runtime closure is promised by this lane.",
   "runtime_ownership": {

--- a/dist/host-claude-code/manifest.json
+++ b/dist/host-claude-code/manifest.json
@@ -6,7 +6,7 @@
   "stability": "supported-with-constraints",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "summary": "Claude Code host adapter lane with bounded managed closure. The repo can write and verify a managed Claude settings surface, while still keeping broader host behavior outside repo ownership.",
   "runtime_ownership": {

--- a/dist/host-codex/manifest.json
+++ b/dist/host-codex/manifest.json
@@ -6,7 +6,7 @@
   "stability": "supported-with-constraints",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "summary": "Codex host adapter lane. Uses the official runtime entrypoints, but remains honest about host-managed plugin and credential surfaces.",
   "runtime_ownership": {

--- a/dist/host-cursor/manifest.json
+++ b/dist/host-cursor/manifest.json
@@ -6,7 +6,7 @@
   "stability": "preview",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "summary": "Cursor host adapter preview. The repository can expose runtime-core payload and preview health checks, but does not claim full governed closure yet.",
   "runtime_ownership": {

--- a/dist/host-openclaw/manifest.json
+++ b/dist/host-openclaw/manifest.json
@@ -6,7 +6,7 @@
   "stability": "preview",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "summary": "OpenClaw host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/host-opencode/manifest.json
+++ b/dist/host-opencode/manifest.json
@@ -6,7 +6,7 @@
   "stability": "preview",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "summary": "OpenCode host adapter preview. The repo can install runtime-core plus OpenCode-native command and agent wrapper payload into OpenCode roots, but final host config and platform closure remain incomplete.",
   "runtime_ownership": {

--- a/dist/host-windsurf/manifest.json
+++ b/dist/host-windsurf/manifest.json
@@ -6,7 +6,7 @@
   "stability": "preview",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "summary": "Windsurf host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/manifests/vibeskills-claude-code.json
+++ b/dist/manifests/vibeskills-claude-code.json
@@ -49,7 +49,7 @@
   "summary": "Claude Code now has a bounded managed install/check lane that writes and verifies a Claude settings surface, but it still does not become the Codex official runtime or full platform-parity lane.",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-codex.json
+++ b/dist/manifests/vibeskills-codex.json
@@ -54,7 +54,7 @@
   "summary": "Codex is the current strongest practical reference lane for the governed runtime payload, but some key surfaces remain host-managed and certain platforms are degraded.",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-core.json
+++ b/dist/manifests/vibeskills-core.json
@@ -47,7 +47,7 @@
   "summary": "Host-agnostic contracts and schemas that stabilize skill metadata without claiming a governed runtime on any host.",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "truth_sources": [
     "docs/universalization/core-contract.md",

--- a/dist/manifests/vibeskills-cursor.json
+++ b/dist/manifests/vibeskills-cursor.json
@@ -51,7 +51,7 @@
   "summary": "Cursor exposes preview adapter entrypoints and truthful readiness boundaries, but this repository does not claim governed or host-native closure for it.",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-generic.json
+++ b/dist/manifests/vibeskills-generic.json
@@ -46,7 +46,7 @@
   "summary": "Generic hosts may consume canonical contracts and a repo-provided runtime-core payload in a neutral target root, but the repository still makes no host closure claim.",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-openclaw.json
+++ b/dist/manifests/vibeskills-openclaw.json
@@ -51,7 +51,7 @@
   "summary": "OpenClaw may consume the shared runtime-core payload through a documented host root, but this repository does not claim host-native governed closure for it.",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-opencode.json
+++ b/dist/manifests/vibeskills-opencode.json
@@ -54,7 +54,7 @@
   "summary": "OpenCode now has a truthful preview adapter lane with bounded install/check entrypoints, skills payload, and wrapper scaffolds, but the repository still avoids claiming full host closure or platform parity.",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-windsurf.json
+++ b/dist/manifests/vibeskills-windsurf.json
@@ -51,7 +51,7 @@
   "summary": "Windsurf may consume the shared runtime-core payload through a documented host root, but this repository does not claim host-native governed closure for it.",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/official-runtime/manifest.json
+++ b/dist/official-runtime/manifest.json
@@ -5,7 +5,7 @@
   "stability": "tier-1",
   "source_release": {
     "version": "3.0.4",
-    "updated": "2026-04-18"
+    "updated": "2026-04-19"
   },
   "summary": "Reference lane for the current governed official runtime. This dist pack points to it and must not rewrite it.",
   "runtime_ownership": {

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -10,7 +10,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ### Current Release Surface
 
-- [`v3.0.4.md`](v3.0.4.md): direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair
+- [`v3.0.4.md`](v3.0.4.md): Windows verification gate Python resolution / direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair
 
 ### Release Runtime / Proof Handoff
 
@@ -24,7 +24,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ## Recent Governed Releases
 
-- [`v3.0.4.md`](v3.0.4.md) - 2026-04-18 - direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair
+- [`v3.0.4.md`](v3.0.4.md) - 2026-04-19 - Windows verification gate Python resolution / direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair
 - [`v3.0.3.md`](v3.0.3.md) - 2026-04-15 - host-global bootstrap lifecycle / specialist decision truth / upgrade metadata hardening / installed runtime payload coverage repair
 - [`v3.0.2.md`](v3.0.2.md) - 2026-04-13 - mainline upgrade flow / workspace memory plane / document artifact governance / specialist lifecycle disclosure / release truth refresh
 - [`v3.0.0.md`](v3.0.0.md) - 2026-04-07 - major public baseline / architecture closure / host-safe install-uninstall / governed execution proof / native MCP-first readiness

--- a/docs/releases/v3.0.4.md
+++ b/docs/releases/v3.0.4.md
@@ -1,22 +1,24 @@
 # VCO Release v3.0.4
 
-- Date: 2026-04-18
-- Commit(base): c0618d0
+- Date: 2026-04-19
+- Commit(base): eeb09f3
 - Previous public release: `v3.0.3`
 - Previous public release commit: `48743c5`
 
 ## Highlights
 
-- Promoted the latest maintained `main` state after `v3.0.3` instead of leaving the direct-routing and canonical-entry hardening work stranded behind the public line. This cut packages the current maintained source at `c0618d0`.
+- Refreshed `v3.0.4` from a later maintained source so the Windows verification-gate repair does not remain stranded behind the original `2026-04-18` cut. This refresh packages the current maintained source at `eeb09f3`.
 - Replaced the odd "open a Codex child session to ask a specialist" behavior with direct in-session specialist routing. The governed runtime now routes specialists to the current session by default, keeps the accounting and proof surfaces explicit, and preserves reviewable fallback truth instead of hiding specialist decisions behind extra host-specific conversation launches.
 - Hardened canonical `vibe` entry truth end to end. Runtime packet coverage, host launch receipts, launch-failure receipt state, and canonical truth-artifact checks now line up more tightly with what the governed runtime actually emits.
 - Repaired a release-train contradiction around adaptive-routing evidence. The adaptive readiness gate now self-seeds route telemetry through the observability gate when a clean checkout has no prior `outputs/telemetry` evidence, so governed release cuts no longer depend on forbidden tracked outputs or a manually primed working tree.
 - Tightened upgrade correctness around installed-target truth and request defaults. Target-root upgrade checks now read the right truth source, specialist snapshot-ignore handling no longer misclassifies consultation state, and empty `/vibe-upgrade` invocations now default to the shared upgrade path for the current host instead of stopping to ask the user what should be upgraded.
+- Hardened Windows PowerShell verification paths so governed checks no longer false-fail just because `python` or `python3` first resolves to a WindowsApps store stub. The governed resolver now skips those stubs, keeps scanning later PATH candidates, and prefers `python3` before `python` to stay aligned with the shell-side Python 3 policy.
 
 ## What Changed Since v3.0.3
 
 - `v3.0.3` moved the public line forward to the then-latest maintained source at `537db3f`, focusing on host-global bootstrap lifecycle, specialist decision truth, upgrade metadata hardening, and installed-runtime payload completeness.
-- `v3.0.4` continues that `3.0.x` line with the next maintained source after the `v3.0.3` cut:
+- The original `v3.0.4` cut moved the public line to `c0618d0` with direct specialist routing, canonical-entry truth hardening, adaptive-routing telemetry seeding, and upgrade behavior repair.
+- This `2026-04-19` refresh keeps the same public version but advances the maintained source to `eeb09f3` so the release surface matches the latest governed Windows verification behavior:
   - PR `#170` hardened canonical `vibe` runtime entry behavior and proof expectations.
   - PR `#171` restored canonical entry runtime payload coverage so the shipped runtime carries the files the governed entry actually depends on.
   - PR `#172` repaired native specialist Codex home seeding and sidecar cleanup so direct specialist execution could stabilize without host-specific bootstrapping regressions.
@@ -25,20 +27,23 @@
   - PR `#176` corrected target-install upgrade truth so upgrade verification reads the selected target root instead of drifting back to the wrong source.
   - PR `#177` fixed specialist consultation snapshot-ignore handling for issue `#173`, closing a runtime truth bug around consultation artifacts.
   - PR `#178` fixed empty `/vibe-upgrade` requests so they resolve to the shared upgrade intent for the current host instead of degenerating into an empty governed request.
+  - PR `#188` hardened governed Python resolution across PowerShell verification gates so Windows checks skip WindowsApps `python` / `python3` stubs, keep walking later PATH candidates, and prefer `python3` before `python`.
 - The release cut itself also closes a stop-ship gap that existed on latest `main`: adaptive-routing readiness no longer assumes pre-tracked telemetry under `outputs/telemetry`, and instead generates bounded replay evidence through the governed observability path during verification.
-- The practical result is a more believable governed runtime surface: specialists route directly, canonical entry proof is stricter and more honest, release gating is reproducible from a clean checkout, and upgrade behavior is less likely to ask the user unnecessary clarifying questions when the intended action is already obvious.
+- The practical result is a more believable governed runtime surface: specialists route directly, canonical entry proof is stricter and more honest, release gating is reproducible from a clean checkout, Windows verification no longer depends on `py.exe` when a real Python is later on PATH, and upgrade behavior is less likely to ask the user unnecessary clarifying questions when the intended action is already obvious.
 
 ## Release Positioning
 
 - This is a `3.0.x` continuation release, not a new major baseline.
-- The release is centered on behavior correctness and runtime truth rather than on opening a brand-new product lane. It closes gaps that were especially visible in real use: specialist routing semantics, canonical launch proof lifecycle, target-root upgrade verification, and empty upgrade invocation behavior.
+- The release is centered on behavior correctness and runtime truth rather than on opening a brand-new product lane. It closes gaps that were especially visible in real use: specialist routing semantics, canonical launch proof lifecycle, target-root upgrade verification, empty upgrade invocation behavior, and Windows verification-gate Python resolution.
+- This `2026-04-19` refresh intentionally re-cuts `v3.0.4` from a later maintained source instead of minting `v3.0.5` just to keep the existing public `3.0.x` line honest about the latest governed verification fixes.
 - As with `v3.0.3`, package metadata remains on the repository's current `3.0.0` package line. The meaningful public version signal for this cut is the governed release surface at `v3.0.4`.
 
 ## Validation Notes
 
-- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/governance/release-cut.ps1 -Version 3.0.4 -Updated 2026-04-18 -Preview -RunGates` -> preview succeeded.
-- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/governance/release-cut.ps1 -Version 3.0.4 -Updated 2026-04-18 -RunGates` -> release cut complete.
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/governance/release-cut.ps1 -Version 3.0.4 -Updated 2026-04-19 -Preview -RunGates` -> preview succeeded.
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/governance/release-cut.ps1 -Version 3.0.4 -Updated 2026-04-19 -RunGates` -> release cut complete.
 - `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/verify/vibe-adaptive-routing-readiness-gate.ps1 -WriteArtifacts` -> PASS from a clean state by auto-seeding replay telemetry through `vibe-observability-gate.ps1`.
+- `python3 -m pytest tests/runtime_neutral/test_governed_runtime_bridge.py` -> `14 passed`.
 - `python3 -m pytest tests/integration/test_release_cut_gate_contract_cutover.py` -> `3 passed`.
 - `git diff --check` -> PASS.
 
@@ -47,3 +52,4 @@
 - Operators upgrading from `v3.0.3` should expect direct in-session specialist routing to be the normal path. The governed runtime should no longer need a host-specific Codex child conversation just to route a specialist during ordinary execution.
 - If you rely on canonical-entry truth artifacts, this release is stricter about host-launch receipt lifecycle and runtime payload completeness. Failure states and proof expectations should now be easier to audit.
 - If you use `/vibe-upgrade` or similar host-visible upgrade wrappers, this is the first public cut where an empty invocation defaults cleanly to the shared current-host upgrade path instead of collapsing into an empty governed request.
+- Windows operators who previously saw `check.ps1` or release/install verification fail with exit `9009` while a real Python existed later on PATH should now see governed PowerShell verification recover automatically without requiring `py.exe` to be installed.

--- a/references/changelog.md
+++ b/references/changelog.md
@@ -1,9 +1,10 @@
 # VCO Changelog
 
-## v3.0.4 (2026-04-18)
+## v3.0.4 (2026-04-19)
 
-- Moved specialist routing onto the current session by default, strengthened canonical-entry truth artifacts and launch-failure receipt handling, and repaired upgrade intent/truth handling across target installs and empty `/vibe-upgrade` invocations.
-- Removed a release-train stop-ship contradiction by letting adaptive-routing readiness self-seed replay telemetry through the governed observability path instead of assuming tracked `outputs/telemetry` evidence in a clean checkout.
+- Refreshed `v3.0.4` from the later maintained source at `eeb09f3` so the public release surface now includes the Windows PowerShell verification-gate Python resolver hardening that landed after the original `2026-04-18` cut.
+- Kept the original `v3.0.4` behavior upgrades intact: specialists route on the current session by default, canonical-entry truth and launch-failure receipt handling are stricter, adaptive-routing readiness self-seeds replay telemetry from a clean checkout, and upgrade intent/truth handling stays repaired across target installs and empty `/vibe-upgrade` invocations.
+- PowerShell verification gates now stay on the governed Python resolver end to end, skip WindowsApps `python` / `python3` stubs, scan later PATH candidates, and prefer `python3` before `python` to match the shell-side Python 3 policy.
 - Detailed release notes: `docs/releases/v3.0.4.md`.
 
 

--- a/references/release-ledger.jsonl
+++ b/references/release-ledger.jsonl
@@ -32,3 +32,4 @@
 {"recorded_at":"2026-04-13T19:03:43","version":"3.0.2","updated":"2026-04-13","git_head":"c2f98b5","actor":null}
 {"recorded_at":"2026-04-15T23:01:43","version":"3.0.3","updated":"2026-04-15","git_head":"537db3f","actor":null}
 {"recorded_at":"2026-04-18T13:34:12","version":"3.0.4","updated":"2026-04-18","git_head":"c0618d0","actor":null}
+{"recorded_at":"2026-04-19T04:28:17","version":"3.0.4","updated":"2026-04-19","git_head":"eeb09f3","actor":null}


### PR DESCRIPTION
## Summary
- refresh the `v3.0.4` release surface from the latest maintained `main`
- include the Windows PowerShell verification-gate Python resolver hardening from PR #188 in the governed release metadata, notes, and manifests
- resync the governed release README, changelog, ledger, and dist manifests for the refreshed `2026-04-19` cut

## Validation
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/governance/release-cut.ps1 -Version 3.0.4 -Updated 2026-04-19 -Preview -RunGates`
- `python3 -m pytest tests/runtime_neutral/test_governed_runtime_bridge.py`
- `python3 -m pytest tests/integration/test_release_cut_gate_contract_cutover.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release metadata and documentation for v3.0.4 to reflect new release date (2026-04-19).
  * Added details on Windows PowerShell verification improvements, including Python stub handling and PATH scanning enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->