### PR TITLE
Release Vibe Skills 3.1.0

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -321,7 +321,7 @@ The governed runtime should leave behind:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 3.0.4
-- Updated: 2026-04-19
+- Version: 3.1.0
+- Updated: 2026-04-25
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/apps/vgo-cli/pyproject.toml
+++ b/apps/vgo-cli/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-cli"
-version = "3.0.0"
+version = "3.1.0"
 description = "Thin CLI launcher for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/config/version-governance.json
+++ b/config/version-governance.json
@@ -1,323 +1,325 @@
 {
-  "schema_version": 2,
-  "release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19",
-    "channel": "stable",
-    "notes": "Windows verification gate Python resolution / direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair"
-  },
-  "source_of_truth": {
-    "canonical_root": ".",
-    "official_self_repo": {
-      "repo_url": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
-      "default_branch": "main"
-    }
-  },
-  "mirror_topology": {
-    "canonical_target_id": "canonical",
-    "sync_source_target_id": "canonical",
-    "targets": [
-      {
-        "id": "canonical",
-        "path": ".",
-        "role": "canonical",
-        "required": true,
-        "presence_policy": "required",
-        "sync_enabled": false,
-        "parity_policy": "authoritative"
-      }
-    ]
-  },
-  "execution_context_policy": {
-    "require_outer_git_root": true,
-    "fail_if_script_path_is_under_mirror_root": true
-  },
-  "version_markers": {
-    "maintenance_files": [
-      "SKILL.md"
-    ],
-    "changelog_path": "references/changelog.md"
-  },
-  "logs": {
-    "release_ledger_jsonl": "references/release-ledger.jsonl",
-    "release_notes_dir": "docs/releases"
-  },
-  "packaging": {
-    "runtime_payload": {
-      "files": [
-        "SKILL.md",
-        "check.ps1",
-        "check.sh",
-        "install.ps1",
-        "install.sh",
-        "core/skill-contracts/v1/vibe.json",
-        "config/runtime-core-packaging.json",
-        "config/runtime-core-packaging.minimal.json",
-        "config/runtime-core-packaging.full.json",
-        "config/runtime-script-manifest.json",
-        "config/runtime-config-manifest.json"
-      ],
-      "directories": [
-        "docs",
-        "protocols",
-        "templates",
-        "mcp"
-      ]
-    },
-    "generated_compatibility": {
-      "nested_runtime_root": {
-        "relative_path": "bundled/skills/vibe",
-        "materialization_mode": "install_only"
-      }
-    },
-    "manifests": [
-      {
-        "id": "runtime_scripts",
-        "path": "config/runtime-script-manifest.json"
-      },
-      {
-        "id": "runtime_configs",
-        "path": "config/runtime-config-manifest.json"
-      }
-    ],
-    "target_overrides": {},
-    "allow_installed_only": [
-      "docs/CODEX_ECOSYSTEM_MAINTENANCE_PRINCIPLES.md"
-    ],
-    "normalized_json_ignore_keys": [
-      "updated",
-      "generated_at"
-    ],
-    "runtime_payload_roles": {
-      "files": {
-        "root_entrypoints": [
-          "SKILL.md",
-          "check.ps1",
-          "check.sh",
-          "install.ps1",
-          "install.sh",
-          "core/skill-contracts/v1/vibe.json"
-        ],
-        "governance_manifests": [
-          "config/runtime-core-packaging.json",
-          "config/runtime-core-packaging.minimal.json",
-          "config/runtime-core-packaging.full.json",
-          "config/runtime-script-manifest.json",
-          "config/runtime-config-manifest.json"
-        ]
-      },
-      "directories": {
-        "runtime_support_assets": [
-          "docs",
-          "protocols",
-          "templates",
-          "mcp"
-        ]
-      },
-      "notes": {
-        "flat_projection_contract": "runtime_payload.files and runtime_payload.directories remain the compatibility projection for existing payload consumers.",
-        "owner_boundary_rule": "Runtime payload root files bootstrap the installed runtime, while semantic ownership for runtime behavior stays in the CLI app and package-owned cores referenced by required_runtime_markers."
-      }
-    }
-  },
-  "runtime": {
-    "installed_runtime": {
-      "target_relpath": "skills/vibe",
-      "receipt_relpath": "skills/vibe/outputs/runtime-freshness-receipt.json",
-      "post_install_gate": "scripts/verify/vibe-installed-runtime-freshness-gate.ps1",
-      "frontmatter_gate": "scripts/verify/vibe-bom-frontmatter-gate.ps1",
-      "coherence_gate": "scripts/verify/vibe-release-install-runtime-coherence-gate.ps1",
-      "receipt_contract_version": 1,
-      "shell_degraded_behavior": "warn_and_skip_authoritative_runtime_gate",
-      "required_runtime_markers": [
-        "SKILL.md",
-        "config/version-governance.json",
-        "config/plugins-manifest.codex.json",
-        "config/runtime-script-manifest.json",
-        "config/runtime-config-manifest.json",
-        "config/secrets-policy.json",
-        "config/tool-registry.json",
-        "config/vibe-entry-surfaces.json",
-        "apps/vgo-cli/src/vgo_cli/__init__.py",
-        "apps/vgo-cli/src/vgo_cli/main.py",
-        "apps/vgo-cli/src/vgo_cli/errors.py",
-        "apps/vgo-cli/src/vgo_cli/hosts.py",
-        "apps/vgo-cli/src/vgo_cli/process.py",
-        "apps/vgo-cli/src/vgo_cli/install_support.py",
-        "apps/vgo-cli/src/vgo_cli/workspace.py",
-        "apps/vgo-cli/src/vgo_cli/commands.py",
-        "apps/vgo-cli/src/vgo_cli/repo.py",
-        "apps/vgo-cli/src/vgo_cli/external.py",
-        "apps/vgo-cli/src/vgo_cli/output.py",
-        "apps/vgo-cli/src/vgo_cli/install_gates.py",
-        "apps/vgo-cli/src/vgo_cli/installer_bridge.py",
-        "apps/vgo-cli/src/vgo_cli/skill_surface.py",
-        "apps/vgo-cli/src/vgo_cli/core_bridge.py",
-        "packages/contracts/src/vgo_contracts/__init__.py",
-        "packages/contracts/src/vgo_contracts/install_ledger.py",
-        "packages/installer-core/src/vgo_installer/__init__.py",
-        "packages/installer-core/src/vgo_installer/install_runtime.py",
-        "packages/installer-core/src/vgo_installer/uninstall_runtime.py",
-        "packages/installer-core/src/vgo_installer/ledger_service.py",
-        "install.ps1",
-        "check.ps1",
-        "scripts/common/vibe-governance-helpers.ps1",
-        "scripts/common/adapter_registry_query.py",
-        "scripts/runtime/VibeRuntime.Common.ps1",
-        "scripts/runtime/VibeMemoryBackends.Common.ps1",
-        "scripts/runtime/Freeze-RuntimeInputPacket.ps1",
-        "scripts/runtime/invoke-vibe-runtime.ps1",
-        "scripts/runtime/Invoke-PlanExecute.ps1",
-        "scripts/runtime/native_specialist_runner.py",
-        "scripts/runtime/Invoke-AntiProxyGoalDriftCompaction.ps1",
-        "scripts/runtime/Invoke-DeepInterview.ps1",
-        "scripts/runtime/Invoke-DelegatedLaneUnit.ps1",
-        "scripts/runtime/Invoke-PhaseCleanup.ps1",
-        "scripts/runtime/Invoke-SkeletonCheck.ps1",
-        "scripts/runtime/Invoke-VibeCanonicalEntry.ps1",
-        "scripts/runtime/VibeConsultation.Common.ps1",
-        "scripts/runtime/VibeExecution.Common.ps1",
-        "scripts/runtime/VibeMemoryActivation.Common.ps1",
-        "scripts/runtime/VibeWorkspaceMemory.Common.ps1",
-        "scripts/runtime/Write-RequirementDoc.ps1",
-        "scripts/runtime/Write-XlPlan.ps1",
-        "scripts/runtime/memory_backend_driver.py",
-        "scripts/runtime/workspace_memory_driver.py",
-        "scripts/verify/vibe-bootstrap-doctor-gate.ps1",
-        "scripts/verify/vibe-canonical-entry-truth-gate.ps1",
-        "scripts/verify/vibe-installed-runtime-freshness-gate.ps1",
-        "scripts/verify/vibe-release-install-runtime-coherence-gate.ps1",
-        "scripts/verify/vibe-governed-runtime-contract-gate.ps1",
-        "scripts/verify/vibe-runtime-execution-proof-gate.ps1",
-        "scripts/verify/vibe-linux-router-no-pwsh-gate.ps1",
-        "scripts/router/resolve-pack-route.ps1",
-        "scripts/router/invoke-pack-route.py",
-        "scripts/router/runtime_neutral/router_contract.py",
-        "packages/runtime-core/src/vgo_runtime/router_bridge.py",
-        "packages/runtime-core/src/vgo_runtime/router_contract_runtime.py",
-        "packages/runtime-core/src/vgo_runtime/custom_admission.py",
-        "scripts/verify/runtime_neutral/router_bridge_gate.py",
-        "config/runtime-contract.json",
-        "config/runtime-modes.json",
-        "config/runtime-input-packet-policy.json",
-        "config/execution-runtime-policy.json",
-        "config/specialist-consultation-policy.json",
-        "config/memory-backend-adapters.json",
-        "config/memory-disclosure-policy.json",
-        "config/memory-ingest-policy.json",
-        "config/memory-runtime-v3-policy.json",
-        "config/memory-tier-router.json",
-        "config/workspace-memory-plane.json",
-        "config/proof-class-registry.json",
-        "config/requirement-doc-policy.json",
-        "config/plan-execution-policy.json",
-        "config/phase-cleanup-policy.json"
-      ],
-      "require_nested_bundled_root": false,
-      "required_runtime_marker_groups": {
-        "governance_and_manifests": [
-          "SKILL.md",
-          "config/version-governance.json",
-          "config/plugins-manifest.codex.json",
-          "config/runtime-script-manifest.json",
-          "config/runtime-config-manifest.json",
-          "config/secrets-policy.json",
-          "config/tool-registry.json",
-          "config/vibe-entry-surfaces.json",
-          "config/runtime-contract.json",
-          "config/runtime-modes.json",
-          "config/runtime-input-packet-policy.json",
-          "config/execution-runtime-policy.json",
-          "config/specialist-consultation-policy.json",
-          "config/memory-backend-adapters.json",
-          "config/memory-disclosure-policy.json",
-          "config/memory-ingest-policy.json",
-          "config/memory-runtime-v3-policy.json",
-          "config/memory-tier-router.json",
-          "config/workspace-memory-plane.json",
-          "config/proof-class-registry.json",
-          "config/requirement-doc-policy.json",
-          "config/plan-execution-policy.json",
-          "config/phase-cleanup-policy.json"
-        ],
-        "semantic_owners": [
-          "apps/vgo-cli/src/vgo_cli/__init__.py",
-          "apps/vgo-cli/src/vgo_cli/main.py",
-          "apps/vgo-cli/src/vgo_cli/errors.py",
-          "apps/vgo-cli/src/vgo_cli/hosts.py",
-          "apps/vgo-cli/src/vgo_cli/process.py",
-          "apps/vgo-cli/src/vgo_cli/install_support.py",
-          "apps/vgo-cli/src/vgo_cli/workspace.py",
-          "apps/vgo-cli/src/vgo_cli/commands.py",
-          "apps/vgo-cli/src/vgo_cli/repo.py",
-          "apps/vgo-cli/src/vgo_cli/external.py",
-          "apps/vgo-cli/src/vgo_cli/output.py",
-          "apps/vgo-cli/src/vgo_cli/install_gates.py",
-          "apps/vgo-cli/src/vgo_cli/installer_bridge.py",
-          "apps/vgo-cli/src/vgo_cli/skill_surface.py",
-          "apps/vgo-cli/src/vgo_cli/core_bridge.py",
-          "packages/contracts/src/vgo_contracts/__init__.py",
-          "packages/contracts/src/vgo_contracts/install_ledger.py",
-          "packages/installer-core/src/vgo_installer/__init__.py",
-          "packages/installer-core/src/vgo_installer/install_runtime.py",
-          "packages/installer-core/src/vgo_installer/uninstall_runtime.py",
-          "packages/installer-core/src/vgo_installer/ledger_service.py",
-          "packages/runtime-core/src/vgo_runtime/router_bridge.py",
-          "packages/runtime-core/src/vgo_runtime/router_contract_runtime.py",
-          "packages/runtime-core/src/vgo_runtime/custom_admission.py"
-        ],
-        "runtime_entrypoints_and_support": [
-          "install.ps1",
-          "check.ps1",
-          "scripts/common/vibe-governance-helpers.ps1",
-          "scripts/common/adapter_registry_query.py",
-          "scripts/runtime/VibeRuntime.Common.ps1",
-          "scripts/runtime/VibeMemoryBackends.Common.ps1",
-          "scripts/runtime/Freeze-RuntimeInputPacket.ps1",
-          "scripts/runtime/invoke-vibe-runtime.ps1",
-          "scripts/runtime/Invoke-PlanExecute.ps1",
-          "scripts/runtime/native_specialist_runner.py",
-          "scripts/runtime/Invoke-AntiProxyGoalDriftCompaction.ps1",
-          "scripts/runtime/Invoke-DeepInterview.ps1",
-          "scripts/runtime/Invoke-DelegatedLaneUnit.ps1",
-          "scripts/runtime/Invoke-PhaseCleanup.ps1",
-          "scripts/runtime/Invoke-SkeletonCheck.ps1",
-          "scripts/runtime/Invoke-VibeCanonicalEntry.ps1",
-          "scripts/runtime/VibeConsultation.Common.ps1",
-          "scripts/runtime/VibeExecution.Common.ps1",
-          "scripts/runtime/VibeMemoryActivation.Common.ps1",
-          "scripts/runtime/VibeWorkspaceMemory.Common.ps1",
-          "scripts/runtime/Write-RequirementDoc.ps1",
-          "scripts/runtime/Write-XlPlan.ps1",
-          "scripts/runtime/memory_backend_driver.py",
-          "scripts/runtime/workspace_memory_driver.py"
-        ],
-        "verification_surfaces": [
-          "scripts/verify/vibe-bootstrap-doctor-gate.ps1",
-          "scripts/verify/vibe-canonical-entry-truth-gate.ps1",
-          "scripts/verify/vibe-installed-runtime-freshness-gate.ps1",
-          "scripts/verify/vibe-release-install-runtime-coherence-gate.ps1",
-          "scripts/verify/vibe-governed-runtime-contract-gate.ps1",
-          "scripts/verify/vibe-runtime-execution-proof-gate.ps1",
-          "scripts/verify/vibe-linux-router-no-pwsh-gate.ps1"
-        ],
-        "router_and_compatibility_surfaces": [
-          "scripts/router/resolve-pack-route.ps1",
-          "scripts/router/invoke-pack-route.py",
-          "scripts/router/runtime_neutral/router_contract.py",
-          "scripts/verify/runtime_neutral/router_bridge_gate.py"
-        ]
-      },
-      "required_runtime_marker_notes": {
-        "flat_projection_contract": "required_runtime_markers remains the flat compatibility projection consumed by installed-runtime checks and gates.",
-        "grouping_scope": "required_runtime_marker_groups classify the same marker set by responsibility; they are parity sentinels, not an exhaustive inventory of every file shipped under each package-owned directory."
-      }
-    }
-  },
-  "metrics": {
-    "governed_mirror_coverage_target": 0,
-    "runtime_only_artifact_count_target": 0,
-    "upstream_manifest_coverage_target": 15,
-    "productization_ratio_target": 0.8
-  }
+    "schema_version":  2,
+    "release":  {
+                    "version":  "3.1.0",
+                    "updated":  "2026-04-25",
+                    "channel":  "stable",
+                    "notes":  "Phoenix release: unified vibe entry surface, structured host routing, bounded continuation, specialist truth gates, install/runtime path hardening, public vibe-upgrade, and package metadata alignment"
+                },
+    "source_of_truth":  {
+                            "canonical_root":  ".",
+                            "official_self_repo":  {
+                                                       "repo_url":  "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+                                                       "default_branch":  "main"
+                                                   }
+                        },
+    "mirror_topology":  {
+                            "canonical_target_id":  "canonical",
+                            "sync_source_target_id":  "canonical",
+                            "targets":  [
+                                            {
+                                                "id":  "canonical",
+                                                "path":  ".",
+                                                "role":  "canonical",
+                                                "required":  true,
+                                                "presence_policy":  "required",
+                                                "sync_enabled":  false,
+                                                "parity_policy":  "authoritative"
+                                            }
+                                        ]
+                        },
+    "execution_context_policy":  {
+                                     "require_outer_git_root":  true,
+                                     "fail_if_script_path_is_under_mirror_root":  true
+                                 },
+    "version_markers":  {
+                            "maintenance_files":  [
+                                                      "SKILL.md"
+                                                  ],
+                            "changelog_path":  "references/changelog.md"
+                        },
+    "logs":  {
+                 "release_ledger_jsonl":  "references/release-ledger.jsonl",
+                 "release_notes_dir":  "docs/releases"
+             },
+    "packaging":  {
+                      "runtime_payload":  {
+                                              "files":  [
+                                                            "SKILL.md",
+                                                            "check.ps1",
+                                                            "check.sh",
+                                                            "install.ps1",
+                                                            "install.sh",
+                                                            "core/skill-contracts/v1/vibe.json",
+                                                            "config/runtime-core-packaging.json",
+                                                            "config/runtime-core-packaging.minimal.json",
+                                                            "config/runtime-core-packaging.full.json",
+                                                            "config/runtime-script-manifest.json",
+                                                            "config/runtime-config-manifest.json"
+                                                        ],
+                                              "directories":  [
+                                                                  "docs",
+                                                                  "protocols",
+                                                                  "templates",
+                                                                  "mcp"
+                                                              ]
+                                          },
+                      "generated_compatibility":  {
+                                                      "nested_runtime_root":  {
+                                                                                  "relative_path":  "bundled/skills/vibe",
+                                                                                  "materialization_mode":  "install_only"
+                                                                              }
+                                                  },
+                      "manifests":  [
+                                        {
+                                            "id":  "runtime_scripts",
+                                            "path":  "config/runtime-script-manifest.json"
+                                        },
+                                        {
+                                            "id":  "runtime_configs",
+                                            "path":  "config/runtime-config-manifest.json"
+                                        }
+                                    ],
+                      "target_overrides":  {
+
+                                           },
+                      "allow_installed_only":  [
+                                                   "docs/CODEX_ECOSYSTEM_MAINTENANCE_PRINCIPLES.md"
+                                               ],
+                      "normalized_json_ignore_keys":  [
+                                                          "updated",
+                                                          "generated_at"
+                                                      ],
+                      "runtime_payload_roles":  {
+                                                    "files":  {
+                                                                  "root_entrypoints":  [
+                                                                                           "SKILL.md",
+                                                                                           "check.ps1",
+                                                                                           "check.sh",
+                                                                                           "install.ps1",
+                                                                                           "install.sh",
+                                                                                           "core/skill-contracts/v1/vibe.json"
+                                                                                       ],
+                                                                  "governance_manifests":  [
+                                                                                               "config/runtime-core-packaging.json",
+                                                                                               "config/runtime-core-packaging.minimal.json",
+                                                                                               "config/runtime-core-packaging.full.json",
+                                                                                               "config/runtime-script-manifest.json",
+                                                                                               "config/runtime-config-manifest.json"
+                                                                                           ]
+                                                              },
+                                                    "directories":  {
+                                                                        "runtime_support_assets":  [
+                                                                                                       "docs",
+                                                                                                       "protocols",
+                                                                                                       "templates",
+                                                                                                       "mcp"
+                                                                                                   ]
+                                                                    },
+                                                    "notes":  {
+                                                                  "flat_projection_contract":  "runtime_payload.files and runtime_payload.directories remain the compatibility projection for existing payload consumers.",
+                                                                  "owner_boundary_rule":  "Runtime payload root files bootstrap the installed runtime, while semantic ownership for runtime behavior stays in the CLI app and package-owned cores referenced by required_runtime_markers."
+                                                              }
+                                                }
+                  },
+    "runtime":  {
+                    "installed_runtime":  {
+                                              "target_relpath":  "skills/vibe",
+                                              "receipt_relpath":  "skills/vibe/outputs/runtime-freshness-receipt.json",
+                                              "post_install_gate":  "scripts/verify/vibe-installed-runtime-freshness-gate.ps1",
+                                              "frontmatter_gate":  "scripts/verify/vibe-bom-frontmatter-gate.ps1",
+                                              "coherence_gate":  "scripts/verify/vibe-release-install-runtime-coherence-gate.ps1",
+                                              "receipt_contract_version":  1,
+                                              "shell_degraded_behavior":  "warn_and_skip_authoritative_runtime_gate",
+                                              "required_runtime_markers":  [
+                                                                               "SKILL.md",
+                                                                               "config/version-governance.json",
+                                                                               "config/plugins-manifest.codex.json",
+                                                                               "config/runtime-script-manifest.json",
+                                                                               "config/runtime-config-manifest.json",
+                                                                               "config/secrets-policy.json",
+                                                                               "config/tool-registry.json",
+                                                                               "config/vibe-entry-surfaces.json",
+                                                                               "apps/vgo-cli/src/vgo_cli/__init__.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/main.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/errors.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/hosts.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/process.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/install_support.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/workspace.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/commands.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/repo.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/external.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/output.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/install_gates.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/installer_bridge.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/skill_surface.py",
+                                                                               "apps/vgo-cli/src/vgo_cli/core_bridge.py",
+                                                                               "packages/contracts/src/vgo_contracts/__init__.py",
+                                                                               "packages/contracts/src/vgo_contracts/install_ledger.py",
+                                                                               "packages/installer-core/src/vgo_installer/__init__.py",
+                                                                               "packages/installer-core/src/vgo_installer/install_runtime.py",
+                                                                               "packages/installer-core/src/vgo_installer/uninstall_runtime.py",
+                                                                               "packages/installer-core/src/vgo_installer/ledger_service.py",
+                                                                               "install.ps1",
+                                                                               "check.ps1",
+                                                                               "scripts/common/vibe-governance-helpers.ps1",
+                                                                               "scripts/common/adapter_registry_query.py",
+                                                                               "scripts/runtime/VibeRuntime.Common.ps1",
+                                                                               "scripts/runtime/VibeMemoryBackends.Common.ps1",
+                                                                               "scripts/runtime/Freeze-RuntimeInputPacket.ps1",
+                                                                               "scripts/runtime/invoke-vibe-runtime.ps1",
+                                                                               "scripts/runtime/Invoke-PlanExecute.ps1",
+                                                                               "scripts/runtime/native_specialist_runner.py",
+                                                                               "scripts/runtime/Invoke-AntiProxyGoalDriftCompaction.ps1",
+                                                                               "scripts/runtime/Invoke-DeepInterview.ps1",
+                                                                               "scripts/runtime/Invoke-DelegatedLaneUnit.ps1",
+                                                                               "scripts/runtime/Invoke-PhaseCleanup.ps1",
+                                                                               "scripts/runtime/Invoke-SkeletonCheck.ps1",
+                                                                               "scripts/runtime/Invoke-VibeCanonicalEntry.ps1",
+                                                                               "scripts/runtime/VibeConsultation.Common.ps1",
+                                                                               "scripts/runtime/VibeExecution.Common.ps1",
+                                                                               "scripts/runtime/VibeMemoryActivation.Common.ps1",
+                                                                               "scripts/runtime/VibeWorkspaceMemory.Common.ps1",
+                                                                               "scripts/runtime/Write-RequirementDoc.ps1",
+                                                                               "scripts/runtime/Write-XlPlan.ps1",
+                                                                               "scripts/runtime/memory_backend_driver.py",
+                                                                               "scripts/runtime/workspace_memory_driver.py",
+                                                                               "scripts/verify/vibe-bootstrap-doctor-gate.ps1",
+                                                                               "scripts/verify/vibe-canonical-entry-truth-gate.ps1",
+                                                                               "scripts/verify/vibe-installed-runtime-freshness-gate.ps1",
+                                                                               "scripts/verify/vibe-release-install-runtime-coherence-gate.ps1",
+                                                                               "scripts/verify/vibe-governed-runtime-contract-gate.ps1",
+                                                                               "scripts/verify/vibe-runtime-execution-proof-gate.ps1",
+                                                                               "scripts/verify/vibe-linux-router-no-pwsh-gate.ps1",
+                                                                               "scripts/router/resolve-pack-route.ps1",
+                                                                               "scripts/router/invoke-pack-route.py",
+                                                                               "scripts/router/runtime_neutral/router_contract.py",
+                                                                               "packages/runtime-core/src/vgo_runtime/router_bridge.py",
+                                                                               "packages/runtime-core/src/vgo_runtime/router_contract_runtime.py",
+                                                                               "packages/runtime-core/src/vgo_runtime/custom_admission.py",
+                                                                               "scripts/verify/runtime_neutral/router_bridge_gate.py",
+                                                                               "config/runtime-contract.json",
+                                                                               "config/runtime-modes.json",
+                                                                               "config/runtime-input-packet-policy.json",
+                                                                               "config/execution-runtime-policy.json",
+                                                                               "config/specialist-consultation-policy.json",
+                                                                               "config/memory-backend-adapters.json",
+                                                                               "config/memory-disclosure-policy.json",
+                                                                               "config/memory-ingest-policy.json",
+                                                                               "config/memory-runtime-v3-policy.json",
+                                                                               "config/memory-tier-router.json",
+                                                                               "config/workspace-memory-plane.json",
+                                                                               "config/proof-class-registry.json",
+                                                                               "config/requirement-doc-policy.json",
+                                                                               "config/plan-execution-policy.json",
+                                                                               "config/phase-cleanup-policy.json"
+                                                                           ],
+                                              "require_nested_bundled_root":  false,
+                                              "required_runtime_marker_groups":  {
+                                                                                     "governance_and_manifests":  [
+                                                                                                                      "SKILL.md",
+                                                                                                                      "config/version-governance.json",
+                                                                                                                      "config/plugins-manifest.codex.json",
+                                                                                                                      "config/runtime-script-manifest.json",
+                                                                                                                      "config/runtime-config-manifest.json",
+                                                                                                                      "config/secrets-policy.json",
+                                                                                                                      "config/tool-registry.json",
+                                                                                                                      "config/vibe-entry-surfaces.json",
+                                                                                                                      "config/runtime-contract.json",
+                                                                                                                      "config/runtime-modes.json",
+                                                                                                                      "config/runtime-input-packet-policy.json",
+                                                                                                                      "config/execution-runtime-policy.json",
+                                                                                                                      "config/specialist-consultation-policy.json",
+                                                                                                                      "config/memory-backend-adapters.json",
+                                                                                                                      "config/memory-disclosure-policy.json",
+                                                                                                                      "config/memory-ingest-policy.json",
+                                                                                                                      "config/memory-runtime-v3-policy.json",
+                                                                                                                      "config/memory-tier-router.json",
+                                                                                                                      "config/workspace-memory-plane.json",
+                                                                                                                      "config/proof-class-registry.json",
+                                                                                                                      "config/requirement-doc-policy.json",
+                                                                                                                      "config/plan-execution-policy.json",
+                                                                                                                      "config/phase-cleanup-policy.json"
+                                                                                                                  ],
+                                                                                     "semantic_owners":  [
+                                                                                                             "apps/vgo-cli/src/vgo_cli/__init__.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/main.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/errors.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/hosts.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/process.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/install_support.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/workspace.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/commands.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/repo.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/external.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/output.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/install_gates.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/installer_bridge.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/skill_surface.py",
+                                                                                                             "apps/vgo-cli/src/vgo_cli/core_bridge.py",
+                                                                                                             "packages/contracts/src/vgo_contracts/__init__.py",
+                                                                                                             "packages/contracts/src/vgo_contracts/install_ledger.py",
+                                                                                                             "packages/installer-core/src/vgo_installer/__init__.py",
+                                                                                                             "packages/installer-core/src/vgo_installer/install_runtime.py",
+                                                                                                             "packages/installer-core/src/vgo_installer/uninstall_runtime.py",
+                                                                                                             "packages/installer-core/src/vgo_installer/ledger_service.py",
+                                                                                                             "packages/runtime-core/src/vgo_runtime/router_bridge.py",
+                                                                                                             "packages/runtime-core/src/vgo_runtime/router_contract_runtime.py",
+                                                                                                             "packages/runtime-core/src/vgo_runtime/custom_admission.py"
+                                                                                                         ],
+                                                                                     "runtime_entrypoints_and_support":  [
+                                                                                                                             "install.ps1",
+                                                                                                                             "check.ps1",
+                                                                                                                             "scripts/common/vibe-governance-helpers.ps1",
+                                                                                                                             "scripts/common/adapter_registry_query.py",
+                                                                                                                             "scripts/runtime/VibeRuntime.Common.ps1",
+                                                                                                                             "scripts/runtime/VibeMemoryBackends.Common.ps1",
+                                                                                                                             "scripts/runtime/Freeze-RuntimeInputPacket.ps1",
+                                                                                                                             "scripts/runtime/invoke-vibe-runtime.ps1",
+                                                                                                                             "scripts/runtime/Invoke-PlanExecute.ps1",
+                                                                                                                             "scripts/runtime/native_specialist_runner.py",
+                                                                                                                             "scripts/runtime/Invoke-AntiProxyGoalDriftCompaction.ps1",
+                                                                                                                             "scripts/runtime/Invoke-DeepInterview.ps1",
+                                                                                                                             "scripts/runtime/Invoke-DelegatedLaneUnit.ps1",
+                                                                                                                             "scripts/runtime/Invoke-PhaseCleanup.ps1",
+                                                                                                                             "scripts/runtime/Invoke-SkeletonCheck.ps1",
+                                                                                                                             "scripts/runtime/Invoke-VibeCanonicalEntry.ps1",
+                                                                                                                             "scripts/runtime/VibeConsultation.Common.ps1",
+                                                                                                                             "scripts/runtime/VibeExecution.Common.ps1",
+                                                                                                                             "scripts/runtime/VibeMemoryActivation.Common.ps1",
+                                                                                                                             "scripts/runtime/VibeWorkspaceMemory.Common.ps1",
+                                                                                                                             "scripts/runtime/Write-RequirementDoc.ps1",
+                                                                                                                             "scripts/runtime/Write-XlPlan.ps1",
+                                                                                                                             "scripts/runtime/memory_backend_driver.py",
+                                                                                                                             "scripts/runtime/workspace_memory_driver.py"
+                                                                                                                         ],
+                                                                                     "verification_surfaces":  [
+                                                                                                                   "scripts/verify/vibe-bootstrap-doctor-gate.ps1",
+                                                                                                                   "scripts/verify/vibe-canonical-entry-truth-gate.ps1",
+                                                                                                                   "scripts/verify/vibe-installed-runtime-freshness-gate.ps1",
+                                                                                                                   "scripts/verify/vibe-release-install-runtime-coherence-gate.ps1",
+                                                                                                                   "scripts/verify/vibe-governed-runtime-contract-gate.ps1",
+                                                                                                                   "scripts/verify/vibe-runtime-execution-proof-gate.ps1",
+                                                                                                                   "scripts/verify/vibe-linux-router-no-pwsh-gate.ps1"
+                                                                                                               ],
+                                                                                     "router_and_compatibility_surfaces":  [
+                                                                                                                               "scripts/router/resolve-pack-route.ps1",
+                                                                                                                               "scripts/router/invoke-pack-route.py",
+                                                                                                                               "scripts/router/runtime_neutral/router_contract.py",
+                                                                                                                               "scripts/verify/runtime_neutral/router_bridge_gate.py"
+                                                                                                                           ]
+                                                                                 },
+                                              "required_runtime_marker_notes":  {
+                                                                                    "flat_projection_contract":  "required_runtime_markers remains the flat compatibility projection consumed by installed-runtime checks and gates.",
+                                                                                    "grouping_scope":  "required_runtime_marker_groups classify the same marker set by responsibility; they are parity sentinels, not an exhaustive inventory of every file shipped under each package-owned directory."
+                                                                                }
+                                          }
+                },
+    "metrics":  {
+                    "governed_mirror_coverage_target":  0,
+                    "runtime_only_artifact_count_target":  0,
+                    "upstream_manifest_coverage_target":  15,
+                    "productization_ratio_target":  0.8
+                }
 }

--- a/dist/core/manifest.json
+++ b/dist/core/manifest.json
@@ -4,8 +4,8 @@
   "lane_kind": "universal-core",
   "stability": "preview",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "summary": "Universal contracts only. No install/check runtime closure is promised by this lane.",
   "runtime_ownership": {

--- a/dist/host-claude-code/manifest.json
+++ b/dist/host-claude-code/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "claude-code",
   "stability": "supported-with-constraints",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "summary": "Claude Code host adapter lane with bounded managed closure. The repo can write and verify a managed Claude settings surface, while still keeping broader host behavior outside repo ownership.",
   "runtime_ownership": {

--- a/dist/host-codex/manifest.json
+++ b/dist/host-codex/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "codex",
   "stability": "supported-with-constraints",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "summary": "Codex host adapter lane. Uses the official runtime entrypoints, but remains honest about host-managed plugin and credential surfaces.",
   "runtime_ownership": {

--- a/dist/host-cursor/manifest.json
+++ b/dist/host-cursor/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "cursor",
   "stability": "preview",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "summary": "Cursor host adapter preview. The repository can expose runtime-core payload and preview health checks, but does not claim full governed closure yet.",
   "runtime_ownership": {

--- a/dist/host-openclaw/manifest.json
+++ b/dist/host-openclaw/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "openclaw",
   "stability": "preview",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "summary": "OpenClaw host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/host-opencode/manifest.json
+++ b/dist/host-opencode/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "opencode",
   "stability": "preview",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "summary": "OpenCode host adapter preview. The repo can install runtime-core plus OpenCode-native command and agent wrapper payload into OpenCode roots, but final host config and platform closure remain incomplete.",
   "runtime_ownership": {

--- a/dist/host-windsurf/manifest.json
+++ b/dist/host-windsurf/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "windsurf",
   "stability": "preview",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "summary": "Windsurf host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/manifests/vibeskills-claude-code.json
+++ b/dist/manifests/vibeskills-claude-code.json
@@ -48,8 +48,8 @@
   },
   "summary": "Claude Code now has a bounded managed install/check lane that writes and verifies a Claude settings surface, but it still does not become the Codex official runtime or full platform-parity lane.",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-codex.json
+++ b/dist/manifests/vibeskills-codex.json
@@ -53,8 +53,8 @@
   },
   "summary": "Codex is the current strongest practical reference lane for the governed runtime payload, but some key surfaces remain host-managed and certain platforms are degraded.",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-core.json
+++ b/dist/manifests/vibeskills-core.json
@@ -46,8 +46,8 @@
   },
   "summary": "Host-agnostic contracts and schemas that stabilize skill metadata without claiming a governed runtime on any host.",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "truth_sources": [
     "docs/universalization/core-contract.md",

--- a/dist/manifests/vibeskills-cursor.json
+++ b/dist/manifests/vibeskills-cursor.json
@@ -50,8 +50,8 @@
   },
   "summary": "Cursor exposes preview adapter entrypoints and truthful readiness boundaries, but this repository does not claim governed or host-native closure for it.",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-generic.json
+++ b/dist/manifests/vibeskills-generic.json
@@ -45,8 +45,8 @@
   },
   "summary": "Generic hosts may consume canonical contracts and a repo-provided runtime-core payload in a neutral target root, but the repository still makes no host closure claim.",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-openclaw.json
+++ b/dist/manifests/vibeskills-openclaw.json
@@ -50,8 +50,8 @@
   },
   "summary": "OpenClaw may consume the shared runtime-core payload through a documented host root, but this repository does not claim host-native governed closure for it.",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-opencode.json
+++ b/dist/manifests/vibeskills-opencode.json
@@ -53,8 +53,8 @@
   },
   "summary": "OpenCode now has a truthful preview adapter lane with bounded install/check entrypoints, skills payload, and wrapper scaffolds, but the repository still avoids claiming full host closure or platform parity.",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-windsurf.json
+++ b/dist/manifests/vibeskills-windsurf.json
@@ -50,8 +50,8 @@
   },
   "summary": "Windsurf may consume the shared runtime-core payload through a documented host root, but this repository does not claim host-native governed closure for it.",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/official-runtime/manifest.json
+++ b/dist/official-runtime/manifest.json
@@ -4,8 +4,8 @@
   "lane_kind": "tier-1-official-runtime",
   "stability": "tier-1",
   "source_release": {
-    "version": "3.0.4",
-    "updated": "2026-04-19"
+    "version": "3.1.0",
+    "updated": "2026-04-25"
   },
   "summary": "Reference lane for the current governed official runtime. This dist pack points to it and must not rewrite it.",
   "runtime_ownership": {

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -10,7 +10,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ### Current Release Surface
 
-- [`v3.0.4.md`](v3.0.4.md): Windows verification gate Python resolution / direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair
+- [`v3.1.0.md`](v3.1.0.md): Phoenix release for unified `vibe` / `vibe-upgrade` public surfaces, structured host routing, bounded continuation, specialist truth gates, TDD applicability, install/runtime path hardening, and package metadata alignment
 
 ### Release Runtime / Proof Handoff
 
@@ -24,6 +24,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ## Recent Governed Releases
 
+- [`v3.1.0.md`](v3.1.0.md) - 2026-04-25 - unified public vibe surfaces / structured host routing / bounded continuation / specialist truth gates / TDD applicability / install-runtime path hardening / package metadata alignment
 - [`v3.0.4.md`](v3.0.4.md) - 2026-04-19 - Windows verification gate Python resolution / direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair
 - [`v3.0.3.md`](v3.0.3.md) - 2026-04-15 - host-global bootstrap lifecycle / specialist decision truth / upgrade metadata hardening / installed runtime payload coverage repair
 - [`v3.0.2.md`](v3.0.2.md) - 2026-04-13 - mainline upgrade flow / workspace memory plane / document artifact governance / specialist lifecycle disclosure / release truth refresh

--- a/docs/releases/v3.1.0.md
+++ b/docs/releases/v3.1.0.md
@@ -1,0 +1,112 @@
+# VCO Release v3.1.0
+
+- Date: 2026-04-25
+- Commit(base): 6d6630b
+- Previous public release: `v3.0.4`
+- Previous public release commit: `6c0b418`
+
+## Highlights
+
+- This is the Phoenix release for the governed Vibe runtime. The public surface is rebuilt around one canonical `vibe` entry, one public `vibe-upgrade` entry, and compatibility metadata that no longer leaks retired wrapper names into host-visible command surfaces.
+- The host now has a clearer operating contract: natural-language user intent should be interpreted by the host, converted into structured decisions, and then validated by the runtime. This avoids raw prompt keyword drift while keeping the runtime authoritative about stage state, bounded re-entry, and dispatch validity.
+- Requirement and plan boundaries are stricter and more honest. `vibe` is expected to stop at `requirement_doc`, stop again at `xl_plan`, and only continue when a later user message authorizes the next governed stage. Continuation context is preserved instead of reducing a complex task to a short approval word.
+- Specialist handling is no longer treated as a forced single-skill funnel. Host curation can approve, defer, or reject only surfaced specialists; no-specialist execution remains valid when no relevant skill exists; and stage assistants are kept out of user-facing specialist surfaces when they are only orchestration support.
+- Direct current-session specialist execution now has a stronger truth model. Routing, consultation, dispatch, attempted execution, executed units, blocked units, degraded units, and failed units are separated so a routed skill is not confused with work that actually ran.
+- TDD evidence no longer pollutes non-code work by default. Document, research, planning, and release tasks can explicitly record `not_applicable`, while real code tasks still keep the red/green evidence path available when the host or runtime freezes that obligation.
+- Windows and host install behavior were hardened across the release train: PowerShell diagnostics are clearer, UTF-8 and non-ASCII path handling is more robust, online configuration keys are hidden from install prompts, and runtime path checks reduce false confidence from stale installs.
+- `vibe-upgrade` remains public as a skill-based upgrade surface. Its job is to update the current host installation from the official upstream `main` line, not to pin users to a temporary PR branch after that branch has merged.
+- The repository release version and Python package metadata are aligned at `3.1.0`, so runtime governance, package metadata, release notes, and dist manifests advertise the same release line.
+
+## What Changed Since v3.0.4
+
+### Entry Surface And Wrapper Cleanup
+
+- Retired public exposure of legacy compatibility wrappers such as `vibe-what-do-i-want`, `vibe-how-do-we-do`, and `vibe-do-it`; these remain compatibility metadata only.
+- Unified host-facing wrapper naming so Codex and Claude Code do not maintain separate visible command families for the same stage concepts.
+- Preserved `vibe-upgrade` as the public self-update skill, with its default upstream target staying on the official repository `main` branch.
+- Clarified that bootstrap files such as `AGENTS.md` are entry surfaces only; canonical proof still requires a real `canonical-entry` launch and proof artifacts under the launched session root.
+
+### Bounded Stage Governance
+
+- Tightened progressive stop behavior so `vibe` pauses at requirement and plan boundaries rather than silently running through want/how/do-like stages in one assistant turn.
+- Hardened bounded re-entry with source-run validation, stable continuation context, and structured host approval payloads.
+- Fixed cases where continuation prompts were allowed to drag stale requirement text, workspace memory, or generic review framing into the next stage without enough host-side structure.
+- Added protection against missing or malformed local entry-surface config being silently replaced by canonical defaults when the repository has an explicit local surface.
+
+### Host-Led Routing And Planning
+
+- Moved the intended routing shape toward `user text -> host judgment -> structured decision -> runtime validation`.
+- Added host phase decomposition so complex tasks can be split into domain phases such as data search, modeling, evaluation, writing, verification, and publication without pretending a single primary skill must own the whole task.
+- Added bounded host specialist dispatch curation. The host can reject irrelevant surfaced skills, defer optional ones, or approve relevant ones without inventing unsurfaced specialists.
+- Allowed framework-only and no-specialist execution to remain normal. When the router has no suitable expert, the host should still decompose and execute the task instead of forcing noisy specialists into the plan.
+
+### Specialist Truth And Delivery Gates
+
+- Recorded current-session specialist handoff state explicitly so `direct_current_session_routed` does not masquerade as completed specialist work.
+- Added sidecar accounting for attempted, executed, degraded, blocked, and failed specialist units.
+- Preserved dictionary-backed runtime records in phase metadata paths so hashtable records do not lose fields such as `skill_id`, `native_skill_entrypoint`, or rationale during execution annotation.
+- Fixed failed specialist outcomes so `failed` and `failing` remain failed, not downgraded to generic blocked states.
+- Separated stage assistants from user-facing specialist recommendations to reduce the appearance that orchestration support skills were domain experts.
+
+### TDD And Artifact Review Discipline
+
+- Reduced false TDD gate pressure on documentation, research, planning, and release work.
+- Kept code-task TDD available as an explicit structured decision rather than a rigid keyword side effect.
+- Ensured artifact review, document baselines, and code-task TDD evidence remain separate truth layers so one kind of evidence does not block unrelated task types.
+
+### Install, Upgrade, And Cross-Host Runtime Parity
+
+- Clarified install docs and runtime path checks for Codex and Claude Code.
+- Kept online model/config keys out of install prompts and generated host surfaces.
+- Restored public `vibe-upgrade` host surfaces in skill form rather than relying on command-only wrappers.
+- Improved installed-runtime remapping and path validation so the live host install can be tied back to the correct source commit.
+- Kept Codex and Claude Code on the same runtime content model to reduce duplicated maintenance surfaces.
+
+### Windows Runtime Robustness
+
+- Hardened PowerShell startup diagnostics, shell quoting, and UTF-8 subprocess handling.
+- Improved router behavior around Windows path and encoding edge cases.
+- Avoided WindowsApps Python alias traps in verification flows by using governed Python resolution and clearer diagnostics.
+- Added more route and runtime tests around PowerShell structured decisions, hashtable handling, and Windows path comparisons.
+
+### Documentation And Positioning
+
+- Reframed the README around VibeSkills as a governed super-skill / harness model rather than a loose command pack.
+- Clarified quick start, install prompts, skill-plane extensibility, and the relationship between runtime governance and host-native skills.
+- Added contributor acknowledgement and updated Chinese / English README messaging to match the current public positioning.
+
+## Why This Is A Phoenix Release
+
+`v3.1.0` is not just a patch train. The runtime was rebuilt from several painful real-world failure modes:
+
+- Asking for one phase accidentally triggered later phases.
+- Routed skills appeared in plans even when they were irrelevant.
+- A skill could be routed without being materially used.
+- Research or writing tasks could be blocked by code-task TDD evidence.
+- Continuation could carry stale requirement, memory, or review wording into a new plan.
+- Codex and Claude Code could drift because they exposed different wrapper names or install surfaces.
+
+This release turns those failures into explicit contracts. The host gets more responsibility to understand the user and structure the decision; the runtime keeps authority over validation, proof, stage lineage, and completion language.
+
+## Validation Notes
+
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\governance\release-cut.ps1 -Version 3.1.0 -Updated 2026-04-25 -Preview -RunGates` -> preview succeeded and wrote `outputs/governance/preview/release-cut.json`.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\governance\release-cut.ps1 -Version 3.1.0 -Updated 2026-04-25` -> release governance files and dist manifests updated.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-version-consistency-gate.ps1` -> PASS, 10 assertions.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-release-notes-quality-gate.ps1` -> PASS.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-version-packaging-gate.ps1` -> PASS, 9 assertions.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-dist-manifest-gate.ps1` -> PASS.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-release-install-runtime-coherence-gate.ps1` -> PASS.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-config-parity-gate.ps1` -> PASS, 45 config pairs matched.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-bom-frontmatter-gate.ps1` -> PASS for canonical surfaces, with non-applicable bundled/installed surfaces skipped.
+- `python -m pytest tests/runtime_neutral/test_runtime_delivery_acceptance.py tests/runtime_neutral/test_structured_bounded_reentry_continuation.py tests/unit/test_canonical_vibe_entry_launcher.py -q` -> `107 passed`.
+- `python -m pytest tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py::NativeExecutionTopologyTests::test_public_vibe_defaults_to_requirement_confirmation_boundary -q` -> `17 passed`.
+- GitHub Actions for the release commit must pass before `v3.1.0` is treated as fully published.
+
+## Migration Notes
+
+- Hosts should use only `vibe` and `vibe-upgrade` as public Vibe entry skills. Legacy stage names should be treated as compatibility metadata, not visible commands.
+- Operators should expect `vibe` to pause at requirement and plan boundaries. This is intentional; it prevents accidental full-pipeline execution from a single ambiguous instruction.
+- If no relevant specialist exists, execution should continue host-led under governed `vibe` rather than forcing unrelated skills into the plan.
+- Release, documentation, and research tasks should not be blocked by code-task TDD unless a structured host or runtime decision explicitly marks the task as code-TDD-required.
+- Upgrade flows should pull from the official upstream `main` release line after merge; temporary PR branches are not long-lived upgrade targets.

--- a/packages/adapter-sdk/pyproject.toml
+++ b/packages/adapter-sdk/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-adapters"
-version = "3.0.0"
+version = "3.1.0"
 description = "Adapter SDK for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/contracts/pyproject.toml
+++ b/packages/contracts/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-contracts"
-version = "3.0.0"
+version = "3.1.0"
 description = "Authoritative contracts for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/installer-core/pyproject.toml
+++ b/packages/installer-core/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-installer"
-version = "3.0.0"
+version = "3.1.0"
 description = "Installer core for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/runtime-core/pyproject.toml
+++ b/packages/runtime-core/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-runtime"
-version = "3.0.0"
+version = "3.1.0"
 description = "Runtime core for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/skill-catalog/pyproject.toml
+++ b/packages/skill-catalog/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-skill-catalog"
-version = "3.0.0"
+version = "3.1.0"
 description = "Detached skill catalog package for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/verification-core/pyproject.toml
+++ b/packages/verification-core/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-verify"
-version = "3.0.0"
+version = "3.1.0"
 description = "Verification core for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vibe-skills-workspace"
-version = "3.0.0"
+version = "3.1.0"
 description = "Clean architecture workspace scaffold for Vibe-Skills"
 requires-python = ">=3.10"

--- a/references/changelog.md
+++ b/references/changelog.md
@@ -1,5 +1,14 @@
 # VCO Changelog
 
+## v3.1.0 (2026-04-25)
+
+- Rebuilt the public Vibe surface around one canonical `vibe` entry plus public `vibe-upgrade`, while demoting legacy want/how/do wrapper names to compatibility metadata only.
+- Tightened bounded stage governance so requirement and plan boundaries return control to the user, preserve structured continuation context, and avoid accidental full-pipeline execution.
+- Added host-led structured routing, phase decomposition, no-specialist execution, and bounded specialist curation so irrelevant router hits no longer have to pollute the plan.
+- Hardened specialist execution truth, TDD applicability, install/runtime path checks, Windows diagnostics, and package metadata alignment for the `3.1.0` release line.
+- Detailed release notes: `docs/releases/v3.1.0.md`.
+
+
 ## v3.0.4 (2026-04-19)
 
 - Refreshed `v3.0.4` from the later maintained source at `eeb09f3` so the public release surface now includes the Windows PowerShell verification-gate Python resolver hardening that landed after the original `2026-04-18` cut.

--- a/references/release-ledger.jsonl
+++ b/references/release-ledger.jsonl
@@ -33,3 +33,4 @@
 {"recorded_at":"2026-04-15T23:01:43","version":"3.0.3","updated":"2026-04-15","git_head":"537db3f","actor":null}
 {"recorded_at":"2026-04-18T13:34:12","version":"3.0.4","updated":"2026-04-18","git_head":"c0618d0","actor":null}
 {"recorded_at":"2026-04-19T04:28:17","version":"3.0.4","updated":"2026-04-19","git_head":"eeb09f3","actor":null}
+{"recorded_at":"2026-04-25T20:27:19","version":"3.1.0","updated":"2026-04-25","git_head":"6d6630b","actor":"羽裳"}


### PR DESCRIPTION
## Summary

Release Vibe Skills `3.1.0` from the current merged `main` baseline.

This cut is the Phoenix release for the governed runtime:
- unifies public host entry surfaces around `vibe` and `vibe-upgrade`
- tightens bounded requirement/plan continuation behavior
- records host-led structured routing and phase decomposition as the intended operating model
- hardens specialist truth gates, no-specialist execution, and TDD applicability boundaries
- updates release governance, dist manifests, release notes, changelog, ledger, and Python package metadata to `3.1.0`

## Verification

- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\governance\release-cut.ps1 -Version 3.1.0 -Updated 2026-04-25 -Preview -RunGates`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\governance\release-cut.ps1 -Version 3.1.0 -Updated 2026-04-25`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-version-consistency-gate.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-release-notes-quality-gate.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-version-packaging-gate.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-dist-manifest-gate.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-release-install-runtime-coherence-gate.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-config-parity-gate.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-bom-frontmatter-gate.ps1`
- `python -m pytest tests/runtime_neutral/test_runtime_delivery_acceptance.py tests/runtime_neutral/test_structured_bounded_reentry_continuation.py tests/unit/test_canonical_vibe_entry_launcher.py -q` -> `107 passed`
- `python -m pytest tests/runtime_neutral/test_governed_runtime_bridge.py tests/runtime_neutral/test_l_xl_native_execution_topology.py::NativeExecutionTopologyTests::test_public_vibe_defaults_to_requirement_confirmation_boundary -q` -> `17 passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 3.1.0 across all packages and governance configurations.
  * Updated version metadata and governance release records.

* **Documentation**
  * Added comprehensive v3.1.0 release documentation with highlights on public entry surfaces, routing improvements, continuation handling, specialist gating mechanisms, runtime hardening, and validation notes.
  * Updated changelog and release navigator for v3.1.0 availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->