### PR TITLE
Improve PowerShell startup diagnostics and lane recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ If your AI supports skills, VibeSkills works. 340+ skills spanning coding, resea
 
 <br/>
 
+<img width="1376" height="768" alt="Generated Image April 21, 2026 - 8_49PM" src="https://github.com/user-attachments/assets/82c6e1f2-23fb-46de-b4c6-2f73b5350d4c" />
 
-<img width="1376" height="768" alt="Generated Image April 21, 2026 - 3_12PM (3)" src="https://github.com/user-attachments/assets/701d4199-566a-4def-b29b-562cd59a8645" />
+
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -121,7 +121,8 @@
 
 <br/>
 
-<img width="1376" height="768" alt="Generated Image April 21, 2026 - 3_12PM" src="https://github.com/user-attachments/assets/0b7837cc-328e-4065-9bc1-325aed949caa" />
+<img width="1376" height="768" alt="Generated Image April 21, 2026 - 8_51PM" src="https://github.com/user-attachments/assets/de9f1d20-3976-40b9-bc7c-37bb308a3591" />
+
 
 ---
 

--- a/apps/vgo-cli/src/vgo_cli/process.py
+++ b/apps/vgo-cli/src/vgo_cli/process.py
@@ -26,6 +26,7 @@ SUPPORTED_POWERSHELL_HOSTS = frozenset({"pwsh", "windows-powershell"})
 
 
 def _powershell_host_policy() -> dict[str, Any]:
+    """Load the shared PowerShell host policy with strict field validation."""
     policy = dict(POWERSHELL_HOST_POLICY_DEFAULTS)
     try:
         raw_payload = POWERSHELL_HOST_POLICY_PATH.read_text(encoding="utf-8")
@@ -92,10 +93,12 @@ def _powershell_host_policy() -> dict[str, Any]:
 
 
 def _is_windows_host() -> bool:
+    """Return whether the current Python host is running on Windows."""
     return os.name == "nt"
 
 
 def choose_powershell(*, return_diagnostics: bool = False) -> str | dict[str, Any] | None:
+    """Resolve the preferred PowerShell executable for the current platform."""
     policy = _powershell_host_policy()
     is_windows = _is_windows_host()
     prefer_pwsh = str(policy["preferred_powershell_host"]).strip().lower() == "pwsh"
@@ -174,6 +177,7 @@ def choose_powershell(*, return_diagnostics: bool = False) -> str | dict[str, An
 
 
 def print_process_output(result: subprocess.CompletedProcess[str]) -> None:
+    """Forward captured subprocess output streams to the current process."""
     if result.stdout:
         sys.stdout.write(result.stdout)
     if result.stderr:
@@ -181,6 +185,7 @@ def print_process_output(result: subprocess.CompletedProcess[str]) -> None:
 
 
 def run_subprocess(command: Sequence[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess with captured UTF-8 text output."""
     return subprocess.run(list(command), cwd=cwd, capture_output=True, text=True)
 
 
@@ -188,6 +193,7 @@ def invoke_python_core(
     main_fn: Callable[[Sequence[str] | None], int | None],
     argv: Sequence[str],
 ) -> subprocess.CompletedProcess[str]:
+    """Invoke a Python CLI entry point and capture its exit code and streams."""
     stdout_buffer = io.StringIO()
     stderr_buffer = io.StringIO()
     exit_code = 0
@@ -214,6 +220,7 @@ def invoke_python_core(
 
 
 def run_powershell_file(script_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a PowerShell script file through the resolved host executable."""
     resolution = choose_powershell(return_diagnostics=True)
     if not isinstance(resolution, dict) or not resolution.get("host_path"):
         checked = []

--- a/apps/vgo-cli/src/vgo_cli/process.py
+++ b/apps/vgo-cli/src/vgo_cli/process.py
@@ -22,6 +22,7 @@ POWERSHELL_HOST_POLICY_DEFAULTS: dict[str, Any] = {
     "allow_windows_powershell_fallback": True,
     "record_host_resolution_artifacts": True,
 }
+SUPPORTED_POWERSHELL_HOSTS = frozenset({"pwsh", "windows-powershell"})
 
 
 def _powershell_host_policy() -> dict[str, Any]:
@@ -61,16 +62,32 @@ def _powershell_host_policy() -> dict[str, Any]:
         )
         return policy
 
-    preferred_host = str(payload.get("preferred_powershell_host", "")).strip()
-    if preferred_host:
+    preferred_host = str(payload.get("preferred_powershell_host", "")).strip().lower()
+    if preferred_host in SUPPORTED_POWERSHELL_HOSTS:
         policy["preferred_powershell_host"] = preferred_host
+    elif preferred_host:
+        warnings.warn(
+            (
+                f"Unsupported preferred_powershell_host in {POWERSHELL_HOST_POLICY_PATH}: "
+                f"{preferred_host!r}; using default"
+            ),
+            RuntimeWarning,
+            stacklevel=2,
+        )
     for key in (
         "require_pwsh_on_non_windows",
         "allow_windows_powershell_fallback",
         "record_host_resolution_artifacts",
     ):
         if key in payload:
-            policy[key] = bool(payload[key])
+            if isinstance(payload[key], bool):
+                policy[key] = payload[key]
+            else:
+                warnings.warn(
+                    f"PowerShell host policy field {key} must be boolean; using default",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
     return policy
 
 

--- a/apps/vgo-cli/src/vgo_cli/process.py
+++ b/apps/vgo-cli/src/vgo_cli/process.py
@@ -2,23 +2,76 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
 import os
 from pathlib import Path
 import shutil
 import subprocess
 import sys
 from typing import Any, Callable, Sequence
+import warnings
 
 from .errors import CliError
 
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+POWERSHELL_HOST_POLICY_PATH = REPO_ROOT / "config" / "powershell-host-policy.json"
+POWERSHELL_HOST_POLICY_DEFAULTS: dict[str, Any] = {
+    "preferred_powershell_host": "pwsh",
+    "require_pwsh_on_non_windows": True,
+    "allow_windows_powershell_fallback": True,
+    "record_host_resolution_artifacts": True,
+}
+
+
 def _powershell_host_policy() -> dict[str, Any]:
-    return {
-        "preferred_powershell_host": "pwsh",
-        "require_pwsh_on_non_windows": True,
-        "allow_windows_powershell_fallback": True,
-        "record_host_resolution_artifacts": True,
-    }
+    policy = dict(POWERSHELL_HOST_POLICY_DEFAULTS)
+    try:
+        raw_payload = POWERSHELL_HOST_POLICY_PATH.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        warnings.warn(
+            f"PowerShell host policy file not found: {POWERSHELL_HOST_POLICY_PATH}; using defaults",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return policy
+    except OSError as exc:
+        warnings.warn(
+            f"Failed to read PowerShell host policy {POWERSHELL_HOST_POLICY_PATH}: {exc}; using defaults",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return policy
+
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        warnings.warn(
+            f"Invalid JSON in PowerShell host policy {POWERSHELL_HOST_POLICY_PATH}: {exc}; using defaults",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return policy
+
+    if not isinstance(payload, dict):
+        warnings.warn(
+            f"PowerShell host policy {POWERSHELL_HOST_POLICY_PATH} must contain a JSON object; using defaults",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return policy
+
+    preferred_host = str(payload.get("preferred_powershell_host", "")).strip()
+    if preferred_host:
+        policy["preferred_powershell_host"] = preferred_host
+    for key in (
+        "require_pwsh_on_non_windows",
+        "allow_windows_powershell_fallback",
+        "record_host_resolution_artifacts",
+    ):
+        if key in payload:
+            policy[key] = bool(payload[key])
+    return policy
 
 
 def _is_windows_host() -> bool:
@@ -28,24 +81,33 @@ def _is_windows_host() -> bool:
 def choose_powershell(*, return_diagnostics: bool = False) -> str | dict[str, Any] | None:
     policy = _powershell_host_policy()
     is_windows = _is_windows_host()
-    candidates: list[tuple[str, str | None, str]] = [
+    prefer_pwsh = str(policy["preferred_powershell_host"]).strip().lower() == "pwsh"
+    pwsh_candidates: list[tuple[str, str | None, str]] = [
         ("path-pwsh", shutil.which("pwsh"), "pwsh"),
         ("path-pwsh-exe", shutil.which("pwsh.exe"), "pwsh"),
     ]
     if is_windows:
-        candidates.extend(
+        pwsh_candidates.extend(
             [
                 ("default-pwsh", r"C:\Program Files\PowerShell\7\pwsh.exe", "pwsh"),
                 ("preview-pwsh", r"C:\Program Files\PowerShell\7-preview\pwsh.exe", "pwsh"),
             ]
         )
-    if is_windows and policy["allow_windows_powershell_fallback"]:
-        candidates.extend(
+    windows_powershell_candidates: list[tuple[str, str | None, str]] = []
+    if is_windows:
+        windows_powershell_candidates.extend(
             [
                 ("path-powershell", shutil.which("powershell"), "windows-powershell"),
                 ("path-powershell-exe", shutil.which("powershell.exe"), "windows-powershell"),
             ]
         )
+    candidates: list[tuple[str, str | None, str]] = []
+    if prefer_pwsh:
+        candidates.extend(pwsh_candidates)
+        if is_windows and policy["allow_windows_powershell_fallback"]:
+            candidates.extend(windows_powershell_candidates)
+    elif is_windows:
+        candidates.extend(windows_powershell_candidates)
 
     checked: list[dict[str, Any]] = []
     for name, candidate, kind in candidates:

--- a/apps/vgo-cli/src/vgo_cli/process.py
+++ b/apps/vgo-cli/src/vgo_cli/process.py
@@ -2,27 +2,90 @@ from __future__ import annotations
 
 import contextlib
 import io
+import os
 from pathlib import Path
 import shutil
 import subprocess
 import sys
-from typing import Callable, Sequence
+from typing import Any, Callable, Sequence
 
 from .errors import CliError
 
 
-def choose_powershell() -> str | None:
-    candidates = [
-        shutil.which('pwsh'),
-        shutil.which('pwsh.exe'),
-        shutil.which('powershell'),
-        shutil.which('powershell.exe'),
-        r'C:\Program Files\PowerShell\7\pwsh.exe',
-        r'C:\Program Files\PowerShell\7-preview\pwsh.exe',
+def _powershell_host_policy() -> dict[str, Any]:
+    return {
+        "preferred_powershell_host": "pwsh",
+        "require_pwsh_on_non_windows": True,
+        "allow_windows_powershell_fallback": True,
+        "record_host_resolution_artifacts": True,
+    }
+
+
+def _is_windows_host() -> bool:
+    return os.name == "nt"
+
+
+def choose_powershell(*, return_diagnostics: bool = False) -> str | dict[str, Any] | None:
+    policy = _powershell_host_policy()
+    is_windows = _is_windows_host()
+    candidates: list[tuple[str, str | None, str]] = [
+        ("path-pwsh", shutil.which("pwsh"), "pwsh"),
+        ("path-pwsh-exe", shutil.which("pwsh.exe"), "pwsh"),
+        ("default-pwsh", r"C:\Program Files\PowerShell\7\pwsh.exe", "pwsh"),
+        ("preview-pwsh", r"C:\Program Files\PowerShell\7-preview\pwsh.exe", "pwsh"),
     ]
-    for candidate in candidates:
-        if candidate and Path(candidate).exists():
-            return str(Path(candidate))
+    if is_windows and policy["allow_windows_powershell_fallback"]:
+        candidates.extend(
+            [
+                ("path-powershell", shutil.which("powershell"), "windows-powershell"),
+                ("path-powershell-exe", shutil.which("powershell.exe"), "windows-powershell"),
+            ]
+        )
+
+    checked: list[dict[str, Any]] = []
+    for name, candidate, kind in candidates:
+        resolved = str(Path(candidate)) if candidate else None
+        exists = bool(resolved and Path(resolved).exists())
+        is_file = bool(resolved and Path(resolved).is_file())
+        checked.append(
+            {
+                "candidate_name": name,
+                "candidate_kind": kind,
+                "candidate_path": resolved,
+                "exists": exists,
+                "is_file": is_file,
+            }
+        )
+        if exists and is_file:
+            diagnostics = {
+                "host_path": resolved,
+                "host_kind": kind,
+                "fallback_used": kind == "windows-powershell",
+                "candidates_checked": checked,
+                "policy": policy,
+            }
+            return diagnostics if return_diagnostics else resolved
+
+    if not is_windows and policy["require_pwsh_on_non_windows"]:
+        if return_diagnostics:
+            return {
+                "host_path": None,
+                "host_kind": None,
+                "fallback_used": False,
+                "candidates_checked": checked,
+                "policy": policy,
+                "error": "pwsh is required on non-Windows hosts",
+            }
+        return None
+
+    if return_diagnostics:
+        return {
+            "host_path": None,
+            "host_kind": None,
+            "fallback_used": False,
+            "candidates_checked": checked,
+            "policy": policy,
+        }
     return None
 
 
@@ -67,9 +130,17 @@ def invoke_python_core(
 
 
 def run_powershell_file(script_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    shell_path = choose_powershell()
-    if not shell_path:
-        raise CliError(f'PowerShell is required to run: {script_path}')
+    resolution = choose_powershell(return_diagnostics=True)
+    if not isinstance(resolution, dict) or not resolution.get("host_path"):
+        checked = []
+        if isinstance(resolution, dict):
+            checked = [
+                entry.get("candidate_path") or entry.get("candidate_name") or "<unknown>"
+                for entry in resolution.get("candidates_checked", [])
+            ]
+        detail = f"; candidates checked: {', '.join(checked)}" if checked else ""
+        raise CliError(f"PowerShell is required to run: {script_path}{detail}")
+    shell_path = str(resolution["host_path"])
     leaf = Path(shell_path).name.lower()
     command = [shell_path, '-NoProfile']
     if leaf.startswith('powershell'):

--- a/apps/vgo-cli/src/vgo_cli/process.py
+++ b/apps/vgo-cli/src/vgo_cli/process.py
@@ -224,12 +224,19 @@ def run_powershell_file(script_path: Path, *args: str) -> subprocess.CompletedPr
     resolution = choose_powershell(return_diagnostics=True)
     if not isinstance(resolution, dict) or not resolution.get("host_path"):
         checked = []
+        policy_error = ""
         if isinstance(resolution, dict):
             checked = [
                 entry.get("candidate_path") or entry.get("candidate_name") or "<unknown>"
                 for entry in resolution.get("candidates_checked", [])
             ]
-        detail = f"; candidates checked: {', '.join(checked)}" if checked else ""
+            policy_error = str(resolution.get("error") or resolution.get("reason") or "").strip()
+        detail_parts: list[str] = []
+        if policy_error:
+            detail_parts.append(policy_error)
+        if checked:
+            detail_parts.append(f"candidates checked: {', '.join(checked)}")
+        detail = f"; {'; '.join(detail_parts)}" if detail_parts else ""
         raise CliError(f"PowerShell is required to run: {script_path}{detail}")
     shell_path = str(resolution["host_path"])
     leaf = Path(shell_path).name.lower()

--- a/apps/vgo-cli/src/vgo_cli/process.py
+++ b/apps/vgo-cli/src/vgo_cli/process.py
@@ -147,7 +147,7 @@ def choose_powershell(*, return_diagnostics: bool = False) -> str | dict[str, An
             diagnostics = {
                 "host_path": resolved,
                 "host_kind": kind,
-                "fallback_used": kind == "windows-powershell",
+                "fallback_used": prefer_pwsh and kind == "windows-powershell",
                 "candidates_checked": checked,
                 "policy": policy,
             }
@@ -186,7 +186,14 @@ def print_process_output(result: subprocess.CompletedProcess[str]) -> None:
 
 def run_subprocess(command: Sequence[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
     """Run a subprocess with captured UTF-8 text output."""
-    return subprocess.run(list(command), cwd=cwd, capture_output=True, text=True)
+    return subprocess.run(
+        list(command),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
 
 
 def invoke_python_core(

--- a/apps/vgo-cli/src/vgo_cli/process.py
+++ b/apps/vgo-cli/src/vgo_cli/process.py
@@ -31,9 +31,14 @@ def choose_powershell(*, return_diagnostics: bool = False) -> str | dict[str, An
     candidates: list[tuple[str, str | None, str]] = [
         ("path-pwsh", shutil.which("pwsh"), "pwsh"),
         ("path-pwsh-exe", shutil.which("pwsh.exe"), "pwsh"),
-        ("default-pwsh", r"C:\Program Files\PowerShell\7\pwsh.exe", "pwsh"),
-        ("preview-pwsh", r"C:\Program Files\PowerShell\7-preview\pwsh.exe", "pwsh"),
     ]
+    if is_windows:
+        candidates.extend(
+            [
+                ("default-pwsh", r"C:\Program Files\PowerShell\7\pwsh.exe", "pwsh"),
+                ("preview-pwsh", r"C:\Program Files\PowerShell\7-preview\pwsh.exe", "pwsh"),
+            ]
+        )
     if is_windows and policy["allow_windows_powershell_fallback"]:
         candidates.extend(
             [

--- a/config/execution-runtime-policy.json
+++ b/config/execution-runtime-policy.json
@@ -49,7 +49,7 @@
               "expected_artifacts": []
             },
             {
-              "unit_id": "version-consistency-gate",
+              "unit_id": "release-install-runtime-coherence-gate",
               "kind": "powershell_file",
               "parallelizable": true,
               "write_scope": "scripts/verify",

--- a/config/execution-runtime-policy.json
+++ b/config/execution-runtime-policy.json
@@ -53,7 +53,7 @@
               "kind": "powershell_file",
               "parallelizable": true,
               "write_scope": "scripts/verify",
-              "script_path": "scripts/verify/vibe-version-consistency-gate.ps1",
+              "script_path": "scripts/verify/vibe-release-install-runtime-coherence-gate.ps1",
               "arguments": [],
               "cwd": "${REPO_ROOT}",
               "timeout_seconds": 240,

--- a/config/powershell-host-policy.json
+++ b/config/powershell-host-policy.json
@@ -1,0 +1,6 @@
+{
+  "preferred_powershell_host": "pwsh",
+  "require_pwsh_on_non_windows": true,
+  "allow_windows_powershell_fallback": true,
+  "record_host_resolution_artifacts": true
+}

--- a/packages/runtime-core/src/vgo_runtime/canonical_entry.py
+++ b/packages/runtime-core/src/vgo_runtime/canonical_entry.py
@@ -48,6 +48,7 @@ REQUIRED_TRUTH_PACKET_FIELDS = (
 
 @dataclass(slots=True)
 class CanonicalLaunchResult:
+    """Structured result returned after a verified canonical vibe launch."""
     run_id: str
     session_root: Path
     summary_path: Path
@@ -57,6 +58,7 @@ class CanonicalLaunchResult:
     artifacts: dict[str, str]
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize the launch result using JSON-friendly path strings."""
         payload = asdict(self)
         payload["session_root"] = str(self.session_root)
         payload["summary_path"] = str(self.summary_path)
@@ -70,6 +72,7 @@ CanonicalEntryResult = CanonicalLaunchResult
 
 
 def _powershell_host_policy() -> dict[str, Any]:
+    """Load the shared PowerShell host policy with strict field validation."""
     policy = dict(POWERSHELL_HOST_POLICY_DEFAULTS)
     try:
         raw_payload = POWERSHELL_HOST_POLICY_PATH.read_text(encoding="utf-8")
@@ -136,10 +139,12 @@ def _powershell_host_policy() -> dict[str, Any]:
 
 
 def _is_windows_host() -> bool:
+    """Return whether the current Python host is running on Windows."""
     return os.name == "nt"
 
 
 def _resolve_powershell_host(*, return_diagnostics: bool = False) -> str | dict[str, Any] | None:
+    """Resolve the PowerShell host path or return detailed search diagnostics."""
     policy = _powershell_host_policy()
     is_windows = _is_windows_host()
     prefer_pwsh = str(policy["preferred_powershell_host"]).strip().lower() == "pwsh"
@@ -216,6 +221,7 @@ def _resolve_powershell_host(*, return_diagnostics: bool = False) -> str | dict[
 
 
 def _load_json_dict(path: Path, *, label: str) -> dict[str, Any]:
+    """Load a JSON object from disk and raise consistent runtime errors on failure."""
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
@@ -226,6 +232,7 @@ def _load_json_dict(path: Path, *, label: str) -> dict[str, Any]:
 
 
 def _normalize_requested_entry_id(entry_id: str | None) -> str:
+    """Normalize and validate the requested canonical entry identifier."""
     requested_entry_id = str(entry_id or "").strip() or CANONICAL_RUNTIME_ENTRY_ID
     if requested_entry_id not in load_allowed_vibe_entry_ids():
         raise RuntimeError(f"unsupported canonical vibe entry id: {requested_entry_id}")
@@ -233,6 +240,7 @@ def _normalize_requested_entry_id(entry_id: str | None) -> str:
 
 
 def _resolve_effective_prompt(*, host_id: str, entry_id: str, prompt: str) -> str:
+    """Derive the runtime prompt, including the upgrade fallback prompt."""
     prompt_text = str(prompt or "")
     if prompt_text.strip():
         return prompt_text
@@ -247,12 +255,14 @@ def _resolve_effective_prompt(*, host_id: str, entry_id: str, prompt: str) -> st
 
 
 def _new_run_id() -> str:
+    """Generate a unique canonical launch run identifier."""
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     suffix = os.urandom(4).hex()
     return f"{timestamp}-{suffix}"
 
 
 def _resolve_artifact_root(repo_root: Path, artifact_root: str | Path | None) -> Path:
+    """Resolve the artifact root relative to the repository when needed."""
     if artifact_root in (None, ""):
         return (repo_root / ".vibeskills").resolve()
 
@@ -263,6 +273,7 @@ def _resolve_artifact_root(repo_root: Path, artifact_root: str | Path | None) ->
 
 
 def _resolve_session_root(*, repo_root: Path, run_id: str, artifact_root: str | Path | None) -> Path:
+    """Build the canonical session output directory for a run."""
     return (_resolve_artifact_root(repo_root, artifact_root) / "outputs" / "runtime" / "vibe-sessions" / run_id).resolve()
 
 
@@ -278,6 +289,7 @@ def invoke_vibe_runtime_entrypoint(
     artifact_root: str | Path | None,
     force_runtime_neutral: bool = False,
 ) -> dict[str, Any]:
+    """Invoke the PowerShell canonical entry bridge and return its JSON payload."""
     if force_runtime_neutral:
         raise RuntimeError("canonical entry requires PowerShell runtime bridge")
 
@@ -340,6 +352,7 @@ def invoke_vibe_runtime_entrypoint(
 
 
 def assert_minimum_truth_artifacts(session_root: str | Path) -> dict[str, str]:
+    """Verify that the minimum canonical truth artifacts exist for a session."""
     base = Path(session_root).resolve()
     resolved: dict[str, str] = {}
     missing: list[str] = []
@@ -355,6 +368,7 @@ def assert_minimum_truth_artifacts(session_root: str | Path) -> dict[str, str]:
 
 
 def _extract_terminal_stage(stage_lineage: dict[str, Any]) -> str | None:
+    """Extract the terminal stage name from known stage-lineage shapes."""
     last_stage_name = str(stage_lineage.get("last_stage_name") or stage_lineage.get("last_stage") or "").strip()
     if last_stage_name:
         return last_stage_name
@@ -384,6 +398,7 @@ def assert_minimum_truth_consistency(
     governance_capsule_path: str | Path,
     stage_lineage_path: str | Path,
 ) -> None:
+    """Validate cross-artifact consistency for a canonical vibe launch."""
     runtime_packet = _load_json_dict(Path(runtime_packet_path), label="runtime-input-packet")
     missing_truth_fields = [field for field in REQUIRED_TRUTH_PACKET_FIELDS if field not in runtime_packet]
     if missing_truth_fields:
@@ -484,6 +499,7 @@ def launch_canonical_vibe(
     artifact_root: str | Path | None = None,
     force_runtime_neutral: bool = False,
 ) -> CanonicalLaunchResult:
+    """Launch canonical vibe, verify its artifacts, and return launch metadata."""
     repo_root_path = Path(repo_root).resolve()
     requested_entry_id = _normalize_requested_entry_id(entry_id)
     effective_prompt = _resolve_effective_prompt(host_id=host_id, entry_id=requested_entry_id, prompt=prompt)
@@ -568,6 +584,7 @@ def launch_canonical_vibe(
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for launching canonical vibe and emitting JSON output."""
     parser = argparse.ArgumentParser(description="Launch canonical vibe entry and emit receipt-backed JSON output.")
     parser.add_argument("--repo-root", required=True)
     parser.add_argument("--host-id", default="codex")

--- a/packages/runtime-core/src/vgo_runtime/canonical_entry.py
+++ b/packages/runtime-core/src/vgo_runtime/canonical_entry.py
@@ -258,7 +258,8 @@ def invoke_vibe_runtime_entrypoint(
                 for entry in resolution.get("candidates_checked", [])
             ]
         raise RuntimeError(
-            "PowerShell executable not available in PATH; candidates checked: " + ", ".join(checked)
+            "PowerShell executable not found; locations searched (PATH and well-known install paths): "
+            + ", ".join(checked)
         )
     shell = str(resolution["host_path"])
 

--- a/packages/runtime-core/src/vgo_runtime/canonical_entry.py
+++ b/packages/runtime-core/src/vgo_runtime/canonical_entry.py
@@ -20,6 +20,7 @@ POWERSHELL_HOST_POLICY_DEFAULTS: dict[str, Any] = {
     "allow_windows_powershell_fallback": True,
     "record_host_resolution_artifacts": True,
 }
+SUPPORTED_POWERSHELL_HOSTS = frozenset({"pwsh", "windows-powershell"})
 if str(CONTRACTS_SRC) not in sys.path:
     sys.path.insert(0, str(CONTRACTS_SRC))
 
@@ -105,22 +106,42 @@ def _powershell_host_policy() -> dict[str, Any]:
         )
         return policy
 
-    preferred_host = str(payload.get("preferred_powershell_host", "")).strip()
-    if preferred_host:
+    preferred_host = str(payload.get("preferred_powershell_host", "")).strip().lower()
+    if preferred_host in SUPPORTED_POWERSHELL_HOSTS:
         policy["preferred_powershell_host"] = preferred_host
+    elif preferred_host:
+        warnings.warn(
+            (
+                f"Unsupported preferred_powershell_host in {POWERSHELL_HOST_POLICY_PATH}: "
+                f"{preferred_host!r}; using default"
+            ),
+            RuntimeWarning,
+            stacklevel=2,
+        )
     for key in (
         "require_pwsh_on_non_windows",
         "allow_windows_powershell_fallback",
         "record_host_resolution_artifacts",
     ):
         if key in payload:
-            policy[key] = bool(payload[key])
+            if isinstance(payload[key], bool):
+                policy[key] = payload[key]
+            else:
+                warnings.warn(
+                    f"PowerShell host policy field {key} must be boolean; using default",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
     return policy
+
+
+def _is_windows_host() -> bool:
+    return os.name == "nt"
 
 
 def _resolve_powershell_host(*, return_diagnostics: bool = False) -> str | dict[str, Any] | None:
     policy = _powershell_host_policy()
-    is_windows = os.name == "nt"
+    is_windows = _is_windows_host()
     prefer_pwsh = str(policy["preferred_powershell_host"]).strip().lower() == "pwsh"
     pwsh_candidates: list[tuple[str, str | None, str]] = [
         ("path-pwsh", shutil.which("pwsh"), "pwsh"),

--- a/packages/runtime-core/src/vgo_runtime/canonical_entry.py
+++ b/packages/runtime-core/src/vgo_runtime/canonical_entry.py
@@ -193,7 +193,7 @@ def _resolve_powershell_host(*, return_diagnostics: bool = False) -> str | dict[
             diagnostics = {
                 "host_path": resolved,
                 "host_kind": kind,
-                "fallback_used": kind == "windows-powershell",
+                "fallback_used": prefer_pwsh and kind == "windows-powershell",
                 "candidates_checked": checked,
                 "policy": policy,
             }

--- a/packages/runtime-core/src/vgo_runtime/canonical_entry.py
+++ b/packages/runtime-core/src/vgo_runtime/canonical_entry.py
@@ -59,17 +59,64 @@ class CanonicalLaunchResult:
 CanonicalEntryResult = CanonicalLaunchResult
 
 
-def _resolve_powershell_host() -> str | None:
-    candidates = [
-        shutil.which("pwsh"),
-        shutil.which("pwsh.exe"),
-        shutil.which("powershell"),
-        shutil.which("powershell.exe"),
+def _powershell_host_policy() -> dict[str, Any]:
+    return {
+        "preferred_powershell_host": "pwsh",
+        "require_pwsh_on_non_windows": True,
+        "allow_windows_powershell_fallback": True,
+        "record_host_resolution_artifacts": True,
+    }
+
+
+def _resolve_powershell_host(*, return_diagnostics: bool = False) -> str | dict[str, Any] | None:
+    policy = _powershell_host_policy()
+    is_windows = os.name == "nt"
+    candidates: list[tuple[str, str | None, str]] = [
+        ("path-pwsh", shutil.which("pwsh"), "pwsh"),
+        ("path-pwsh-exe", shutil.which("pwsh.exe"), "pwsh"),
+        ("default-pwsh", r"C:\Program Files\PowerShell\7\pwsh.exe", "pwsh"),
+        ("preview-pwsh", r"C:\Program Files\PowerShell\7-preview\pwsh.exe", "pwsh"),
     ]
-    for candidate in candidates:
-        if candidate and Path(candidate).exists():
-            return str(Path(candidate))
-    return None
+    if is_windows and policy["allow_windows_powershell_fallback"]:
+        candidates.extend(
+            [
+                ("path-powershell", shutil.which("powershell"), "windows-powershell"),
+                ("path-powershell-exe", shutil.which("powershell.exe"), "windows-powershell"),
+            ]
+        )
+
+    checked: list[dict[str, Any]] = []
+    for name, candidate, kind in candidates:
+        resolved = str(Path(candidate)) if candidate else None
+        exists = bool(resolved and Path(resolved).exists())
+        is_file = bool(resolved and Path(resolved).is_file())
+        checked.append(
+            {
+                "candidate_name": name,
+                "candidate_kind": kind,
+                "candidate_path": resolved,
+                "exists": exists,
+                "is_file": is_file,
+            }
+        )
+        if exists and is_file:
+            diagnostics = {
+                "host_path": resolved,
+                "host_kind": kind,
+                "fallback_used": kind == "windows-powershell",
+                "candidates_checked": checked,
+                "policy": policy,
+            }
+            return diagnostics if return_diagnostics else resolved
+
+    diagnostics = {
+        "host_path": None,
+        "host_kind": None,
+        "fallback_used": False,
+        "candidates_checked": checked,
+        "policy": policy,
+    }
+    return diagnostics if return_diagnostics else None
 
 
 def _load_json_dict(path: Path, *, label: str) -> dict[str, Any]:
@@ -138,9 +185,18 @@ def invoke_vibe_runtime_entrypoint(
     if force_runtime_neutral:
         raise RuntimeError("canonical entry requires PowerShell runtime bridge")
 
-    shell = _resolve_powershell_host()
-    if shell is None:
-        raise RuntimeError("PowerShell executable not available in PATH")
+    resolution = _resolve_powershell_host(return_diagnostics=True)
+    if not isinstance(resolution, dict) or not resolution.get("host_path"):
+        checked = []
+        if isinstance(resolution, dict):
+            checked = [
+                entry.get("candidate_path") or entry.get("candidate_name") or "<unknown>"
+                for entry in resolution.get("candidates_checked", [])
+            ]
+        raise RuntimeError(
+            "PowerShell executable not available in PATH; candidates checked: " + ", ".join(checked)
+        )
+    shell = str(resolution["host_path"])
 
     bridge_path = repo_root / CANONICAL_ENTRY_BRIDGE_RELPATH
     if not bridge_path.exists():

--- a/packages/runtime-core/src/vgo_runtime/canonical_entry.py
+++ b/packages/runtime-core/src/vgo_runtime/canonical_entry.py
@@ -74,9 +74,14 @@ def _resolve_powershell_host(*, return_diagnostics: bool = False) -> str | dict[
     candidates: list[tuple[str, str | None, str]] = [
         ("path-pwsh", shutil.which("pwsh"), "pwsh"),
         ("path-pwsh-exe", shutil.which("pwsh.exe"), "pwsh"),
-        ("default-pwsh", r"C:\Program Files\PowerShell\7\pwsh.exe", "pwsh"),
-        ("preview-pwsh", r"C:\Program Files\PowerShell\7-preview\pwsh.exe", "pwsh"),
     ]
+    if is_windows:
+        candidates.extend(
+            [
+                ("default-pwsh", r"C:\Program Files\PowerShell\7\pwsh.exe", "pwsh"),
+                ("preview-pwsh", r"C:\Program Files\PowerShell\7-preview\pwsh.exe", "pwsh"),
+            ]
+        )
     if is_windows and policy["allow_windows_powershell_fallback"]:
         candidates.extend(
             [

--- a/packages/runtime-core/src/vgo_runtime/canonical_entry.py
+++ b/packages/runtime-core/src/vgo_runtime/canonical_entry.py
@@ -9,8 +9,17 @@ from pathlib import Path
 import shutil
 import sys
 from typing import Any
+import warnings
 
-CONTRACTS_SRC = Path(__file__).resolve().parents[4] / "packages" / "contracts" / "src"
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONTRACTS_SRC = REPO_ROOT / "packages" / "contracts" / "src"
+POWERSHELL_HOST_POLICY_PATH = REPO_ROOT / "config" / "powershell-host-policy.json"
+POWERSHELL_HOST_POLICY_DEFAULTS: dict[str, Any] = {
+    "preferred_powershell_host": "pwsh",
+    "require_pwsh_on_non_windows": True,
+    "allow_windows_powershell_fallback": True,
+    "record_host_resolution_artifacts": True,
+}
 if str(CONTRACTS_SRC) not in sys.path:
     sys.path.insert(0, str(CONTRACTS_SRC))
 
@@ -60,35 +69,85 @@ CanonicalEntryResult = CanonicalLaunchResult
 
 
 def _powershell_host_policy() -> dict[str, Any]:
-    return {
-        "preferred_powershell_host": "pwsh",
-        "require_pwsh_on_non_windows": True,
-        "allow_windows_powershell_fallback": True,
-        "record_host_resolution_artifacts": True,
-    }
+    policy = dict(POWERSHELL_HOST_POLICY_DEFAULTS)
+    try:
+        raw_payload = POWERSHELL_HOST_POLICY_PATH.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        warnings.warn(
+            f"PowerShell host policy file not found: {POWERSHELL_HOST_POLICY_PATH}; using defaults",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return policy
+    except OSError as exc:
+        warnings.warn(
+            f"Failed to read PowerShell host policy {POWERSHELL_HOST_POLICY_PATH}: {exc}; using defaults",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return policy
+
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        warnings.warn(
+            f"Invalid JSON in PowerShell host policy {POWERSHELL_HOST_POLICY_PATH}: {exc}; using defaults",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return policy
+
+    if not isinstance(payload, dict):
+        warnings.warn(
+            f"PowerShell host policy {POWERSHELL_HOST_POLICY_PATH} must contain a JSON object; using defaults",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return policy
+
+    preferred_host = str(payload.get("preferred_powershell_host", "")).strip()
+    if preferred_host:
+        policy["preferred_powershell_host"] = preferred_host
+    for key in (
+        "require_pwsh_on_non_windows",
+        "allow_windows_powershell_fallback",
+        "record_host_resolution_artifacts",
+    ):
+        if key in payload:
+            policy[key] = bool(payload[key])
+    return policy
 
 
 def _resolve_powershell_host(*, return_diagnostics: bool = False) -> str | dict[str, Any] | None:
     policy = _powershell_host_policy()
     is_windows = os.name == "nt"
-    candidates: list[tuple[str, str | None, str]] = [
+    prefer_pwsh = str(policy["preferred_powershell_host"]).strip().lower() == "pwsh"
+    pwsh_candidates: list[tuple[str, str | None, str]] = [
         ("path-pwsh", shutil.which("pwsh"), "pwsh"),
         ("path-pwsh-exe", shutil.which("pwsh.exe"), "pwsh"),
     ]
     if is_windows:
-        candidates.extend(
+        pwsh_candidates.extend(
             [
                 ("default-pwsh", r"C:\Program Files\PowerShell\7\pwsh.exe", "pwsh"),
                 ("preview-pwsh", r"C:\Program Files\PowerShell\7-preview\pwsh.exe", "pwsh"),
             ]
         )
-    if is_windows and policy["allow_windows_powershell_fallback"]:
-        candidates.extend(
+    windows_powershell_candidates: list[tuple[str, str | None, str]] = []
+    if is_windows:
+        windows_powershell_candidates.extend(
             [
                 ("path-powershell", shutil.which("powershell"), "windows-powershell"),
                 ("path-powershell-exe", shutil.which("powershell.exe"), "windows-powershell"),
             ]
         )
+    candidates: list[tuple[str, str | None, str]] = []
+    if prefer_pwsh:
+        candidates.extend(pwsh_candidates)
+        if is_windows and policy["allow_windows_powershell_fallback"]:
+            candidates.extend(windows_powershell_candidates)
+    elif is_windows:
+        candidates.extend(windows_powershell_candidates)
 
     checked: list[dict[str, Any]] = []
     for name, candidate, kind in candidates:

--- a/packages/runtime-core/src/vgo_runtime/canonical_entry.py
+++ b/packages/runtime-core/src/vgo_runtime/canonical_entry.py
@@ -173,6 +173,17 @@ def _resolve_powershell_host(*, return_diagnostics: bool = False) -> str | dict[
             }
             return diagnostics if return_diagnostics else resolved
 
+    if not is_windows and policy["require_pwsh_on_non_windows"]:
+        diagnostics = {
+            "host_path": None,
+            "host_kind": None,
+            "fallback_used": False,
+            "candidates_checked": checked,
+            "policy": policy,
+            "error": "pwsh is required on non-Windows hosts",
+        }
+        return diagnostics if return_diagnostics else None
+
     diagnostics = {
         "host_path": None,
         "host_kind": None,
@@ -252,14 +263,20 @@ def invoke_vibe_runtime_entrypoint(
     resolution = _resolve_powershell_host(return_diagnostics=True)
     if not isinstance(resolution, dict) or not resolution.get("host_path"):
         checked = []
+        policy_error = ""
         if isinstance(resolution, dict):
             checked = [
                 entry.get("candidate_path") or entry.get("candidate_name") or "<unknown>"
                 for entry in resolution.get("candidates_checked", [])
             ]
+            policy_error = str(resolution.get("error") or "").strip()
+        searched = ", ".join(checked) if checked else "<none>"
+        reason = f"{policy_error}; " if policy_error else ""
         raise RuntimeError(
-            "PowerShell executable not found; locations searched (PATH and well-known install paths): "
-            + ", ".join(checked)
+            "PowerShell executable not found; "
+            + reason
+            + "locations searched (PATH and well-known install paths): "
+            + searched
         )
     shell = str(resolution["host_path"])
 

--- a/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
+++ b/packages/runtime-core/src/vgo_runtime/powershell_bridge.py
@@ -148,6 +148,70 @@ def _command_preview(command: Sequence[str]) -> str:
     return " ".join(redacted)
 
 
+def _stream_preview_parts(*, stdout: bytes | str | None, stderr: bytes | str | None) -> list[str]:
+    parts: list[str] = []
+    stdout_preview = _preview_stream(stdout)
+    stderr_preview = _preview_stream(stderr)
+    if stdout_preview:
+        parts.append(f"stdout={stdout_preview}")
+    if stderr_preview:
+        parts.append(f"stderr={stderr_preview}")
+    return parts
+
+
+def _classify_bridge_failure(bridge_label: str) -> str:
+    normalized = bridge_label.strip().lower()
+    if "delegated lane" in normalized:
+        return "delegated lane payload handoff"
+    if "canonical entry" in normalized:
+        return "canonical bridge startup"
+    return "powershell bridge invocation"
+
+
+def _bridge_context_parts(
+    *,
+    command: Sequence[str],
+    cwd: Path,
+    completed: subprocess.CompletedProcess[bytes] | None = None,
+    stdout: bytes | str | None = None,
+    stderr: bytes | str | None = None,
+    extra_parts: Sequence[str] | None = None,
+) -> list[str]:
+    context_parts = [f"cwd={cwd}", f"command={_command_preview(command)}"]
+    if completed is not None:
+        context_parts.insert(0, f"exit={completed.returncode}")
+        stdout = completed.stdout
+        stderr = completed.stderr
+    context_parts.extend(extra_parts or [])
+    context_parts.extend(_stream_preview_parts(stdout=stdout, stderr=stderr))
+    return context_parts
+
+
+def _raise_bridge_failure(
+    *,
+    bridge_label: str,
+    message: str,
+    command: Sequence[str],
+    cwd: Path,
+    completed: subprocess.CompletedProcess[bytes] | None = None,
+    stdout: bytes | str | None = None,
+    stderr: bytes | str | None = None,
+    extra_parts: Sequence[str] | None = None,
+) -> None:
+    failure_kind = _classify_bridge_failure(bridge_label)
+    details = "; ".join(
+        _bridge_context_parts(
+            command=command,
+            cwd=cwd,
+            completed=completed,
+            stdout=stdout,
+            stderr=stderr,
+            extra_parts=extra_parts,
+        )
+    )
+    raise RuntimeError(f"{bridge_label} failed during {failure_kind}: {message} ({details})")
+
+
 def _build_stream_detail(
     *,
     stdout: bytes | str | None,
@@ -260,25 +324,34 @@ def run_powershell_json_command(
             timeout=resolved_timeout,
         )
     except subprocess.TimeoutExpired as exc:
-        detail_parts = [f"timeout={resolved_timeout}s", f"cwd={cwd}", f"command={_command_preview(command)}"]
-        stdout_preview = _preview_stream(exc.stdout)
-        stderr_preview = _preview_stream(exc.stderr)
-        if stdout_preview:
-            detail_parts.append(f"stdout={stdout_preview}")
-        if stderr_preview:
-            detail_parts.append(f"stderr={stderr_preview}")
-        raise RuntimeError(f"{bridge_label} timed out ({'; '.join(detail_parts)})") from exc
+        _raise_bridge_failure(
+            bridge_label=bridge_label,
+            message=f"timed out after {resolved_timeout}s",
+            command=command,
+            cwd=cwd,
+            stdout=exc.stdout,
+            stderr=exc.stderr,
+            extra_parts=[f"timeout={resolved_timeout}s"],
+        )
     if completed.returncode != 0:
-        detail_parts = [f"exit={completed.returncode}", f"cwd={cwd}", f"command={_command_preview(command)}"]
-        stdout_preview = _preview_stream(completed.stdout)
-        stderr_preview = _preview_stream(completed.stderr)
-        if stdout_preview:
-            detail_parts.append(f"stdout={stdout_preview}")
-        if stderr_preview:
-            detail_parts.append(f"stderr={stderr_preview}")
-        raise RuntimeError(f"{bridge_label} failed ({'; '.join(detail_parts)})")
-    return _decode_json_object_stdout(
-        completed.stdout,
-        bridge_label=bridge_label,
-        stderr=completed.stderr,
-    )
+        _raise_bridge_failure(
+            bridge_label=bridge_label,
+            message="subprocess exited non-zero before JSON payload was returned",
+            command=command,
+            cwd=cwd,
+            completed=completed,
+        )
+    try:
+        return _decode_json_object_stdout(
+            completed.stdout,
+            bridge_label=bridge_label,
+            stderr=completed.stderr,
+        )
+    except RuntimeError as exc:
+        _raise_bridge_failure(
+            bridge_label=bridge_label,
+            message=str(exc),
+            command=command,
+            cwd=cwd,
+            completed=completed,
+        )

--- a/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
+++ b/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
@@ -299,6 +299,33 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
         self.assertEqual(1, len(caught))
         self.assertIn("Invalid JSON in PowerShell host policy", str(caught[0].message))
 
+    def test_choose_powershell_policy_rejects_invalid_field_types(self):
+        module = _load_cli_process_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            policy_path = Path(temp_dir) / "powershell-host-policy.json"
+            policy_path.write_text(
+                json.dumps(
+                    {
+                        "preferred_powershell_host": "not-a-host",
+                        "require_pwsh_on_non_windows": "false",
+                        "allow_windows_powershell_fallback": "false",
+                        "record_host_resolution_artifacts": 1,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with patch.object(module, "POWERSHELL_HOST_POLICY_PATH", policy_path), warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                policy = module._powershell_host_policy()
+
+        self.assertEqual(policy, module.POWERSHELL_HOST_POLICY_DEFAULTS)
+        self.assertEqual(4, len(caught))
+        messages = [str(item.message) for item in caught]
+        self.assertTrue(any("Unsupported preferred_powershell_host" in message for message in messages))
+        self.assertTrue(any("require_pwsh_on_non_windows must be boolean" in message for message in messages))
+        self.assertTrue(any("allow_windows_powershell_fallback must be boolean" in message for message in messages))
+        self.assertTrue(any("record_host_resolution_artifacts must be boolean" in message for message in messages))
+
 
 class DelegatedLaneContractTests(unittest.TestCase):
     def test_plan_execute_uses_repo_root_first_working_directory_logic(self):
@@ -438,7 +465,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
                 }
                 return mapping.get(name)
 
-            with patch.object(module, "POWERSHELL_HOST_POLICY_PATH", policy_path), patch.object(module.os, "name", "nt"), patch.object(module.shutil, "which", side_effect=fake_which):
+            with patch.object(module, "POWERSHELL_HOST_POLICY_PATH", policy_path), patch.object(module, "_is_windows_host", return_value=True), patch.object(module.shutil, "which", side_effect=fake_which):
                 resolution = module._resolve_powershell_host(return_diagnostics=True)
 
         self.assertIsInstance(resolution, dict)
@@ -458,13 +485,40 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         def fake_is_file(path_self: Path) -> bool:
             return False
 
-        with patch.object(module.os, "name", "posix"), patch.object(module.shutil, "which", side_effect=fake_which), patch.object(module.Path, "exists", fake_exists), patch.object(module.Path, "is_file", fake_is_file):
+        with patch.object(module, "_is_windows_host", return_value=False), patch.object(module.shutil, "which", side_effect=fake_which), patch.object(module.Path, "exists", fake_exists), patch.object(module.Path, "is_file", fake_is_file):
             resolution = module._resolve_powershell_host(return_diagnostics=True)
 
         self.assertIsInstance(resolution, dict)
         self.assertEqual(resolution.get("error"), "pwsh is required on non-Windows hosts")
         checked_names = [entry["candidate_name"] for entry in resolution["candidates_checked"]]
         self.assertEqual(["path-pwsh", "path-pwsh-exe"], checked_names)
+
+    def test_canonical_entry_policy_rejects_invalid_field_types(self):
+        module = _load_canonical_entry_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            policy_path = Path(temp_dir) / "powershell-host-policy.json"
+            policy_path.write_text(
+                json.dumps(
+                    {
+                        "preferred_powershell_host": "bad-host",
+                        "require_pwsh_on_non_windows": "false",
+                        "allow_windows_powershell_fallback": "false",
+                        "record_host_resolution_artifacts": 1,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with patch.object(module, "POWERSHELL_HOST_POLICY_PATH", policy_path), warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                policy = module._powershell_host_policy()
+
+        self.assertEqual(policy, module.POWERSHELL_HOST_POLICY_DEFAULTS)
+        self.assertEqual(4, len(caught))
+        messages = [str(item.message) for item in caught]
+        self.assertTrue(any("Unsupported preferred_powershell_host" in message for message in messages))
+        self.assertTrue(any("require_pwsh_on_non_windows must be boolean" in message for message in messages))
+        self.assertTrue(any("allow_windows_powershell_fallback must be boolean" in message for message in messages))
+        self.assertTrue(any("record_host_resolution_artifacts must be boolean" in message for message in messages))
 
     def test_canonical_entry_startup_failure_is_distinct_from_payload_handoff_failure(self):
         module = _load_canonical_entry_module()

--- a/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
+++ b/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
@@ -315,6 +315,8 @@ class DelegatedLaneContractTests(unittest.TestCase):
         script_text = SCRIPT_PATH.read_text(encoding="utf-8")
         self.assertIn("Resolve-VibeDelegatedLanePayload", script_text)
         self.assertIn("source = 'lane_payload_artifact'", script_text)
+        self.assertIn("lane_payload_artifact:read_failed", script_text)
+        self.assertIn("empty_lane_receipt_path", script_text)
         self.assertIn("payload_source = [string]$payloadRecovery.source", script_text)
 
     def test_plan_execute_failure_message_is_actionable(self):
@@ -340,6 +342,7 @@ class DelegatedLaneContractTests(unittest.TestCase):
         self.assertIn("function New-VibeProcessPreflightResult", script_text)
         self.assertIn("command = [string]$Command", script_text)
         self.assertIn("Preflight.resolved_command", script_text)
+        self.assertIn("Failed to persist launch metadata to", script_text)
         self.assertIn("Process preflight failed:", script_text)
         self.assertIn("arguments_render_mode = if ($usedArgumentList) { 'ArgumentList' } else { 'RenderedString' }", script_text)
         self.assertIn("launch_metadata_path", script_text)
@@ -510,9 +513,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         self.assertNotIn("canonical bridge startup", payload_message)
 
     def test_bridge_succeeds_from_unicode_working_directory(self):
-        base_dir = Path(tempfile.gettempdir()) / "vibe-桥接-羽裳"
-        base_dir.mkdir(parents=True, exist_ok=True)
-        with tempfile.TemporaryDirectory(dir=base_dir) as temp_dir:
+        with tempfile.TemporaryDirectory(prefix="vibe-桥接-羽裳-") as temp_dir:
             cwd = Path(temp_dir)
             payload = {"status": "ok", "cwd": str(cwd)}
             command = [
@@ -526,9 +527,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         self.assertIn("桥接", result["cwd"])
 
     def test_bridge_failure_from_unicode_working_directory_preserves_context(self):
-        base_dir = Path(tempfile.gettempdir()) / "vibe-桥接-羽裳"
-        base_dir.mkdir(parents=True, exist_ok=True)
-        with tempfile.TemporaryDirectory(dir=base_dir) as temp_dir:
+        with tempfile.TemporaryDirectory(prefix="vibe-桥接-羽裳-") as temp_dir:
             cwd = Path(temp_dir)
             command = [
                 sys.executable,
@@ -550,13 +549,11 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         runtime_text = (REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1").read_text(encoding="utf-8")
         self.assertIn("Test-VgoWindowsRunnableCommandPath", helper_text)
         self.assertIn("powershell script path does not exist:", runtime_text)
-        self.assertNotIn("Process startup failed for C:\\Users\\羽裳\\bin\\python3", runtime_text)
+        self.assertIn("Process startup failed for {0}:", runtime_text)
 
     def test_canonical_entry_builds_command_for_unicode_repo_root(self):
         module = _load_canonical_entry_module()
-        base_dir = Path(tempfile.gettempdir()) / "vibe-规范入口-羽裳"
-        base_dir.mkdir(parents=True, exist_ok=True)
-        with tempfile.TemporaryDirectory(dir=base_dir) as repo_dir:
+        with tempfile.TemporaryDirectory(prefix="vibe-规范入口-羽裳-") as repo_dir:
             repo_root = Path(repo_dir)
             bridge_dir = repo_root / "scripts" / "runtime"
             bridge_dir.mkdir(parents=True, exist_ok=True)
@@ -668,7 +665,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
                         force_runtime_neutral=False,
                     )
         message = str(ctx.exception)
-        self.assertIn("PowerShell executable not available in PATH; candidates checked:", message)
+        self.assertIn("PowerShell executable not found; locations searched (PATH and well-known install paths):", message)
         self.assertIn("path-pwsh", message)
         self.assertIn("powershell.exe", message)
 

--- a/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
+++ b/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
@@ -23,6 +23,7 @@ from vgo_runtime.powershell_bridge import run_powershell_json_command
 
 
 def _restore_modules(originals: dict[str, types.ModuleType | None]) -> None:
+    """Restore sys.modules entries after dynamic import stubbing."""
     for name, original in originals.items():
         if original is None:
             sys.modules.pop(name, None)
@@ -31,6 +32,7 @@ def _restore_modules(originals: dict[str, types.ModuleType | None]) -> None:
 
 
 def _load_canonical_entry_module() -> types.ModuleType:
+    """Import canonical_entry.py with lightweight contract and router stubs."""
     touched = {
         "vgo_runtime",
         "vgo_contracts",
@@ -94,6 +96,7 @@ def _load_canonical_entry_module() -> types.ModuleType:
 
 
 def _load_cli_process_module() -> types.ModuleType:
+    """Import the CLI process module while restoring the previous module state."""
     cli_root = REPO_ROOT / "apps" / "vgo-cli" / "src"
     if str(cli_root) not in sys.path:
         sys.path.insert(0, str(cli_root))
@@ -126,6 +129,7 @@ def _load_cli_process_module() -> types.ModuleType:
 
 
 class DynamicLoaderIsolationTests(unittest.TestCase):
+    """Verify dynamic import helpers do not leak stub modules across tests."""
     def test_canonical_entry_loader_restores_sys_modules(self):
         managed = (
             "vgo_runtime",
@@ -151,6 +155,7 @@ class DynamicLoaderIsolationTests(unittest.TestCase):
 
 
 class CliProcessPowerShellPolicyTests(unittest.TestCase):
+    """Cover CLI PowerShell host policy parsing and resolution behavior."""
     def test_choose_powershell_reads_shared_policy_file_override(self):
         module = _load_cli_process_module()
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -328,6 +333,7 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
 
 
 class DelegatedLaneContractTests(unittest.TestCase):
+    """Assert delegated-lane contract and runtime policy wiring."""
     def test_plan_execute_uses_repo_root_first_working_directory_logic(self):
         script_text = SCRIPT_PATH.read_text(encoding="utf-8")
         self.assertIn("Resolve-VibeDelegatedLaneWorkingDirectory", script_text)
@@ -403,6 +409,7 @@ class DelegatedLaneContractTests(unittest.TestCase):
 
 
 class PowerShellBridgeDiagnosticTests(unittest.TestCase):
+    """Exercise bridge error classification for subprocess startup failures."""
     def test_delegated_lane_empty_stdout_is_classified(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             script_path = Path(temp_dir) / "empty.ps1"
@@ -436,6 +443,7 @@ class PowerShellBridgeDiagnosticTests(unittest.TestCase):
 
 
 class BridgeFailureLayeringTests(unittest.TestCase):
+    """Verify canonical entry failure modes preserve the right diagnostics."""
     def test_canonical_entry_reads_shared_policy_file_override(self):
         module = _load_canonical_entry_module()
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
+++ b/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import types
@@ -61,13 +62,17 @@ def _load_canonical_entry_module() -> types.ModuleType:
         host_receipt_module = types.ModuleType("vgo_contracts.host_launch_receipt")
 
         class HostLaunchReceipt:
+            """Minimal receipt stub that mimics the pydantic dump surface."""
             def __init__(self, **kwargs):
+                """Store receipt fields as plain attributes for tests."""
                 self.__dict__.update(kwargs)
 
             def model_dump(self):
+                """Return the stored receipt payload as a dictionary."""
                 return dict(self.__dict__)
 
         def write_host_launch_receipt(path_or_session_root, receipt):
+            """Persist a host-launch receipt stub next to the requested session root."""
             base = Path(path_or_session_root)
             if base.suffix:
                 path = base
@@ -131,6 +136,7 @@ def _load_cli_process_module() -> types.ModuleType:
 class DynamicLoaderIsolationTests(unittest.TestCase):
     """Verify dynamic import helpers do not leak stub modules across tests."""
     def test_canonical_entry_loader_restores_sys_modules(self):
+        """Restore all canonical-entry module stubs after import completes."""
         managed = (
             "vgo_runtime",
             "vgo_contracts",
@@ -146,6 +152,7 @@ class DynamicLoaderIsolationTests(unittest.TestCase):
             self.assertIs(sys.modules.get(name), original)
 
     def test_cli_process_loader_restores_sys_modules(self):
+        """Restore all CLI process module stubs after import completes."""
         managed = ("vgo_cli", "vgo_cli.errors", "vgo_cli.process")
         originals = {name: sys.modules.get(name) for name in managed}
         module = _load_cli_process_module()
@@ -157,6 +164,7 @@ class DynamicLoaderIsolationTests(unittest.TestCase):
 class CliProcessPowerShellPolicyTests(unittest.TestCase):
     """Cover CLI PowerShell host policy parsing and resolution behavior."""
     def test_choose_powershell_reads_shared_policy_file_override(self):
+        """Report Windows PowerShell as preferred, not a fallback, when policy requests it."""
         module = _load_cli_process_module()
         with tempfile.TemporaryDirectory() as temp_dir:
             policy_path = Path(temp_dir) / "powershell-host-policy.json"
@@ -177,6 +185,7 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
             powershell_path.write_text("", encoding="utf-8")
 
             def fake_which(name: str) -> str | None:
+                """Return test shell paths for pwsh and Windows PowerShell lookups."""
                 mapping = {
                     "pwsh": str(pwsh_path),
                     "pwsh.exe": str(pwsh_path),
@@ -191,9 +200,11 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
         self.assertIsInstance(resolution, dict)
         self.assertEqual(resolution["host_path"], str(powershell_path))
         self.assertEqual(resolution["host_kind"], "windows-powershell")
+        self.assertFalse(resolution["fallback_used"])
         self.assertTrue(resolution["policy"]["allow_windows_powershell_fallback"])
 
     def test_choose_powershell_prefers_pwsh_over_windows_powershell(self):
+        """Keep pwsh as the primary host when both shells are available."""
         module = _load_cli_process_module()
         with tempfile.TemporaryDirectory() as temp_dir:
             pwsh_path = Path(temp_dir) / "pwsh.exe"
@@ -202,6 +213,7 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
             powershell_path.write_text("", encoding="utf-8")
 
             def fake_which(name: str) -> str | None:
+                """Return both shell paths so the preference order can be asserted."""
                 mapping = {
                     "pwsh": str(pwsh_path),
                     "pwsh.exe": str(pwsh_path),
@@ -219,12 +231,14 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
         self.assertFalse(resolution["fallback_used"])
 
     def test_choose_powershell_uses_windows_fallback_when_pwsh_missing(self):
+        """Mark Windows PowerShell as a fallback only when pwsh resolution failed."""
         module = _load_cli_process_module()
         with tempfile.TemporaryDirectory() as temp_dir:
             powershell_path = Path(temp_dir) / "powershell.exe"
             powershell_path.write_text("", encoding="utf-8")
 
             def fake_which(name: str) -> str | None:
+                """Return only the Windows PowerShell candidate to force fallback."""
                 mapping = {
                     "pwsh": None,
                     "pwsh.exe": None,
@@ -234,9 +248,11 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
                 return mapping.get(name)
 
             def fake_exists(path_self: Path) -> bool:
+                """Mark only the fallback host path as existing."""
                 return str(path_self) == str(powershell_path)
 
             def fake_is_file(path_self: Path) -> bool:
+                """Mark only the fallback host path as a file."""
                 return str(path_self) == str(powershell_path)
 
             with patch.object(module, "_is_windows_host", return_value=True), patch.object(module.shutil, "which", side_effect=fake_which), patch.object(module.Path, "exists", fake_exists), patch.object(module.Path, "is_file", fake_is_file):
@@ -248,14 +264,18 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
         self.assertTrue(resolution["fallback_used"])
 
     def test_choose_powershell_reports_pwsh_required_on_non_windows(self):
+        """Surface the non-Windows pwsh policy error when no host can be resolved."""
         module = _load_cli_process_module()
         def fake_which(name: str) -> str | None:
+            """Report no PowerShell executable on PATH."""
             return None
 
         def fake_exists(path_self: Path) -> bool:
+            """Pretend every probed PowerShell path is missing."""
             return False
 
         def fake_is_file(path_self: Path) -> bool:
+            """Pretend every probed PowerShell path is not a file."""
             return False
 
         with patch.object(module.shutil, "which", side_effect=fake_which), patch.object(module, "_is_windows_host", return_value=False), patch.object(module, "_powershell_host_policy", return_value={
@@ -273,6 +293,7 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
         self.assertEqual(["path-pwsh", "path-pwsh-exe"], checked_names)
 
     def test_run_powershell_file_failure_reports_candidates_checked(self):
+        """Include policy and candidate diagnostics in CLI PowerShell resolution failures."""
         module = _load_cli_process_module()
         with self.assertRaises(Exception) as ctx:
             with patch.object(module, "choose_powershell", return_value={
@@ -294,6 +315,7 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
         self.assertIn("powershell.exe", message)
 
     def test_choose_powershell_invalid_policy_warns_and_uses_defaults(self):
+        """Warn and keep defaults when the shared host policy JSON is invalid."""
         module = _load_cli_process_module()
         with tempfile.TemporaryDirectory() as temp_dir:
             policy_path = Path(temp_dir) / "powershell-host-policy.json"
@@ -307,6 +329,7 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
         self.assertIn("Invalid JSON in PowerShell host policy", str(caught[0].message))
 
     def test_choose_powershell_policy_rejects_invalid_field_types(self):
+        """Reject non-boolean policy fields instead of coercing them."""
         module = _load_cli_process_module()
         with tempfile.TemporaryDirectory() as temp_dir:
             policy_path = Path(temp_dir) / "powershell-host-policy.json"
@@ -333,10 +356,34 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
         self.assertTrue(any("allow_windows_powershell_fallback must be boolean" in message for message in messages))
         self.assertTrue(any("record_host_resolution_artifacts must be boolean" in message for message in messages))
 
+    def test_run_subprocess_uses_utf8_decoding(self):
+        """Decode captured subprocess output as UTF-8 to match the helper contract."""
+        module = _load_cli_process_module()
+        expected = subprocess.CompletedProcess(
+            args=["git", "status"],
+            returncode=0,
+            stdout="stdout",
+            stderr="stderr",
+        )
+
+        with patch.object(module.subprocess, "run", return_value=expected) as run_mock:
+            result = module.run_subprocess(["git", "status"], cwd=Path("repo"))
+
+        self.assertIs(result, expected)
+        run_mock.assert_called_once_with(
+            ["git", "status"],
+            cwd=Path("repo"),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+
 
 class DelegatedLaneContractTests(unittest.TestCase):
     """Assert delegated-lane contract and runtime policy wiring."""
     def test_plan_execute_uses_repo_root_first_working_directory_logic(self):
+        """Keep delegated-lane working-directory fallback rooted at the repository first."""
         script_text = SCRIPT_PATH.read_text(encoding="utf-8")
         self.assertIn("Resolve-VibeDelegatedLaneWorkingDirectory", script_text)
         self.assertIn("requested_lane_root = $requestedLaneRoot", script_text)
@@ -347,6 +394,7 @@ class DelegatedLaneContractTests(unittest.TestCase):
         self.assertIn("repo_root_missing", script_text)
 
     def test_plan_execute_recovers_payload_from_artifact_when_stdout_missing(self):
+        """Recover delegated-lane payloads from receipt artifacts when stdout is empty."""
         script_text = SCRIPT_PATH.read_text(encoding="utf-8")
         self.assertIn("Resolve-VibeDelegatedLanePayload", script_text)
         self.assertIn("source = 'lane_payload_artifact'", script_text)
@@ -355,6 +403,7 @@ class DelegatedLaneContractTests(unittest.TestCase):
         self.assertIn("payload_source = [string]$payloadRecovery.source", script_text)
 
     def test_plan_execute_failure_message_is_actionable(self):
+        """Include lane and artifact context in delegated payload failure messages."""
         script_text = SCRIPT_PATH.read_text(encoding="utf-8")
         self.assertIn("Delegated lane payload handoff failed for lane_id=", script_text)
         self.assertIn("effective_working_directory=", script_text)
@@ -363,6 +412,7 @@ class DelegatedLaneContractTests(unittest.TestCase):
         self.assertIn("payload_path=", script_text)
 
     def test_delegated_lane_launch_metadata_records_host_resolution(self):
+        """Persist PowerShell host-resolution details in delegated lane launch metadata."""
         script_text = SCRIPT_PATH.read_text(encoding="utf-8")
         self.assertIn("host_kind = if ($invocation.PSObject.Properties.Name -contains 'host_kind')", script_text)
         self.assertIn("fallback_used = [bool]$(if ($invocation.PSObject.Properties.Name -contains 'fallback_used')", script_text)
@@ -373,6 +423,7 @@ class DelegatedLaneContractTests(unittest.TestCase):
         self.assertIn("preflight = [pscustomobject]@{", script_text)
 
     def test_runtime_execution_records_preflight_and_render_mode(self):
+        """Record process preflight fields and argument render mode in runtime metadata."""
         script_text = (REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1").read_text(encoding="utf-8")
         self.assertIn("function New-VibeProcessPreflightResult", script_text)
         self.assertIn("command = [string]$Command", script_text)
@@ -384,12 +435,14 @@ class DelegatedLaneContractTests(unittest.TestCase):
         self.assertIn("script_used_as_executable", script_text)
 
     def test_parallel_lane_failure_cleans_up_remaining_handles(self):
+        """Stop leftover delegated lane handles when one parallel lane fails."""
         script_text = SCRIPT_PATH.read_text(encoding="utf-8")
         self.assertIn("function Stop-VibeDelegatedLaneHandle", script_text)
         self.assertIn("$completedLaneIds = New-Object 'System.Collections.Generic.HashSet[string]'", script_text)
         self.assertIn("Stop-VibeDelegatedLaneHandle -Handle $remainingHandle", script_text)
 
     def test_runtime_execution_mentions_unicode_path_preflight_surfaces(self):
+        """Keep preflight error text explicit for missing paths and host resolution failures."""
         script_text = (REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1").read_text(encoding="utf-8")
         self.assertIn("resolved executable does not exist:", script_text)
         self.assertIn("working directory does not exist:", script_text)
@@ -397,11 +450,13 @@ class DelegatedLaneContractTests(unittest.TestCase):
         self.assertIn("python command spec did not resolve to a host executable:", script_text)
 
     def test_execution_runtime_policy_uses_existing_coherence_gate_path(self):
+        """Reference the runtime coherence gate instead of the retired version gate."""
         policy_text = (REPO_ROOT / "config" / "execution-runtime-policy.json").read_text(encoding="utf-8")
         self.assertIn("scripts/verify/vibe-release-install-runtime-coherence-gate.ps1", policy_text)
         self.assertNotIn("scripts/verify/vibe-version-consistency-gate.ps1", policy_text)
 
     def test_runtime_summary_artifacts_allow_early_bounded_stop_nulls(self):
+        """Allow empty bounded-stop artifact paths to round-trip as nulls in summaries."""
         script_text = (REPO_ROOT / "scripts" / "runtime" / "VibeRuntime.Common.ps1").read_text(encoding="utf-8")
         self.assertIn("[AllowEmptyString()] [string]$IntentContractPath = ''", script_text)
         self.assertIn("[AllowEmptyString()] [string]$RequirementDocPath = ''", script_text)
@@ -413,6 +468,7 @@ class DelegatedLaneContractTests(unittest.TestCase):
 class PowerShellBridgeDiagnosticTests(unittest.TestCase):
     """Exercise bridge error classification for subprocess startup failures."""
     def test_delegated_lane_empty_stdout_is_classified(self):
+        """Classify empty bridge stdout as a delegated payload handoff failure."""
         with tempfile.TemporaryDirectory() as temp_dir:
             script_path = Path(temp_dir) / "empty.ps1"
             script_path.write_text("", encoding="utf-8")
@@ -430,6 +486,7 @@ class PowerShellBridgeDiagnosticTests(unittest.TestCase):
         self.assertIn(f"command={Path(sys.executable).name}", message)
 
     def test_non_zero_exit_mentions_canonical_bridge_startup(self):
+        """Classify non-zero bridge exits as canonical startup failures."""
         with tempfile.TemporaryDirectory() as temp_dir:
             command = [
                 sys.executable,
@@ -447,6 +504,7 @@ class PowerShellBridgeDiagnosticTests(unittest.TestCase):
 class BridgeFailureLayeringTests(unittest.TestCase):
     """Verify canonical entry failure modes preserve the right diagnostics."""
     def test_canonical_entry_reads_shared_policy_file_override(self):
+        """Report Windows PowerShell as preferred, not fallback, when policy requests it."""
         module = _load_canonical_entry_module()
         with tempfile.TemporaryDirectory() as temp_dir:
             policy_path = Path(temp_dir) / "powershell-host-policy.json"
@@ -467,6 +525,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
             powershell_path.write_text("", encoding="utf-8")
 
             def fake_which(name: str) -> str | None:
+                """Return test shell paths for canonical-entry host resolution lookups."""
                 mapping = {
                     "pwsh": str(pwsh_path),
                     "pwsh.exe": str(pwsh_path),
@@ -481,18 +540,23 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         self.assertIsInstance(resolution, dict)
         self.assertEqual(resolution["host_path"], str(powershell_path))
         self.assertEqual(resolution["host_kind"], "windows-powershell")
+        self.assertFalse(resolution["fallback_used"])
         self.assertTrue(resolution["policy"]["allow_windows_powershell_fallback"])
 
     def test_canonical_entry_non_windows_skips_windows_install_path_candidates(self):
+        """Skip Windows-only install paths when resolving hosts on non-Windows systems."""
         module = _load_canonical_entry_module()
 
         def fake_which(name: str) -> str | None:
+            """Report no PowerShell executable on PATH."""
             return None
 
         def fake_exists(path_self: Path) -> bool:
+            """Pretend every well-known PowerShell path is missing."""
             return False
 
         def fake_is_file(path_self: Path) -> bool:
+            """Pretend every well-known PowerShell path is not a file."""
             return False
 
         with patch.object(module, "_is_windows_host", return_value=False), patch.object(module.shutil, "which", side_effect=fake_which), patch.object(module.Path, "exists", fake_exists), patch.object(module.Path, "is_file", fake_is_file):
@@ -504,6 +568,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         self.assertEqual(["path-pwsh", "path-pwsh-exe"], checked_names)
 
     def test_canonical_entry_policy_rejects_invalid_field_types(self):
+        """Reject malformed shared host policy fields for canonical entry resolution."""
         module = _load_canonical_entry_module()
         with tempfile.TemporaryDirectory() as temp_dir:
             policy_path = Path(temp_dir) / "powershell-host-policy.json"
@@ -531,6 +596,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         self.assertTrue(any("record_host_resolution_artifacts must be boolean" in message for message in messages))
 
     def test_canonical_entry_startup_failure_is_distinct_from_payload_handoff_failure(self):
+        """Keep canonical startup failures distinct from delegated payload handoff failures."""
         module = _load_canonical_entry_module()
         with tempfile.TemporaryDirectory() as repo_dir:
             repo_root = Path(repo_dir)
@@ -539,11 +605,13 @@ class BridgeFailureLayeringTests(unittest.TestCase):
             (bridge_path / "Invoke-VibeCanonicalEntry.ps1").write_text("# stub", encoding="utf-8")
 
             def fake_startup_bridge(command, *, cwd, bridge_label, env=None, timeout=None):
+                """Raise the startup-stage bridge failure expected by this test."""
                 raise RuntimeError(
                     "canonical entry bridge failed during canonical bridge startup: subprocess exited non-zero before JSON payload was returned (exit=11; cwd=%s; command=python; stderr=startup boom)" % cwd
                 )
 
             def fake_payload_bridge(command, *, cwd, bridge_label, env=None, timeout=None):
+                """Raise the payload-stage bridge failure expected by this test."""
                 raise RuntimeError(
                     "canonical entry bridge failed during delegated lane payload handoff: canonical entry bridge returned invalid JSON stdout (cwd=%s; command=python; stdout=not-json)" % cwd
                 )
@@ -584,6 +652,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         self.assertNotIn("canonical bridge startup", payload_message)
 
     def test_bridge_succeeds_from_unicode_working_directory(self):
+        """Round-trip UTF-8 JSON output from a Unicode working directory."""
         with tempfile.TemporaryDirectory(prefix="vibe-桥接-羽裳-") as temp_dir:
             cwd = Path(temp_dir)
             payload = {"status": "ok", "cwd": str(cwd)}
@@ -598,6 +667,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         self.assertIn("桥接", result["cwd"])
 
     def test_bridge_failure_from_unicode_working_directory_preserves_context(self):
+        """Preserve Unicode working-directory context in bridge startup failures."""
         with tempfile.TemporaryDirectory(prefix="vibe-桥接-羽裳-") as temp_dir:
             cwd = Path(temp_dir)
             command = [
@@ -616,6 +686,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
 
 
     def test_real_bridge_smoke_surfaces_preflight_script_missing_instead_of_invalid_python_host(self):
+        """Keep preflight failures focused on missing scripts rather than Python host confusion."""
         helper_text = (REPO_ROOT / "scripts" / "common" / "vibe-governance-helpers.ps1").read_text(encoding="utf-8")
         runtime_text = (REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1").read_text(encoding="utf-8")
         self.assertIn("Test-VgoWindowsRunnableCommandPath", helper_text)
@@ -623,6 +694,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         self.assertIn("Process startup failed for {0}:", runtime_text)
 
     def test_canonical_entry_builds_command_for_unicode_repo_root(self):
+        """Build the canonical bridge command correctly when the repo root contains Unicode."""
         module = _load_canonical_entry_module()
         with tempfile.TemporaryDirectory(prefix="vibe-规范入口-羽裳-") as repo_dir:
             repo_root = Path(repo_dir)
@@ -633,6 +705,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
             observed: dict[str, object] = {}
 
             def fake_bridge(command, *, cwd, bridge_label, env=None, timeout=None):
+                """Capture the bridge invocation for command-shape assertions."""
                 observed["command"] = list(command)
                 observed["cwd"] = cwd
                 observed["bridge_label"] = bridge_label
@@ -668,6 +741,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         self.assertIn("规范入口", str(repo_root))
 
     def test_canonical_entry_preserves_bridge_context_when_not_launched_from_repo_cwd(self):
+        """Run the bridge from repo_root even when the current process cwd differs."""
         module = _load_canonical_entry_module()
         with tempfile.TemporaryDirectory() as repo_dir, tempfile.TemporaryDirectory() as other_dir:
             repo_root = Path(repo_dir)
@@ -678,6 +752,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
             observed: dict[str, object] = {}
 
             def fake_bridge(command, *, cwd, bridge_label, env=None, timeout=None):
+                """Capture the cwd used for bridge execution and raise a known failure."""
                 observed["cwd"] = cwd
                 raise RuntimeError("canonical entry bridge failed during delegated lane payload handoff")
 
@@ -704,6 +779,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         self.assertIn("delegated lane payload handoff", str(ctx.exception))
 
     def test_canonical_entry_reports_candidates_when_powershell_missing(self):
+        """List searched PowerShell locations when canonical entry cannot resolve a host."""
         module = _load_canonical_entry_module()
         with tempfile.TemporaryDirectory() as repo_dir:
             repo_root = Path(repo_dir)
@@ -741,6 +817,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         self.assertIn("powershell.exe", message)
 
     def test_canonical_entry_surfaces_pwsh_policy_reason_when_missing_on_non_windows(self):
+        """Bubble up the pwsh-required policy reason when canonical entry has no host."""
         module = _load_canonical_entry_module()
         with tempfile.TemporaryDirectory() as repo_dir:
             repo_root = Path(repo_dir)

--- a/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
+++ b/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
@@ -348,6 +348,12 @@ class DelegatedLaneContractTests(unittest.TestCase):
         self.assertIn("launch_metadata_path", script_text)
         self.assertIn("script_used_as_executable", script_text)
 
+    def test_parallel_lane_failure_cleans_up_remaining_handles(self):
+        script_text = SCRIPT_PATH.read_text(encoding="utf-8")
+        self.assertIn("function Stop-VibeDelegatedLaneHandle", script_text)
+        self.assertIn("$completedLaneIds = New-Object 'System.Collections.Generic.HashSet[string]'", script_text)
+        self.assertIn("Stop-VibeDelegatedLaneHandle -Handle $remainingHandle", script_text)
+
     def test_runtime_execution_mentions_unicode_path_preflight_surfaces(self):
         script_text = (REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1").read_text(encoding="utf-8")
         self.assertIn("resolved executable does not exist:", script_text)
@@ -456,6 +462,7 @@ class BridgeFailureLayeringTests(unittest.TestCase):
             resolution = module._resolve_powershell_host(return_diagnostics=True)
 
         self.assertIsInstance(resolution, dict)
+        self.assertEqual(resolution.get("error"), "pwsh is required on non-Windows hosts")
         checked_names = [entry["candidate_name"] for entry in resolution["candidates_checked"]]
         self.assertEqual(["path-pwsh", "path-pwsh-exe"], checked_names)
 
@@ -668,6 +675,43 @@ class BridgeFailureLayeringTests(unittest.TestCase):
         self.assertIn("PowerShell executable not found; locations searched (PATH and well-known install paths):", message)
         self.assertIn("path-pwsh", message)
         self.assertIn("powershell.exe", message)
+
+    def test_canonical_entry_surfaces_pwsh_policy_reason_when_missing_on_non_windows(self):
+        module = _load_canonical_entry_module()
+        with tempfile.TemporaryDirectory() as repo_dir:
+            repo_root = Path(repo_dir)
+            bridge_path = repo_root / "scripts" / "runtime"
+            bridge_path.mkdir(parents=True, exist_ok=True)
+            (bridge_path / "Invoke-VibeCanonicalEntry.ps1").write_text("# stub", encoding="utf-8")
+            with self.assertRaises(RuntimeError) as ctx:
+                with patch.object(
+                    module,
+                    "_resolve_powershell_host",
+                    return_value={
+                        "host_path": None,
+                        "host_kind": None,
+                        "fallback_used": False,
+                        "candidates_checked": [
+                            {"candidate_name": "path-pwsh", "candidate_path": None},
+                            {"candidate_name": "path-pwsh-exe", "candidate_path": None},
+                        ],
+                        "error": "pwsh is required on non-Windows hosts",
+                    },
+                ):
+                    module.invoke_vibe_runtime_entrypoint(
+                        repo_root=repo_root,
+                        host_id="codex",
+                        entry_id="vibe",
+                        prompt="test",
+                        requested_stage_stop=None,
+                        requested_grade_floor=None,
+                        run_id="run-1",
+                        artifact_root=None,
+                        force_runtime_neutral=False,
+                    )
+        message = str(ctx.exception)
+        self.assertIn("pwsh is required on non-Windows hosts", message)
+        self.assertIn("locations searched (PATH and well-known install paths): path-pwsh, path-pwsh-exe", message)
 
 
 if __name__ == "__main__":

--- a/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
+++ b/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
@@ -21,55 +21,75 @@ if str(RUNTIME_CORE_SRC) not in sys.path:
 from vgo_runtime.powershell_bridge import run_powershell_json_command
 
 
-def _load_canonical_entry_module() -> types.ModuleType:
-    package = types.ModuleType("vgo_runtime")
-    package.__path__ = [str(RUNTIME_CORE_SRC / "vgo_runtime")]
-    sys.modules.setdefault("vgo_runtime", package)
-
-    contracts_package = types.ModuleType("vgo_contracts")
-    contracts_package.__path__ = []
-    sys.modules.setdefault("vgo_contracts", contracts_package)
-
-    canonical_contract_module = types.ModuleType("vgo_contracts.canonical_vibe_contract")
-    canonical_contract_module.resolve_canonical_vibe_contract = lambda repo_root, host_id: {
-        "fallback_policy": "blocked",
-        "allow_skill_doc_fallback": False,
-    }
-    sys.modules[canonical_contract_module.__name__] = canonical_contract_module
-
-    host_receipt_module = types.ModuleType("vgo_contracts.host_launch_receipt")
-
-    class HostLaunchReceipt:
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-        def model_dump(self):
-            return dict(self.__dict__)
-
-    def write_host_launch_receipt(path_or_session_root, receipt):
-        base = Path(path_or_session_root)
-        if base.suffix:
-            path = base
+def _restore_modules(originals: dict[str, types.ModuleType | None]) -> None:
+    for name, original in originals.items():
+        if original is None:
+            sys.modules.pop(name, None)
         else:
-            path = base / "host-launch-receipt.json"
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(receipt.model_dump()), encoding="utf-8")
-        return path
+            sys.modules[name] = original
 
-    host_receipt_module.HostLaunchReceipt = HostLaunchReceipt
-    host_receipt_module.write_host_launch_receipt = write_host_launch_receipt
-    sys.modules[host_receipt_module.__name__] = host_receipt_module
 
-    router_module = types.ModuleType("vgo_runtime.router")
-    router_module.load_allowed_vibe_entry_ids = lambda: {"vibe", "vibe-upgrade"}
-    sys.modules[router_module.__name__] = router_module
+def _load_canonical_entry_module() -> types.ModuleType:
+    touched = {
+        "vgo_runtime",
+        "vgo_contracts",
+        "vgo_contracts.canonical_vibe_contract",
+        "vgo_contracts.host_launch_receipt",
+        "vgo_runtime.router",
+        "vgo_runtime.canonical_entry",
+    }
+    originals = {name: sys.modules.get(name) for name in touched}
+    try:
+        package = types.ModuleType("vgo_runtime")
+        package.__path__ = [str(RUNTIME_CORE_SRC / "vgo_runtime")]
+        sys.modules["vgo_runtime"] = package
 
-    spec = importlib.util.spec_from_file_location("vgo_runtime.canonical_entry", RUNTIME_CORE_SRC / "vgo_runtime" / "canonical_entry.py")
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
+        contracts_package = types.ModuleType("vgo_contracts")
+        contracts_package.__path__ = []
+        sys.modules["vgo_contracts"] = contracts_package
+
+        canonical_contract_module = types.ModuleType("vgo_contracts.canonical_vibe_contract")
+        canonical_contract_module.resolve_canonical_vibe_contract = lambda repo_root, host_id: {
+            "fallback_policy": "blocked",
+            "allow_skill_doc_fallback": False,
+        }
+        sys.modules[canonical_contract_module.__name__] = canonical_contract_module
+
+        host_receipt_module = types.ModuleType("vgo_contracts.host_launch_receipt")
+
+        class HostLaunchReceipt:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+            def model_dump(self):
+                return dict(self.__dict__)
+
+        def write_host_launch_receipt(path_or_session_root, receipt):
+            base = Path(path_or_session_root)
+            if base.suffix:
+                path = base
+            else:
+                path = base / "host-launch-receipt.json"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(receipt.model_dump()), encoding="utf-8")
+            return path
+
+        host_receipt_module.HostLaunchReceipt = HostLaunchReceipt
+        host_receipt_module.write_host_launch_receipt = write_host_launch_receipt
+        sys.modules[host_receipt_module.__name__] = host_receipt_module
+
+        router_module = types.ModuleType("vgo_runtime.router")
+        router_module.load_allowed_vibe_entry_ids = lambda: {"vibe", "vibe-upgrade"}
+        sys.modules[router_module.__name__] = router_module
+
+        spec = importlib.util.spec_from_file_location("vgo_runtime.canonical_entry", RUNTIME_CORE_SRC / "vgo_runtime" / "canonical_entry.py")
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        _restore_modules(originals)
 
 
 def _load_cli_process_module() -> types.ModuleType:
@@ -77,22 +97,56 @@ def _load_cli_process_module() -> types.ModuleType:
     if str(cli_root) not in sys.path:
         sys.path.insert(0, str(cli_root))
 
-    package = types.ModuleType("vgo_cli")
-    package.__path__ = [str(cli_root / "vgo_cli")]
-    sys.modules.setdefault("vgo_cli", package)
+    touched = {
+        "vgo_cli",
+        "vgo_cli.errors",
+        "vgo_cli.process",
+    }
+    originals = {name: sys.modules.get(name) for name in touched}
+    try:
+        package = types.ModuleType("vgo_cli")
+        package.__path__ = [str(cli_root / "vgo_cli")]
+        sys.modules["vgo_cli"] = package
 
-    errors_spec = importlib.util.spec_from_file_location("vgo_cli.errors", cli_root / "vgo_cli" / "errors.py")
-    assert errors_spec and errors_spec.loader
-    errors_module = importlib.util.module_from_spec(errors_spec)
-    sys.modules[errors_spec.name] = errors_module
-    errors_spec.loader.exec_module(errors_module)
+        errors_spec = importlib.util.spec_from_file_location("vgo_cli.errors", cli_root / "vgo_cli" / "errors.py")
+        assert errors_spec and errors_spec.loader
+        errors_module = importlib.util.module_from_spec(errors_spec)
+        sys.modules[errors_spec.name] = errors_module
+        errors_spec.loader.exec_module(errors_module)
 
-    spec = importlib.util.spec_from_file_location("vgo_cli.process", cli_root / "vgo_cli" / "process.py")
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
+        spec = importlib.util.spec_from_file_location("vgo_cli.process", cli_root / "vgo_cli" / "process.py")
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        _restore_modules(originals)
+
+
+class DynamicLoaderIsolationTests(unittest.TestCase):
+    def test_canonical_entry_loader_restores_sys_modules(self):
+        managed = (
+            "vgo_runtime",
+            "vgo_contracts",
+            "vgo_contracts.canonical_vibe_contract",
+            "vgo_contracts.host_launch_receipt",
+            "vgo_runtime.router",
+            "vgo_runtime.canonical_entry",
+        )
+        originals = {name: sys.modules.get(name) for name in managed}
+        module = _load_canonical_entry_module()
+        self.assertEqual("vgo_runtime.canonical_entry", module.__name__)
+        for name, original in originals.items():
+            self.assertIs(sys.modules.get(name), original)
+
+    def test_cli_process_loader_restores_sys_modules(self):
+        managed = ("vgo_cli", "vgo_cli.errors", "vgo_cli.process")
+        originals = {name: sys.modules.get(name) for name in managed}
+        module = _load_cli_process_module()
+        self.assertEqual("vgo_cli.process", module.__name__)
+        for name, original in originals.items():
+            self.assertIs(sys.modules.get(name), original)
 
 
 class CliProcessPowerShellPolicyTests(unittest.TestCase):
@@ -172,6 +226,8 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
         self.assertIsInstance(resolution, dict)
         self.assertIsNone(resolution["host_path"])
         self.assertEqual(resolution.get("error"), "pwsh is required on non-Windows hosts")
+        checked_names = [entry["candidate_name"] for entry in resolution["candidates_checked"]]
+        self.assertEqual(["path-pwsh", "path-pwsh-exe"], checked_names)
 
     def test_run_powershell_file_failure_reports_candidates_checked(self):
         module = _load_cli_process_module()
@@ -260,7 +316,7 @@ class PowerShellBridgeDiagnosticTests(unittest.TestCase):
             script_path = Path(temp_dir) / "empty.ps1"
             script_path.write_text("", encoding="utf-8")
             command = [
-                "python",
+                sys.executable,
                 "-c",
                 "import sys; sys.exit(0)",
             ]
@@ -270,12 +326,12 @@ class PowerShellBridgeDiagnosticTests(unittest.TestCase):
         self.assertIn("delegated lane payload handoff", message)
         self.assertIn("returned empty stdout", message)
         self.assertIn("cwd=", message)
-        self.assertIn("command=python", message)
+        self.assertIn(f"command={Path(sys.executable).name}", message)
 
     def test_non_zero_exit_mentions_canonical_bridge_startup(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             command = [
-                "python",
+                sys.executable,
                 "-c",
                 "import sys; sys.stderr.write('boom\\n'); sys.exit(7)",
             ]
@@ -288,6 +344,25 @@ class PowerShellBridgeDiagnosticTests(unittest.TestCase):
 
 
 class BridgeFailureLayeringTests(unittest.TestCase):
+    def test_canonical_entry_non_windows_skips_windows_install_path_candidates(self):
+        module = _load_canonical_entry_module()
+
+        def fake_which(name: str) -> str | None:
+            return None
+
+        def fake_exists(path_self: Path) -> bool:
+            return False
+
+        def fake_is_file(path_self: Path) -> bool:
+            return False
+
+        with patch.object(module.os, "name", "posix"), patch.object(module.shutil, "which", side_effect=fake_which), patch.object(module.Path, "exists", fake_exists), patch.object(module.Path, "is_file", fake_is_file):
+            resolution = module._resolve_powershell_host(return_diagnostics=True)
+
+        self.assertIsInstance(resolution, dict)
+        checked_names = [entry["candidate_name"] for entry in resolution["candidates_checked"]]
+        self.assertEqual(["path-pwsh", "path-pwsh-exe"], checked_names)
+
     def test_canonical_entry_startup_failure_is_distinct_from_payload_handoff_failure(self):
         module = _load_canonical_entry_module()
         with tempfile.TemporaryDirectory() as repo_dir:

--- a/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
+++ b/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
@@ -9,6 +9,7 @@ import types
 import unittest
 from pathlib import Path
 from unittest.mock import patch
+import warnings
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -150,6 +151,43 @@ class DynamicLoaderIsolationTests(unittest.TestCase):
 
 
 class CliProcessPowerShellPolicyTests(unittest.TestCase):
+    def test_choose_powershell_reads_shared_policy_file_override(self):
+        module = _load_cli_process_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            policy_path = Path(temp_dir) / "powershell-host-policy.json"
+            policy_path.write_text(
+                json.dumps(
+                    {
+                        "preferred_powershell_host": "windows-powershell",
+                        "require_pwsh_on_non_windows": True,
+                        "allow_windows_powershell_fallback": True,
+                        "record_host_resolution_artifacts": True,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            pwsh_path = Path(temp_dir) / "pwsh.exe"
+            powershell_path = Path(temp_dir) / "powershell.exe"
+            pwsh_path.write_text("", encoding="utf-8")
+            powershell_path.write_text("", encoding="utf-8")
+
+            def fake_which(name: str) -> str | None:
+                mapping = {
+                    "pwsh": str(pwsh_path),
+                    "pwsh.exe": str(pwsh_path),
+                    "powershell": str(powershell_path),
+                    "powershell.exe": str(powershell_path),
+                }
+                return mapping.get(name)
+
+            with patch.object(module, "POWERSHELL_HOST_POLICY_PATH", policy_path), patch.object(module, "_is_windows_host", return_value=True), patch.object(module.shutil, "which", side_effect=fake_which):
+                resolution = module.choose_powershell(return_diagnostics=True)
+
+        self.assertIsInstance(resolution, dict)
+        self.assertEqual(resolution["host_path"], str(powershell_path))
+        self.assertEqual(resolution["host_kind"], "windows-powershell")
+        self.assertTrue(resolution["policy"]["allow_windows_powershell_fallback"])
+
     def test_choose_powershell_prefers_pwsh_over_windows_powershell(self):
         module = _load_cli_process_module()
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -248,11 +286,26 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
         self.assertIn("path-pwsh", message)
         self.assertIn("powershell.exe", message)
 
+    def test_choose_powershell_invalid_policy_warns_and_uses_defaults(self):
+        module = _load_cli_process_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            policy_path = Path(temp_dir) / "powershell-host-policy.json"
+            policy_path.write_text("{invalid-json", encoding="utf-8")
+            with patch.object(module, "POWERSHELL_HOST_POLICY_PATH", policy_path), warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                policy = module._powershell_host_policy()
+
+        self.assertEqual(policy, module.POWERSHELL_HOST_POLICY_DEFAULTS)
+        self.assertEqual(1, len(caught))
+        self.assertIn("Invalid JSON in PowerShell host policy", str(caught[0].message))
+
 
 class DelegatedLaneContractTests(unittest.TestCase):
     def test_plan_execute_uses_repo_root_first_working_directory_logic(self):
         script_text = SCRIPT_PATH.read_text(encoding="utf-8")
         self.assertIn("Resolve-VibeDelegatedLaneWorkingDirectory", script_text)
+        self.assertIn("requested_lane_root = $requestedLaneRoot", script_text)
+        self.assertIn("lane_root_invalid", script_text)
         self.assertIn("requested_working_directory = if", script_text)
         self.assertIn("effective_working_directory = [string]$workingDirectoryInfo.effective_working_directory", script_text)
         self.assertIn("repo_root_invalid", script_text)
@@ -276,6 +329,7 @@ class DelegatedLaneContractTests(unittest.TestCase):
         script_text = SCRIPT_PATH.read_text(encoding="utf-8")
         self.assertIn("host_kind = if ($invocation.PSObject.Properties.Name -contains 'host_kind')", script_text)
         self.assertIn("fallback_used = [bool]$(if ($invocation.PSObject.Properties.Name -contains 'fallback_used')", script_text)
+        self.assertIn("lane_root_fallback_reason = if ($null -eq $workingDirectoryInfo.lane_root_fallback_reason)", script_text)
         self.assertIn("resolved_command = [string]($invocation.host_path)", script_text)
         self.assertIn("resolved_arguments = @($invocation.arguments)", script_text)
         self.assertIn("arguments_render_mode = 'RenderedString'", script_text)
@@ -284,6 +338,8 @@ class DelegatedLaneContractTests(unittest.TestCase):
     def test_runtime_execution_records_preflight_and_render_mode(self):
         script_text = (REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1").read_text(encoding="utf-8")
         self.assertIn("function New-VibeProcessPreflightResult", script_text)
+        self.assertIn("command = [string]$Command", script_text)
+        self.assertIn("Preflight.resolved_command", script_text)
         self.assertIn("Process preflight failed:", script_text)
         self.assertIn("arguments_render_mode = if ($usedArgumentList) { 'ArgumentList' } else { 'RenderedString' }", script_text)
         self.assertIn("launch_metadata_path", script_text)
@@ -344,6 +400,43 @@ class PowerShellBridgeDiagnosticTests(unittest.TestCase):
 
 
 class BridgeFailureLayeringTests(unittest.TestCase):
+    def test_canonical_entry_reads_shared_policy_file_override(self):
+        module = _load_canonical_entry_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            policy_path = Path(temp_dir) / "powershell-host-policy.json"
+            policy_path.write_text(
+                json.dumps(
+                    {
+                        "preferred_powershell_host": "windows-powershell",
+                        "require_pwsh_on_non_windows": True,
+                        "allow_windows_powershell_fallback": True,
+                        "record_host_resolution_artifacts": True,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            pwsh_path = Path(temp_dir) / "pwsh.exe"
+            powershell_path = Path(temp_dir) / "powershell.exe"
+            pwsh_path.write_text("", encoding="utf-8")
+            powershell_path.write_text("", encoding="utf-8")
+
+            def fake_which(name: str) -> str | None:
+                mapping = {
+                    "pwsh": str(pwsh_path),
+                    "pwsh.exe": str(pwsh_path),
+                    "powershell": str(powershell_path),
+                    "powershell.exe": str(powershell_path),
+                }
+                return mapping.get(name)
+
+            with patch.object(module, "POWERSHELL_HOST_POLICY_PATH", policy_path), patch.object(module.os, "name", "nt"), patch.object(module.shutil, "which", side_effect=fake_which):
+                resolution = module._resolve_powershell_host(return_diagnostics=True)
+
+        self.assertIsInstance(resolution, dict)
+        self.assertEqual(resolution["host_path"], str(powershell_path))
+        self.assertEqual(resolution["host_kind"], "windows-powershell")
+        self.assertTrue(resolution["policy"]["allow_windows_powershell_fallback"])
+
     def test_canonical_entry_non_windows_skips_windows_install_path_candidates(self):
         module = _load_canonical_entry_module()
 

--- a/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
+++ b/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
@@ -279,6 +279,7 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
                 "host_path": None,
                 "host_kind": None,
                 "fallback_used": False,
+                "error": "pwsh is required on non-Windows hosts",
                 "candidates_checked": [
                     {"candidate_name": "path-pwsh", "candidate_path": None},
                     {"candidate_name": "path-powershell", "candidate_path": r"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"},
@@ -287,6 +288,7 @@ class CliProcessPowerShellPolicyTests(unittest.TestCase):
                 module.run_powershell_file(Path("demo.ps1"), "-Task", "probe")
         message = str(ctx.exception)
         self.assertIn("PowerShell is required to run: demo.ps1", message)
+        self.assertIn("pwsh is required on non-Windows hosts", message)
         self.assertIn("candidates checked:", message)
         self.assertIn("path-pwsh", message)
         self.assertIn("powershell.exe", message)

--- a/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
+++ b/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+RUNTIME_CORE_SRC = REPO_ROOT / "packages" / "runtime-core" / "src"
+SCRIPT_PATH = REPO_ROOT / "scripts" / "runtime" / "Invoke-PlanExecute.ps1"
+
+if str(RUNTIME_CORE_SRC) not in sys.path:
+    sys.path.insert(0, str(RUNTIME_CORE_SRC))
+
+from vgo_runtime.powershell_bridge import run_powershell_json_command
+
+
+def _load_canonical_entry_module() -> types.ModuleType:
+    package = types.ModuleType("vgo_runtime")
+    package.__path__ = [str(RUNTIME_CORE_SRC / "vgo_runtime")]
+    sys.modules.setdefault("vgo_runtime", package)
+
+    contracts_package = types.ModuleType("vgo_contracts")
+    contracts_package.__path__ = []
+    sys.modules.setdefault("vgo_contracts", contracts_package)
+
+    canonical_contract_module = types.ModuleType("vgo_contracts.canonical_vibe_contract")
+    canonical_contract_module.resolve_canonical_vibe_contract = lambda repo_root, host_id: {
+        "fallback_policy": "blocked",
+        "allow_skill_doc_fallback": False,
+    }
+    sys.modules[canonical_contract_module.__name__] = canonical_contract_module
+
+    host_receipt_module = types.ModuleType("vgo_contracts.host_launch_receipt")
+
+    class HostLaunchReceipt:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+        def model_dump(self):
+            return dict(self.__dict__)
+
+    def write_host_launch_receipt(path_or_session_root, receipt):
+        base = Path(path_or_session_root)
+        if base.suffix:
+            path = base
+        else:
+            path = base / "host-launch-receipt.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(receipt.model_dump()), encoding="utf-8")
+        return path
+
+    host_receipt_module.HostLaunchReceipt = HostLaunchReceipt
+    host_receipt_module.write_host_launch_receipt = write_host_launch_receipt
+    sys.modules[host_receipt_module.__name__] = host_receipt_module
+
+    router_module = types.ModuleType("vgo_runtime.router")
+    router_module.load_allowed_vibe_entry_ids = lambda: {"vibe", "vibe-upgrade"}
+    sys.modules[router_module.__name__] = router_module
+
+    spec = importlib.util.spec_from_file_location("vgo_runtime.canonical_entry", RUNTIME_CORE_SRC / "vgo_runtime" / "canonical_entry.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_cli_process_module() -> types.ModuleType:
+    cli_root = REPO_ROOT / "apps" / "vgo-cli" / "src"
+    if str(cli_root) not in sys.path:
+        sys.path.insert(0, str(cli_root))
+
+    package = types.ModuleType("vgo_cli")
+    package.__path__ = [str(cli_root / "vgo_cli")]
+    sys.modules.setdefault("vgo_cli", package)
+
+    errors_spec = importlib.util.spec_from_file_location("vgo_cli.errors", cli_root / "vgo_cli" / "errors.py")
+    assert errors_spec and errors_spec.loader
+    errors_module = importlib.util.module_from_spec(errors_spec)
+    sys.modules[errors_spec.name] = errors_module
+    errors_spec.loader.exec_module(errors_module)
+
+    spec = importlib.util.spec_from_file_location("vgo_cli.process", cli_root / "vgo_cli" / "process.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CliProcessPowerShellPolicyTests(unittest.TestCase):
+    def test_choose_powershell_prefers_pwsh_over_windows_powershell(self):
+        module = _load_cli_process_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pwsh_path = Path(temp_dir) / "pwsh.exe"
+            powershell_path = Path(temp_dir) / "powershell.exe"
+            pwsh_path.write_text("", encoding="utf-8")
+            powershell_path.write_text("", encoding="utf-8")
+
+            def fake_which(name: str) -> str | None:
+                mapping = {
+                    "pwsh": str(pwsh_path),
+                    "pwsh.exe": str(pwsh_path),
+                    "powershell": str(powershell_path),
+                    "powershell.exe": str(powershell_path),
+                }
+                return mapping.get(name)
+
+            with patch.object(module, "_is_windows_host", return_value=True), patch.object(module.shutil, "which", side_effect=fake_which):
+                resolution = module.choose_powershell(return_diagnostics=True)
+
+        self.assertIsInstance(resolution, dict)
+        self.assertEqual(resolution["host_path"], str(pwsh_path))
+        self.assertEqual(resolution["host_kind"], "pwsh")
+        self.assertFalse(resolution["fallback_used"])
+
+    def test_choose_powershell_uses_windows_fallback_when_pwsh_missing(self):
+        module = _load_cli_process_module()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            powershell_path = Path(temp_dir) / "powershell.exe"
+            powershell_path.write_text("", encoding="utf-8")
+
+            def fake_which(name: str) -> str | None:
+                mapping = {
+                    "pwsh": None,
+                    "pwsh.exe": None,
+                    "powershell": str(powershell_path),
+                    "powershell.exe": str(powershell_path),
+                }
+                return mapping.get(name)
+
+            def fake_exists(path_self: Path) -> bool:
+                return str(path_self) == str(powershell_path)
+
+            def fake_is_file(path_self: Path) -> bool:
+                return str(path_self) == str(powershell_path)
+
+            with patch.object(module, "_is_windows_host", return_value=True), patch.object(module.shutil, "which", side_effect=fake_which), patch.object(module.Path, "exists", fake_exists), patch.object(module.Path, "is_file", fake_is_file):
+                resolution = module.choose_powershell(return_diagnostics=True)
+
+        self.assertIsInstance(resolution, dict)
+        self.assertEqual(resolution["host_path"], str(powershell_path))
+        self.assertEqual(resolution["host_kind"], "windows-powershell")
+        self.assertTrue(resolution["fallback_used"])
+
+    def test_choose_powershell_reports_pwsh_required_on_non_windows(self):
+        module = _load_cli_process_module()
+        def fake_which(name: str) -> str | None:
+            return None
+
+        def fake_exists(path_self: Path) -> bool:
+            return False
+
+        def fake_is_file(path_self: Path) -> bool:
+            return False
+
+        with patch.object(module.shutil, "which", side_effect=fake_which), patch.object(module, "_is_windows_host", return_value=False), patch.object(module, "_powershell_host_policy", return_value={
+            "preferred_powershell_host": "pwsh",
+            "require_pwsh_on_non_windows": True,
+            "allow_windows_powershell_fallback": False,
+            "record_host_resolution_artifacts": True,
+        }), patch.object(module.Path, "exists", fake_exists), patch.object(module.Path, "is_file", fake_is_file):
+            resolution = module.choose_powershell(return_diagnostics=True)
+
+        self.assertIsInstance(resolution, dict)
+        self.assertIsNone(resolution["host_path"])
+        self.assertEqual(resolution.get("error"), "pwsh is required on non-Windows hosts")
+
+    def test_run_powershell_file_failure_reports_candidates_checked(self):
+        module = _load_cli_process_module()
+        with self.assertRaises(Exception) as ctx:
+            with patch.object(module, "choose_powershell", return_value={
+                "host_path": None,
+                "host_kind": None,
+                "fallback_used": False,
+                "candidates_checked": [
+                    {"candidate_name": "path-pwsh", "candidate_path": None},
+                    {"candidate_name": "path-powershell", "candidate_path": r"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"},
+                ],
+            }):
+                module.run_powershell_file(Path("demo.ps1"), "-Task", "probe")
+        message = str(ctx.exception)
+        self.assertIn("PowerShell is required to run: demo.ps1", message)
+        self.assertIn("candidates checked:", message)
+        self.assertIn("path-pwsh", message)
+        self.assertIn("powershell.exe", message)
+
+
+class DelegatedLaneContractTests(unittest.TestCase):
+    def test_plan_execute_uses_repo_root_first_working_directory_logic(self):
+        script_text = SCRIPT_PATH.read_text(encoding="utf-8")
+        self.assertIn("Resolve-VibeDelegatedLaneWorkingDirectory", script_text)
+        self.assertIn("requested_working_directory = if", script_text)
+        self.assertIn("effective_working_directory = [string]$workingDirectoryInfo.effective_working_directory", script_text)
+        self.assertIn("repo_root_invalid", script_text)
+        self.assertIn("repo_root_missing", script_text)
+
+    def test_plan_execute_recovers_payload_from_artifact_when_stdout_missing(self):
+        script_text = SCRIPT_PATH.read_text(encoding="utf-8")
+        self.assertIn("Resolve-VibeDelegatedLanePayload", script_text)
+        self.assertIn("source = 'lane_payload_artifact'", script_text)
+        self.assertIn("payload_source = [string]$payloadRecovery.source", script_text)
+
+    def test_plan_execute_failure_message_is_actionable(self):
+        script_text = SCRIPT_PATH.read_text(encoding="utf-8")
+        self.assertIn("Delegated lane payload handoff failed for lane_id=", script_text)
+        self.assertIn("effective_working_directory=", script_text)
+        self.assertIn("stdout_path=", script_text)
+        self.assertIn("stderr_path=", script_text)
+        self.assertIn("payload_path=", script_text)
+
+    def test_delegated_lane_launch_metadata_records_host_resolution(self):
+        script_text = SCRIPT_PATH.read_text(encoding="utf-8")
+        self.assertIn("host_kind = if ($invocation.PSObject.Properties.Name -contains 'host_kind')", script_text)
+        self.assertIn("fallback_used = [bool]$(if ($invocation.PSObject.Properties.Name -contains 'fallback_used')", script_text)
+        self.assertIn("resolved_command = [string]($invocation.host_path)", script_text)
+        self.assertIn("resolved_arguments = @($invocation.arguments)", script_text)
+        self.assertIn("arguments_render_mode = 'RenderedString'", script_text)
+        self.assertIn("preflight = [pscustomobject]@{", script_text)
+
+    def test_runtime_execution_records_preflight_and_render_mode(self):
+        script_text = (REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1").read_text(encoding="utf-8")
+        self.assertIn("function New-VibeProcessPreflightResult", script_text)
+        self.assertIn("Process preflight failed:", script_text)
+        self.assertIn("arguments_render_mode = if ($usedArgumentList) { 'ArgumentList' } else { 'RenderedString' }", script_text)
+        self.assertIn("launch_metadata_path", script_text)
+        self.assertIn("script_used_as_executable", script_text)
+
+    def test_runtime_execution_mentions_unicode_path_preflight_surfaces(self):
+        script_text = (REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1").read_text(encoding="utf-8")
+        self.assertIn("resolved executable does not exist:", script_text)
+        self.assertIn("working directory does not exist:", script_text)
+        self.assertIn("powershell script path is being used as the executable instead of the host:", script_text)
+        self.assertIn("python command spec did not resolve to a host executable:", script_text)
+
+    def test_execution_runtime_policy_uses_existing_coherence_gate_path(self):
+        policy_text = (REPO_ROOT / "config" / "execution-runtime-policy.json").read_text(encoding="utf-8")
+        self.assertIn("scripts/verify/vibe-release-install-runtime-coherence-gate.ps1", policy_text)
+        self.assertNotIn("scripts/verify/vibe-version-consistency-gate.ps1", policy_text)
+
+    def test_runtime_summary_artifacts_allow_early_bounded_stop_nulls(self):
+        script_text = (REPO_ROOT / "scripts" / "runtime" / "VibeRuntime.Common.ps1").read_text(encoding="utf-8")
+        self.assertIn("[AllowEmptyString()] [string]$IntentContractPath = ''", script_text)
+        self.assertIn("[AllowEmptyString()] [string]$RequirementDocPath = ''", script_text)
+        self.assertIn("[AllowEmptyString()] [string]$RequirementReceiptPath = ''", script_text)
+        self.assertIn("intent_contract = if ([string]::IsNullOrWhiteSpace($IntentContractPath)) { $null } else { $IntentContractPath }", script_text)
+
+
+
+class PowerShellBridgeDiagnosticTests(unittest.TestCase):
+    def test_delegated_lane_empty_stdout_is_classified(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            script_path = Path(temp_dir) / "empty.ps1"
+            script_path.write_text("", encoding="utf-8")
+            command = [
+                "python",
+                "-c",
+                "import sys; sys.exit(0)",
+            ]
+            with self.assertRaises(RuntimeError) as ctx:
+                run_powershell_json_command(command, cwd=Path(temp_dir), bridge_label="delegated lane bridge")
+        message = str(ctx.exception)
+        self.assertIn("delegated lane payload handoff", message)
+        self.assertIn("returned empty stdout", message)
+        self.assertIn("cwd=", message)
+        self.assertIn("command=python", message)
+
+    def test_non_zero_exit_mentions_canonical_bridge_startup(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            command = [
+                "python",
+                "-c",
+                "import sys; sys.stderr.write('boom\\n'); sys.exit(7)",
+            ]
+            with self.assertRaises(RuntimeError) as ctx:
+                run_powershell_json_command(command, cwd=Path(temp_dir), bridge_label="canonical entry bridge")
+        message = str(ctx.exception)
+        self.assertIn("canonical bridge startup", message)
+        self.assertIn("exit=7", message)
+        self.assertIn("stderr=boom", message)
+
+
+class BridgeFailureLayeringTests(unittest.TestCase):
+    def test_canonical_entry_startup_failure_is_distinct_from_payload_handoff_failure(self):
+        module = _load_canonical_entry_module()
+        with tempfile.TemporaryDirectory() as repo_dir:
+            repo_root = Path(repo_dir)
+            bridge_path = repo_root / "scripts" / "runtime"
+            bridge_path.mkdir(parents=True, exist_ok=True)
+            (bridge_path / "Invoke-VibeCanonicalEntry.ps1").write_text("# stub", encoding="utf-8")
+
+            def fake_startup_bridge(command, *, cwd, bridge_label, env=None, timeout=None):
+                raise RuntimeError(
+                    "canonical entry bridge failed during canonical bridge startup: subprocess exited non-zero before JSON payload was returned (exit=11; cwd=%s; command=python; stderr=startup boom)" % cwd
+                )
+
+            def fake_payload_bridge(command, *, cwd, bridge_label, env=None, timeout=None):
+                raise RuntimeError(
+                    "canonical entry bridge failed during delegated lane payload handoff: canonical entry bridge returned invalid JSON stdout (cwd=%s; command=python; stdout=not-json)" % cwd
+                )
+
+            with patch.object(module, "_resolve_powershell_host", return_value={"host_path": sys.executable, "host_kind": "pwsh", "fallback_used": False, "candidates_checked": []}):
+                with patch.object(module, "run_powershell_json_command", side_effect=fake_startup_bridge):
+                    with self.assertRaises(RuntimeError) as startup_ctx:
+                        module.invoke_vibe_runtime_entrypoint(
+                            repo_root=repo_root,
+                            host_id="codex",
+                            entry_id="vibe",
+                            prompt="test",
+                            requested_stage_stop=None,
+                            requested_grade_floor=None,
+                            run_id="run-startup",
+                            artifact_root=None,
+                            force_runtime_neutral=False,
+                        )
+                with patch.object(module, "run_powershell_json_command", side_effect=fake_payload_bridge):
+                    with self.assertRaises(RuntimeError) as payload_ctx:
+                        module.invoke_vibe_runtime_entrypoint(
+                            repo_root=repo_root,
+                            host_id="codex",
+                            entry_id="vibe",
+                            prompt="test",
+                            requested_stage_stop=None,
+                            requested_grade_floor=None,
+                            run_id="run-payload",
+                            artifact_root=None,
+                            force_runtime_neutral=False,
+                        )
+
+        startup_message = str(startup_ctx.exception)
+        payload_message = str(payload_ctx.exception)
+        self.assertIn("canonical bridge startup", startup_message)
+        self.assertNotIn("delegated lane payload handoff", startup_message)
+        self.assertIn("delegated lane payload handoff", payload_message)
+        self.assertNotIn("canonical bridge startup", payload_message)
+
+    def test_bridge_succeeds_from_unicode_working_directory(self):
+        base_dir = Path(tempfile.gettempdir()) / "vibe-桥接-羽裳"
+        base_dir.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=base_dir) as temp_dir:
+            cwd = Path(temp_dir)
+            payload = {"status": "ok", "cwd": str(cwd)}
+            command = [
+                sys.executable,
+                "-c",
+                "import json, os; print(json.dumps({'status':'ok','cwd':os.getcwd()}, ensure_ascii=False))",
+            ]
+            result = run_powershell_json_command(command, cwd=cwd, bridge_label="canonical entry bridge")
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["cwd"], str(cwd))
+        self.assertIn("桥接", result["cwd"])
+
+    def test_bridge_failure_from_unicode_working_directory_preserves_context(self):
+        base_dir = Path(tempfile.gettempdir()) / "vibe-桥接-羽裳"
+        base_dir.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=base_dir) as temp_dir:
+            cwd = Path(temp_dir)
+            command = [
+                sys.executable,
+                "-c",
+                "import sys; sys.stderr.write('unicode boom\\n'); sys.exit(9)",
+            ]
+            with self.assertRaises(RuntimeError) as ctx:
+                run_powershell_json_command(command, cwd=cwd, bridge_label="canonical entry bridge")
+        message = str(ctx.exception)
+        self.assertIn("canonical bridge startup", message)
+        self.assertIn("exit=9", message)
+        self.assertIn("unicode boom", message)
+        self.assertIn(str(cwd), message)
+        self.assertIn("桥接", message)
+
+
+    def test_real_bridge_smoke_surfaces_preflight_script_missing_instead_of_invalid_python_host(self):
+        helper_text = (REPO_ROOT / "scripts" / "common" / "vibe-governance-helpers.ps1").read_text(encoding="utf-8")
+        runtime_text = (REPO_ROOT / "scripts" / "runtime" / "VibeExecution.Common.ps1").read_text(encoding="utf-8")
+        self.assertIn("Test-VgoWindowsRunnableCommandPath", helper_text)
+        self.assertIn("powershell script path does not exist:", runtime_text)
+        self.assertNotIn("Process startup failed for C:\\Users\\羽裳\\bin\\python3", runtime_text)
+
+    def test_canonical_entry_builds_command_for_unicode_repo_root(self):
+        module = _load_canonical_entry_module()
+        base_dir = Path(tempfile.gettempdir()) / "vibe-规范入口-羽裳"
+        base_dir.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=base_dir) as repo_dir:
+            repo_root = Path(repo_dir)
+            bridge_dir = repo_root / "scripts" / "runtime"
+            bridge_dir.mkdir(parents=True, exist_ok=True)
+            (bridge_dir / "Invoke-VibeCanonicalEntry.ps1").write_text("# stub", encoding="utf-8")
+
+            observed: dict[str, object] = {}
+
+            def fake_bridge(command, *, cwd, bridge_label, env=None, timeout=None):
+                observed["command"] = list(command)
+                observed["cwd"] = cwd
+                observed["bridge_label"] = bridge_label
+                return {
+                    "run_id": "run-1",
+                    "session_root": str(repo_root / ".vibeskills" / "outputs" / "runtime" / "vibe-sessions" / "run-1"),
+                    "summary_path": str(repo_root / ".vibeskills" / "outputs" / "runtime" / "vibe-sessions" / "run-1" / "runtime-summary.json"),
+                    "summary": {},
+                }
+
+            with patch.object(module, "_resolve_powershell_host", return_value={
+                "host_path": sys.executable,
+                "host_kind": "pwsh",
+                "fallback_used": False,
+                "candidates_checked": [],
+            }), patch.object(module, "run_powershell_json_command", side_effect=fake_bridge):
+                module.invoke_vibe_runtime_entrypoint(
+                    repo_root=repo_root,
+                    host_id="claude-code",
+                    entry_id="vibe",
+                    prompt="unicode probe",
+                    requested_stage_stop=None,
+                    requested_grade_floor=None,
+                    run_id="run-1",
+                    artifact_root=None,
+                    force_runtime_neutral=False,
+                )
+
+        self.assertEqual(observed["cwd"], repo_root)
+        self.assertEqual(observed["bridge_label"], "canonical entry bridge")
+        self.assertEqual(observed["command"][0], sys.executable)
+        self.assertIn(str((repo_root / "scripts" / "runtime" / "Invoke-VibeCanonicalEntry.ps1")), observed["command"])
+        self.assertIn("规范入口", str(repo_root))
+
+    def test_canonical_entry_preserves_bridge_context_when_not_launched_from_repo_cwd(self):
+        module = _load_canonical_entry_module()
+        with tempfile.TemporaryDirectory() as repo_dir, tempfile.TemporaryDirectory() as other_dir:
+            repo_root = Path(repo_dir)
+            bridge_path = repo_root / "scripts" / "runtime"
+            bridge_path.mkdir(parents=True, exist_ok=True)
+            (bridge_path / "Invoke-VibeCanonicalEntry.ps1").write_text("# stub", encoding="utf-8")
+
+            observed: dict[str, object] = {}
+
+            def fake_bridge(command, *, cwd, bridge_label, env=None, timeout=None):
+                observed["cwd"] = cwd
+                raise RuntimeError("canonical entry bridge failed during delegated lane payload handoff")
+
+            old_cwd = Path.cwd()
+            os.chdir(other_dir)
+            try:
+                with patch.object(module, "_resolve_powershell_host", return_value={"host_path": sys.executable, "host_kind": "pwsh", "fallback_used": False, "candidates_checked": []}), patch.object(module, "run_powershell_json_command", side_effect=fake_bridge):
+                    with self.assertRaises(RuntimeError) as ctx:
+                        module.invoke_vibe_runtime_entrypoint(
+                            repo_root=repo_root,
+                            host_id="codex",
+                            entry_id="vibe",
+                            prompt="test",
+                            requested_stage_stop=None,
+                            requested_grade_floor=None,
+                            run_id="run-1",
+                            artifact_root=None,
+                            force_runtime_neutral=False,
+                        )
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(observed["cwd"], repo_root)
+        self.assertIn("delegated lane payload handoff", str(ctx.exception))
+
+    def test_canonical_entry_reports_candidates_when_powershell_missing(self):
+        module = _load_canonical_entry_module()
+        with tempfile.TemporaryDirectory() as repo_dir:
+            repo_root = Path(repo_dir)
+            bridge_path = repo_root / "scripts" / "runtime"
+            bridge_path.mkdir(parents=True, exist_ok=True)
+            (bridge_path / "Invoke-VibeCanonicalEntry.ps1").write_text("# stub", encoding="utf-8")
+            with self.assertRaises(RuntimeError) as ctx:
+                with patch.object(
+                    module,
+                    "_resolve_powershell_host",
+                    return_value={
+                        "host_path": None,
+                        "host_kind": None,
+                        "fallback_used": False,
+                        "candidates_checked": [
+                            {"candidate_name": "path-pwsh", "candidate_path": None},
+                            {"candidate_name": "path-powershell", "candidate_path": r"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"},
+                        ],
+                    },
+                ):
+                    module.invoke_vibe_runtime_entrypoint(
+                        repo_root=repo_root,
+                        host_id="codex",
+                        entry_id="vibe",
+                        prompt="test",
+                        requested_stage_stop=None,
+                        requested_grade_floor=None,
+                        run_id="run-1",
+                        artifact_root=None,
+                        force_runtime_neutral=False,
+                    )
+        message = str(ctx.exception)
+        self.assertIn("PowerShell executable not available in PATH; candidates checked:", message)
+        self.assertIn("path-pwsh", message)
+        self.assertIn("powershell.exe", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/common/vibe-governance-helpers.ps1
+++ b/scripts/common/vibe-governance-helpers.ps1
@@ -670,7 +670,37 @@ function Resolve-VgoPathSpec {
     return [System.IO.Path]::GetFullPath($expanded)
 }
 
-function Get-VgoPowerShellCommand {
+function Get-VgoPowerShellHostPolicy {
+    $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $script:VgoGovernanceHelpersRoot '..\..'))
+    $policyPath = Join-Path $repoRoot 'config\powershell-host-policy.json'
+    $defaults = [pscustomobject]@{
+        preferred_powershell_host = 'pwsh'
+        require_pwsh_on_non_windows = $true
+        allow_windows_powershell_fallback = $true
+        record_host_resolution_artifacts = $true
+    }
+
+    if (-not (Test-Path -LiteralPath $policyPath -PathType Leaf)) {
+        return $defaults
+    }
+
+    try {
+        $rawPolicy = Get-Content -LiteralPath $policyPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    } catch {
+        return $defaults
+    }
+
+    return [pscustomobject]@{
+        preferred_powershell_host = if ($rawPolicy.PSObject.Properties.Name -contains 'preferred_powershell_host' -and -not [string]::IsNullOrWhiteSpace([string]$rawPolicy.preferred_powershell_host)) { [string]$rawPolicy.preferred_powershell_host } else { [string]$defaults.preferred_powershell_host }
+        require_pwsh_on_non_windows = if ($rawPolicy.PSObject.Properties.Name -contains 'require_pwsh_on_non_windows') { [bool]$rawPolicy.require_pwsh_on_non_windows } else { [bool]$defaults.require_pwsh_on_non_windows }
+        allow_windows_powershell_fallback = if ($rawPolicy.PSObject.Properties.Name -contains 'allow_windows_powershell_fallback') { [bool]$rawPolicy.allow_windows_powershell_fallback } else { [bool]$defaults.allow_windows_powershell_fallback }
+        record_host_resolution_artifacts = if ($rawPolicy.PSObject.Properties.Name -contains 'record_host_resolution_artifacts') { [bool]$rawPolicy.record_host_resolution_artifacts } else { [bool]$defaults.record_host_resolution_artifacts }
+    }
+}
+
+function Resolve-VgoPowerShellHost {
+    $policy = Get-VgoPowerShellHostPolicy
+    $isWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
     $currentProcessPath = $null
     try {
         $currentProcessPath = (Get-Process -Id $PID -ErrorAction Stop).Path
@@ -678,29 +708,84 @@ function Get-VgoPowerShellCommand {
         $currentProcessPath = $null
     }
 
-    $candidates = @(
-        $currentProcessPath,
-        (Join-Path $PSHOME 'pwsh.exe'),
-        (Join-Path $PSHOME 'pwsh'),
-        (Join-Path $PSHOME 'powershell.exe'),
-        (Join-Path $PSHOME 'powershell'),
-        (Get-Command pwsh -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1),
-        (Get-Command powershell -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1),
-        (Get-Command pwsh.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1),
-        (Get-Command powershell.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1)
-    )
-
-    foreach ($candidate in $candidates) {
-        if ([string]::IsNullOrWhiteSpace($candidate)) {
-            continue
-        }
-
-        if (Test-Path -LiteralPath $candidate) {
-            return [System.IO.Path]::GetFullPath($candidate)
+    $currentLeaf = if ([string]::IsNullOrWhiteSpace($currentProcessPath)) { '' } else { [System.IO.Path]::GetFileName($currentProcessPath).ToLowerInvariant() }
+    $preferPwsh = ([string]$policy.preferred_powershell_host).Trim().ToLowerInvariant() -eq 'pwsh'
+    $orderedCandidates = @()
+    if ($preferPwsh) {
+        $orderedCandidates += @(
+            @{ name = 'current-process'; path = if ($currentLeaf -like 'pwsh*') { $currentProcessPath } else { $null }; kind = 'pwsh' },
+            @{ name = 'pshome-pwsh-exe'; path = (Join-Path $PSHOME 'pwsh.exe'); kind = 'pwsh' },
+            @{ name = 'pshome-pwsh'; path = (Join-Path $PSHOME 'pwsh'); kind = 'pwsh' },
+            @{ name = 'command-pwsh'; path = (Get-Command pwsh -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1); kind = 'pwsh' },
+            @{ name = 'command-pwsh-exe'; path = (Get-Command pwsh.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1); kind = 'pwsh' }
+        )
+        if ($isWindows -and [bool]$policy.allow_windows_powershell_fallback) {
+            $orderedCandidates += @(
+                @{ name = 'current-process'; path = if ($currentLeaf -like 'powershell*') { $currentProcessPath } else { $null }; kind = 'windows-powershell' },
+                @{ name = 'pshome-powershell-exe'; path = (Join-Path $PSHOME 'powershell.exe'); kind = 'windows-powershell' },
+                @{ name = 'pshome-powershell'; path = (Join-Path $PSHOME 'powershell'); kind = 'windows-powershell' },
+                @{ name = 'command-powershell'; path = (Get-Command powershell -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1); kind = 'windows-powershell' },
+                @{ name = 'command-powershell-exe'; path = (Get-Command powershell.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1); kind = 'windows-powershell' }
+            )
         }
     }
 
-    throw 'Unable to resolve a PowerShell host for governed sub-process execution.'
+    $checked = @()
+    foreach ($candidate in @($orderedCandidates)) {
+        $candidatePath = if ($null -eq $candidate.path) { '' } else { [string]$candidate.path }
+        $resolvedPath = $null
+        $exists = $false
+        $isFile = $false
+        if (-not [string]::IsNullOrWhiteSpace($candidatePath)) {
+            try {
+                $resolvedPath = [System.IO.Path]::GetFullPath($candidatePath)
+                $exists = Test-Path -LiteralPath $resolvedPath
+                $isFile = Test-Path -LiteralPath $resolvedPath -PathType Leaf
+            } catch {
+                $resolvedPath = $candidatePath
+                $exists = $false
+                $isFile = $false
+            }
+        }
+
+        $checked += [pscustomobject]@{
+            candidate_name = [string]$candidate.name
+            candidate_kind = [string]$candidate.kind
+            candidate_path = if ([string]::IsNullOrWhiteSpace($resolvedPath)) { $null } else { [string]$resolvedPath }
+            exists = [bool]$exists
+            is_file = [bool]$isFile
+        }
+
+        if ($exists -and $isFile) {
+            $fallbackUsed = ($preferPwsh -and ([string]$candidate.kind -eq 'windows-powershell'))
+            return [pscustomobject]@{
+                host_path = [string]$resolvedPath
+                host_leaf = [System.IO.Path]::GetFileName($resolvedPath).ToLowerInvariant()
+                host_kind = [string]$candidate.kind
+                fallback_used = [bool]$fallbackUsed
+                policy = $policy
+                candidates_checked = @($checked)
+            }
+        }
+    }
+
+    $checkedNames = @($checked | ForEach-Object {
+        if ($_.candidate_path) {
+            '{0}={1}' -f [string]$_.candidate_name, [string]$_.candidate_path
+        } else {
+            '{0}=<unresolved>' -f [string]$_.candidate_name
+        }
+    })
+    if (-not $isWindows -and [bool]$policy.require_pwsh_on_non_windows) {
+        throw ("Unable to resolve a PowerShell host for governed sub-process execution. pwsh is required on non-Windows hosts. Candidates checked: {0}" -f ([string]::Join(', ', @($checkedNames))))
+    }
+
+    throw ("Unable to resolve a PowerShell host for governed sub-process execution. Candidates checked: {0}" -f ([string]::Join(', ', @($checkedNames))))
+}
+
+function Get-VgoPowerShellCommand {
+    $resolution = Resolve-VgoPowerShellHost
+    return [string]$resolution.host_path
 }
 
 function Test-VgoWindowsAppsPythonStubPath {
@@ -722,6 +807,29 @@ function Test-VgoWindowsAppsPythonStubPath {
     return $normalizedPath -match '(^|[\\/])Microsoft[\\/]WindowsApps[\\/].*python3?(\.(exe|cmd|bat))?$'
 }
 
+function Test-VgoWindowsRunnableCommandPath {
+    param(
+        [AllowEmptyString()] [string]$Path,
+        [AllowEmptyString()] [string]$CommandName = ''
+    )
+
+    $isWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+    if (-not $isWindows) {
+        return $true
+    }
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $false
+    }
+
+    $extension = [System.IO.Path]::GetExtension([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($extension)) {
+        return $false
+    }
+
+    $normalizedExtension = $extension.Trim().ToLowerInvariant()
+    return $normalizedExtension -in @('.exe', '.cmd', '.bat', '.com')
+}
+
 function Resolve-VgoPythonCandidate {
     param(
         [Parameter(Mandatory)] [string]$CommandName,
@@ -735,6 +843,10 @@ function Resolve-VgoPythonCandidate {
         }
 
         if (Test-VgoWindowsAppsPythonStubPath -Path $candidate -CommandName $CommandName) {
+            continue
+        }
+
+        if (-not (Test-VgoWindowsRunnableCommandPath -Path $candidate -CommandName $CommandName)) {
             continue
         }
 
@@ -804,7 +916,8 @@ function Get-VgoPowerShellFileInvocation {
         [switch]$NoProfile
     )
 
-    $hostPath = Get-VgoPowerShellCommand
+    $resolution = Resolve-VgoPowerShellHost
+    $hostPath = [string]$resolution.host_path
     $hostLeaf = [System.IO.Path]::GetFileName($hostPath).ToLowerInvariant()
     $args = @()
 
@@ -824,6 +937,10 @@ function Get-VgoPowerShellFileInvocation {
     return [pscustomobject]@{
         host_path = $hostPath
         host_leaf = $hostLeaf
+        host_kind = [string]$resolution.host_kind
+        fallback_used = [bool]$resolution.fallback_used
+        candidates_checked = @($resolution.candidates_checked)
+        policy = $resolution.policy
         arguments = @($args)
     }
 }

--- a/scripts/common/vibe-governance-helpers.ps1
+++ b/scripts/common/vibe-governance-helpers.ps1
@@ -700,7 +700,7 @@ function Get-VgoPowerShellHostPolicy {
 
 function Resolve-VgoPowerShellHost {
     $policy = Get-VgoPowerShellHostPolicy
-    $isWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+    $runningOnWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
     $currentProcessPath = $null
     try {
         $currentProcessPath = (Get-Process -Id $PID -ErrorAction Stop).Path
@@ -710,24 +710,28 @@ function Resolve-VgoPowerShellHost {
 
     $currentLeaf = if ([string]::IsNullOrWhiteSpace($currentProcessPath)) { '' } else { [System.IO.Path]::GetFileName($currentProcessPath).ToLowerInvariant() }
     $preferPwsh = ([string]$policy.preferred_powershell_host).Trim().ToLowerInvariant() -eq 'pwsh'
+    $pwshCandidates = @(
+        @{ name = 'current-process'; path = if ($currentLeaf -like 'pwsh*') { $currentProcessPath } else { $null }; kind = 'pwsh' },
+        @{ name = 'pshome-pwsh-exe'; path = (Join-Path $PSHOME 'pwsh.exe'); kind = 'pwsh' },
+        @{ name = 'pshome-pwsh'; path = (Join-Path $PSHOME 'pwsh'); kind = 'pwsh' },
+        @{ name = 'command-pwsh'; path = (Get-Command pwsh -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1); kind = 'pwsh' },
+        @{ name = 'command-pwsh-exe'; path = (Get-Command pwsh.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1); kind = 'pwsh' }
+    )
+    $windowsPowerShellCandidates = @(
+        @{ name = 'current-process'; path = if ($currentLeaf -like 'powershell*') { $currentProcessPath } else { $null }; kind = 'windows-powershell' },
+        @{ name = 'pshome-powershell-exe'; path = (Join-Path $PSHOME 'powershell.exe'); kind = 'windows-powershell' },
+        @{ name = 'pshome-powershell'; path = (Join-Path $PSHOME 'powershell'); kind = 'windows-powershell' },
+        @{ name = 'command-powershell'; path = (Get-Command powershell -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1); kind = 'windows-powershell' },
+        @{ name = 'command-powershell-exe'; path = (Get-Command powershell.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1); kind = 'windows-powershell' }
+    )
     $orderedCandidates = @()
     if ($preferPwsh) {
-        $orderedCandidates += @(
-            @{ name = 'current-process'; path = if ($currentLeaf -like 'pwsh*') { $currentProcessPath } else { $null }; kind = 'pwsh' },
-            @{ name = 'pshome-pwsh-exe'; path = (Join-Path $PSHOME 'pwsh.exe'); kind = 'pwsh' },
-            @{ name = 'pshome-pwsh'; path = (Join-Path $PSHOME 'pwsh'); kind = 'pwsh' },
-            @{ name = 'command-pwsh'; path = (Get-Command pwsh -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1); kind = 'pwsh' },
-            @{ name = 'command-pwsh-exe'; path = (Get-Command pwsh.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1); kind = 'pwsh' }
-        )
-        if ($isWindows -and [bool]$policy.allow_windows_powershell_fallback) {
-            $orderedCandidates += @(
-                @{ name = 'current-process'; path = if ($currentLeaf -like 'powershell*') { $currentProcessPath } else { $null }; kind = 'windows-powershell' },
-                @{ name = 'pshome-powershell-exe'; path = (Join-Path $PSHOME 'powershell.exe'); kind = 'windows-powershell' },
-                @{ name = 'pshome-powershell'; path = (Join-Path $PSHOME 'powershell'); kind = 'windows-powershell' },
-                @{ name = 'command-powershell'; path = (Get-Command powershell -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1); kind = 'windows-powershell' },
-                @{ name = 'command-powershell-exe'; path = (Get-Command powershell.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -First 1); kind = 'windows-powershell' }
-            )
+        $orderedCandidates += @($pwshCandidates)
+        if ($runningOnWindows -and [bool]$policy.allow_windows_powershell_fallback) {
+            $orderedCandidates += @($windowsPowerShellCandidates)
         }
+    } elseif ($runningOnWindows) {
+        $orderedCandidates += @($windowsPowerShellCandidates)
     }
 
     $checked = @()
@@ -776,7 +780,7 @@ function Resolve-VgoPowerShellHost {
             '{0}=<unresolved>' -f [string]$_.candidate_name
         }
     })
-    if (-not $isWindows -and [bool]$policy.require_pwsh_on_non_windows) {
+    if (-not $runningOnWindows -and [bool]$policy.require_pwsh_on_non_windows) {
         throw ("Unable to resolve a PowerShell host for governed sub-process execution. pwsh is required on non-Windows hosts. Candidates checked: {0}" -f ([string]::Join(', ', @($checkedNames))))
     }
 
@@ -813,8 +817,8 @@ function Test-VgoWindowsRunnableCommandPath {
         [AllowEmptyString()] [string]$CommandName = ''
     )
 
-    $isWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
-    if (-not $isWindows) {
+    $runningOnWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+    if (-not $runningOnWindows) {
         return $true
     }
     if ([string]::IsNullOrWhiteSpace($Path)) {

--- a/scripts/runtime/Invoke-DelegatedLaneUnit.ps1
+++ b/scripts/runtime/Invoke-DelegatedLaneUnit.ps1
@@ -170,6 +170,7 @@ Write-VibeJsonArtifact -Path $receiptPath -Value $receipt
 $payload = [pscustomobject]@{
     lane_id = [string]$laneSpec.lane_id
     lane_kind = $laneKind
+    payload_contract_version = '1.0'
     status = if ($receipt) { [string]$receipt.status } else { '' }
     payload_written = $true
     lane_receipt_path = $receiptPath
@@ -180,4 +181,4 @@ $payload = [pscustomobject]@{
 }
 Write-VibeJsonArtifact -Path $payloadPath -Value $payload
 
-$payload | ConvertTo-Json -Depth 20 -Compress
+[Console]::Out.WriteLine(($payload | ConvertTo-Json -Depth 20 -Compress))

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -174,6 +174,7 @@ function Resolve-VibeDelegatedLanePayload {
     )
 
     $payloadCandidates = @()
+    $parseFailures = @()
     $payloadText = ($StdoutText -split "`r?`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Last 1)
     if (-not [string]::IsNullOrWhiteSpace($payloadText)) {
         $payloadCandidates += [pscustomobject]@{
@@ -183,13 +184,16 @@ function Resolve-VibeDelegatedLanePayload {
     }
 
     if (Test-Path -LiteralPath $PayloadPath) {
-        $payloadCandidates += [pscustomobject]@{
-            source = 'lane_payload_artifact'
-            content = Get-Content -LiteralPath $PayloadPath -Raw -Encoding UTF8
+        try {
+            $payloadCandidates += [pscustomobject]@{
+                source = 'lane_payload_artifact'
+                content = Get-Content -LiteralPath $PayloadPath -Raw -Encoding UTF8
+            }
+        } catch {
+            $parseFailures += 'lane_payload_artifact:read_failed'
         }
     }
 
-    $parseFailures = @()
     foreach ($candidate in @($payloadCandidates)) {
         if ([string]::IsNullOrWhiteSpace([string]$candidate.content)) {
             $parseFailures += ('{0}:empty' -f [string]$candidate.source)
@@ -205,6 +209,11 @@ function Resolve-VibeDelegatedLanePayload {
 
         if (-not ($payload.PSObject.Properties.Name -contains 'lane_receipt_path')) {
             $parseFailures += ('{0}:missing_lane_receipt_path' -f [string]$candidate.source)
+            continue
+        }
+        $laneReceiptPath = [string]$payload.lane_receipt_path
+        if ([string]::IsNullOrWhiteSpace($laneReceiptPath)) {
+            $parseFailures += ('{0}:empty_lane_receipt_path' -f [string]$candidate.source)
             continue
         }
 

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -92,7 +92,26 @@ function Resolve-VibeDelegatedLaneWorkingDirectory {
         [Parameter(Mandatory)] [object]$LaneRuntime
     )
 
-    $laneRoot = [System.IO.Path]::GetFullPath([string]($LaneRuntime.lane_root))
+    $requestedLaneRoot = if (
+        $LaneRuntime.PSObject.Properties.Name -contains 'lane_root' -and
+        -not [string]::IsNullOrWhiteSpace([string]($LaneRuntime.lane_root))
+    ) {
+        [string]($LaneRuntime.lane_root)
+    } else {
+        $null
+    }
+    $resolvedLaneRoot = $null
+    $laneRootValid = $false
+    if (-not [string]::IsNullOrWhiteSpace($requestedLaneRoot)) {
+        try {
+            $resolvedLaneRoot = [System.IO.Path]::GetFullPath($requestedLaneRoot)
+            $laneRootValid = Test-Path -LiteralPath $resolvedLaneRoot -PathType Container
+        } catch {
+            $resolvedLaneRoot = $requestedLaneRoot
+            $laneRootValid = $false
+        }
+    }
+
     $requestedWorkingDirectory = if (
         $LaneRuntime.PSObject.Properties.Name -contains 'repo_root' -and
         -not [string]::IsNullOrWhiteSpace([string]($LaneRuntime.repo_root))
@@ -114,14 +133,33 @@ function Resolve-VibeDelegatedLaneWorkingDirectory {
         }
     }
 
-    $effectiveWorkingDirectory = if ($repoRootValid) { $resolvedRepoRoot } else { $laneRoot }
+    $laneRootFallbackReason = if ($laneRootValid) { $null } elseif ([string]::IsNullOrWhiteSpace($requestedLaneRoot)) { 'lane_root_missing' } else { 'lane_root_invalid' }
+    $effectiveWorkingDirectory = if ($repoRootValid) {
+        $resolvedRepoRoot
+    } elseif (-not [string]::IsNullOrWhiteSpace($resolvedLaneRoot)) {
+        $resolvedLaneRoot
+    } elseif (-not [string]::IsNullOrWhiteSpace($requestedLaneRoot)) {
+        $requestedLaneRoot
+    } else {
+        [System.IO.Path]::GetFullPath('.')
+    }
     return [pscustomobject]@{
-        lane_root = $laneRoot
+        lane_root = if (-not [string]::IsNullOrWhiteSpace($resolvedLaneRoot)) { $resolvedLaneRoot } elseif (-not [string]::IsNullOrWhiteSpace($requestedLaneRoot)) { $requestedLaneRoot } else { [System.IO.Path]::GetFullPath('.') }
+        requested_lane_root = $requestedLaneRoot
+        resolved_lane_root = $resolvedLaneRoot
+        lane_root_valid = [bool]$laneRootValid
+        lane_root_fallback_reason = if ($null -eq $laneRootFallbackReason) { $null } else { [string]$laneRootFallbackReason }
         requested_working_directory = $requestedWorkingDirectory
         resolved_repo_root = $resolvedRepoRoot
         repo_root_valid = [bool]$repoRootValid
         effective_working_directory = $effectiveWorkingDirectory
-        fallback_reason = if ($repoRootValid) { $null } elseif ([string]::IsNullOrWhiteSpace($requestedWorkingDirectory)) { 'repo_root_missing' } else { 'repo_root_invalid' }
+        fallback_reason = if ($repoRootValid) {
+            if ($null -eq $laneRootFallbackReason) { $null } else { [string]$laneRootFallbackReason }
+        } elseif ([string]::IsNullOrWhiteSpace($requestedWorkingDirectory)) {
+            'repo_root_missing'
+        } else {
+            'repo_root_invalid'
+        }
     }
 }
 
@@ -227,6 +265,10 @@ function Start-VibeDelegatedLaneProcess {
         resolved_arguments = @($invocation.arguments)
         arguments_render_mode = 'RenderedString'
         payload_contract_version = Get-VibeDelegatedLanePayloadContractVersion
+        requested_lane_root = if ($null -eq $workingDirectoryInfo.requested_lane_root) { $null } else { [string]$workingDirectoryInfo.requested_lane_root }
+        resolved_lane_root = if ($null -eq $workingDirectoryInfo.resolved_lane_root) { $null } else { [string]$workingDirectoryInfo.resolved_lane_root }
+        lane_root_valid = [bool]$workingDirectoryInfo.lane_root_valid
+        lane_root_fallback_reason = if ($null -eq $workingDirectoryInfo.lane_root_fallback_reason) { $null } else { [string]$workingDirectoryInfo.lane_root_fallback_reason }
         requested_working_directory = if ($null -eq $workingDirectoryInfo.requested_working_directory) { $null } else { [string]$workingDirectoryInfo.requested_working_directory }
         resolved_repo_root = if ($null -eq $workingDirectoryInfo.resolved_repo_root) { $null } else { [string]$workingDirectoryInfo.resolved_repo_root }
         effective_working_directory = [string]$workingDirectoryInfo.effective_working_directory

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -323,6 +323,41 @@ function Start-VibeDelegatedLaneProcess {
     }
 }
 
+function Stop-VibeDelegatedLaneHandle {
+    param(
+        [Parameter(Mandatory)] [object]$Handle
+    )
+
+    if ($null -eq $Handle -or $null -eq $Handle.process) {
+        return
+    }
+
+    try {
+        $hasExited = $true
+        try {
+            $hasExited = [bool]$Handle.process.HasExited
+        } catch {
+            $hasExited = $true
+        }
+
+        if (-not $hasExited) {
+            try {
+                $Handle.process.Kill($true)
+            } catch {
+            }
+            try {
+                $Handle.process.WaitForExit()
+            } catch {
+            }
+        }
+    } finally {
+        try {
+            $Handle.process.Dispose()
+        } catch {
+        }
+    }
+}
+
 function Wait-VibeDelegatedLaneProcess {
     param(
         [Parameter(Mandatory)] [object]$Handle,
@@ -369,7 +404,7 @@ function Wait-VibeDelegatedLaneProcess {
             ('stderr_path={0}' -f [string]($Handle.stderr_path)),
             ('payload_path={0}' -f [string]($Handle.payload_path))
         ) -join '; '
-        $Handle.process.Dispose()
+        Stop-VibeDelegatedLaneHandle -Handle $Handle
         throw $message
     }
 
@@ -1334,8 +1369,20 @@ foreach ($topologyWave in @($executionTopology.waves)) {
                     }
 
                     $windowOutcomes = @()
-                    foreach ($handle in @($handles)) {
-                        $windowOutcomes += Wait-VibeDelegatedLaneProcess -Handle $handle -TimeoutSeconds ([int]$policy.scheduler.default_timeout_seconds)
+                    $completedLaneIds = New-Object 'System.Collections.Generic.HashSet[string]'
+                    try {
+                        foreach ($handle in @($handles)) {
+                            $windowOutcomes += Wait-VibeDelegatedLaneProcess -Handle $handle -TimeoutSeconds ([int]$policy.scheduler.default_timeout_seconds)
+                            [void]$completedLaneIds.Add([string]$handle.lane_id)
+                        }
+                    } catch {
+                        foreach ($remainingHandle in @($handles)) {
+                            if ($completedLaneIds.Contains([string]$remainingHandle.lane_id)) {
+                                continue
+                            }
+                            Stop-VibeDelegatedLaneHandle -Handle $remainingHandle
+                        }
+                        throw
                     }
                     $stepOutcomes += $windowOutcomes
                     $parallelUnitsExecutedCount += @($windowOutcomes).Count

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -82,7 +82,105 @@ function New-VibeDelegatedLaneSpec {
         lane_id = $laneId
         lane_root = $laneRoot
         spec_path = $specPath
+        repo_root = [string]$laneSpec.repo_root
         lane_entry = $LaneEntry
+    }
+}
+
+function Resolve-VibeDelegatedLaneWorkingDirectory {
+    param(
+        [Parameter(Mandatory)] [object]$LaneRuntime
+    )
+
+    $laneRoot = [System.IO.Path]::GetFullPath([string]($LaneRuntime.lane_root))
+    $requestedWorkingDirectory = if (
+        $LaneRuntime.PSObject.Properties.Name -contains 'repo_root' -and
+        -not [string]::IsNullOrWhiteSpace([string]($LaneRuntime.repo_root))
+    ) {
+        [string]($LaneRuntime.repo_root)
+    } else {
+        $null
+    }
+
+    $resolvedRepoRoot = $null
+    $repoRootValid = $false
+    if (-not [string]::IsNullOrWhiteSpace($requestedWorkingDirectory)) {
+        try {
+            $resolvedRepoRoot = [System.IO.Path]::GetFullPath($requestedWorkingDirectory)
+            $repoRootValid = Test-Path -LiteralPath $resolvedRepoRoot -PathType Container
+        } catch {
+            $resolvedRepoRoot = $requestedWorkingDirectory
+            $repoRootValid = $false
+        }
+    }
+
+    $effectiveWorkingDirectory = if ($repoRootValid) { $resolvedRepoRoot } else { $laneRoot }
+    return [pscustomobject]@{
+        lane_root = $laneRoot
+        requested_working_directory = $requestedWorkingDirectory
+        resolved_repo_root = $resolvedRepoRoot
+        repo_root_valid = [bool]$repoRootValid
+        effective_working_directory = $effectiveWorkingDirectory
+        fallback_reason = if ($repoRootValid) { $null } elseif ([string]::IsNullOrWhiteSpace($requestedWorkingDirectory)) { 'repo_root_missing' } else { 'repo_root_invalid' }
+    }
+}
+
+function Get-VibeDelegatedLanePayloadContractVersion {
+    return '1.0'
+}
+
+function Resolve-VibeDelegatedLanePayload {
+    param(
+        [AllowEmptyString()] [string]$StdoutText = '',
+        [Parameter(Mandatory)] [string]$PayloadPath
+    )
+
+    $payloadCandidates = @()
+    $payloadText = ($StdoutText -split "`r?`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Last 1)
+    if (-not [string]::IsNullOrWhiteSpace($payloadText)) {
+        $payloadCandidates += [pscustomobject]@{
+            source = 'stdout_terminal_json'
+            content = $payloadText
+        }
+    }
+
+    if (Test-Path -LiteralPath $PayloadPath) {
+        $payloadCandidates += [pscustomobject]@{
+            source = 'lane_payload_artifact'
+            content = Get-Content -LiteralPath $PayloadPath -Raw -Encoding UTF8
+        }
+    }
+
+    $parseFailures = @()
+    foreach ($candidate in @($payloadCandidates)) {
+        if ([string]::IsNullOrWhiteSpace([string]$candidate.content)) {
+            $parseFailures += ('{0}:empty' -f [string]$candidate.source)
+            continue
+        }
+
+        try {
+            $payload = [string]$candidate.content | ConvertFrom-Json
+        } catch {
+            $parseFailures += ('{0}:invalid_json' -f [string]$candidate.source)
+            continue
+        }
+
+        if (-not ($payload.PSObject.Properties.Name -contains 'lane_receipt_path')) {
+            $parseFailures += ('{0}:missing_lane_receipt_path' -f [string]$candidate.source)
+            continue
+        }
+
+        return [pscustomobject]@{
+            payload = $payload
+            source = [string]$candidate.source
+            parse_failures = @($parseFailures)
+        }
+    }
+
+    return [pscustomobject]@{
+        payload = $null
+        source = $null
+        parse_failures = @($parseFailures)
     }
 }
 
@@ -94,7 +192,10 @@ function Start-VibeDelegatedLaneProcess {
 
     $stdoutPath = Join-Path ([string]($LaneRuntime.lane_root)) 'lane-process.stdout.log'
     $stderrPath = Join-Path ([string]($LaneRuntime.lane_root)) 'lane-process.stderr.log'
+    $payloadPath = Join-Path ([string]($LaneRuntime.lane_root)) 'lane-payload.json'
+    $launchMetadataPath = Join-Path ([string]($LaneRuntime.lane_root)) 'lane-launch.json'
     $invocation = Get-VgoPowerShellFileInvocation -ScriptPath $HelperScriptPath -ArgumentList @('-LaneSpecPath', ([string]($LaneRuntime.spec_path))) -NoProfile
+    $workingDirectoryInfo = Resolve-VibeDelegatedLaneWorkingDirectory -LaneRuntime $LaneRuntime
 
     $startInfo = New-Object System.Diagnostics.ProcessStartInfo
     $startInfo.FileName = [string]($invocation.host_path)
@@ -102,7 +203,7 @@ function Start-VibeDelegatedLaneProcess {
     $startInfo.RedirectStandardOutput = $true
     $startInfo.RedirectStandardError = $true
     $startInfo.CreateNoWindow = $true
-    $startInfo.WorkingDirectory = Split-Path -Parent ([string]($LaneRuntime.spec_path))
+    $startInfo.WorkingDirectory = [string]$workingDirectoryInfo.effective_working_directory
 
     $quotedArguments = foreach ($argument in @($invocation.arguments)) {
         $text = [string]$argument
@@ -113,6 +214,40 @@ function Start-VibeDelegatedLaneProcess {
         }
     }
     $startInfo.Arguments = [string]::Join(' ', @($quotedArguments))
+
+    $launchMetadata = [pscustomobject]@{
+        lane_id = [string]($LaneRuntime.lane_id)
+        lane_root = [string]($LaneRuntime.lane_root)
+        spec_path = [string]($LaneRuntime.spec_path)
+        helper_script_path = [string]$HelperScriptPath
+        host_kind = if ($invocation.PSObject.Properties.Name -contains 'host_kind') { [string]$invocation.host_kind } else { 'pwsh' }
+        powershell_host_path = [string]($invocation.host_path)
+        fallback_used = [bool]$(if ($invocation.PSObject.Properties.Name -contains 'fallback_used') { $invocation.fallback_used } else { $false })
+        resolved_command = [string]($invocation.host_path)
+        resolved_arguments = @($invocation.arguments)
+        arguments_render_mode = 'RenderedString'
+        payload_contract_version = Get-VibeDelegatedLanePayloadContractVersion
+        requested_working_directory = if ($null -eq $workingDirectoryInfo.requested_working_directory) { $null } else { [string]$workingDirectoryInfo.requested_working_directory }
+        resolved_repo_root = if ($null -eq $workingDirectoryInfo.resolved_repo_root) { $null } else { [string]$workingDirectoryInfo.resolved_repo_root }
+        effective_working_directory = [string]$workingDirectoryInfo.effective_working_directory
+        resolved_working_directory = [string]$workingDirectoryInfo.effective_working_directory
+        repo_root_valid = [bool]$workingDirectoryInfo.repo_root_valid
+        fallback_reason = if ($null -eq $workingDirectoryInfo.fallback_reason) { $null } else { [string]$workingDirectoryInfo.fallback_reason }
+        preflight = [pscustomobject]@{
+            executable_exists = [bool](Test-Path -LiteralPath ([string]($invocation.host_path)))
+            executable_is_file = [bool](Test-Path -LiteralPath ([string]($invocation.host_path)) -PathType Leaf)
+            working_directory_exists = [bool](Test-Path -LiteralPath ([string]$workingDirectoryInfo.effective_working_directory))
+            working_directory_is_directory = [bool](Test-Path -LiteralPath ([string]$workingDirectoryInfo.effective_working_directory) -PathType Container)
+            script_exists = [bool](Test-Path -LiteralPath ([string]$HelperScriptPath))
+            script_is_file = [bool](Test-Path -LiteralPath ([string]$HelperScriptPath) -PathType Leaf)
+            script_used_as_executable = [bool]([string]($invocation.host_path) -eq [string]$HelperScriptPath)
+        }
+        stdout_path = $stdoutPath
+        stderr_path = $stderrPath
+        payload_path = $payloadPath
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    }
+    Write-VibeJsonArtifact -Path $launchMetadataPath -Value $launchMetadata
 
     $process = New-Object System.Diagnostics.Process
     $process.StartInfo = $startInfo
@@ -127,6 +262,11 @@ function Start-VibeDelegatedLaneProcess {
         process = $process
         stdout_path = $stdoutPath
         stderr_path = $stderrPath
+        payload_path = $payloadPath
+        launch_metadata_path = $launchMetadataPath
+        requested_working_directory = if ($null -eq $workingDirectoryInfo.requested_working_directory) { $null } else { [string]$workingDirectoryInfo.requested_working_directory }
+        effective_working_directory = [string]$workingDirectoryInfo.effective_working_directory
+        repo_root_valid = [bool]$workingDirectoryInfo.repo_root_valid
         stdout_task = $process.StandardOutput.ReadToEndAsync()
         stderr_task = $process.StandardError.ReadToEndAsync()
     }
@@ -152,19 +292,37 @@ function Wait-VibeDelegatedLaneProcess {
     Write-VgoUtf8NoBomText -Path ([string]($Handle.stdout_path)) -Content $stdoutText
     Write-VgoUtf8NoBomText -Path ([string]($Handle.stderr_path)) -Content $stderrText
 
-    $payloadText = ($stdoutText -split "`r?`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Last 1)
-    if ([string]::IsNullOrWhiteSpace($payloadText)) {
-        throw ("Delegated lane process returned empty payload for {0}" -f ([string]($Handle.lane_id)))
+    $processExitCode = if ($timedOut) { -1 } else { [int]($Handle.process.ExitCode) }
+    $payloadRecovery = Resolve-VibeDelegatedLanePayload -StdoutText $stdoutText -PayloadPath ([string]($Handle.payload_path))
+    if ($timedOut -or $processExitCode -ne 0 -or $null -eq $payloadRecovery.payload) {
+        $failureReasons = @()
+        if ($timedOut) {
+            $failureReasons += 'timeout'
+        }
+        if ($processExitCode -ne 0) {
+            $failureReasons += ('exit_code={0}' -f $processExitCode)
+        }
+        if ($null -eq $payloadRecovery.payload) {
+            $failureReasons += 'payload_unavailable'
+        }
+        if (@($payloadRecovery.parse_failures).Count -gt 0) {
+            $failureReasons += ('payload_parse_failures={0}' -f ([string]::Join(', ', @($payloadRecovery.parse_failures))))
+        }
+
+        $message = @(
+            ('Delegated lane payload handoff failed for lane_id={0}' -f ([string]($Handle.lane_id))),
+            ('reasons={0}' -f ([string]::Join(', ', @($failureReasons)))),
+            ('effective_working_directory={0}' -f [string]($Handle.effective_working_directory)),
+            ('requested_working_directory={0}' -f $(if ($Handle.requested_working_directory) { [string]$Handle.requested_working_directory } else { '<none>' })),
+            ('stdout_path={0}' -f [string]($Handle.stdout_path)),
+            ('stderr_path={0}' -f [string]($Handle.stderr_path)),
+            ('payload_path={0}' -f [string]($Handle.payload_path))
+        ) -join '; '
+        $Handle.process.Dispose()
+        throw $message
     }
 
-    $payload = $payloadText | ConvertFrom-Json
-    if (-not ($payload.PSObject.Properties.Name -contains 'lane_receipt_path')) {
-        $payloadPath = Join-Path ([string]($Handle.lane_root)) 'lane-payload.json'
-        if (-not (Test-Path -LiteralPath $payloadPath)) {
-            throw ("Delegated lane payload missing lane_receipt_path and no lane-payload.json exists for {0}" -f ([string]($Handle.lane_id)))
-        }
-        $payload = Get-Content -LiteralPath $payloadPath -Raw -Encoding UTF8 | ConvertFrom-Json
-    }
+    $payload = $payloadRecovery.payload
     $laneReceipt = Get-Content -LiteralPath ([string]($payload.lane_receipt_path)) -Raw -Encoding UTF8 | ConvertFrom-Json
     $laneResult = if ($payload.lane_result_path -and (Test-Path -LiteralPath ([string]($payload.lane_result_path)))) {
         Get-Content -LiteralPath ([string]($payload.lane_result_path)) -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -172,7 +330,6 @@ function Wait-VibeDelegatedLaneProcess {
         $null
     }
 
-    $processExitCode = if ($timedOut) { -1 } else { [int]($Handle.process.ExitCode) }
     $Handle.process.Dispose()
 
     return [pscustomobject]@{
@@ -182,6 +339,10 @@ function Wait-VibeDelegatedLaneProcess {
         timed_out = [bool]$timedOut
         stdout_path = [string]($Handle.stdout_path)
         stderr_path = [string]($Handle.stderr_path)
+        payload_path = [string]($Handle.payload_path)
+        payload_source = [string]$payloadRecovery.source
+        effective_working_directory = [string]($Handle.effective_working_directory)
+        requested_working_directory = if ($Handle.requested_working_directory) { [string]$Handle.requested_working_directory } else { $null }
         lane_receipt_path = [string]($payload.lane_receipt_path)
         lane_notes_path = [string]($payload.lane_notes_path)
         lane_result_path = if ($payload.lane_result_path) { [string]($payload.lane_result_path) } else { $null }

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -323,14 +323,16 @@ function Wait-VibeDelegatedLaneProcess {
     }
 
     $payload = $payloadRecovery.payload
-    $laneReceipt = Get-Content -LiteralPath ([string]($payload.lane_receipt_path)) -Raw -Encoding UTF8 | ConvertFrom-Json
-    $laneResult = if ($payload.lane_result_path -and (Test-Path -LiteralPath ([string]($payload.lane_result_path)))) {
-        Get-Content -LiteralPath ([string]($payload.lane_result_path)) -Raw -Encoding UTF8 | ConvertFrom-Json
-    } else {
-        $null
+    try {
+        $laneReceipt = Get-Content -LiteralPath ([string]($payload.lane_receipt_path)) -Raw -Encoding UTF8 | ConvertFrom-Json
+        $laneResult = if ($payload.lane_result_path -and (Test-Path -LiteralPath ([string]($payload.lane_result_path)))) {
+            Get-Content -LiteralPath ([string]($payload.lane_result_path)) -Raw -Encoding UTF8 | ConvertFrom-Json
+        } else {
+            $null
+        }
+    } finally {
+        $Handle.process.Dispose()
     }
-
-    $Handle.process.Dispose()
 
     return [pscustomobject]@{
         lane_id = [string]($Handle.lane_id)
@@ -1011,7 +1013,7 @@ function Get-VibeEffectiveExecutionPolicy {
                             -ScriptPath 'scripts/verify/vibe-installed-runtime-freshness-gate.ps1'
                         continue
                     }
-                    'version-consistency-gate' {
+                    { $_ -in @('version-consistency-gate', 'release-install-runtime-coherence-gate') } {
                         New-VibeInstalledRuntimeVerificationUnit `
                             -UnitId 'release-install-runtime-coherence-gate' `
                             -ScriptPath 'scripts/verify/vibe-release-install-runtime-coherence-gate.ps1'

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -261,7 +261,11 @@ function Invoke-VibeCapturedProcess {
         generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     }
     if (-not [string]::IsNullOrWhiteSpace($LaunchMetadataPath)) {
-        Write-VibeJsonArtifact -Path $LaunchMetadataPath -Value ([pscustomobject]$launchMetadata)
+        try {
+            Write-VibeJsonArtifact -Path $LaunchMetadataPath -Value ([pscustomobject]$launchMetadata)
+        } catch {
+            Write-Warning ("Failed to persist launch metadata to {0}: {1}" -f [string]$LaunchMetadataPath, $_.Exception.Message)
+        }
     }
 
     if ($null -ne $Preflight -and -not [bool]$Preflight.passed) {

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -68,6 +68,76 @@ function New-VibeExecutedSpecialistUnitSummary {
     }
 }
 
+function New-VibeProcessPreflightResult {
+    param(
+        [Parameter(Mandatory)] [string]$Command,
+        [string[]]$Arguments = @(),
+        [Parameter(Mandatory)] [string]$WorkingDirectory,
+        [AllowEmptyString()] [string]$HostKind = '',
+        [AllowEmptyString()] [string]$ScriptPath = '',
+        [AllowEmptyString()] [string]$PythonCommandSpec = '',
+        [AllowNull()] [object]$Invocation = $null
+    )
+
+    $resolvedCommand = try { [System.IO.Path]::GetFullPath($Command) } catch { [string]$Command }
+    $resolvedWorkingDirectory = try { [System.IO.Path]::GetFullPath($WorkingDirectory) } catch { [string]$WorkingDirectory }
+    $resolvedScriptPath = if ([string]::IsNullOrWhiteSpace($ScriptPath)) { $null } else { try { [System.IO.Path]::GetFullPath($ScriptPath) } catch { [string]$ScriptPath } }
+    $resolvedPythonSpec = if ([string]::IsNullOrWhiteSpace($PythonCommandSpec)) { $null } else { [string]$PythonCommandSpec }
+
+    $commandExists = Test-Path -LiteralPath $resolvedCommand
+    $commandIsFile = Test-Path -LiteralPath $resolvedCommand -PathType Leaf
+    $workingDirectoryExists = Test-Path -LiteralPath $resolvedWorkingDirectory
+    $workingDirectoryIsDirectory = Test-Path -LiteralPath $resolvedWorkingDirectory -PathType Container
+    $scriptExists = if ($null -eq $resolvedScriptPath) { $null } else { [bool](Test-Path -LiteralPath $resolvedScriptPath) }
+    $scriptIsFile = if ($null -eq $resolvedScriptPath) { $null } else { [bool](Test-Path -LiteralPath $resolvedScriptPath -PathType Leaf) }
+    $scriptUsedAsExecutable = if ($null -eq $resolvedScriptPath) { $false } else { [string]$resolvedCommand -eq [string]$resolvedScriptPath }
+    $pythonSpecExpanded = if ($null -eq $Invocation) { $null } else { [bool](-not [string]::IsNullOrWhiteSpace([string]$Invocation.host_path)) }
+
+    $failures = @()
+    if (-not $commandExists) {
+        $failures += ('resolved executable does not exist: {0}' -f $resolvedCommand)
+    } elseif (-not $commandIsFile) {
+        $failures += ('resolved executable is not a file: {0}' -f $resolvedCommand)
+    }
+    if (-not $workingDirectoryExists) {
+        $failures += ('working directory does not exist: {0}' -f $resolvedWorkingDirectory)
+    } elseif (-not $workingDirectoryIsDirectory) {
+        $failures += ('working directory is not a directory: {0}' -f $resolvedWorkingDirectory)
+    }
+    if ($null -ne $resolvedScriptPath) {
+        if (-not [bool]$scriptExists) {
+            $failures += ('powershell script path does not exist: {0}' -f $resolvedScriptPath)
+        } elseif (-not [bool]$scriptIsFile) {
+            $failures += ('powershell script path is not a file: {0}' -f $resolvedScriptPath)
+        }
+        if ($scriptUsedAsExecutable) {
+            $failures += ('powershell script path is being used as the executable instead of the host: {0}' -f $resolvedScriptPath)
+        }
+    }
+    if ($null -ne $resolvedPythonSpec -and -not [bool]$pythonSpecExpanded) {
+        $failures += ('python command spec did not resolve to a host executable: {0}' -f $resolvedPythonSpec)
+    }
+
+    return [pscustomobject]@{
+        host_kind = if ([string]::IsNullOrWhiteSpace($HostKind)) { $null } else { [string]$HostKind }
+        resolved_command = [string]$resolvedCommand
+        resolved_arguments = @($Arguments | ForEach-Object { [string]$_ })
+        resolved_working_directory = [string]$resolvedWorkingDirectory
+        script_path = $resolvedScriptPath
+        python_command_spec = $resolvedPythonSpec
+        executable_exists = [bool]$commandExists
+        executable_is_file = [bool]$commandIsFile
+        working_directory_exists = [bool]$workingDirectoryExists
+        working_directory_is_directory = [bool]$workingDirectoryIsDirectory
+        script_exists = $scriptExists
+        script_is_file = $scriptIsFile
+        script_used_as_executable = [bool]$scriptUsedAsExecutable
+        python_spec_expanded = $pythonSpecExpanded
+        passed = [bool](@($failures).Count -eq 0)
+        failures = @($failures)
+    }
+}
+
 function Invoke-VibeCapturedProcess {
     param(
         [Parameter(Mandatory)] [string]$Command,
@@ -76,7 +146,9 @@ function Invoke-VibeCapturedProcess {
         [Parameter(Mandatory)] [int]$TimeoutSeconds,
         [Parameter(Mandatory)] [string]$StdOutPath,
         [Parameter(Mandatory)] [string]$StdErrPath,
-        [AllowNull()] [hashtable]$EnvironmentOverrides = $null
+        [AllowNull()] [hashtable]$EnvironmentOverrides = $null,
+        [AllowNull()] [object]$Preflight = $null,
+        [AllowEmptyString()] [string]$LaunchMetadataPath = ''
     )
 
     $startInfo = New-Object System.Diagnostics.ProcessStartInfo
@@ -133,6 +205,7 @@ function Invoke-VibeCapturedProcess {
         $usedArgumentList = $false
     }
 
+    $renderedArguments = $null
     if (-not $usedArgumentList) {
         $quotedArguments = foreach ($argument in @($Arguments)) {
             $text = [string]$argument
@@ -142,15 +215,40 @@ function Invoke-VibeCapturedProcess {
                 $text
             }
         }
-        $startInfo.Arguments = [string]::Join(' ', @($quotedArguments))
+        $renderedArguments = [string]::Join(' ', @($quotedArguments))
+        $startInfo.Arguments = $renderedArguments
+    }
+
+    $launchMetadata = [ordered]@{
+        resolved_command = [string]$Command
+        resolved_arguments = @($Arguments | ForEach-Object { [string]$_ })
+        resolved_working_directory = [string]$WorkingDirectory
+        stdout_path = [string]$StdOutPath
+        stderr_path = [string]$StdErrPath
+        arguments_render_mode = if ($usedArgumentList) { 'ArgumentList' } else { 'RenderedString' }
+        rendered_arguments = if ($usedArgumentList) { $null } else { [string]$renderedArguments }
+        preflight = if ($null -eq $Preflight) { $null } else { $Preflight }
+        generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    }
+    if (-not [string]::IsNullOrWhiteSpace($LaunchMetadataPath)) {
+        Write-VibeJsonArtifact -Path $LaunchMetadataPath -Value ([pscustomobject]$launchMetadata)
+    }
+
+    if ($null -ne $Preflight -and -not [bool]$Preflight.passed) {
+        throw ('Process preflight failed: {0}' -f ([string]::Join('; ', @($Preflight.failures))))
     }
 
     $process = New-Object System.Diagnostics.Process
     $process.StartInfo = $startInfo
 
     try {
-        if (-not $process.Start()) {
-            throw "Failed to start process: $Command"
+        try {
+            if (-not $process.Start()) {
+                throw "Failed to start process: $Command"
+            }
+        } catch {
+            $message = if ($_.Exception -and -not [string]::IsNullOrWhiteSpace([string]$_.Exception.Message)) { [string]$_.Exception.Message } else { [string]$_ }
+            throw ('Process startup failed for {0}: {1}; working_directory={2}; arguments_render_mode={3}' -f [string]$Command, $message, [string]$WorkingDirectory, [string]$launchMetadata.arguments_render_mode)
         }
         try {
             $process.StandardInput.Close()
@@ -181,6 +279,10 @@ function Invoke-VibeCapturedProcess {
             stderr_path = $StdErrPath
             stdout_preview = (($stdoutText -split "`r?`n" | Where-Object { $_ -ne '' }) | Select-Object -First 5)
             stderr_preview = (($stderrText -split "`r?`n" | Where-Object { $_ -ne '' }) | Select-Object -First 5)
+            arguments_render_mode = [string]$launchMetadata.arguments_render_mode
+            rendered_arguments = if ($usedArgumentList) { $null } else { [string]$renderedArguments }
+            preflight = if ($null -eq $Preflight) { $null } else { $Preflight }
+            launch_metadata_path = if ([string]::IsNullOrWhiteSpace($LaunchMetadataPath)) { $null } else { [string]$LaunchMetadataPath }
         }
     } finally {
         $process.Dispose()
@@ -228,6 +330,12 @@ function Invoke-VibeExecutionUnit {
     $command = ''
     $arguments = @()
     $display = ''
+    $hostKind = $null
+    $fallbackUsed = $false
+    $scriptPath = $null
+    $pythonCommandSpec = $null
+    $invocationDetails = $null
+    $launchMetadataPath = Join-Path $logsRoot ("{0}.launch.json" -f $unitId)
 
     switch ($kind) {
         'powershell_file' {
@@ -247,9 +355,13 @@ function Invoke-VibeExecutionUnit {
             $command = [string]$invocation.host_path
             $arguments = @($invocation.arguments)
             $display = @($command) + @($arguments) -join ' '
+            $hostKind = if ($invocation.PSObject.Properties.Name -contains 'host_kind') { [string]$invocation.host_kind } else { 'pwsh' }
+            $fallbackUsed = [bool]$(if ($invocation.PSObject.Properties.Name -contains 'fallback_used') { $invocation.fallback_used } else { $false })
+            $invocationDetails = $invocation
         }
         'python_command' {
             $commandSpec = Expand-VibeExecutionTemplate -Text ([string]$Unit.command) -Tokens $Tokens
+            $pythonCommandSpec = $commandSpec
             $pythonInvocation = Resolve-VgoPythonCommandSpec -Command $commandSpec
             $command = [string]$pythonInvocation.host_path
             $arguments = @($pythonInvocation.prefix_arguments)
@@ -257,6 +369,8 @@ function Invoke-VibeExecutionUnit {
                 $arguments += (Expand-VibeExecutionTemplate -Text ([string]$arg) -Tokens $Tokens)
             }
             $display = @($command) + @($arguments) -join ' '
+            $hostKind = 'python'
+            $invocationDetails = $pythonInvocation
         }
         'shell_command' {
             $command = Expand-VibeExecutionTemplate -Text ([string]$Unit.command) -Tokens $Tokens
@@ -264,13 +378,15 @@ function Invoke-VibeExecutionUnit {
                 $arguments += (Expand-VibeExecutionTemplate -Text ([string]$arg) -Tokens $Tokens)
             }
             $display = @($command) + @($arguments) -join ' '
+            $hostKind = 'shell'
         }
         default {
             throw "Unsupported execution unit kind: $kind"
         }
     }
 
-    $processResult = Invoke-VibeCapturedProcess -Command $command -Arguments $arguments -WorkingDirectory $cwd -TimeoutSeconds $timeoutSeconds -StdOutPath $stdoutPath -StdErrPath $stderrPath
+    $preflight = New-VibeProcessPreflightResult -Command $command -Arguments $arguments -WorkingDirectory $cwd -HostKind $hostKind -ScriptPath $scriptPath -PythonCommandSpec $pythonCommandSpec -Invocation $invocationDetails
+    $processResult = Invoke-VibeCapturedProcess -Command $command -Arguments $arguments -WorkingDirectory $cwd -TimeoutSeconds $timeoutSeconds -StdOutPath $stdoutPath -StdErrPath $stderrPath -Preflight $preflight -LaunchMetadataPath $launchMetadataPath
 
     $resolvedArtifacts = @()
     foreach ($artifact in @($Unit.expected_artifacts)) {
@@ -297,6 +413,8 @@ function Invoke-VibeExecutionUnit {
         finished_at = $finishedAt
         command = $command
         arguments = @($arguments)
+        host_kind = $hostKind
+        fallback_used = [bool]$fallbackUsed
         display_command = $display
         cwd = $cwd
         timeout_seconds = $timeoutSeconds
@@ -307,6 +425,10 @@ function Invoke-VibeExecutionUnit {
         stderr_path = $processResult.stderr_path
         stdout_preview = @($processResult.stdout_preview)
         stderr_preview = @($processResult.stderr_preview)
+        arguments_render_mode = if ($processResult.PSObject.Properties.Name -contains 'arguments_render_mode') { [string]$processResult.arguments_render_mode } else { $null }
+        rendered_arguments = if ($processResult.PSObject.Properties.Name -contains 'rendered_arguments') { $processResult.rendered_arguments } else { $null }
+        launch_metadata_path = if ($processResult.PSObject.Properties.Name -contains 'launch_metadata_path') { [string]$processResult.launch_metadata_path } else { $launchMetadataPath }
+        preflight = if ($processResult.PSObject.Properties.Name -contains 'preflight') { $processResult.preflight } else { $preflight }
         expected_artifacts = @($resolvedArtifacts)
         verification_passed = [bool]$verificationPassed
     }

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -79,13 +79,32 @@ function New-VibeProcessPreflightResult {
         [AllowNull()] [object]$Invocation = $null
     )
 
-    $resolvedCommand = try { [System.IO.Path]::GetFullPath($Command) } catch { [string]$Command }
+    $resolvedCommand = if ([string]::IsNullOrWhiteSpace($Command)) {
+        ''
+    } elseif ([System.IO.Path]::IsPathRooted($Command) -or [string]$Command -match '[\\/]') {
+        try { [System.IO.Path]::GetFullPath($Command) } catch { [string]$Command }
+    } else {
+        $commandCandidate = Get-Command -Name $Command -ErrorAction SilentlyContinue |
+            Where-Object { $_.CommandType -in @('Application', 'ExternalScript') } |
+            Select-Object -First 1
+        if ($null -ne $commandCandidate) {
+            if ($commandCandidate.PSObject.Properties.Name -contains 'Source' -and -not [string]::IsNullOrWhiteSpace([string]$commandCandidate.Source)) {
+                [string]$commandCandidate.Source
+            } elseif ($commandCandidate.PSObject.Properties.Name -contains 'Path' -and -not [string]::IsNullOrWhiteSpace([string]$commandCandidate.Path)) {
+                [string]$commandCandidate.Path
+            } else {
+                [string]$Command
+            }
+        } else {
+            [string]$Command
+        }
+    }
     $resolvedWorkingDirectory = try { [System.IO.Path]::GetFullPath($WorkingDirectory) } catch { [string]$WorkingDirectory }
     $resolvedScriptPath = if ([string]::IsNullOrWhiteSpace($ScriptPath)) { $null } else { try { [System.IO.Path]::GetFullPath($ScriptPath) } catch { [string]$ScriptPath } }
     $resolvedPythonSpec = if ([string]::IsNullOrWhiteSpace($PythonCommandSpec)) { $null } else { [string]$PythonCommandSpec }
 
-    $commandExists = Test-Path -LiteralPath $resolvedCommand
-    $commandIsFile = Test-Path -LiteralPath $resolvedCommand -PathType Leaf
+    $commandExists = (-not [string]::IsNullOrWhiteSpace($resolvedCommand)) -and (Test-Path -LiteralPath $resolvedCommand)
+    $commandIsFile = (-not [string]::IsNullOrWhiteSpace($resolvedCommand)) -and (Test-Path -LiteralPath $resolvedCommand -PathType Leaf)
     $workingDirectoryExists = Test-Path -LiteralPath $resolvedWorkingDirectory
     $workingDirectoryIsDirectory = Test-Path -LiteralPath $resolvedWorkingDirectory -PathType Container
     $scriptExists = if ($null -eq $resolvedScriptPath) { $null } else { [bool](Test-Path -LiteralPath $resolvedScriptPath) }

--- a/scripts/runtime/VibeExecution.Common.ps1
+++ b/scripts/runtime/VibeExecution.Common.ps1
@@ -238,8 +238,19 @@ function Invoke-VibeCapturedProcess {
         $startInfo.Arguments = $renderedArguments
     }
 
+    $launchMetadataResolvedCommand = if (
+        $null -ne $Preflight -and
+        $Preflight.PSObject.Properties.Name -contains 'resolved_command' -and
+        -not [string]::IsNullOrWhiteSpace([string]$Preflight.resolved_command)
+    ) {
+        [string]$Preflight.resolved_command
+    } else {
+        [string]$Command
+    }
+
     $launchMetadata = [ordered]@{
-        resolved_command = [string]$Command
+        command = [string]$Command
+        resolved_command = $launchMetadataResolvedCommand
         resolved_arguments = @($Arguments | ForEach-Object { [string]$_ })
         resolved_working_directory = [string]$WorkingDirectory
         stdout_path = [string]$StdOutPath

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -1641,9 +1641,9 @@ function New-VibeRuntimeSummaryArtifactProjection {
         [Parameter(Mandatory)] [string]$RuntimeInputPacketPath,
         [Parameter(Mandatory)] [string]$GovernanceCapsulePath,
         [Parameter(Mandatory)] [string]$StageLineagePath,
-        [Parameter(Mandatory)] [string]$IntentContractPath,
-        [Parameter(Mandatory)] [string]$RequirementDocPath,
-        [Parameter(Mandatory)] [string]$RequirementReceiptPath,
+        [AllowEmptyString()] [string]$IntentContractPath = '',
+        [AllowEmptyString()] [string]$RequirementDocPath = '',
+        [AllowEmptyString()] [string]$RequirementReceiptPath = '',
         [AllowEmptyString()] [string]$ExecutionPlanPath = '',
         [AllowEmptyString()] [string]$ExecutionPlanReceiptPath = '',
         [AllowEmptyString()] [string]$ExecuteReceiptPath = '',
@@ -1669,9 +1669,9 @@ function New-VibeRuntimeSummaryArtifactProjection {
         runtime_input_packet = $RuntimeInputPacketPath
         governance_capsule = $GovernanceCapsulePath
         stage_lineage = $StageLineagePath
-        intent_contract = $IntentContractPath
-        requirement_doc = $RequirementDocPath
-        requirement_receipt = $RequirementReceiptPath
+        intent_contract = if ([string]::IsNullOrWhiteSpace($IntentContractPath)) { $null } else { $IntentContractPath }
+        requirement_doc = if ([string]::IsNullOrWhiteSpace($RequirementDocPath)) { $null } else { $RequirementDocPath }
+        requirement_receipt = if ([string]::IsNullOrWhiteSpace($RequirementReceiptPath)) { $null } else { $RequirementReceiptPath }
         execution_plan = if ([string]::IsNullOrWhiteSpace($ExecutionPlanPath)) { $null } else { $ExecutionPlanPath }
         execution_plan_receipt = if ([string]::IsNullOrWhiteSpace($ExecutionPlanReceiptPath)) { $null } else { $ExecutionPlanReceiptPath }
         execute_receipt = if ([string]::IsNullOrWhiteSpace($ExecuteReceiptPath)) { $null } else { $ExecuteReceiptPath }

--- a/tests/runtime_neutral/test_installed_host_runtime_simulation.py
+++ b/tests/runtime_neutral/test_installed_host_runtime_simulation.py
@@ -21,7 +21,7 @@ MEMORY_TASK_SECOND = "Follow up on the hidden skill topology decision and recall
 SUPPORTED_CANONICAL_HOSTS = ("codex", "claude-code", "opencode")
 INSTALLED_RUNTIME_ADVISORY_FAILURE_UNITS = {
     "runtime-neutral-freshness-gate-tests",
-    "version-consistency-gate",
+    "release-install-runtime-coherence-gate",
 }
 HOST_BRIDGE_ENV = {
     "claude-code": "VGO_CLAUDE_CODE_SPECIALIST_BRIDGE_COMMAND",


### PR DESCRIPTION
## Summary
- adopt a pwsh-first PowerShell host policy with explicit Windows fallback diagnostics in CLI, canonical entry, and shared helper resolution
- add process preflight validation plus launch metadata artifacts so startup failures surface missing executables, cwd issues, and host/script mismatches clearly
- harden delegated lane working-directory resolution and payload recovery, and add focused regression coverage for Unicode paths, host resolution, and bridge failure layering

## Test plan
- [x] `python -m unittest discover -s "/f/test/Vibe-Skills-remote-latest/packages/runtime-core/src/vgo_runtime" -p "test_delegated_lane_contract.py"`
- [x] `python -m py_compile "/f/test/Vibe-Skills-remote-latest/apps/vgo-cli/src/vgo_cli/process.py" "/f/test/Vibe-Skills-remote-latest/packages/runtime-core/src/vgo_runtime/canonical_entry.py" "/f/test/Vibe-Skills-remote-latest/packages/runtime-core/src/vgo_runtime/powershell_bridge.py" "/f/test/Vibe-Skills-remote-latest/packages/runtime-core/src/vgo_runtime/test_delegated_lane_contract.py"`
- [x] `PYTHONPATH="/f/test/Vibe-Skills-remote-latest/apps/vgo-cli/src" python -m vgo_cli.main canonical-entry --repo-root "/f/test/Vibe-Skills-remote-latest" --artifact-root "/f/test" --host-id "claude-code" --entry-id "vibe" --prompt "remote clone smoke verification"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Policy-driven PowerShell host selection with repo-configurable policy, platform-aware candidates, and structured resolution outputs
  * Delegated-lane payload contract versioning and explicit compressed JSON payload output

* **Improvements**
  * Richer diagnostics and failure messages (candidate checks, stdout/stderr previews, launch/preflight metadata)
  * Stronger host enforcement, safer Windows/non-Windows fallback, preflight validation, and persisted launch metadata

* **Tests**
  * New tests for host policy, bridge error classification, delegated-lane payload handling, and runtime flows

* **Chores**
  * Renamed runtime gate ID to release-install-runtime-coherence-gate
<!-- end of auto-generated comment: release notes by coderabbit.ai -->