### PR TITLE
Fix Claude Code vibe-upgrade routing

### DIFF
--- a/apps/vgo-cli/src/vgo_cli/main.py
+++ b/apps/vgo-cli/src/vgo_cli/main.py
@@ -72,6 +72,7 @@ def build_parser() -> argparse.ArgumentParser:
     canonical_entry_parser.add_argument('--bounded-reentry-token')
     canonical_entry_parser.add_argument('--host-decision-json')
     canonical_entry_parser.add_argument('--force-runtime-neutral', action='store_true')
+    canonical_entry_parser.add_argument('--allow-public-grade-flags', nargs='?', const='true', help=argparse.SUPPRESS)
     canonical_entry_parser.set_defaults(handler=canonical_entry_command)
 
     check_parser = subparsers.add_parser('check')

--- a/apps/vgo-cli/src/vgo_cli/upgrade_service.py
+++ b/apps/vgo-cli/src/vgo_cli/upgrade_service.py
@@ -24,6 +24,43 @@ def resolve_upgrade_repo_root(repo_root: Path) -> Path | None:
     return resolve_canonical_repo_root(repo_root)
 
 
+def prepare_managed_upgrade_repo_root(repo_root: Path, target_root: Path) -> Path | None:
+    if not (repo_root / 'config' / 'version-governance.json').exists():
+        return None
+
+    official_repo = get_official_self_repo_metadata(repo_root)
+    repo_url = str(official_repo.get('repo_url') or '').strip()
+    branch = str(official_repo.get('default_branch') or '').strip() or 'main'
+    canonical_root = str(official_repo.get('canonical_root') or '.').strip() or '.'
+    if not repo_url:
+        raise CliError('Official self repository URL is not configured in version-governance.json.')
+
+    checkout_root = target_root / '.vibeskills' / 'upgrade-source'
+    checkout_root.parent.mkdir(parents=True, exist_ok=True)
+    if (checkout_root / '.git').exists():
+        fetch_result = run_subprocess(['git', 'fetch', '--quiet', repo_url, branch], cwd=checkout_root)
+        if fetch_result.returncode != 0:
+            raise CliError(fetch_result.stderr.strip() or 'Failed to refresh managed upgrade source checkout.')
+    elif checkout_root.exists() and any(checkout_root.iterdir()):
+        raise CliError(
+            'Managed upgrade source path exists but is not a git checkout: '
+            f'{checkout_root}. Remove or rename it before running vibe-upgrade.'
+        )
+    else:
+        clone_result = run_subprocess(
+            ['git', 'clone', '--quiet', '--branch', branch, '--single-branch', repo_url, str(checkout_root)],
+            cwd=target_root,
+        )
+        if clone_result.returncode != 0:
+            raise CliError(clone_result.stderr.strip() or 'Failed to clone managed upgrade source checkout.')
+
+    candidate_root = (checkout_root / canonical_root).resolve()
+    resolved = resolve_canonical_repo_root(candidate_root)
+    if resolved is None:
+        raise CliError('Managed upgrade source checkout is missing config/version-governance.json.')
+    return resolved
+
+
 def load_recorded_install_status(repo_root: Path, target_root: Path, host_id: str) -> dict[str, object]:
     existing = load_upgrade_status(target_root)
     repo_remote = str(existing.get('repo_remote') or '').strip()
@@ -231,6 +268,8 @@ def upgrade_runtime(
     skip_runtime_freshness_gate: bool,
 ) -> dict[str, object]:
     resolved_repo_root = resolve_upgrade_repo_root(repo_root)
+    if resolved_repo_root is None:
+        resolved_repo_root = prepare_managed_upgrade_repo_root(repo_root, target_root)
     if resolved_repo_root is None:
         raise CliError(
             'Upgrade requires a canonical git checkout with config/version-governance.json. '

--- a/bundled/skills/vibe-upgrade/SKILL.md
+++ b/bundled/skills/vibe-upgrade/SKILL.md
@@ -1,34 +1,29 @@
 ---
 name: vibe-upgrade
-description: Upgrade the local Vibe-Skills installation to the latest official default-branch state while keeping canonical vibe as the only governed runtime.
+description: Upgrade the local Vibe-Skills installation to the latest official default-branch state.
 ---
 
-Use canonical `vibe` as the only governed runtime authority for this request.
+This is an upgrade operation, not a normal staged `vibe` task.
 
-Entry bias:
+Do not run the router for this entry. Do not relaunch this request as `entry_id = vibe`.
+Do not freeze a requirement document or execution plan for this entry.
+Do not invoke TDD, specialist dispatch, or delivery-acceptance gates unless the upgrade backend itself reports a verification failure.
 
-- upgrade the local Vibe-Skills installation for a supported host
-- use the official repository default branch only
-- run reinstall and verification through shared product pathways
+Run the shared upgrade backend for the current host installation, then verify and report the before/after install state.
+Use the installed runtime root as `--repo-root`; the backend will resolve or prepare the official default-branch source checkout when needed.
 
-Execution rules:
+PowerShell execution shape:
 
-- delegate to canonical `vibe`
-- keep `vibe` as the only runtime authority
-- do not create a second requirement surface
-- do not create a second plan surface
-- do not create a parallel runtime
-- do not preflight-scan the current workspace or repository for canonical proof files before launch
-- Launch canonical-entry first; validate receipts only after it returns a session root
-- do not upgrade from arbitrary remotes, branches, or filesystem roots
+```powershell
+# Set this to the host root that contains skills\vibe-upgrade\SKILL.md.
+$targetRoot = '<host-root>'
+$repoRoot = Join-Path $targetRoot 'skills\vibe'
+$env:PYTHONPATH = Join-Path $repoRoot 'apps\vgo-cli\src'
+py -3 -m vgo_cli.main upgrade --repo-root $repoRoot --host <host-id> --target-root $targetRoot --frontend powershell --profile full
+```
 
-When this wrapper is chosen, bias canonical `vibe` toward:
-
-- shared `vgo-cli upgrade` execution
-- overwrite-style upgrade for the selected supported host
-- post-upgrade verification and concise before/after reporting
-
-If invoked with no arguments, default the request to upgrading the current host installation through shared `vgo-cli upgrade` and verifying the result.
+If the request is empty, default to upgrading the current host installation through shared `vgo-cli upgrade` and verify the result.
+If the backend fails, report the exact backend error and do not fall back to ordinary `vibe` routing.
 
 Request:
 $ARGUMENTS

--- a/packages/installer-core/src/vgo_installer/discoverable_wrappers.py
+++ b/packages/installer-core/src/vgo_installer/discoverable_wrappers.py
@@ -48,6 +48,49 @@ def _wrapper_contract(host_id: str) -> dict[str, object]:
 
 
 def _body_lines(host_id: str, entry: DiscoverableEntry, *, contract: dict[str, object]) -> list[str]:
+    if entry.id == "vibe-upgrade":
+        normalized_host_id = str(contract.get("host_id") or (host_id or "").strip().lower())
+        upgrade_payload = {
+            "schema": "vibe-upgrade-skill/v1",
+            "entry_id": entry.id,
+            "operation": "upgrade_current_host_installation",
+            "host_id": normalized_host_id,
+            "backend": "vgo-cli upgrade",
+            "official_default_branch_only": True,
+            "bypass_vibe_router": True,
+        }
+        upgrade_json = json.dumps(upgrade_payload, ensure_ascii=False, indent=2)
+        return [
+            "Installer-managed upgrade skill contract:",
+            "```json",
+            upgrade_json,
+            "```",
+            "",
+            f"Wrapper entry: {entry.display_name} (`{entry.id}`)",
+            "This is an upgrade operation, not a normal staged `vibe` task.",
+            "Do not run the router for this entry.",
+            "Do not relaunch this request as `entry_id = vibe`.",
+            "Do not freeze a requirement document or execution plan for this entry.",
+            "Do not invoke TDD, specialist dispatch, or delivery-acceptance gates for this entry unless the upgrade backend itself reports a verification failure.",
+            "Run the shared upgrade backend for the current host installation, then verify and report the before/after install state.",
+            "Use the installed runtime root as `--repo-root`; the backend will resolve or prepare the official default-branch source checkout when needed.",
+            "",
+            "PowerShell execution shape:",
+            "```powershell",
+            "# Set this to the host root that contains skills\\vibe-upgrade\\SKILL.md.",
+            "$targetRoot = '<host-root>'",
+            "$repoRoot = Join-Path $targetRoot 'skills\\vibe'",
+            "$env:PYTHONPATH = Join-Path $repoRoot 'apps\\vgo-cli\\src'",
+            f"py -3 -m vgo_cli.main upgrade --repo-root $repoRoot --host {normalized_host_id} --target-root $targetRoot --frontend powershell --profile full",
+            "```",
+            "",
+            "If the request is empty, default to upgrading the current host installation through shared `vgo-cli upgrade` and verify the result.",
+            "If the backend fails, report the exact backend error and do not fall back to ordinary `vibe` routing.",
+            "",
+            "Request:",
+            "$ARGUMENTS",
+        ]
+
     grade_line = "yes" if entry.allow_grade_flags else "no"
     stop_stage = entry.requested_stage_stop
     progressive_stop_sequence = [stage for stage in entry.progressive_stage_stops if stage]

--- a/tests/unit/test_discoverable_wrappers.py
+++ b/tests/unit/test_discoverable_wrappers.py
@@ -44,7 +44,13 @@ def test_build_wrapper_descriptors_renders_all_discoverable_entries_for_codex() 
     assert 'Wrapper labels only select the bounded terminal stage.' in rendered['vibe'].content
     assert 'name: vibe-upgrade' in rendered['vibe-upgrade'].content
     assert 'Wrapper entry: Vibe: Upgrade (`vibe-upgrade`)' in rendered['vibe-upgrade'].content
+    assert '"schema": "vibe-upgrade-skill/v1"' in rendered['vibe-upgrade'].content
     assert '"entry_id": "vibe-upgrade"' in rendered['vibe-upgrade'].content
+    assert '"bypass_vibe_router": true' in rendered['vibe-upgrade'].content
+    assert 'Do not run the router for this entry.' in rendered['vibe-upgrade'].content
+    assert 'Do not relaunch this request as `entry_id = vibe`.' in rendered['vibe-upgrade'].content
+    assert 'Do not freeze a requirement document or execution plan for this entry.' in rendered['vibe-upgrade'].content
+    assert '--host codex' in rendered['vibe-upgrade'].content
     assert 'default to upgrading the current host installation' in rendered['vibe-upgrade'].content
 
 
@@ -74,6 +80,8 @@ def test_build_wrapper_descriptors_renders_skill_wrappers_for_skill_only_hosts()
     assert '$ARGUMENTS' in rendered['vibe'].content
     assert 'name: vibe-upgrade' in rendered['vibe-upgrade'].content
     assert 'Wrapper entry: Vibe: Upgrade (`vibe-upgrade`)' in rendered['vibe-upgrade'].content
+    assert 'Do not run the router for this entry.' in rendered['vibe-upgrade'].content
+    assert '--host claude-code' in rendered['vibe-upgrade'].content
 
 
 def test_build_wrapper_descriptors_renders_upgrade_as_skill_for_command_hosts() -> None:
@@ -88,6 +96,7 @@ def test_build_wrapper_descriptors_renders_upgrade_as_skill_for_command_hosts() 
     assert rendered['vibe-upgrade'].relpath.as_posix() == 'skills/vibe-upgrade/SKILL.md'
     assert 'name: vibe-upgrade' in rendered['vibe-upgrade'].content
     assert 'Wrapper entry: Vibe: Upgrade (`vibe-upgrade`)' in rendered['vibe-upgrade'].content
+    assert 'vgo_cli.main upgrade' in rendered['vibe-upgrade'].content
 
 
 def test_build_wrapper_descriptors_fails_closed_when_canonical_contract_is_unresolved(monkeypatch) -> None:

--- a/tests/unit/test_vgo_cli_commands.py
+++ b/tests/unit/test_vgo_cli_commands.py
@@ -270,6 +270,24 @@ def test_build_parser_includes_canonical_entry_subcommand() -> None:
     assert args.entry_id == 'vibe'
 
 
+def test_build_parser_accepts_legacy_wrapper_metadata_flag_for_canonical_entry() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            'canonical-entry',
+            '--repo-root',
+            '/tmp/repo',
+            '--prompt',
+            'enter canonical vibe',
+            '--allow-public-grade-flags',
+            'false',
+        ]
+    )
+
+    assert args.command == 'canonical-entry'
+    assert args.allow_public_grade_flags == 'false'
+
+
 def test_install_command_skips_external_dependency_install_when_strict_offline(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/test_vgo_cli_upgrade_service.py
+++ b/tests/unit/test_vgo_cli_upgrade_service.py
@@ -403,6 +403,129 @@ def test_resolve_upgrade_repo_root_does_not_fall_back_to_unrelated_cwd_repo(
     assert upgrade_service.resolve_upgrade_repo_root(repo_root) is None
 
 
+def test_prepare_managed_upgrade_repo_root_clones_official_source_for_installed_runtime(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    installed_runtime = tmp_path / "target" / "skills" / "vibe"
+    (installed_runtime / "config").mkdir(parents=True)
+    (installed_runtime / "config" / "version-governance.json").write_text(
+        '{"source_of_truth":{"official_self_repo":{"repo_url":"https://example.test/Vibe-Skills.git","default_branch":"main"}}}\n',
+        encoding="utf-8",
+    )
+    target_root = tmp_path / "target"
+    commands: list[list[str]] = []
+
+    def fake_run_subprocess(command: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        if command[:2] == ["git", "clone"]:
+            checkout_root = Path(command[-1])
+            (checkout_root / ".git").mkdir(parents=True)
+            (checkout_root / "config").mkdir()
+            (checkout_root / "config" / "version-governance.json").write_text("{}\n", encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(upgrade_service, "run_subprocess", fake_run_subprocess)
+
+    resolved = upgrade_service.prepare_managed_upgrade_repo_root(installed_runtime, target_root)
+
+    assert resolved == (target_root / ".vibeskills" / "upgrade-source").resolve()
+    assert commands == [
+        [
+            "git",
+            "clone",
+            "--quiet",
+            "--branch",
+            "main",
+            "--single-branch",
+            "https://example.test/Vibe-Skills.git",
+            str(target_root / ".vibeskills" / "upgrade-source"),
+        ]
+    ]
+
+
+def test_upgrade_runtime_uses_managed_source_when_started_from_installed_runtime(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
+
+    installed_runtime = tmp_path / "target" / "skills" / "vibe"
+    installed_runtime.mkdir(parents=True)
+    target_root = tmp_path / "target"
+    managed_source = target_root / ".vibeskills" / "upgrade-source"
+    managed_source.mkdir(parents=True)
+    steps: list[str] = []
+    recorded: dict[str, object] = {}
+
+    monkeypatch.setattr(upgrade_service, "resolve_upgrade_repo_root", lambda path: None)
+    monkeypatch.setattr(
+        upgrade_service,
+        "prepare_managed_upgrade_repo_root",
+        lambda repo_root_arg, target_root_arg: managed_source,
+    )
+
+    def fake_load_recorded_install_status(repo_root_arg: Path, target_root_arg: Path, host_id: str) -> dict[str, object]:
+        recorded["repo_root"] = repo_root_arg
+        return {
+            "installed_version": "3.0.4",
+            "installed_commit": "old-install",
+            "repo_remote": "https://github.com/foryourhealth111-pixel/Vibe-Skills.git",
+            "repo_default_branch": "main",
+        }
+
+    monkeypatch.setattr(upgrade_service, "load_recorded_install_status", fake_load_recorded_install_status)
+    monkeypatch.setattr(upgrade_service, "has_recorded_install_truth", lambda status: True)
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_upstream_status",
+        lambda repo_root_arg, target_root_arg, status, **kwargs: {
+            **status,
+            "remote_latest_version": "3.1.0",
+            "remote_latest_commit": "new-install",
+            "update_available": True,
+        },
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "reset_repo_to_official_head",
+        lambda repo_root_arg, branch, target_commit=None: steps.append(f"reset:{repo_root_arg}:{target_commit}"),
+    )
+    monkeypatch.setattr(upgrade_service, "reinstall_runtime", lambda **kwargs: steps.append("reinstall"))
+    monkeypatch.setattr(
+        upgrade_service,
+        "run_upgrade_check",
+        lambda **kwargs: (steps.append("check") or subprocess.CompletedProcess(args=["check"], returncode=0, stdout="", stderr="")),
+    )
+    monkeypatch.setattr(
+        upgrade_service,
+        "refresh_installed_status",
+        lambda repo_root_arg, target_root_arg, host_id, **kwargs: {
+            "installed_version": "3.1.0",
+            "installed_commit": "new-install",
+        },
+    )
+
+    result = upgrade_service.upgrade_runtime(
+        repo_root=installed_runtime,
+        target_root=target_root,
+        host_id="claude-code",
+        profile="full",
+        frontend="powershell",
+        install_external=False,
+        strict_offline=False,
+        require_closed_ready=False,
+        allow_external_skill_fallback=False,
+        skip_runtime_freshness_gate=False,
+    )
+
+    assert recorded["repo_root"] == managed_source
+    assert steps == [f"reset:{managed_source}:new-install", "reinstall", "check"]
+    assert result["changed"] is True
+    assert result["after"]["installed_version"] == "3.1.0"
+
+
 def test_upgrade_runtime_raises_clear_error_when_no_canonical_git_repo_exists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     upgrade_service = importlib.import_module("vgo_cli.upgrade_service")
 


### PR DESCRIPTION
## Summary
- make `vibe-upgrade` a hard upgrade skill surface instead of a normal staged `vibe` routing wrapper
- let `vgo-cli upgrade` start from an installed runtime root and prepare a managed official default-branch source checkout when no git checkout is present
- accept legacy `--allow-public-grade-flags` metadata on `canonical-entry` so old generated wrappers do not fail at argument parsing

## Why
Claude Code reads skill files as model-executed instructions. The previous `vibe-upgrade` wrapper looked like a normal canonical `vibe` trampoline, so Claude could route it back through `entry_id=vibe`, stop at `requirement_doc`, and trigger unrelated TDD/specialist routing. This PR makes upgrade intent explicit and keeps the shared backend responsible for the actual install refresh.

## Verification
- `python -m pytest tests/unit/test_vgo_cli_upgrade_service.py tests/unit/test_vgo_cli_commands.py tests/unit/test_discoverable_wrappers.py -q` -> 37 passed
- `git diff --check` -> pass
- PowerShell temp Claude install generated hard `vibe-upgrade` wrapper with no-router / no-entry_id-vibe instructions
- PowerShell temp Claude upgrade from installed runtime root -> already current at 3.1.0@ff6175072a846e8eb24b25668d8b06e885bdf081
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-bom-frontmatter-gate.ps1` -> PASS
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-version-packaging-gate.ps1` -> PASS
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-release-install-runtime-coherence-gate.ps1` -> PASS

## Known local limitation
- Bash-backed runtime-neutral install tests failed locally before assertions with exit 127 / GBK decode noise in this Windows shell. The PowerShell install and upgrade paths were verified directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgrade service now supports managed repository fallback, automatically creating a checkout when the provided repository cannot be resolved.
  * Enhanced upgrade workflow with improved error handling and backend validation.

* **Documentation**
  * Updated upgrade skill documentation to clarify its role as a dedicated upgrade operation.

* **Tests**
  * Added comprehensive unit test coverage for upgrade service and CLI functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->