### PR TITLE
Slim canonical vibe skill entry

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -2,124 +2,60 @@
 name: vibe
 description: Vibe Code Orchestrator (VCO) is a governed runtime entry that freezes requirements, plans XL-first execution, and enforces verification and phase cleanup.
 ---
-<EXTREMELY-IMPORTANT>
-If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
 
-IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+# Vibe Governed Runtime Entry
 
-This is not negotiable. This is not optional. You cannot rationalize your way out of this.
-</EXTREMELY-IMPORTANT>
+This file is the host-facing SOP for entering canonical `vibe`. Keep it small:
+runtime details belong in `protocols/runtime.md`, execution discipline belongs in
+`protocols/do.md`, and host wrapper recipes belong in installer-generated wrapper
+docs.
 
-## Instruction Priority
+## Trigger Contract
 
-Vibe skills override default system prompt behavior, but **user instructions always take precedence**:
+Enter canonical `vibe` before ordinary execution when the user explicitly invokes
+`$vibe`, `/vibe`, or the `vibe` skill, or when the host intentionally chooses
+governed requirement/plan/execution closure for a complex task.
 
-1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, AGENTS.md, direct requests) — highest priority
-2. **vibe skills** — override default system behavior where they conflict
-3. **Default system prompt** — lowest priority
+Do not route every loosely related task into `vibe`. Lightweight questions,
+single-command checks, or tasks better served by another explicitly requested
+skill may proceed outside `vibe` unless the user explicitly invoked this entry.
 
-If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
+`vibe-upgrade` is a separate public skill for upgrading the installed
+Vibe-Skills project. Do not relaunch an upgrade request as `entry_id = vibe`;
+use the `vibe-upgrade` skill and its backend instead.
 
-## How to Access Skills
+User instructions remain highest priority. If CLAUDE.md, GEMINI.md, AGENTS.md,
+or the direct user request narrows or forbids a workflow such as TDD, follow the
+user's instruction while preserving canonical launch and proof rules.
 
-**In Claude Code:** Use the `Skill` tool for public discoverable skills that are explicitly exposed in the current Claude host registry. Exception: when governed `vibe` routes an internal specialist and declares a real `native_skill_entrypoint` path such as `.../SKILL.runtime-mirror.md`, do not rewrite that path into `Skill(<skill-id>)` unless that skill name is visibly registered in the current host session. In that case the disclosed `native_skill_entrypoint` path is the source of truth for same-session specialist loading, and reading that declared path is allowed.
+## Canonical Launch SOP
 
-**In Copilot CLI:** Use the `skill` tool. Skills are auto-discovered from installed plugins. The `skill` tool works the same as Claude Code's `Skill` tool.
+Before canonical launch, do only the minimum needed to launch:
 
-**In Gemini CLI:** Skills activate via the `activate_skill` tool. Gemini loads skill metadata at session start and activates the full content on demand.
+- Resolve `skill_root`: the directory containing this `SKILL.md`.
+- Resolve `workspace_root`: the task workspace where governed artifacts should
+  be written.
+- Resolve `host_id`: `codex`, `claude-code`, `cursor`, `windsurf`, `openclaw`,
+  or `opencode`.
+- Extract core intent as keyword text. Do not pass the raw prompt, full chat
+  history, or mixed-language filler to the router.
 
-**In OpenCode:** Use the `skill` tool. OpenCode natively supports skills from `.claude/skills/`, `.opencode/skills/`, and `.agents/skills/`. Invoke via `skill({ name: "skill-name" })`.
-
-**In other environments:** Check your platform's documentation for how skills are loaded.
-
-
-## Red Flags
-
-These thoughts mean STOP—you're rationalizing:
-
-| Thought | Reality |
-|---------|---------|
-| "This is just a simple question" | Questions are tasks. Check for skills. |
-| "I need more context first" | Skill check comes BEFORE clarifying questions. |
-| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
-| "I can check git/files quickly" | Files lack conversation context. Check for skills. |
-| "Let me gather information first" | Skills tell you HOW to gather information. |
-| "This doesn't need a formal skill" | If a skill exists, use it. |
-| "I remember this skill" | Skills evolve. Read current version. |
-| "This doesn't count as a task" | Action = task. Check for skills. |
-| "The skill is overkill" | Simple things become complex. Use it. |
-| "I'll just do this one thing first" | Check BEFORE doing anything. |
-| "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
-| "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
-
-
-# Vibe Governed Runtime
-
-## Mandatory Router Invocation With Intent Optimization
-
-When AI activates (reads and acts on) the `vibe` skill, AI MUST call the canonical
-router before entering any governed runtime stage. This is not an automatic trigger --
-it is a mandatory self-discipline requirement.
+Do not inspect repository files, protocol docs, previous run outputs, or old
+proof artifacts before canonical launch returns. Reading this file, a wrapper,
+or an AGENTS/CLAUDE bootstrap block is not proof of canonical entry.
 
 Canonical router: `scripts/router/resolve-pack-route.ps1`
 
-### Router Input: Extract Core Intent as Keyword Text
+Router input rules:
 
-When calling the router, AI must NOT pass the raw user prompt, language mix, or full
-context. Instead, AI must extract and distill the core intent into a structured keyword
-text block. This improves router intent hit rate.
+- Include work type, domain/technology, deliverable, and explicit constraints.
+- Reuse verified frozen requirement/plan facts when continuing a run.
+- If the router returns `confirm_required`, surface the machine-readable route
+  contract and convert the user's natural-language reply into a structured route
+  decision.
+- If the router fails, report `blocked` with the concrete failure reason.
 
-Prompt extraction rules:
-1. Extract nouns/verbs that describe the WORK TYPE (e.g., "refactor", "debug", "plan", "review", "research", "implement")
-2. Extract nouns that describe the DOMAIN/TECHNOLOGY (e.g., "typescript", "react", "database", "api")
-3. Extract nouns that describe the DELIVERABLE (e.g., "feature", "fix", "migration", "documentation")
-4. Remove filler language, politeness, meta-commentary, and system-level framing
-5. If the user gave explicit constraints or requirements, encode them as keyword tags
-
-Bad example (raw prompt passed through):
-"Hi! I've been working on a React project lately and sometimes I encounter some performance issues, like component re-rendering problems. Could you help me analyze and give optimization suggestions? Thank you so much!"
-
-Good example (keyword text extracted):
-"debug performance-react component-re-render optimization analysis coding typescript react"
-
-Required router call steps at vibe entry:
-1. Extract core intent as keyword text (do NOT pass raw prompt)
-2. Call router with extracted keyword text
-3. If route_mode == "confirm_required", present confirm surface to user
-4. If router returns hazard alert or fallback_active, surface it explicitly
-5. If router call fails, report "blocked" with failure reason -- do NOT continue
-
-The fact that the router may internally enter "auto_route" mode does NOT mean the
-router was skipped. The router was called and made that decision. AI must invoke
-it explicitly every time.
-
-### Continuation-Aware Router Input
-
-When continuing a prior run that records a legacy compatibility entry ID such as
-`vibe-what-do-i-want`, `vibe-how-do-we-do`, or `vibe-do-it`, do not pretend this is a brand-new task if the same thread
-already has a verified governed requirement or plan. These IDs are retained as non-public compatibility metadata, not as host-visible public entries.
-
-Continuation rules:
-1. Reuse the latest verified frozen requirement/plan from the same thread or workspace as continuation context when it exists.
-2. Build the router keyword text from the frozen goal, deliverable, constraints, and capability hints plus the current delta, not from a bare summary such as `execute plan`.
-3. Treat previously frozen requirement/plan facts as authoritative context for deliverable, constraints, and capability coverage.
-4. Reopen generic clarification only when the user changed scope, the frozen artifacts are missing, or the prior artifacts are clearly stale or mismatched.
-
-Bad continuation example:
-`execute plan facial-recognition phase-cleanup`
-
-Better continuation example:
-`execute governed-plan facial-recognition dataset-download literature-review few-shot-modeling training evaluation latex-paper gpu-aware constraints-public-dataset deliverable-report-and-paper`
-
-## Canonical Bootstrap
-
-Bootstrap sequence (run canonical launch before reading repo files, protocol docs, or writing any artifact):
-
-1. Resolve `skill_root` (directory containing this `SKILL.md`) and `workspace_root` (current task working root; governed artifacts go here when working outside the Vibe installation).
-2. Resolve host adapter id: `codex` in Codex, `claude-code` in Claude Code, `cursor` in Cursor, `windsurf` in Windsurf, `openclaw` in OpenClaw, `opencode` in OpenCode.
-3. Launch the proof-complete canonical entry.
-
-Windows PowerShell launch (primary):
+Canonical entry command shape:
 
 ```powershell
 $env:PYTHONPATH = "<skill_root>/apps/vgo-cli/src"
@@ -131,26 +67,51 @@ py -3 -m vgo_cli.main canonical-entry `
   --prompt "<extracted keyword intent text>"
 ```
 
-If `py -3` is unavailable, try `python` instead.
-
-If you are in Claude Code or another Bash-like tool surface, prefer the Bash-safe form instead of wrapping PowerShell:
+Bash-like hosts, including Claude Code, should avoid Bash-wrapped PowerShell.
+Set `PYTHONPATH` in the outer shell and call Python directly:
 
 ```bash
 REPO_ROOT='<skill_root>'
+WORKSPACE_ROOT="${WORKSPACE_ROOT:-$PWD}"
 PYTHONPATH="$REPO_ROOT/apps/vgo-cli/src" py -3 -m vgo_cli.main canonical-entry \
   --repo-root "$REPO_ROOT" \
-  --artifact-root "<workspace_root>" \
+  --artifact-root "$WORKSPACE_ROOT" \
   --host-id "<host_id>" \
   --entry-id "vibe" \
   --prompt "<extracted keyword intent text>"
 ```
 
-For bounded re-entry with a structured host decision, write the decision to a file and pass `--host-decision-json-file`:
+After canonical-entry returns a `session_root`, validate proof artifacts only
+inside that launched session:
+
+- `host-launch-receipt.json`
+- `runtime-input-packet.json`
+- `governance-capsule.json`
+- `stage-lineage.json`
+
+## Bounded Stop And Re-entry
+
+`vibe` uses progressive governed stops:
+
+1. `requirement_doc`
+2. `xl_plan`
+3. `phase_cleanup`
+
+When `bounded_return_control.explicit_user_reentry_required = true`, stop the
+current assistant turn. Do not consume re-entry credentials until a later user
+message approves or revises the current boundary.
+
+For re-entry, inspect `runtime-summary.json ->
+bounded_return_control.host_decision_contract`, infer the user's intent, and
+write a structured host decision JSON file. Use the same `run_id`,
+`bounded_reentry_token`, and stable `workspace_root`:
 
 ```bash
 REPO_ROOT='<skill_root>'
-DECISION_JSON="<workspace_root>/.vibeskills/tmp/host-decision.json"
+WORKSPACE_ROOT="${WORKSPACE_ROOT:-$PWD}"
+DECISION_JSON="$WORKSPACE_ROOT/.vibeskills/tmp/host-decision.json"
 mkdir -p "$(dirname "$DECISION_JSON")"
+
 cat > "$DECISION_JSON" <<'JSON'
 {
   "decision_kind": "approval_response",
@@ -161,16 +122,18 @@ JSON
 
 PYTHONPATH="$REPO_ROOT/apps/vgo-cli/src" py -3 -m vgo_cli.main canonical-entry \
   --repo-root "$REPO_ROOT" \
-  --artifact-root "<workspace_root>" \
+  --artifact-root "$WORKSPACE_ROOT" \
   --host-id "<host_id>" \
   --entry-id "vibe" \
-  --prompt "continue approved governed requirement with prior task context" \
+  --prompt "<stable continuation intent, not just the user's short reply>" \
   --continue-from-run-id "<source_run_id>" \
   --bounded-reentry-token "<reentry_token>" \
   --host-decision-json-file "$DECISION_JSON"
 ```
 
-For a host-inferred revision, do not ask the user to approve first. Keep the same re-entry credentials, use the current bounded stage's revise action, and include a non-empty `revision_delta`. The runtime validates this as a same-stage refreeze instead of advancing:
+A structured approval advances to the next progressive stop. A structured
+revision must include non-empty `revision_delta` and refreezes the same bounded
+stage without asking the user for a separate approval first:
 
 ```json
 {
@@ -184,196 +147,87 @@ For a host-inferred revision, do not ask the user to approve first. Keep the sam
 }
 ```
 
-If you must invoke PowerShell through a Bash-like tool surface, do not place `$env:PYTHONPATH=...` inside a double-quoted `-Command` string. The outer shell can expand `$env` first and corrupt it to `:PYTHONPATH`, leaving `PYTHONPATH` unset and causing `ModuleNotFoundError: No module named 'vgo_cli'`. In that situation, either set `PYTHONPATH=...` in the outer shell before invoking `py -3 -m ...`, or single-quote / escape the PowerShell payload so `$env:` reaches PowerShell literally.
+Route confirmations must stay inside surfaced confirm options. Bounded approvals
+or revisions must stay inside the surfaced bounded-stage action contract.
 
-Public discoverable entries still enter canonical `vibe`; only the bounded stop contract changes:
-- `vibe` uses progressive governed stops: first `requirement_doc`, then `xl_plan`, then `phase_cleanup` after explicit re-entry approval at each boundary
-- `vibe-upgrade` is the public governed upgrade entry.
-- compatibility stage IDs are non-public and must not be materialized as host-visible command or skill wrappers: `vibe-what-do-i-want` -> `requirement_doc`, `vibe-how-do-we-do` -> `xl_plan --requested-grade-floor XL`, `vibe-do-it` -> `phase_cleanup`
+## Runtime Contract Summary
 
-Hard rules:
-- Do not inspect the repo, protocol docs, or prior run outputs before canonical launch returns, except to resolve `skill_root` and current host id.
-- Do not use the Vibe installation root as the governed artifact root when the user asked you to work in another workspace or repository.
-- Do not manually create `outputs/runtime/vibe-sessions/<run-id>/`, `docs/requirements/`, or `docs/plans/` as a substitute for launch.
-- Do not search the current workspace, repository, or install root for canonical proof files before launch; those artifacts are emitted by canonical-entry after the run session is created.
-- Only validate canonical proof artifacts after canonical-entry returns a `session_root`, and only against that launched session root.
-- Do not simulate stages, claim canonical entry from reading this file or wrapper text, or silently continue if canonical launch fails -- report `blocked` with the concrete failure reason.
+Canonical `vibe` owns one runtime authority and one visible requirement/plan
+surface. The fixed state machine is:
 
-Proof of canonical launch is post-launch and requires: `host-launch-receipt.json`, `runtime-input-packet.json`, `governance-capsule.json`, and `stage-lineage.json` under the returned `session_root`.
+1. `skeleton_check`
+2. `deep_interview`
+3. `requirement_doc`
+4. `xl_plan`
+5. `plan_execute`
+6. `phase_cleanup`
 
-`vibe` is a host-syntax-neutral skill contract. `/vibe`, `$vibe`, and agent-invoked `vibe` all mean the same thing: enter the same governed runtime.
+These stages may be light for simple work, but they are not silently skipped.
+The full runtime contract, stage ownership, lineage rules, internal `M`/`L`/`XL`
+grades, cleanup rules, and output inventory are defined in
+`protocols/runtime.md`.
 
-## Unified Runtime Contract
+Public wrapper entries remain limited to:
 
-`vibe` always runs the same 6-stage state machine:
+- `vibe`
+- `vibe-upgrade`
 
-1. `skeleton_check` -- verify repo shape, prerequisites, and existing artifacts
-2. `deep_interview` -- clarify intent and infer constraints
-3. `requirement_doc` -- freeze the single requirement source under `docs/requirements/`
-4. `xl_plan` -- write execution plan under `docs/plans/`
-5. `plan_execute` -- execute from the frozen plan
-6. `phase_cleanup` -- cleanup temp artifacts, write receipts, delivery-acceptance report
+Compatibility stage IDs are non-public metadata and must not be materialized as
+host-visible command or skill wrappers:
 
-These stages are mandatory. They may become lighter for simple work, but they are not skipped as a matter of policy.
-
-Runtime mode: only `interactive_governed` is supported. The system asks high-value questions, confirms frozen requirements, and pauses at plan approval boundaries.
-
-If a canonical run returns `bounded_return_control.explicit_user_reentry_required = true`, stop in the current assistant turn and hand control back to the user. Do not consume the returned re-entry credentials until a later user message explicitly approves or revises the frozen requirement/plan boundary.
-
-Structured host decision SOP:
-- Do not ask the user to repeat magic words such as `approve`, `continue`, `1`, or `enter unattended mode` just to satisfy routing or bounded re-entry.
-- For complex or obviously multi-part work, the host should decompose the task into execution phases before launch. Keep that decomposition inside `--host-decision-json -> phase_decomposition` so canonical `vibe` can freeze it under the single requirement/plan surface. Do not create a second runtime, second requirement doc, or second plan.
-- If the surfaced specialist set needs curation, keep it inside `--host-decision-json -> specialist_dispatch_decision`. Host curation stays bounded to the surfaced recommendation ids from the current governed run; do not invent unsurfaced specialists or bypass runtime validation.
-- For routing confirmation, inspect the returned machine-readable route contract under `runtime-summary.json -> host_user_briefing.route_decision_contract` when present. Convert the user's natural-language reply into a structured route decision and relaunch canonical `vibe` with `--host-decision-json` or `--host-decision-json-file`.
-- For bounded stage re-entry, inspect `runtime-summary.json -> bounded_return_control.host_decision_contract` when present. Convert the user's natural-language approval or revision into a structured decision and relaunch canonical `vibe` with `--host-decision-json-file` when the host tool surface is Bash-like, plus `--continue-from-run-id` and `--bounded-reentry-token`.
-- A structured approval advances to the next progressive stop. A structured revision must include `revision_delta` and refreezes the same bounded stage (`requirement_doc` or `xl_plan`) without asking the user for a separate approval first.
-- Route decisions must stay inside the surfaced confirm options. Bounded stage approvals must stay inside the surfaced approval action contract. Specialist curation must stay inside the surfaced specialist recommendation ids. Runtime validation remains authoritative.
-- Keep the task context stable across re-entry. Do not reduce the next canonical launch prompt to the user's short approval text alone when the governed task context is already known.
-
-Public wrapper entries remain limited to `vibe` and `vibe-upgrade`.
-Non-public compatibility stage metadata may request an earlier terminal stage (that changes where a legacy run stops, not which runtime owns authority):
 - `vibe-what-do-i-want` -> `requirement_doc`
 - `vibe-how-do-we-do` -> `xl_plan`
-- `vibe` progresses through `requirement_doc -> xl_plan -> phase_cleanup`
 - `vibe-do-it` -> `phase_cleanup`
 
-Official governed entry records lineage:
-- root or child entry writes `governance-capsule.json`
-- each validated stage transition appends `stage-lineage.json`
-- child-governed startup validates inherited context through `delegation-envelope.json`
+## Specialist Dispatch
 
-The user does not choose between `M`, `L`, or `XL` as entry branches. Those grades exist only as internal execution strategy; only `--l` and `--xl` are allowed as lightweight public grade-floor overrides.
+The router may surface specialist recommendations, but `vibe` remains the
+runtime-selected skill and runtime authority.
 
-## Governor And Specialist Contract
+The host must inspect surfaced specialist recommendations and make a structured
+dispatch decision when curation is needed. It may approve, defer, or reject only
+surfaced recommendation ids. Unsuitable or noisy specialists should be rejected
+or deferred with a reason rather than forced into execution.
 
-`vibe` owns runtime authority even when the canonical router surfaces a specialist skill.
+Only approved specialists become execution units. The host must not invent
+unsurfaced specialists, bypass runtime validation, create hidden specialist
+sub-sessions, or open a second requirement/plan/runtime surface. Specialist work
+must preserve the specialist skill's own workflow, inputs, outputs, and
+validation style.
 
-That means:
-- governed `vibe` runs must surface bounded specialist recommendations and treat router-selected specialist skills as route truth or executable recommendation candidates
-- direct specialist handling should stay in the current host session by default; do not create hidden specialist sub-sessions unless policy explicitly opts back into that bridge path
-- runtime-selected skill remains `vibe` for governed entry
-- eligible specialist help MUST be promoted (elevated) into bounded native-mode dispatch as the default governance policy unless a valid structured host specialist dispatch decision curates the surfaced set
-- host orchestration power is bounded: it may approve, defer, or reject only surfaced specialist recommendation ids, and runtime validation still decides blocked/degraded outcomes
-- specialist help must preserve the specialist skill's own workflow, inputs, outputs, and validation style
-- specialist help must not create a second requirement doc, second plan surface, or second runtime authority
+For XL delegation, root/child hierarchy remains governed: only `root_governed`
+may freeze canonical requirements/plans or make final completion claims.
+`child_governed` lanes inherit the frozen context, stay inside assigned write
+scopes, validate `delegation-envelope.json`, and emit local receipts only.
 
-## Root/Child Governance Lanes
+## Quality Rules
 
-For XL delegation, `vibe` runs with hierarchy semantics:
+Never claim success without evidence. Minimum invariants:
 
-- `root_governed`: the only lane that may freeze canonical requirement and plan surfaces and issue final completion claims
-- `child_governed`: subordinate execution lane that inherits frozen context and emits local receipts only
-
-Child-governed lanes must: keep `$vibe` at prompt tail, inherit frozen requirement and plan context, stay within assigned ownership boundaries and write scopes, and validate a root-authored `delegation-envelope.json` before bounded execution.
-
-Child-governed lanes must not: create a second canonical requirement or plan surface, or publish final completion claims for the full root task.
-
-Specialist dispatch under hierarchy:
-- `approved_dispatch`: root-approved specialist usage in the frozen plan
-- `local_suggestion`: residual child-detected specialist suggestion that only remains advisory when blocked, degraded, or explicitly forced to escalate
-
-## Internal Execution Grades
-
-`M`, `L`, and `XL` remain active, but only as internal orchestration grades.
-
-- `M`: narrow execution, single-agent or tightly scoped work
-- `L`: native serial execution lane for staged work; delegated units stay bounded and sequence-first
-- `XL`: wave-sequential execution with step-level bounded parallelism for independent units only
-
-The governed runtime selects the internal grade after `deep_interview` and before `plan_execute`. User-facing behavior stays the same regardless of host syntax: one governed runtime authority, one frozen requirement surface, one XL-style plan surface, one execution and cleanup contract.
-
-## Stage Contract
-
-### 1. `skeleton_check`
-
-Check repo shape, active branch, existing plan or requirement artifacts, and runtime prerequisites before starting. Produce a skeleton receipt.
-
-### 2. `deep_interview`
-
-Produce a structured intent contract containing: goal, deliverable, constraints, acceptance criteria, product acceptance criteria, manual spot checks, completion language policy, delivery truth contract, non-goals, autonomy mode, inferred assumptions. In `interactive_governed`, this stage may ask direct questions.
-
-### 3. `requirement_doc`
-
-Freeze a single requirement document under `docs/requirements/`. After this point, execution traces back to this document rather than to raw chat history.
-
-### 4. `xl_plan`
-
-Write the execution plan under `docs/plans/`. The plan must contain: internal grade decision, wave or batch structure, ownership boundaries, verification commands, delivery acceptance plan, completion language rules, rollback rules, phase cleanup expectations.
-
-### 5. `plan_execute`
-
-Execute from the approved plan. L grade executes serially; XL grade executes waves sequentially with bounded parallel independent units only. Spawned subagent prompts must end with `$vibe`. Bounded specialist recommendations must be promoted into native dispatch units per the skill promotion policy; only blocked, degraded, or forced-escalation cases remain `local_suggestion`. Child-governed lanes inherit root-frozen context and must not reopen canonical requirement or plan truth surfaces.
-
-### 6. `phase_cleanup`
-
-Each phase must leave behind: cleanup receipt, temp-file cleanup result, node audit or cleanup result, proof artifacts needed for later verification, delivery-acceptance report proving whether full completion wording is allowed.
-
-## Router Invocation At Entry
-
-See "Mandatory Router Invocation With Intent Optimization" above for the required router call protocol (intent extraction + mandatory invocation). This section covers how vibe consumes the router output.
-
-Rules:
-- always extract core intent as keyword text before calling router (never pass raw prompt)
-- explicit user tool choice overrides routing
-- `confirm_required` surfaces via existing user_confirm interface
-- unattended behavior maps to governed runtime mode, not a separate control plane
-- provider-backed intelligence may advise but must not replace route authority
-- the router may internally enter "auto_route" mode when confidence exceeds threshold -- this is a router-internal behavior, not evidence that AI skipped the router call
+- Verify before completion.
+- Do not make silent no-regression claims.
+- Keep requirement and plan artifacts traceable to the launched run.
+- Emit cleanup receipts before claiming phase completion.
+- Expose failures, fallback, degraded status, or blocked state explicitly.
+- Do not add mock success paths, swallowed errors, or template-only pass results.
+- Do not use fallback or boundary behavior to bypass real execution,
+  verification, or root-cause repair.
 
 ## Protocol Map
 
-Read these protocols on demand:
+Read these references only after canonical launch or when maintaining the repo:
+
 - `protocols/runtime.md`: governed runtime contract and stage ownership
 - `protocols/think.md`: planning, research, and pre-execution analysis
 - `protocols/do.md`: coding, debugging, and verification
 - `protocols/review.md`: review and quality gates
 - `protocols/team.md`: XL multi-agent orchestration
-- `protocols/retro.md`: retrospective and learning capture; retro outputs should preserve `CER format` artifacts when that protocol is invoked; completion-language corrections remain governed and evidence-backed
-
-## Quality Rules
-
-Never claim success without evidence. Minimum invariants:
-- verification before completion
-- no silent no-regression claims
-- requirement and plan artifacts remain traceable
-- cleanup receipts are emitted before phase completion is claimed
-- Reading `SKILL.md`, wrapper markdown, or bootstrap text alone is not proof of canonical vibe entry; canonical vibe claims require `host-launch-receipt.json`, `runtime-input-packet.json`, `governance-capsule.json`, and `stage-lineage.json`
-
-### Failure Exposure And Fallback Discipline
-
-- Do not introduce new fallback, degraded-success, or boundary behavior just to keep a path running when it would otherwise fail.
-- Do not add mock success paths, template-only success outputs, swallowed errors, or any other fake-success behavior that hides the root cause.
-- Prefer full exposure: surface real failures with explicit errors, exceptions, logs, failing verification, or downgraded closure wording instead of pretending the primary path succeeded.
-- Only introduce or retain fallback / degraded behavior when the active requirement explicitly asks for it.
-- Any allowed fallback or boundary behavior must be explicit, traceable in artifacts or logs, documented in the relevant contract or requirement surface, and easy to disable.
-- Fallback or boundary behavior must not be used to bypass real execution, verification, or root-cause repair.
-
-## Outputs
-
-The governed runtime should leave behind:
-- `outputs/runtime/vibe-sessions/<run-id>/skeleton-receipt.json`
-- `outputs/runtime/vibe-sessions/<run-id>/intent-contract.json`
-- `outputs/runtime/vibe-sessions/<run-id>/runtime-input-packet.json` with `route_snapshot` and specialist surfaces
-- `docs/requirements/YYYY-MM-DD-<topic>.md`
-- `docs/plans/YYYY-MM-DD-<topic>-execution-plan.md`
-- `outputs/runtime/vibe-sessions/<run-id>/phase-*.json`
-- `outputs/runtime/vibe-sessions/<run-id>/cleanup-receipt.json`
-- specialist recommendation and dispatch accounting when bounded specialist help is planned
-- canonical host-entry receipts (`host-launch-receipt.json`)
-
-## Known Boundaries
-
-- canonical router must be called at vibe entry (mandatory self-discipline, not auto-trigger); router may enter auto_route mode internally -- this does NOT mean AI skips the router call
-- memory remains runtime-neutral: `state_store` (default session), `Serena` (explicit decisions only), `ruflo` (optional short-horizon), `Cognee` (optional long-horizon), episodic memory disabled in governed routing
-- install or check surfaces should not be rebaselined casually
-- host adapters may shape capability declarations but must not fork runtime truth
-- benchmark autonomy does not mean governance-free execution
-- other workflow layers may shape discipline but must not become a parallel runtime; explicitly forbidden: second visible runtime entry surface, second requirement freeze surface, second execution-plan surface, second route authority
+- `protocols/retro.md`: retrospective and evidence-backed corrections
 
 ## Maintenance
 
 - Runtime family: governed-runtime-first
 - Version: 3.1.0
-- Updated: 2026-04-25
+- Updated: 2026-04-26
 - Canonical router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py
+++ b/tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py
@@ -59,12 +59,14 @@ class GlobalInstructionBootstrapRuntimeTests(unittest.TestCase):
             self.assertIn("only after canonical-entry returns a session root may you validate proof artifacts inside that session root.", bootstrap_text)
             self.assertIn("host-launch-receipt.json", bootstrap_text)
 
-            wrapper_text = (target_root / "commands" / "vibe-how-do-we-do.md").read_text(encoding="utf-8")
+            wrapper_text = (target_root / "commands" / "vibe.md").read_text(encoding="utf-8")
             self.assertIn('"schema": "vibe-wrapper-trampoline/v1"', wrapper_text)
             self.assertIn('"launch_mode": "canonical-entry"', wrapper_text)
             self.assertIn('"host_id": "codex"', wrapper_text)
-            self.assertIn('"entry_id": "vibe-how-do-we-do"', wrapper_text)
+            self.assertIn('"entry_id": "vibe"', wrapper_text)
+            self.assertIn('"progressive_stage_stops"', wrapper_text)
             self.assertNotIn("Use the `vibe` skill", wrapper_text)
+            self.assertFalse((target_root / "commands" / "vibe-how-do-we-do.md").exists())
 
     def test_reinstall_keeps_single_block_and_reports_unchanged(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -96,12 +98,11 @@ class GlobalInstructionBootstrapRuntimeTests(unittest.TestCase):
             self.assertIn("Do not preflight-scan the current workspace or repository for canonical proof files before launch.", merged)
             self.assertIn("only after canonical-entry returns a session root may you validate proof artifacts inside that session root.", merged)
             self.assertIn("host-launch-receipt.json", merged)
-            wrapper_text = (target_root / "skills" / "vibe-how-do-we-do" / "SKILL.md").read_text(encoding="utf-8")
-            self.assertIn('"schema": "vibe-wrapper-trampoline/v1"', wrapper_text)
-            self.assertIn('"launch_mode": "canonical-entry"', wrapper_text)
-            self.assertIn('"host_id": "claude-code"', wrapper_text)
-            self.assertIn('"entry_id": "vibe-how-do-we-do"', wrapper_text)
-            self.assertNotIn("Use the `vibe` skill", wrapper_text)
+            skill_text = (target_root / "skills" / "vibe" / "SKILL.md").read_text(encoding="utf-8")
+            self.assertIn("Vibe Governed Runtime Entry", skill_text)
+            self.assertIn("py -3 -m vgo_cli.main canonical-entry", skill_text)
+            self.assertTrue((target_root / "skills" / "vibe-upgrade" / "SKILL.md").exists())
+            self.assertFalse((target_root / "skills" / "vibe-how-do-we-do" / "SKILL.md").exists())
 
     def test_opencode_install_preserves_existing_agents_md_and_real_config(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -123,13 +124,14 @@ class GlobalInstructionBootstrapRuntimeTests(unittest.TestCase):
             self.assertIn("only after canonical-entry returns a session root may you validate proof artifacts inside that session root.", merged)
             self.assertIn("host-launch-receipt.json", merged)
             self.assertEqual(original, json.loads(real_config.read_text(encoding="utf-8")))
-            wrapper_text = (target_root / "commands" / "vibe-how-do-we-do.md").read_text(encoding="utf-8")
+            wrapper_text = (target_root / "commands" / "vibe.md").read_text(encoding="utf-8")
             self.assertIn('"schema": "vibe-wrapper-trampoline/v1"', wrapper_text)
             self.assertIn('"launch_mode": "canonical-entry"', wrapper_text)
             self.assertIn('"host_id": "opencode"', wrapper_text)
-            self.assertIn('"entry_id": "vibe-how-do-we-do"', wrapper_text)
+            self.assertIn('"entry_id": "vibe"', wrapper_text)
             self.assertIn("agent: vibe-plan", wrapper_text)
             self.assertNotIn("Use the `vibe` skill", wrapper_text)
+            self.assertFalse((target_root / "commands" / "vibe-how-do-we-do.md").exists())
 
     def test_bootstrap_receipts_are_scoped_per_host_surface_with_shared_target_root(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/unit/test_vibe_skill_entry_contract.py
+++ b/tests/unit/test_vibe_skill_entry_contract.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL_MD = ROOT / "SKILL.md"
+
+
+def _skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def test_vibe_skill_entry_preserves_canonical_runtime_anchors() -> None:
+    text = _skill_text()
+
+    required = [
+        "$vibe",
+        "/vibe",
+        "scripts/router/resolve-pack-route.ps1",
+        "py -3 -m vgo_cli.main canonical-entry",
+        "--host-decision-json-file",
+        "--continue-from-run-id",
+        "--bounded-reentry-token",
+        "revision_delta",
+        "vibe-upgrade",
+        "protocols/runtime.md",
+        "core/skill-contracts/v1/vibe.json",
+    ]
+    for needle in required:
+        assert needle in text
+
+    for artifact in (
+        "host-launch-receipt.json",
+        "runtime-input-packet.json",
+        "governance-capsule.json",
+        "stage-lineage.json",
+    ):
+        assert artifact in text
+
+    for stage in (
+        "skeleton_check",
+        "deep_interview",
+        "requirement_doc",
+        "xl_plan",
+        "plan_execute",
+        "phase_cleanup",
+    ):
+        assert stage in text
+
+
+def test_vibe_skill_entry_stays_sop_sized_and_avoids_overtriggering_language() -> None:
+    text = _skill_text()
+
+    assert len(text.splitlines()) <= 240
+    assert "1% chance" not in text
+    assert "YOU DO NOT HAVE A CHOICE" not in text
+    assert "This is not negotiable" not in text
+


### PR DESCRIPTION
## Summary
- Slim the root `SKILL.md` into a focused canonical vibe entry SOP while preserving launch, proof, bounded re-entry, and upgrade invariants.
- Remove over-broad skill-trigger language that could cause noisy or unrelated vibe activation.
- Update bootstrap expectations to current public entry design: only `vibe` and `vibe-upgrade` are public surfaces.
- Add a narrow contract test that keeps the entry SOP-sized and protects canonical runtime anchors.

## Tests
- `py -3 -m pytest tests/unit/test_vibe_skill_entry_contract.py tests/runtime_neutral/test_global_instruction_bootstrap_runtime.py tests/unit/test_discoverable_entry_surface.py tests/unit/test_discoverable_wrappers.py`
- `py -3 -m pytest tests/unit/test_installed_runtime_contract.py tests/unit/test_canonical_vibe_entry_launcher.py tests/runtime_neutral/test_structured_bounded_reentry_continuation.py`

## Notes
- Existing untracked governed artifacts under `.vibeskills/`, `docs/plans/`, and `docs/requirements/` were intentionally not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified skill entry documentation with consolidated canonical launch procedures and streamlined runtime execution guidance
  * Updated command references and execution workflows for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->