### PR TITLE
Document failure exposure and fallback discipline

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -357,6 +357,16 @@ Minimum invariants:
 - canonical vibe claims require `host-launch-receipt.json`, `runtime-input-packet.json`, `governance-capsule.json`, and `stage-lineage.json`
 - canonical vibe claims require runtime artifact proof, not SKILL.md-only simulation
 
+### Failure Exposure And Fallback Discipline
+
+- Do not introduce new fallback, degraded-success, or boundary behavior just to keep a path running when it would otherwise fail.
+- Do not add mock success paths, template-only success outputs, swallowed errors, or any other fake-success behavior that hides the root cause.
+- Prefer full exposure: surface real failures with explicit errors, exceptions, logs, failing verification, or downgraded closure wording instead of pretending the primary path succeeded.
+- Only introduce or retain fallback / degraded behavior when the active requirement explicitly asks for it.
+- Any allowed fallback or boundary behavior must be explicit, traceable in artifacts or logs, documented in the relevant contract or requirement surface, and easy to disable.
+- Fallback or boundary behavior must not be used to bypass real execution, verification, or root-cause repair.
+- Existing explicit governance boundaries are not themselves violations; this rule targets newly introduced behavior that hides capability loss or papers over a broken primary path.
+
 ## Outputs
 
 The governed runtime should leave behind:

--- a/protocols/do.md
+++ b/protocols/do.md
@@ -203,3 +203,6 @@ Before leaving this protocol, write or preserve the evidence needed for cleanup:
 - For L grade, use Superpowers subagent system, NOT Everything-CC agents.
 - If the preferred orchestration stack is unavailable, do not silently downgrade. Follow `fallback-chains.md` only as an explicit degraded path, emit a standalone hazard alert, and record that the resulting execution is non-authoritative.
 - Do not self-introduce new fallback logic during implementation unless the active requirement document explicitly approves fallback-related changes.
+- Do not convert primary-path failure into fake success by swallowing exceptions, returning template-only success text, or leaving mock / simulation placeholders in production behavior.
+- Prefer explicit failure exposure over convenience recovery: if the real path fails, keep the failure visible in logs, receipts, verification output, or downgraded closure wording.
+- If a requirement explicitly permits fallback or degraded behavior, keep it explicit, document the trigger and non-authoritative status, and make the path easy to disable or remove later.

--- a/protocols/review.md
+++ b/protocols/review.md
@@ -82,14 +82,16 @@ Before approving code:
 8. Immutable patterns used (no mutation)
 9. No new fallback or degraded-path logic unless the active requirement explicitly approves it
 10. Any fallback path is labeled as a hazard, not presented as equivalent success
-11. The reviewed change states its primary objective, not only its local success signal
-12. Validation material is not absorbed into product logic or route truth
-13. The claimed completion state matches the evidence bundle and scope
-14. Bounded specialization is either preserved as specialization or explicitly marked as not-yet-generalized
-15. Any anti-drift warning is recorded as report-only review evidence, not hidden hard enforcement
-16. Product acceptance criteria are frozen in the requirement doc rather than improvised at closeout
-17. Manual spot checks are either explicitly not needed or honestly left as pending manual review
-18. Delivery-truth wording does not collapse workflow/process success into downstream project acceptance
+11. No mock-success, template-success, swallowed-error, or simulation-only path is introduced where the real execution path can fail
+12. Any allowed fallback or degraded path is explicit, traceable, documented, and easy to disable
+13. The reviewed change states its primary objective, not only its local success signal
+14. Validation material is not absorbed into product logic or route truth
+15. The claimed completion state matches the evidence bundle and scope
+16. Bounded specialization is either preserved as specialization or explicitly marked as not-yet-generalized
+17. Any anti-drift warning is recorded as report-only review evidence, not hidden hard enforcement
+18. Product acceptance criteria are frozen in the requirement doc rather than improvised at closeout
+19. Manual spot checks are either explicitly not needed or honestly left as pending manual review
+20. Delivery-truth wording does not collapse workflow/process success into downstream project acceptance
 
 ## Output Format
 Review findings categorized by severity:
@@ -100,6 +102,7 @@ Review findings categorized by severity:
 
 Fallback-specific review rule:
 - Treat silent fallback, silent degradation, or self-introduced fallback logic as HIGH at minimum and CRITICAL when it can hide capability loss from users.
+- Treat swallowed errors, mock-success branches, or template-only pass results as HIGH at minimum and CRITICAL when they can mislead users or reviewers about real execution success.
 
 Objective-protection disposition:
 - `aligned`: objective, scope, and completion wording match the evidence.

--- a/protocols/runtime.md
+++ b/protocols/runtime.md
@@ -50,7 +50,9 @@ These are syntax variants for the same governed runtime, not separate entrypoint
 5. Cleanup is mandatory before a phase is considered complete.
 6. Silent fallback and silent degradation are forbidden.
 7. Fallback success is non-authoritative unless a requirement explicitly approves otherwise.
-8. `L` runs serial native units; `XL` runs wave-sequential with step-level bounded parallel units only when dependency-safe.
+8. Fake-success behavior is forbidden: the runtime must not swallow errors, emit mock completion, or template a pass result when the primary path failed.
+9. New fallback or boundary behavior may exist only when the active requirement explicitly approves it, and it must remain explicit, traceable, and easy to disable.
+10. `L` runs serial native units; `XL` runs wave-sequential with step-level bounded parallel units only when dependency-safe.
 
 ## Official Runtime Modes
 


### PR DESCRIPTION
## Summary
- add a top-level failure-exposure and fallback-discipline rule set to canonical `SKILL.md`
- align `runtime`, `do`, and `review` protocols around explicit failure exposure and fake-success prohibition
- keep the rule scoped to newly introduced masking behavior so existing explicit governance boundaries are not mislabeled as violations

## Validation
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Failure Exposure And Fallback Discipline" guidelines requiring failures to be surfaced explicitly rather than masked by fallback behavior.
  * Enhanced system failure handling contracts to forbid fake-success behavior and mandate explicit documentation of any permitted degraded execution paths.
  * Expanded review and runtime guardrails to prevent misleading completion signals and ensure real failures remain visible to users and reviewers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->