### PR TITLE
Bucket specialist consultation selection

### DIFF
--- a/config/specialist-consultation-policy.json
+++ b/config/specialist-consultation-policy.json
@@ -4,7 +4,12 @@
   "updated_at": "2026-04-12",
   "enabled": true,
   "mode": "direct_current_session_route",
-  "max_consults_per_window": 2,
+  "max_consults_per_window": 3,
+  "selection_mode": "bucketed_with_backfill",
+  "bucket_limits": {
+    "primary": 2,
+    "stage_assistant": 1
+  },
   "allowed_windows": [
     "discussion",
     "planning"

--- a/scripts/runtime/VibeConsultation.Common.ps1
+++ b/scripts/runtime/VibeConsultation.Common.ps1
@@ -4,6 +4,51 @@ $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'VibeRuntime.Common.ps1')
 . (Join-Path $PSScriptRoot 'VibeExecution.Common.ps1')
 
+function ConvertTo-VibeSpecialistConsultationBucketLimits {
+    param(
+        [AllowNull()] [object]$BucketLimits = $null
+    )
+
+    $resolved = @{}
+    if ($null -eq $BucketLimits) {
+        return $resolved
+    }
+
+    if ($BucketLimits -is [System.Collections.IDictionary]) {
+        foreach ($key in @($BucketLimits.Keys)) {
+            $name = if ($null -eq $key) { '' } else { [string]$key }
+            if ([string]::IsNullOrWhiteSpace($name)) {
+                continue
+            }
+            $limit = [int]$BucketLimits[$key]
+            if ($limit -le 0) {
+                continue
+            }
+            $resolved[$name.Trim().ToLowerInvariant()] = $limit
+        }
+        return $resolved
+    }
+
+    foreach ($property in @($BucketLimits.PSObject.Properties)) {
+        if ($null -eq $property) {
+            continue
+        }
+
+        $name = if ([string]::IsNullOrWhiteSpace([string]$property.Name)) { '' } else { [string]$property.Name }
+        if ([string]::IsNullOrWhiteSpace($name)) {
+            continue
+        }
+
+        $limit = [int]$property.Value
+        if ($limit -le 0) {
+            continue
+        }
+        $resolved[$name.Trim().ToLowerInvariant()] = $limit
+    }
+
+    return $resolved
+}
+
 function Get-VibeSpecialistConsultationPolicy {
     param(
         [AllowNull()] [object]$Policy = $null
@@ -47,12 +92,31 @@ function Get-VibeSpecialistConsultationPolicy {
         throw ("Unsupported specialist consultation mode: {0}" -f $consultationMode)
     }
 
+    $selectionMode = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'selection_mode') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedPolicy.selection_mode)) {
+        [string]$resolvedPolicy.selection_mode
+    } else {
+        'flat_ranked'
+    }
+    $selectionMode = $selectionMode.Trim().ToLowerInvariant()
+    $allowedSelectionModes = @('flat_ranked', 'bucketed_with_backfill')
+    if ($selectionMode -notin $allowedSelectionModes) {
+        throw ("Unsupported specialist consultation selection mode: {0}" -f $selectionMode)
+    }
+
+    $bucketLimits = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'bucket_limits')) {
+        ConvertTo-VibeSpecialistConsultationBucketLimits -BucketLimits $resolvedPolicy.bucket_limits
+    } else {
+        @{}
+    }
+
     return [pscustomobject]@{
         enabled = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'enabled')) { [bool]$resolvedPolicy.enabled } else { $false }
         version = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'version')) { [int]$resolvedPolicy.version } else { 1 }
         policy_id = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'policy_id') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedPolicy.policy_id)) { [string]$resolvedPolicy.policy_id } else { 'specialist-consultation-v1' }
         mode = $consultationMode
         max_consults_per_window = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'max_consults_per_window')) { [int]$resolvedPolicy.max_consults_per_window } else { 2 }
+        selection_mode = $selectionMode
+        bucket_limits = $bucketLimits
         allowed_windows = @($allowedWindows)
         require_contract_complete = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'require_contract_complete')) { [bool]$resolvedPolicy.require_contract_complete } else { $true }
         require_native_workflow = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'require_native_workflow')) { [bool]$resolvedPolicy.require_native_workflow } else { $true }
@@ -70,6 +134,26 @@ function Get-VibeSpecialistConsultationPolicy {
         fail_freeze_on_live_degraded_results = if ($null -ne $resolvedPolicy -and (Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'fail_freeze_on_live_degraded_results')) { [bool]$resolvedPolicy.fail_freeze_on_live_degraded_results } else { $true }
         window_prompts = $windowPrompts
     }
+}
+
+function Get-VibeSpecialistConsultationBucket {
+    param(
+        [Parameter(Mandatory)] [object]$Recommendation
+    )
+
+    $source = if (
+        (Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'source') -and
+        -not [string]::IsNullOrWhiteSpace([string]$Recommendation.source)
+    ) {
+        [string]$Recommendation.source
+    } else {
+        ''
+    }
+
+    if ([string]::Equals($source, 'route_stage_assistant', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return 'stage_assistant'
+    }
+    return 'primary'
 }
 
 function Get-VibeSpecialistConsultationReceiptPath {
@@ -135,6 +219,7 @@ function New-VibeSpecialistConsultationCandidate {
     } else {
         [string]$defaults.consultation_reason
     }
+    $consultationBucket = Get-VibeSpecialistConsultationBucket -Recommendation $Recommendation
 
     return [pscustomobject]@{
         skill_id = [string]$Recommendation.skill_id
@@ -158,6 +243,7 @@ function New-VibeSpecialistConsultationCandidate {
         execution_priority = if ((Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'execution_priority') -and $null -ne $Recommendation.execution_priority) { [int]$Recommendation.execution_priority } else { 0 }
         rank = if ((Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'rank') -and $null -ne $Recommendation.rank) { [int]$Recommendation.rank } else { 9999 }
         confidence = if ((Test-VibeObjectHasProperty -InputObject $Recommendation -PropertyName 'confidence') -and $null -ne $Recommendation.confidence) { [double]$Recommendation.confidence } else { 0.0 }
+        consultation_bucket = $consultationBucket
     }
 }
 
@@ -173,7 +259,19 @@ function Split-VibeSpecialistConsultationCandidates {
     $approved = New-Object System.Collections.Generic.List[object]
     $deferred = New-Object System.Collections.Generic.List[object]
     $blocked = New-Object System.Collections.Generic.List[object]
+    $overflow = New-Object System.Collections.Generic.List[object]
     $seenSkillIds = @{}
+    $bucketUsage = @{}
+    $selectionMode = if ((Test-VibeObjectHasProperty -InputObject $resolvedPolicy -PropertyName 'selection_mode') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedPolicy.selection_mode)) {
+        [string]$resolvedPolicy.selection_mode
+    } else {
+        'flat_ranked'
+    }
+    $bucketedSelectionEnabled = (
+        [string]::Equals($selectionMode, 'bucketed_with_backfill', [System.StringComparison]::OrdinalIgnoreCase) -and
+        $null -ne $resolvedPolicy.bucket_limits -and
+        $resolvedPolicy.bucket_limits.Count -gt 0
+    )
 
     if (-not [bool]$resolvedPolicy.enabled -or -not (@($resolvedPolicy.allowed_windows) -contains $WindowId)) {
         return [pscustomobject]@{
@@ -238,17 +336,86 @@ function Split-VibeSpecialistConsultationCandidates {
             ) | Out-Null
             continue
         }
+        $candidateBucket = if (
+            (Test-VibeObjectHasProperty -InputObject $candidate -PropertyName 'consultation_bucket') -and
+            -not [string]::IsNullOrWhiteSpace([string]$candidate.consultation_bucket)
+        ) {
+            [string]$candidate.consultation_bucket
+        } else {
+            'primary'
+        }
+        $candidateBucket = $candidateBucket.Trim().ToLowerInvariant()
+
+        if ($bucketedSelectionEnabled -and $resolvedPolicy.bucket_limits.ContainsKey($candidateBucket)) {
+            $bucketLimit = [int]$resolvedPolicy.bucket_limits[$candidateBucket]
+            $bucketUsed = if ($bucketUsage.ContainsKey($candidateBucket)) { [int]$bucketUsage[$candidateBucket] } else { 0 }
+            if ($bucketUsed -ge $bucketLimit) {
+                $overflow.Add(
+                    [pscustomobject]@{
+                        candidate = $candidate
+                        consultation_bucket = $candidateBucket
+                    }
+                ) | Out-Null
+                continue
+            }
+        }
         if ($approved.Count -ge [int]$resolvedPolicy.max_consults_per_window) {
             $deferred.Add(
                 [pscustomobject]@{
                     skill_id = $candidate.skill_id
                     reason = 'max_consults_per_window_reached'
+                    consultation_bucket = $candidateBucket
                 }
             ) | Out-Null
             continue
         }
 
         $approved.Add($candidate) | Out-Null
+        $bucketUsage[$candidateBucket] = if ($bucketUsage.ContainsKey($candidateBucket)) { [int]$bucketUsage[$candidateBucket] + 1 } else { 1 }
+    }
+
+    if ($bucketedSelectionEnabled -and $approved.Count -lt [int]$resolvedPolicy.max_consults_per_window) {
+        foreach ($overflowEntry in $overflow.ToArray()) {
+            if ($approved.Count -ge [int]$resolvedPolicy.max_consults_per_window) {
+                break
+            }
+
+            $candidate = $overflowEntry.candidate
+            if ($null -eq $candidate) {
+                continue
+            }
+
+            $approved.Add($candidate) | Out-Null
+            $candidateBucket = if ($null -eq $overflowEntry.consultation_bucket) { 'primary' } else { [string]$overflowEntry.consultation_bucket }
+            $bucketUsage[$candidateBucket] = if ($bucketUsage.ContainsKey($candidateBucket)) { [int]$bucketUsage[$candidateBucket] + 1 } else { 1 }
+        }
+    }
+
+    if ($overflow.Count -gt 0) {
+        $approvedSkillIndex = @{}
+        foreach ($approvedItem in $approved.ToArray()) {
+            if ($null -eq $approvedItem) {
+                continue
+            }
+            $approvedSkillIndex[[string]$approvedItem.skill_id] = $true
+        }
+
+        foreach ($overflowEntry in $overflow.ToArray()) {
+            $candidate = $overflowEntry.candidate
+            if ($null -eq $candidate) {
+                continue
+            }
+            if ($approvedSkillIndex.ContainsKey([string]$candidate.skill_id)) {
+                continue
+            }
+            $deferred.Add(
+                [pscustomobject]@{
+                    skill_id = $candidate.skill_id
+                    reason = 'max_consults_per_window_reached'
+                    consultation_bucket = if ($null -eq $overflowEntry.consultation_bucket) { 'primary' } else { [string]$overflowEntry.consultation_bucket }
+                }
+            ) | Out-Null
+        }
     }
 
     return [pscustomobject]@{

--- a/tests/runtime_neutral/test_vibe_specialist_consultation.py
+++ b/tests/runtime_neutral/test_vibe_specialist_consultation.py
@@ -548,6 +548,102 @@ def set_directory_writable(path: Path) -> None:
 
 
 class VibeSpecialistConsultationTests(unittest.TestCase):
+    def test_bucketed_consultation_selection_keeps_stage_assistant_visible(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_root = Path(tempdir)
+            primary_one = temp_root / "primary-one" / "SKILL.md"
+            primary_two = temp_root / "primary-two" / "SKILL.md"
+            stage_one = temp_root / "stage-one" / "SKILL.md"
+            stage_two = temp_root / "stage-two" / "SKILL.md"
+            for path in (primary_one, primary_two, stage_one, stage_two):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("# Skill\n", encoding="utf-8")
+
+            result = run_runtime_common_json(
+                f"""
+                . {_ps_single_quote(str(CONSULTATION_SCRIPT))}
+                $policy = [pscustomobject]@{{
+                    enabled = $true
+                    mode = 'direct_current_session_route'
+                    max_consults_per_window = 3
+                    selection_mode = 'bucketed_with_backfill'
+                    bucket_limits = [pscustomobject]@{{
+                        primary = 2
+                        stage_assistant = 1
+                    }}
+                    allowed_windows = @('discussion', 'planning')
+                    require_contract_complete = $true
+                    require_native_workflow = $true
+                    require_native_usage_required = $true
+                    require_entrypoint_path = $true
+                }}
+                $recommendations = @(
+                    [pscustomobject]@{{
+                        skill_id = 'ml-expert'
+                        source = 'route_ranked'
+                        native_skill_entrypoint = {_ps_single_quote(primary_one.as_posix())}
+                        reason = 'primary specialist one'
+                        contract_complete = $true
+                        must_preserve_workflow = $true
+                        native_usage_required = $true
+                        rank = 1
+                        confidence = 0.99
+                    }},
+                    [pscustomobject]@{{
+                        skill_id = 'science-plotting'
+                        source = 'route_ranked'
+                        native_skill_entrypoint = {_ps_single_quote(primary_two.as_posix())}
+                        reason = 'primary specialist two'
+                        contract_complete = $true
+                        must_preserve_workflow = $true
+                        native_usage_required = $true
+                        rank = 2
+                        confidence = 0.98
+                    }},
+                    [pscustomobject]@{{
+                        skill_id = 'brainstorming'
+                        source = 'route_stage_assistant'
+                        native_skill_entrypoint = {_ps_single_quote(stage_one.as_posix())}
+                        reason = 'stage assistant one'
+                        contract_complete = $true
+                        must_preserve_workflow = $true
+                        native_usage_required = $true
+                        rank = 3
+                        confidence = 0.70
+                    }},
+                    [pscustomobject]@{{
+                        skill_id = 'writing-plans'
+                        source = 'route_stage_assistant'
+                        native_skill_entrypoint = {_ps_single_quote(stage_two.as_posix())}
+                        reason = 'stage assistant two'
+                        contract_complete = $true
+                        must_preserve_workflow = $true
+                        native_usage_required = $true
+                        rank = 4
+                        confidence = 0.60
+                    }}
+                )
+                $result = Split-VibeSpecialistConsultationCandidates -Recommendations $recommendations -WindowId 'discussion' -Stage 'deep_interview' -Policy $policy
+                $result | ConvertTo-Json -Depth 20
+                """
+            )
+
+            assert isinstance(result, dict)
+            approved = list(result["approved_consultation"])
+            deferred = list(result["deferred_to_execution"])
+            self.assertEqual(
+                ["ml-expert", "science-plotting", "brainstorming"],
+                [item["skill_id"] for item in approved],
+            )
+            self.assertEqual(
+                ["primary", "primary", "stage_assistant"],
+                [item["consultation_bucket"] for item in approved],
+            )
+            self.assertEqual(1, len(deferred))
+            self.assertEqual("writing-plans", deferred[0]["skill_id"])
+            self.assertEqual("max_consults_per_window_reached", deferred[0]["reason"])
+            self.assertEqual("stage_assistant", deferred[0]["consultation_bucket"])
+
     def test_user_disclosure_projection_retains_entries_with_missing_or_invalid_entrypoints(self) -> None:
         result = run_runtime_common_json(
             """


### PR DESCRIPTION
## Summary
- bucket specialist consultation approval into `primary` and `stage_assistant` lanes instead of flat top-N truncation
- reserve one consultation slot for stage assistants while allowing backfill when a bucket is underused
- add a regression test that locks the expected `2 primary + 1 stage assistant` behavior

## Problem
Consultation routing was previously a flat sorted cutoff with `max_consults_per_window = 2`. That caused stage assistants such as `brainstorming` to be consistently deferred behind higher-ranked domain specialists, even when the route had already surfaced them as stage helpers.

## Fix
- increase `max_consults_per_window` to `3`
- add `selection_mode = bucketed_with_backfill`
- classify `route_stage_assistant` recommendations into a dedicated `stage_assistant` bucket
- enforce per-bucket limits before falling back to total-cap deferral
- preserve explicit deferred reasons in the consultation receipt

## Validation
- `python3 -m pytest tests/runtime_neutral/test_vibe_specialist_consultation.py -q`
- real governed runtime simulation in a clean worktree confirmed user-visible behavior changed from `2 primary only` to `2 primary + 1 stage assistant` in both discussion and planning consultation receipts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bucketed consultation selection mode with configurable allocation limits across consultation categories
  * Specialist consultations now tracked with separate limits for different consultation types

* **Configuration Updates**
  * Increased consultation limit per window from 2 to 3
  * New selection mode option available: bucketed_with_backfill

<!-- end of auto-generated comment: release notes by coderabbit.ai -->