### PR TITLE
fix: doctor Claude Code global MCP config on Windows

### DIFF
--- a/check.ps1
+++ b/check.ps1
@@ -175,13 +175,13 @@ function Invoke-RuntimeNeutralBootstrapDoctor {
     return 127
   }
 
-  $args = @()
-  if ([System.IO.Path]::GetFileName([string]$pythonCommand.Source).ToLowerInvariant() -eq 'py.exe' -or
-      [System.IO.Path]::GetFileName([string]$pythonCommand.Source).ToLowerInvariant() -eq 'py') {
-    $args += '-3'
+  $pythonLeaf = [System.IO.Path]::GetFileName([string]$pythonCommand.Source).ToLowerInvariant()
+  $pythonArgs = @()
+  if ($pythonLeaf -eq 'py.exe' -or $pythonLeaf -eq 'py') {
+    $pythonArgs += '-3'
   }
-  $args += @($doctorPath, '--target-root', $TargetRoot, '--write-artifacts')
-  & $pythonCommand.Source @args | ForEach-Object { Write-Host $_ }
+  $pythonArgs += @($doctorPath, '--target-root', $TargetRoot, '--write-artifacts')
+  & $pythonCommand.Source @pythonArgs 2>&1 | ForEach-Object { Write-Host $_ }
   if ($null -eq $LASTEXITCODE) {
     return 0
   }

--- a/check.ps1
+++ b/check.ps1
@@ -152,6 +152,42 @@ function Resolve-DirectRuntimeExecutableForCheck {
   }
 }
 
+function Invoke-RuntimeNeutralBootstrapDoctor {
+  param(
+    [Parameter(Mandatory)] [string]$RepoRoot,
+    [Parameter(Mandatory)] [string]$TargetRoot
+  )
+
+  $doctorPath = Join-Path $RepoRoot 'scripts\verify\runtime_neutral\bootstrap_doctor.py'
+  if (-not (Test-Path -LiteralPath $doctorPath)) {
+    return 127
+  }
+
+  $pythonCommand = $null
+  foreach ($candidate in @('python', 'python3', 'py')) {
+    $command = Get-Command $candidate -ErrorAction SilentlyContinue
+    if ($null -ne $command) {
+      $pythonCommand = $command
+      break
+    }
+  }
+  if ($null -eq $pythonCommand) {
+    return 127
+  }
+
+  $args = @()
+  if ([System.IO.Path]::GetFileName([string]$pythonCommand.Source).ToLowerInvariant() -eq 'py.exe' -or
+      [System.IO.Path]::GetFileName([string]$pythonCommand.Source).ToLowerInvariant() -eq 'py') {
+    $args += '-3'
+  }
+  $args += @($doctorPath, '--target-root', $TargetRoot, '--write-artifacts')
+  & $pythonCommand.Source @args | ForEach-Object { Write-Host $_ }
+  if ($null -eq $LASTEXITCODE) {
+    return 0
+  }
+  return [int]$LASTEXITCODE
+}
+
 function Resolve-CheckTargetContext {
   param(
     [Parameter(Mandatory)] [string]$InputRoot,
@@ -886,15 +922,18 @@ if ($Adapter.check_mode -eq 'governed' -and (Get-Command npm -ErrorAction Silent
 }
 
 if ($Deep) {
-  if ($Adapter.check_mode -eq 'governed') {
+  if ($Adapter.check_mode -eq 'governed' -or $HostId -eq 'claude-code') {
     $doctorPath = Join-Path $RepoRoot 'scripts\verify\vibe-bootstrap-doctor-gate.ps1'
     if (-not (Test-Path -LiteralPath $doctorPath)) {
       Write-Host "[FAIL] vibe bootstrap doctor gate script -> $doctorPath" -ForegroundColor Red
       $fail++
     } else {
-      $global:LASTEXITCODE = 0
-      & $doctorPath -TargetRoot $TargetRoot -WriteArtifacts
-      $doctorExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+      $doctorExitCode = Invoke-RuntimeNeutralBootstrapDoctor -RepoRoot $RepoRoot -TargetRoot $TargetRoot
+      if ($doctorExitCode -eq 127) {
+        $global:LASTEXITCODE = 0
+        & $doctorPath -TargetRoot $TargetRoot -WriteArtifacts
+        $doctorExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+      }
       if ($doctorExitCode -eq 0) {
         Write-Host '[OK] vibe bootstrap doctor gate'
         $pass++
@@ -904,7 +943,7 @@ if ($Deep) {
       }
     }
   } else {
-    Write-Host "[WARN] deep doctor skipped for adapter mode '$($Adapter.check_mode)'" -ForegroundColor Yellow
+    Write-Host "[WARN] deep doctor skipped for adapter mode '$($Adapter.check_mode)' on host '$HostId'" -ForegroundColor Yellow
     $warn++
   }
 }

--- a/check.sh
+++ b/check.sh
@@ -403,6 +403,11 @@ import os
 import re
 import sys
 
+def emit(text):
+    if text is None:
+        return
+    sys.stdout.buffer.write(f"{text}\n".encode("utf-8", errors="backslashreplace"))
+
 value = (sys.argv[1] or "").strip()
 cwd = sys.argv[2]
 normalized = value.replace("\\", "/")
@@ -421,7 +426,7 @@ else:
     candidate = os.path.abspath(os.path.join(cwd, normalized))
 
 candidate = re.sub(r"/+", "/", candidate).rstrip("/")
-print(candidate.lower() if candidate else candidate)
+emit(candidate.lower() if candidate else candidate)
 PY
     return 0
   fi
@@ -439,6 +444,12 @@ json_query_lines_from_file() {
   if command -v python3 >/dev/null 2>&1; then
     python3 - "$json_path" "$expr" <<'PY'
 import json, sys
+
+def emit(value):
+    if value is None:
+        return
+    sys.stdout.buffer.write(f"{value}\n".encode("utf-8", errors="backslashreplace"))
+
 path, expr = sys.argv[1], sys.argv[2]
 with open(path, encoding='utf-8-sig') as fh:
     data = json.load(fh)
@@ -447,18 +458,24 @@ for part in expr.split('.'):
     value = value[part]
 if isinstance(value, list):
     for item in value:
-        print('true' if item is True else 'false' if item is False else item)
+        emit('true' if item is True else 'false' if item is False else item)
 elif isinstance(value, bool):
-    print('true' if value else 'false')
+    emit('true' if value else 'false')
 elif value is None:
     pass
 else:
-    print(value)
+    emit(value)
 PY
     return $?
   elif command -v python >/dev/null 2>&1; then
     python - "$json_path" "$expr" <<'PY'
 import json, sys
+
+def emit(value):
+    if value is None:
+        return
+    sys.stdout.buffer.write(f"{value}\n".encode("utf-8", errors="backslashreplace"))
+
 path, expr = sys.argv[1], sys.argv[2]
 with open(path, encoding='utf-8-sig') as fh:
     data = json.load(fh)
@@ -467,13 +484,13 @@ for part in expr.split('.'):
     value = value[part]
 if isinstance(value, list):
     for item in value:
-        print('true' if item is True else 'false' if item is False else item)
+        emit('true' if item is True else 'false' if item is False else item)
 elif isinstance(value, bool):
-    print('true' if value else 'false')
+    emit('true' if value else 'false')
 elif value is None:
     pass
 else:
-    print(value)
+    emit(value)
 PY
     return $?
   elif pick_powershell >/dev/null 2>&1; then
@@ -998,8 +1015,8 @@ else
 fi
 
 if [[ "${DEEP}" == "true" ]]; then
-  if [[ "${ADAPTER_CHECK_MODE}" != "governed" ]]; then
-    echo "[WARN] deep doctor skipped for adapter mode '${ADAPTER_CHECK_MODE}'"
+  if [[ "${ADAPTER_CHECK_MODE}" != "governed" && "${HOST_ID}" != "claude-code" ]]; then
+    echo "[WARN] deep doctor skipped for adapter mode '${ADAPTER_CHECK_MODE}' on host '${HOST_ID}'"
     WARN=$((WARN+1))
   else
     doctor_path="${SCRIPT_DIR}/scripts/verify/vibe-bootstrap-doctor-gate.ps1"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,6 +10,12 @@
 - Verify server entries in `mcp/servers.template.json`
 - Check environment variables and local binaries
 
+## Claude Code Windows MCP warnings
+- Run `check.ps1 -HostId claude-code -TargetRoot ~/.claude -Deep`
+- If doctor reports bare `npx` MCP commands under `~/.claude.json`, wrap them as `cmd /c npx`
+- If doctor reports `claude-flow` / `ruflo` schema breakage, remove those MCP registrations or upgrade `claude-flow`
+- Use `scripts/setup/repair-claude-code-global-mcp.ps1` for the supported in-repo repair path
+
 ## Upstream update broke behavior
 - Do not hot-replace bundled content from upstream
 - Use manual merge workflow and update `config/upstream-lock.json`

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor.py
@@ -54,6 +54,21 @@ def write_artifacts(repo_root: Path, artifact: dict[str, Any], output_directory:
             f"- Corruption: `{global_instruction_bootstrap.get('corruption')}`",
             "",
         ]
+    claude_code_global_mcp = ((artifact.get("host_runtime") or {}).get("claude_code_global_mcp") or {})
+    if claude_code_global_mcp.get("applicable"):
+        schema_issue = claude_code_global_mcp.get("claude_flow_schema_issue") or {}
+        lines += [
+            "## Claude Code Global MCP",
+            "",
+            f"- Status: `{claude_code_global_mcp.get('status')}`",
+            f"- Config Path: `{claude_code_global_mcp.get('config_path')}`",
+            f"- Bare npx Servers: `{', '.join(claude_code_global_mcp.get('windows_bare_npx_servers') or []) or 'none'}`",
+            f"- claude-flow MCP Aliases: `{', '.join(claude_code_global_mcp.get('claude_flow_mcp_servers') or []) or 'none'}`",
+            f"- Duplicate claude-flow Aliases: `{', '.join(claude_code_global_mcp.get('duplicate_claude_flow_aliases') or []) or 'none'}`",
+            f"- Schema Issue Detected: `{schema_issue.get('detected')}`",
+            f"- claude-flow Version: `{schema_issue.get('package_version')}`",
+            "",
+        ]
     if artifact["plugins"]:
         lines += ["## Plugin Readiness", ""]
         for plugin in artifact["plugins"]:
@@ -152,6 +167,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[FAIL] {exc}", file=sys.stderr)
         return 1
     print(f"[INFO] readiness_state={artifact['summary']['readiness_state']}")
+    for issue in artifact["summary"]["blocking_issues"]:
+        print(f"[BLOCK] {issue}")
+    for action in artifact["summary"]["manual_actions"]:
+        print(f"[ACTION] {action}")
+    for warning in artifact["summary"]["warnings"]:
+        print(f"[WARN] {warning}")
     return 0 if artifact["gate_result"] == "PASS" else 1
 
 

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_runtime.py
@@ -7,6 +7,7 @@ from vgo_contracts.host_runtime_readiness import evaluate_host_runtime_readiness
 
 from .bootstrap_doctor_support import (
     command_present,
+    inspect_claude_code_global_mcp_config,
     inspect_global_instruction_bootstrap,
     load_json,
     os_environ,
@@ -227,6 +228,11 @@ def collect_host_runtime(repo_root: Path, target_root: Path) -> dict[str, Any]:
         target_root,
         host_id=str(runtime_readiness.get("host_id") or host_id or "").strip() or None,
     )
+    claude_code_global_mcp = (
+        inspect_claude_code_global_mcp_config(target_root)
+        if (str(runtime_readiness.get("host_id") or host_id or "").strip() == "claude-code")
+        else {"applicable": False}
+    )
     return {
         "host_id": str(runtime_readiness.get("host_id") or host_id or "").strip() or None,
         "entry_mode": str(runtime_readiness["entry_mode"]),
@@ -250,6 +256,7 @@ def collect_host_runtime(repo_root: Path, target_root: Path) -> dict[str, Any]:
         "vibe_host_ready": vibe_host_ready,
         "direct_runtime": dict(runtime_readiness["direct_runtime"]),
         "global_instruction_bootstrap": global_instruction_bootstrap,
+        "claude_code_global_mcp": claude_code_global_mcp,
     }
 
 
@@ -355,6 +362,35 @@ def build_summary(
             status = str(global_instruction_bootstrap.get("status") or "unhealthy")
             blocking_issues.append(
                 f"global instruction bootstrap is unhealthy ({status})"
+            )
+    claude_code_global_mcp = host_runtime.get("claude_code_global_mcp") if isinstance(host_runtime, dict) else None
+    if isinstance(claude_code_global_mcp, dict) and bool(claude_code_global_mcp.get("applicable")):
+        repair_hint = "Run scripts/setup/repair-claude-code-global-mcp.ps1 or fix ~/.claude.json manually."
+        if str(claude_code_global_mcp.get("status") or "") == "parse_failed":
+            warnings.append("Claude Code global MCP config exists but could not be parsed; inspect ~/.claude.json manually.")
+        bare_npx_servers = [str(item) for item in claude_code_global_mcp.get("windows_bare_npx_servers") or []]
+        if bare_npx_servers:
+            manual_actions.append(
+                "Claude Code global MCP config uses bare npx entries on Windows for: "
+                + ", ".join(bare_npx_servers)
+                + f". {repair_hint}"
+            )
+        duplicate_aliases = [str(item) for item in claude_code_global_mcp.get("duplicate_claude_flow_aliases") or []]
+        if duplicate_aliases:
+            warnings.append(
+                "Claude Code global MCP config registers multiple claude-flow MCP aliases: "
+                + ", ".join(duplicate_aliases)
+                + ". Keep at most one alias."
+            )
+        schema_issue = claude_code_global_mcp.get("claude_flow_schema_issue") or {}
+        if isinstance(schema_issue, dict) and bool(schema_issue.get("detected")):
+            package_version = str(schema_issue.get("package_version") or "unknown")
+            manual_actions.append(
+                "Installed claude-flow "
+                + package_version
+                + " emits an invalid MCP schema for hooks_intelligence_learn.trajectoryIds. "
+                + "Disable/remove global claude-flow/ruflo MCP entries or upgrade claude-flow. "
+                + repair_hint
             )
     if install_state != "installed_locally":
         warnings.append(f"Install state is '{install_state}'; verify the local install receipt.")

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -21,6 +22,10 @@ HOST_GLOBAL_INSTRUCTION_TARGETS = {
     "claude-code": {"relpath": "CLAUDE.md", "documented_path": "~/.claude/CLAUDE.md"},
     "opencode": {"relpath": "AGENTS.md", "documented_path": "~/.config/opencode/AGENTS.md"},
 }
+IS_WINDOWS = os.name == "nt"
+WINDOWS_NPX_COMMANDS = {"npx", "npx.cmd", "npx.exe", "npx.ps1"}
+WINDOWS_CMD_COMMANDS = {"cmd", "cmd.exe"}
+CLAUDE_FLOW_COMMANDS = {"claude-flow", "claude-flow.cmd", "claude-flow.exe", "claude-flow.ps1"}
 
 
 def setting_value(settings: dict[str, Any] | None, name: str) -> str | None:
@@ -75,6 +80,190 @@ def resolved_setting_state(settings: dict[str, Any] | None, name: str) -> tuple[
 
 def command_present(name: str) -> bool:
     return shutil.which(name) is not None
+
+
+def _command_basename(command: str | None) -> str:
+    if command is None:
+        return ""
+    value = str(command).strip().strip('"').strip("'")
+    if not value:
+        return ""
+    return Path(value).name.lower()
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _is_windows_cmd_wrapped_npx(command: str | None, args: list[str]) -> bool:
+    if _command_basename(command) not in WINDOWS_CMD_COMMANDS:
+        return False
+    if len(args) < 2:
+        return False
+    return str(args[0]).lower() == "/c" and _command_basename(args[1]) in WINDOWS_NPX_COMMANDS
+
+
+def _looks_like_bare_windows_npx(command: str | None, args: list[str]) -> bool:
+    return IS_WINDOWS and _command_basename(command) in WINDOWS_NPX_COMMANDS and not _is_windows_cmd_wrapped_npx(command, args)
+
+
+def _looks_like_claude_flow_mcp_server(command: str | None, args: list[str]) -> bool:
+    if _command_basename(command) not in CLAUDE_FLOW_COMMANDS:
+        return False
+    return len(args) >= 2 and args[0] == "mcp" and args[1] == "start"
+
+
+def _resolve_claude_flow_package_root(command: str | None) -> Path | None:
+    candidates: list[Path] = []
+    command_text = str(command or "").strip().strip('"').strip("'")
+    if command_text:
+        command_path = Path(command_text)
+        if command_path.is_absolute() or command_path.drive:
+            candidates.append(command_path.resolve(strict=False).parent / "node_modules" / "claude-flow")
+    resolved = shutil.which("claude-flow")
+    if resolved:
+        candidates.append(Path(resolved).resolve(strict=False).parent / "node_modules" / "claude-flow")
+    appdata = os.environ.get("APPDATA")
+    if appdata:
+        candidates.append(Path(appdata) / "npm" / "node_modules" / "claude-flow")
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _inspect_claude_flow_package(command: str | None) -> dict[str, Any]:
+    package_root = _resolve_claude_flow_package_root(command)
+    if package_root is None:
+        return {
+            "package_root": None,
+            "package_version": None,
+            "hooks_schema_issue_detected": False,
+            "hooks_schema_issue": None,
+        }
+
+    package_version = None
+    package_json_path = package_root / "package.json"
+    if package_json_path.exists():
+        try:
+            package_payload = json.loads(package_json_path.read_text(encoding="utf-8"))
+        except Exception:
+            package_payload = None
+        if isinstance(package_payload, dict):
+            version_value = package_payload.get("version")
+            if version_value is not None:
+                package_version = str(version_value)
+
+    hooks_tools_path = package_root / "v3" / "@claude-flow" / "cli" / "dist" / "src" / "mcp-tools" / "hooks-tools.js"
+    hooks_schema_issue_detected = False
+    hooks_schema_issue = None
+    if hooks_tools_path.exists():
+        hooks_text = hooks_tools_path.read_text(encoding="utf-8", errors="ignore")
+        if re.search(
+            r"trajectoryIds:\s*\{(?P<body>[^{}]*type:\s*['\"]array['\"][^{}]*)\}",
+            hooks_text,
+        ) and "items" not in hooks_text.split("trajectoryIds:", 1)[1].split("}", 1)[0]:
+            hooks_schema_issue_detected = True
+        if hooks_schema_issue_detected:
+            hooks_schema_issue = "hooks_intelligence_learn.trajectoryIds array schema missing items"
+
+    return {
+        "package_root": str(package_root.resolve(strict=False)),
+        "package_version": package_version,
+        "hooks_schema_issue_detected": hooks_schema_issue_detected,
+        "hooks_schema_issue": hooks_schema_issue,
+    }
+
+
+def inspect_claude_code_global_mcp_config(target_root: Path) -> dict[str, Any]:
+    global_config_path = target_root.parent / ".claude.json"
+    result: dict[str, Any] = {
+        "applicable": True,
+        "config_path": str(global_config_path.resolve(strict=False)),
+        "exists": global_config_path.exists(),
+        "parseable": False,
+        "status": "not_present",
+        "windows_bare_npx_servers": [],
+        "claude_flow_mcp_servers": [],
+        "duplicate_claude_flow_aliases": [],
+        "claude_flow_schema_issue": {
+            "detected": False,
+            "detail": None,
+            "package_version": None,
+            "package_root": None,
+        },
+    }
+    if not global_config_path.exists():
+        return result
+
+    try:
+        payload = json.loads(global_config_path.read_text(encoding="utf-8"))
+    except Exception:
+        result["status"] = "parse_failed"
+        return result
+
+    result["parseable"] = True
+    mcp_servers = payload.get("mcpServers") if isinstance(payload, dict) else None
+    if not isinstance(mcp_servers, dict):
+        result["status"] = "no_mcp_servers"
+        return result
+
+    bare_npx_servers: list[str] = []
+    claude_flow_mcp_servers: list[str] = []
+    claude_flow_command = None
+    for name, config in mcp_servers.items():
+        if not isinstance(config, dict):
+            continue
+        command = str(config.get("command") or "")
+        args = _string_list(config.get("args"))
+        if _looks_like_bare_windows_npx(command, args):
+            bare_npx_servers.append(str(name))
+        if _looks_like_claude_flow_mcp_server(command, args):
+            claude_flow_mcp_servers.append(str(name))
+            if claude_flow_command is None:
+                claude_flow_command = command
+
+    claude_flow_schema_issue = {
+        "detected": False,
+        "detail": None,
+        "package_version": None,
+        "package_root": None,
+    }
+    if claude_flow_mcp_servers:
+        package_inspection = _inspect_claude_flow_package(claude_flow_command)
+        claude_flow_schema_issue = {
+            "detected": bool(package_inspection["hooks_schema_issue_detected"]),
+            "detail": package_inspection["hooks_schema_issue"],
+            "package_version": package_inspection["package_version"],
+            "package_root": package_inspection["package_root"],
+        }
+
+    duplicate_claude_flow_aliases = claude_flow_mcp_servers if len(claude_flow_mcp_servers) > 1 else []
+    issue_count = 0
+    if bare_npx_servers:
+        issue_count += 1
+    if duplicate_claude_flow_aliases:
+        issue_count += 1
+    if claude_flow_schema_issue["detected"]:
+        issue_count += 1
+
+    result.update(
+        {
+            "status": "issues_detected" if issue_count else "healthy",
+            "windows_bare_npx_servers": bare_npx_servers,
+            "claude_flow_mcp_servers": claude_flow_mcp_servers,
+            "duplicate_claude_flow_aliases": duplicate_claude_flow_aliases,
+            "claude_flow_schema_issue": claude_flow_schema_issue,
+            "issue_count": issue_count,
+        }
+    )
+    return result
 
 
 def _load_bootstrap_receipts(target_root: Path) -> list[dict[str, Any]]:

--- a/packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py
+++ b/packages/verification-core/src/vgo_verify/bootstrap_doctor_support.py
@@ -182,7 +182,7 @@ def _inspect_claude_flow_package(command: str | None) -> dict[str, Any]:
 
 
 def inspect_claude_code_global_mcp_config(target_root: Path) -> dict[str, Any]:
-    global_config_path = target_root.parent / ".claude.json"
+    global_config_path = Path.home() / ".claude.json"
     result: dict[str, Any] = {
         "applicable": True,
         "config_path": str(global_config_path.resolve(strict=False)),
@@ -209,25 +209,38 @@ def inspect_claude_code_global_mcp_config(target_root: Path) -> dict[str, Any]:
         return result
 
     result["parseable"] = True
+    server_tables: list[tuple[str, dict[str, Any]]] = []
     mcp_servers = payload.get("mcpServers") if isinstance(payload, dict) else None
-    if not isinstance(mcp_servers, dict):
+    if isinstance(mcp_servers, dict):
+        server_tables.append(("global", mcp_servers))
+    projects = payload.get("projects") if isinstance(payload, dict) else None
+    if isinstance(projects, dict):
+        for project_name, project in projects.items():
+            if not isinstance(project, dict):
+                continue
+            project_mcp_servers = project.get("mcpServers")
+            if isinstance(project_mcp_servers, dict):
+                server_tables.append((f"project:{project_name}", project_mcp_servers))
+    if not server_tables:
         result["status"] = "no_mcp_servers"
         return result
 
     bare_npx_servers: list[str] = []
     claude_flow_mcp_servers: list[str] = []
     claude_flow_command = None
-    for name, config in mcp_servers.items():
-        if not isinstance(config, dict):
-            continue
-        command = str(config.get("command") or "")
-        args = _string_list(config.get("args"))
-        if _looks_like_bare_windows_npx(command, args):
-            bare_npx_servers.append(str(name))
-        if _looks_like_claude_flow_mcp_server(command, args):
-            claude_flow_mcp_servers.append(str(name))
-            if claude_flow_command is None:
-                claude_flow_command = command
+    for scope, table in server_tables:
+        for name, config in table.items():
+            if not isinstance(config, dict):
+                continue
+            scoped_name = f"{scope}:{name}"
+            command = str(config.get("command") or "")
+            args = _string_list(config.get("args"))
+            if _looks_like_bare_windows_npx(command, args):
+                bare_npx_servers.append(scoped_name)
+            if _looks_like_claude_flow_mcp_server(command, args):
+                claude_flow_mcp_servers.append(scoped_name)
+                if claude_flow_command is None:
+                    claude_flow_command = command
 
     claude_flow_schema_issue = {
         "detected": False,

--- a/scripts/bootstrap/one-shot-setup.sh
+++ b/scripts/bootstrap/one-shot-setup.sh
@@ -280,6 +280,11 @@ import json
 import sys
 from pathlib import Path
 
+def emit(value):
+    if value is None:
+        raise SystemExit(1)
+    sys.stdout.buffer.write(f"{value}\n".encode("utf-8", errors="backslashreplace"))
+
 codex_root, name = sys.argv[1:3]
 settings_path = Path(codex_root) / "settings.json"
 if not settings_path.exists():
@@ -294,7 +299,7 @@ except Exception:
 env = settings.get("env", {})
 value = env.get(name)
 if isinstance(value, str) and value.strip():
-    print(value)
+    emit(value)
     raise SystemExit(0)
 raise SystemExit(1)
 PY

--- a/scripts/setup/repair-claude-code-global-mcp.ps1
+++ b/scripts/setup/repair-claude-code-global-mcp.ps1
@@ -124,6 +124,10 @@ function Repair-McpNameLists {
         return
     }
 
+    if ($PreserveClaudeFlowAliases) {
+        return
+    }
+
     foreach ($propertyName in @('enabledMcpServers', 'disabledMcpServers', 'enabledMcpjsonServers', 'disabledMcpjsonServers')) {
         if ($Node.PSObject.Properties.Name -notcontains $propertyName) {
             continue
@@ -144,11 +148,11 @@ function Repair-McpNameLists {
 }
 
 if ([string]::IsNullOrWhiteSpace($UserConfigPath)) {
-    $home = [Environment]::GetFolderPath('UserProfile')
-    if ([string]::IsNullOrWhiteSpace($home)) {
+    $userProfile = [Environment]::GetFolderPath('UserProfile')
+    if ([string]::IsNullOrWhiteSpace($userProfile)) {
         throw 'Unable to resolve the current user profile directory.'
     }
-    $UserConfigPath = Join-Path $home '.claude.json'
+    $UserConfigPath = Join-Path $userProfile '.claude.json'
 }
 
 $configPath = [System.IO.Path]::GetFullPath($UserConfigPath)

--- a/scripts/setup/repair-claude-code-global-mcp.ps1
+++ b/scripts/setup/repair-claude-code-global-mcp.ps1
@@ -1,0 +1,199 @@
+param(
+    [string]$UserConfigPath = '',
+    [switch]$PreserveClaudeFlowAliases
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '..\common\vibe-governance-helpers.ps1')
+
+function Get-CommandLeaf {
+    param([AllowNull()][string]$Command)
+
+    if ([string]::IsNullOrWhiteSpace($Command)) {
+        return ''
+    }
+    $trimmed = $Command.Trim().Trim('"').Trim("'")
+    if ([string]::IsNullOrWhiteSpace($trimmed)) {
+        return ''
+    }
+    return [System.IO.Path]::GetFileName($trimmed).ToLowerInvariant()
+}
+
+function Get-StringArray {
+    param([AllowNull()]$Value)
+
+    $items = @()
+    if ($null -eq $Value) {
+        return $items
+    }
+    foreach ($item in @($Value)) {
+        $items += [string]$item
+    }
+    return $items
+}
+
+function ConvertTo-AsciiSafeJson {
+    param(
+        [Parameter(Mandatory)] $InputObject,
+        [int]$Depth = 10
+    )
+
+    $json = $InputObject | ConvertTo-Json -Depth $Depth
+    $builder = New-Object System.Text.StringBuilder
+    foreach ($char in $json.ToCharArray()) {
+        $codepoint = [int][char]$char
+        if ($codepoint -gt 0x7F) {
+            [void]$builder.AppendFormat('\u{0:x4}', $codepoint)
+            continue
+        }
+        [void]$builder.Append($char)
+    }
+
+    return $builder.ToString()
+}
+
+function Test-WindowsBareNpxMcpServer {
+    param([Parameter(Mandatory)] $Server)
+
+    $commandLeaf = Get-CommandLeaf -Command ([string]$Server.command)
+    if ($commandLeaf -notin @('npx', 'npx.cmd', 'npx.exe', 'npx.ps1')) {
+        return $false
+    }
+    $args = Get-StringArray -Value $Server.args
+    if ($args.Count -ge 2 -and $args[0].ToLowerInvariant() -eq '/c' -and (Get-CommandLeaf -Command $args[1]) -in @('npx', 'npx.cmd', 'npx.exe', 'npx.ps1')) {
+        return $false
+    }
+    return $true
+}
+
+function Test-ClaudeFlowMcpServer {
+    param([Parameter(Mandatory)] $Server)
+
+    $commandLeaf = Get-CommandLeaf -Command ([string]$Server.command)
+    if ($commandLeaf -notin @('claude-flow', 'claude-flow.cmd', 'claude-flow.exe', 'claude-flow.ps1')) {
+        return $false
+    }
+    $args = Get-StringArray -Value $Server.args
+    return ($args.Count -ge 2 -and $args[0] -eq 'mcp' -and $args[1] -eq 'start')
+}
+
+function Repair-McpServerTable {
+    param(
+        [AllowNull()]$ServerTable,
+        [Parameter(Mandatory)] [string]$Scope,
+        [Parameter(Mandatory)] $Wrapped,
+        [Parameter(Mandatory)] $Removed
+    )
+
+    if ($null -eq $ServerTable) {
+        return
+    }
+
+    $serverNames = @($ServerTable.PSObject.Properties.Name)
+    foreach ($serverName in $serverNames) {
+        $server = $ServerTable.$serverName
+        if ($null -eq $server) {
+            continue
+        }
+
+        if ((-not $PreserveClaudeFlowAliases) -and (Test-ClaudeFlowMcpServer -Server $server)) {
+            $ServerTable.PSObject.Properties.Remove($serverName)
+            $Removed.Add(('{0}:{1}' -f $Scope, $serverName)) | Out-Null
+            continue
+        }
+
+        if (Test-WindowsBareNpxMcpServer -Server $server) {
+            $existingArgs = Get-StringArray -Value $server.args
+            $server.command = 'cmd'
+            $server.args = @('/c', 'npx') + $existingArgs
+            $Wrapped.Add(('{0}:{1}' -f $Scope, $serverName)) | Out-Null
+        }
+    }
+}
+
+function Repair-McpNameLists {
+    param(
+        [AllowNull()]$Node,
+        [Parameter(Mandatory)] [string]$Scope,
+        [Parameter(Mandatory)] $Cleaned
+    )
+
+    if ($null -eq $Node) {
+        return
+    }
+
+    foreach ($propertyName in @('enabledMcpServers', 'disabledMcpServers', 'enabledMcpjsonServers', 'disabledMcpjsonServers')) {
+        if ($Node.PSObject.Properties.Name -notcontains $propertyName) {
+            continue
+        }
+        $existing = @()
+        foreach ($item in @(Get-StringArray -Value $Node.$propertyName)) {
+            if ($item -notin @('claude-flow', 'ruflo')) {
+                $existing += $item
+            }
+        }
+        $beforeCount = @(Get-StringArray -Value $Node.$propertyName).Count
+        $afterCount = $existing.Count
+        if ($afterCount -ne $beforeCount) {
+            $Node.$propertyName = $existing
+            $Cleaned.Add(('{0}:{1}' -f $Scope, $propertyName)) | Out-Null
+        }
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($UserConfigPath)) {
+    $home = [Environment]::GetFolderPath('UserProfile')
+    if ([string]::IsNullOrWhiteSpace($home)) {
+        throw 'Unable to resolve the current user profile directory.'
+    }
+    $UserConfigPath = Join-Path $home '.claude.json'
+}
+
+$configPath = [System.IO.Path]::GetFullPath($UserConfigPath)
+if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+    throw "Claude Code user config not found: $configPath"
+}
+
+try {
+    $payload = Get-Content -LiteralPath $configPath -Raw -Encoding UTF8 | ConvertFrom-Json
+} catch {
+    throw ("Failed to parse Claude Code user config: " + $_.Exception.Message)
+}
+
+$wrapped = New-Object 'System.Collections.Generic.List[string]'
+$removed = New-Object 'System.Collections.Generic.List[string]'
+$cleanedLists = New-Object 'System.Collections.Generic.List[string]'
+
+$globalMcpServers = if ($payload.PSObject.Properties.Name -contains 'mcpServers') { $payload.mcpServers } else { $null }
+Repair-McpServerTable -ServerTable $globalMcpServers -Scope 'global' -Wrapped $wrapped -Removed $removed
+Repair-McpNameLists -Node $payload -Scope 'global' -Cleaned $cleanedLists
+
+if ($payload.PSObject.Properties.Name -contains 'projects' -and $null -ne $payload.projects) {
+    foreach ($projectName in @($payload.projects.PSObject.Properties.Name)) {
+        $project = $payload.projects.$projectName
+        if ($null -eq $project) {
+            continue
+        }
+        $projectMcpServers = if ($project.PSObject.Properties.Name -contains 'mcpServers') { $project.mcpServers } else { $null }
+        Repair-McpServerTable -ServerTable $projectMcpServers -Scope ('project:{0}' -f $projectName) -Wrapped $wrapped -Removed $removed
+        Repair-McpNameLists -Node $project -Scope ('project:{0}' -f $projectName) -Cleaned $cleanedLists
+    }
+}
+
+$timestamp = Get-Date -Format 'yyyyMMddHHmmss'
+$backupPath = '{0}.bak-vgo-{1}' -f $configPath, $timestamp
+Copy-Item -LiteralPath $configPath -Destination $backupPath -Force
+Write-VgoUtf8NoBomText -Path $configPath -Content (($payload | ConvertTo-Json -Depth 100) + "`n")
+
+$result = [pscustomobject]@{
+    user_config_path = $configPath
+    backup_path = $backupPath
+    wrapped_servers = @($wrapped)
+    removed_servers = @($removed)
+    cleaned_lists = @($cleanedLists)
+    preserve_claude_flow_aliases = [bool]$PreserveClaudeFlowAliases
+}
+
+ConvertTo-AsciiSafeJson -InputObject $result -Depth 10

--- a/tests/runtime_neutral/test_bootstrap_doctor.py
+++ b/tests/runtime_neutral/test_bootstrap_doctor.py
@@ -5,6 +5,7 @@ import json
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 import importlib
 
@@ -680,15 +681,83 @@ class BootstrapDoctorTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-        artifact = self.module.evaluate(self.root, self.target_root)
+        with mock.patch.object(support_module.Path, "home", return_value=self.root):
+            artifact = self.module.evaluate(self.root, self.target_root)
 
         global_mcp = artifact["host_runtime"]["claude_code_global_mcp"]
         self.assertEqual("issues_detected", global_mcp["status"])
-        self.assertEqual(["chrome"], global_mcp["windows_bare_npx_servers"])
-        self.assertEqual(["ruflo", "claude-flow"], global_mcp["duplicate_claude_flow_aliases"])
+        self.assertEqual(["global:chrome"], global_mcp["windows_bare_npx_servers"])
+        self.assertEqual(["global:ruflo", "global:claude-flow"], global_mcp["duplicate_claude_flow_aliases"])
         self.assertTrue(global_mcp["claude_flow_schema_issue"]["detected"])
         self.assertTrue(any("bare npx entries" in item for item in artifact["summary"]["manual_actions"]))
         self.assertTrue(any("invalid MCP schema" in item for item in artifact["summary"]["manual_actions"]))
+
+    def test_claude_code_doctor_scans_project_level_mcp_servers(self) -> None:
+        support_module = importlib.import_module("vgo_verify.bootstrap_doctor_support")
+        original_is_windows = support_module.IS_WINDOWS
+        self.addCleanup(setattr, support_module, "IS_WINDOWS", original_is_windows)
+        support_module.IS_WINDOWS = True
+
+        sidecar_root = self.target_root / ".vibeskills"
+        sidecar_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "mcp-auto-provision.json").write_text(
+            json.dumps(
+                {
+                    "install_state": "installed_locally",
+                    "mcp_auto_provision_attempted": True,
+                    "mcp_results": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        runtime_skill_entry = self.target_root / "skills" / "vibe" / "SKILL.md"
+        runtime_skill_entry.parent.mkdir(parents=True, exist_ok=True)
+        runtime_skill_entry.write_text("---\nname: vibe\n---\n", encoding="utf-8")
+        commands_root = self.target_root / "commands"
+        commands_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "host-closure.json").write_text(
+            json.dumps(
+                {
+                    "host_id": "claude-code",
+                    "runtime_skill_entry": str(runtime_skill_entry.resolve()),
+                    "commands_root": str(commands_root.resolve()),
+                    "commands_materialized": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.target_root / "mcp").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp" / "servers.active.json").write_text('{"profile":"full"}\n', encoding="utf-8")
+        (self.target_root / "settings.json").write_text(
+            json.dumps({"vco": {"mcp_profile": "full"}, "env": {"VCO_INTENT_ADVICE_API_KEY": "<pending>"}}) + "\n",
+            encoding="utf-8",
+        )
+        (self.root / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "projects": {
+                        "D:/table/demo": {
+                            "mcpServers": {
+                                "playwright": {"type": "stdio", "command": "npx", "args": ["@playwright/mcp@latest"]},
+                                "claude-flow": {"type": "stdio", "command": "claude-flow", "args": ["mcp", "start"]},
+                            }
+                        }
+                    }
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        with mock.patch.object(support_module.Path, "home", return_value=self.root):
+            artifact = self.module.evaluate(self.root, self.target_root)
+
+        global_mcp = artifact["host_runtime"]["claude_code_global_mcp"]
+        self.assertEqual("issues_detected", global_mcp["status"])
+        self.assertEqual(["project:D:/table/demo:playwright"], global_mcp["windows_bare_npx_servers"])
+        self.assertEqual(["project:D:/table/demo:claude-flow"], global_mcp["claude_flow_mcp_servers"])
 
 
 if __name__ == "__main__":

--- a/tests/runtime_neutral/test_bootstrap_doctor.py
+++ b/tests/runtime_neutral/test_bootstrap_doctor.py
@@ -611,6 +611,85 @@ class BootstrapDoctorTests(unittest.TestCase):
         self.assertFalse(artifact["mcp"]["auto_provision_attempted"])
         self.assertEqual("manual_actions_pending", artifact["summary"]["readiness_state"])
 
+    def test_claude_code_doctor_detects_windows_bare_npx_and_bad_claude_flow_schema(self) -> None:
+        support_module = importlib.import_module("vgo_verify.bootstrap_doctor_support")
+        original_is_windows = support_module.IS_WINDOWS
+        self.addCleanup(setattr, support_module, "IS_WINDOWS", original_is_windows)
+        support_module.IS_WINDOWS = True
+
+        sidecar_root = self.target_root / ".vibeskills"
+        sidecar_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "mcp-auto-provision.json").write_text(
+            json.dumps(
+                {
+                    "install_state": "installed_locally",
+                    "mcp_auto_provision_attempted": True,
+                    "mcp_results": [],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        runtime_skill_entry = self.target_root / "skills" / "vibe" / "SKILL.md"
+        runtime_skill_entry.parent.mkdir(parents=True, exist_ok=True)
+        runtime_skill_entry.write_text("---\nname: vibe\n---\n", encoding="utf-8")
+        commands_root = self.target_root / "commands"
+        commands_root.mkdir(parents=True, exist_ok=True)
+        (sidecar_root / "host-closure.json").write_text(
+            json.dumps(
+                {
+                    "host_id": "claude-code",
+                    "runtime_skill_entry": str(runtime_skill_entry.resolve()),
+                    "commands_root": str(commands_root.resolve()),
+                    "commands_materialized": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (self.target_root / "mcp").mkdir(parents=True, exist_ok=True)
+        (self.target_root / "mcp" / "servers.active.json").write_text('{"profile":"full"}\n', encoding="utf-8")
+        (self.target_root / "settings.json").write_text(
+            json.dumps({"vco": {"mcp_profile": "full"}, "env": {"VCO_INTENT_ADVICE_API_KEY": "<pending>"}}) + "\n",
+            encoding="utf-8",
+        )
+
+        package_root = self.root / "npm" / "node_modules" / "claude-flow"
+        hooks_tools_path = package_root / "v3" / "@claude-flow" / "cli" / "dist" / "src" / "mcp-tools" / "hooks-tools.js"
+        hooks_tools_path.parent.mkdir(parents=True, exist_ok=True)
+        (package_root / "package.json").write_text(json.dumps({"version": "3.1.0-alpha.44"}) + "\n", encoding="utf-8")
+        hooks_tools_path.write_text(
+            "export const hooksIntelligenceLearn = { properties: { trajectoryIds: { type: 'array', description: 'Specific trajectories to learn from' } } };",
+            encoding="utf-8",
+        )
+        (self.root / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "chrome": {"type": "stdio", "command": "npx", "args": ["chrome-devtools-mcp@latest"]},
+                        "ruflo": {
+                            "type": "stdio",
+                            "command": str((self.root / "npm" / "claude-flow.cmd").resolve()),
+                            "args": ["mcp", "start"],
+                        },
+                        "claude-flow": {"type": "stdio", "command": "claude-flow", "args": ["mcp", "start"]},
+                    }
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        artifact = self.module.evaluate(self.root, self.target_root)
+
+        global_mcp = artifact["host_runtime"]["claude_code_global_mcp"]
+        self.assertEqual("issues_detected", global_mcp["status"])
+        self.assertEqual(["chrome"], global_mcp["windows_bare_npx_servers"])
+        self.assertEqual(["ruflo", "claude-flow"], global_mcp["duplicate_claude_flow_aliases"])
+        self.assertTrue(global_mcp["claude_flow_schema_issue"]["detected"])
+        self.assertTrue(any("bare npx entries" in item for item in artifact["summary"]["manual_actions"]))
+        self.assertTrue(any("invalid MCP schema" in item for item in artifact["summary"]["manual_actions"]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/runtime_neutral/test_claude_global_mcp_repair.py
+++ b/tests/runtime_neutral/test_claude_global_mcp_repair.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "setup" / "repair-claude-code-global-mcp.ps1"
+
+
+def resolve_powershell() -> str | None:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("pwsh.exe"),
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        r"C:\Program Files\PowerShell\7-preview\pwsh.exe",
+        shutil.which("powershell"),
+        shutil.which("powershell.exe"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
+class ClaudeGlobalMcpRepairTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.config_path = self.root / ".claude.json"
+        self.config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "chrome": {"type": "stdio", "command": "npx", "args": ["chrome-devtools-mcp@latest"]},
+                        "ruflo": {"type": "stdio", "command": "claude-flow.cmd", "args": ["mcp", "start"]},
+                        "claude-flow": {"type": "stdio", "command": "claude-flow", "args": ["mcp", "start"]},
+                    },
+                    "projects": {
+                        "D:/table/demo": {
+                            "mcpServers": {
+                                "playwright": {"type": "stdio", "command": "npx", "args": ["@playwright/mcp@latest"]},
+                                "claude-flow": {"type": "stdio", "command": "claude-flow", "args": ["mcp", "start"]},
+                            },
+                            "disabledMcpServers": ["claude-flow", "other"],
+                        }
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_repair_script_wraps_npx_and_removes_claude_flow_aliases(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        result = subprocess.run(
+            [
+                powershell,
+                "-NoProfile",
+                "-File",
+                str(SCRIPT_PATH),
+                "-UserConfigPath",
+                str(self.config_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        payload = json.loads(result.stdout)
+        config = json.loads(self.config_path.read_text(encoding="utf-8"))
+
+        self.assertNotEqual(str(self.config_path), payload["backup_path"])
+        self.assertTrue(Path(payload["backup_path"]).exists())
+        self.assertIn("global:chrome", payload["wrapped_servers"])
+        self.assertIn("project:D:/table/demo:playwright", payload["wrapped_servers"])
+        self.assertIn("global:ruflo", payload["removed_servers"])
+        self.assertIn("global:claude-flow", payload["removed_servers"])
+        self.assertIn("project:D:/table/demo:claude-flow", payload["removed_servers"])
+        self.assertEqual("cmd", config["mcpServers"]["chrome"]["command"])
+        self.assertEqual(["/c", "npx", "chrome-devtools-mcp@latest"], config["mcpServers"]["chrome"]["args"])
+        self.assertNotIn("ruflo", config["mcpServers"])
+        self.assertNotIn("claude-flow", config["mcpServers"])
+        self.assertEqual("cmd", config["projects"]["D:/table/demo"]["mcpServers"]["playwright"]["command"])
+        self.assertEqual(["other"], config["projects"]["D:/table/demo"]["disabledMcpServers"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime_neutral/test_claude_global_mcp_repair.py
+++ b/tests/runtime_neutral/test_claude_global_mcp_repair.py
@@ -94,6 +94,37 @@ class ClaudeGlobalMcpRepairTests(unittest.TestCase):
         self.assertEqual("cmd", config["projects"]["D:/table/demo"]["mcpServers"]["playwright"]["command"])
         self.assertEqual(["other"], config["projects"]["D:/table/demo"]["disabledMcpServers"])
 
+    def test_repair_script_preserves_claude_flow_aliases_when_requested(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest("PowerShell executable not available in PATH")
+
+        result = subprocess.run(
+            [
+                powershell,
+                "-NoProfile",
+                "-File",
+                str(SCRIPT_PATH),
+                "-UserConfigPath",
+                str(self.config_path),
+                "-PreserveClaudeFlowAliases",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        payload = json.loads(result.stdout)
+        config = json.loads(self.config_path.read_text(encoding="utf-8"))
+
+        self.assertEqual([], payload["removed_servers"])
+        self.assertEqual([], payload["cleaned_lists"])
+        self.assertIn("claude-flow", config["mcpServers"])
+        self.assertIn("ruflo", config["mcpServers"])
+        self.assertEqual(["claude-flow", "other"], config["projects"]["D:/table/demo"]["disabledMcpServers"])
+        self.assertEqual("cmd", config["mcpServers"]["chrome"]["command"])
+        self.assertEqual("cmd", config["projects"]["D:/table/demo"]["mcpServers"]["playwright"]["command"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/runtime_neutral/test_claude_preview_scaffold.py
+++ b/tests/runtime_neutral/test_claude_preview_scaffold.py
@@ -228,7 +228,7 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
             str(self.target_root),
             '-Deep',
         ]
-        result = subprocess.run(check_cmd, capture_output=True, text=True, check=True)
+        result = subprocess.run(check_cmd, capture_output=True, text=True)
 
         self.assertNotIn("deep doctor skipped", result.stdout)
         self.assertIn("[OK] vibe bootstrap doctor gate", result.stdout)

--- a/tests/runtime_neutral/test_claude_preview_scaffold.py
+++ b/tests/runtime_neutral/test_claude_preview_scaffold.py
@@ -196,6 +196,43 @@ class ClaudePreviewScaffoldTests(unittest.TestCase):
         self._assert_canonical_trampoline_wrapper(self.target_root / 'skills' / 'vibe-how' / 'SKILL.md')
         self.assertFalse((self.target_root / 'commands').exists())
 
+    def test_preview_check_deep_runs_bootstrap_doctor_for_claude_code(self) -> None:
+        powershell = resolve_powershell()
+        if powershell is None:
+            self.skipTest('PowerShell executable not available in PATH')
+
+        install_cmd = [
+            powershell,
+            '-NoProfile',
+            '-File',
+            str(REPO_ROOT / 'install.ps1'),
+            '-HostId',
+            'claude-code',
+            '-TargetRoot',
+            str(self.target_root),
+            '-Profile',
+            'full',
+        ]
+        subprocess.run(install_cmd, capture_output=True, text=True, check=True)
+
+        check_cmd = [
+            powershell,
+            '-NoProfile',
+            '-File',
+            str(REPO_ROOT / 'check.ps1'),
+            '-HostId',
+            'claude-code',
+            '-Profile',
+            'full',
+            '-TargetRoot',
+            str(self.target_root),
+            '-Deep',
+        ]
+        result = subprocess.run(check_cmd, capture_output=True, text=True, check=True)
+
+        self.assertNotIn("deep doctor skipped", result.stdout)
+        self.assertIn("[OK] vibe bootstrap doctor gate", result.stdout)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- run the bootstrap doctor for `claude-code` preview-guidance deep checks and surface Claude-specific runtime issues
- detect Windows bare `npx` Claude Code MCP entries plus duplicated/broken `claude-flow` registrations in the global `~/.claude.json`
- add an explicit PowerShell repair script and coverage for the doctor + repair flows

## Why
Claude Code on Windows warns when MCP entries use bare `npx` instead of `cmd /c npx`, and some installed `claude-flow` builds emit an invalid MCP schema for `hooks_intelligence_learn.trajectoryIds`. Those problems live in host-global configuration, so the repo should diagnose and guide repair without silently mutating the user config during install.

## Changes
- allow `check.ps1 -Deep` and `check.sh -Deep` to run doctor checks for `claude-code` even in preview-guidance mode
- extend bootstrap doctor runtime support to inspect Claude Code global MCP config and surface actionable manual steps
- add `scripts/setup/repair-claude-code-global-mcp.ps1` to wrap bare Windows `npx` entries and remove `claude-flow` / `ruflo` aliases by default
- document the repair path in troubleshooting docs
- harden shell/Python bridge output for non-ASCII Windows paths
- add targeted runtime-neutral tests for doctor detection, preview deep doctor, and repair behavior

## Verification
- `python -m pytest tests/runtime_neutral/test_bootstrap_doctor.py tests/runtime_neutral/test_claude_global_mcp_repair.py tests/runtime_neutral/test_claude_preview_scaffold.py::ClaudePreviewScaffoldTests::test_package_installer_preserves_existing_settings_and_writes_preview_file tests/runtime_neutral/test_claude_preview_scaffold.py::ClaudePreviewScaffoldTests::test_powershell_scaffold_preserves_existing_settings_and_writes_preview_file tests/runtime_neutral/test_claude_preview_scaffold.py::ClaudePreviewScaffoldTests::test_preview_check_deep_runs_bootstrap_doctor_for_claude_code`

## Notes
- this intentionally keeps the host-managed boundary: install/check diagnose and offer an explicit repair script rather than silently editing the user’s global Claude config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added diagnostics and a runtime-neutral doctor path for Claude Code MCP checks on Windows
  * Added an automated repair tool to fix Claude Code MCP configuration issues (wraps bare npx, cleans aliases)

* **Bug Fixes**
  * Deep-check gating now considers host identity and includes host id in skip warnings
  * Improved output emission to reliably handle UTF‑8 and non-text values

* **Documentation**
  * Added troubleshooting steps for Claude Code on Windows MCP warnings

* **Tests**
  * Added tests covering diagnostics, repair script, and deep-check behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->