### PR TITLE
Fix requirement revision delta freezing

### DIFF
--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -281,12 +281,12 @@ function Get-VibeHostRevisionDelta {
         if (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket -PropertyName 'host_revision_delta') {
             $items += @(Get-VibeNormalizedStringList -Values $RuntimeInputPacket.host_revision_delta)
         }
+        $runtimeContinuationContext = Get-VibeHostContinuationContext -HostDecision $RuntimeInputPacket
         if (
-            (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket -PropertyName 'continuation_context') -and
-            $null -ne $RuntimeInputPacket.continuation_context -and
-            (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket.continuation_context -PropertyName 'revision_delta')
+            $null -ne $runtimeContinuationContext -and
+            (Test-VibeObjectHasProperty -InputObject $runtimeContinuationContext -PropertyName 'revision_delta')
         ) {
-            $items += @(Get-VibeNormalizedStringList -Values $RuntimeInputPacket.continuation_context.revision_delta)
+            $items += @(Get-VibeNormalizedStringList -Values $runtimeContinuationContext.revision_delta)
         }
     }
 
@@ -303,7 +303,7 @@ function Test-VibeRevisionDeltaRequestsAdvisoryOnlySpecialists {
         return $false
     }
 
-    return ($text -match 'advisory[- ]?only|do not (adopt|require)|not (adopt|required|require)|no forced (adopt|specialist)|不得.*强制|不强制.*专家|仅.*advisory|只.*advisory')
+    return ($text -match 'advisory[- ]?only[^.;。；]*(specialist|skill|dispatch)|(?:specialist|skill|dispatch)[^.;。；]*advisory[- ]?only|do not (?:adopt|require)[^.;。；]*(?:specialist|skill|dispatch)|(?:specialist|skill|dispatch)[^.;。；]*(?:do not|not)[^.;。；]*(?:adopt(?:ed)?|require(?:d)?)|not[^.;。；]*(?:adopt(?:ed)?|require(?:d)?)[^.;。；]*(?:specialist|skill|dispatch)|no forced (?:adopt(?:ion)?|specialist|skill|dispatch)|不得[^.;。；]*强制[^.;。；]*(?:专家|技能|specialist|skill)|不强制[^.;。；]*(?:专家|技能|specialist|skill)|(?:仅|只)[^.;。；]*(?:advisory|建议)[^.;。；]*(?:专家|技能|specialist|skill)')
 }
 
 function Test-VibeRevisionDeltaRequestsTddNotApplicable {
@@ -316,7 +316,7 @@ function Test-VibeRevisionDeltaRequestsTddNotApplicable {
         return $false
     }
 
-    return ($text -match 'tdd[^.;。]*not[_ -]?applicable|not[_ -]?applicable[^.;。]*tdd|tdd[^.;。]*(not required|not require|skip|disabled|off)|研究/设计阶段\s*tdd\s*not[_ -]?applicable')
+    return ($text -match 'tdd[^.;。；]*not[_ -]?applicable|not[_ -]?applicable[^.;。；]*tdd|tdd[^.;。；]*(not\s+required|not\s+require|skip(?:ped)?|disabled|turn(?:ed)?\s+off|switch(?:ed)?\s+off)|研究/设计阶段\s*tdd\s*not[_ -]?applicable')
 }
 
 function Split-VibeRequirementRevisionItems {
@@ -329,7 +329,7 @@ function Split-VibeRequirementRevisionItems {
         return @()
     }
 
-    $items = @($normalized -split '\s*;\s*' | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
+    $items = @($normalized -split '\s*[;；]\s*' | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
     if (@($items).Count -eq 0) {
         return @($normalized)
     }
@@ -681,13 +681,12 @@ function Resolve-VibeHostSpecialistDispatchDecision {
         return $null
     }
     $revisionDelta = @(Get-VibeHostRevisionDelta -HostDecision $HostDecision)
+    $isRootGovernanceScope = [string]::Equals([string]$GovernanceScope, 'root', [System.StringComparison]::OrdinalIgnoreCase)
     if (
+        $isRootGovernanceScope -and
         ($null -eq $HostDecision -or -not (Test-VibeObjectHasProperty -InputObject $HostDecision -PropertyName 'specialist_dispatch_decision')) -and
         (Test-VibeRevisionDeltaRequestsAdvisoryOnlySpecialists -RevisionDelta $revisionDelta)
     ) {
-        if ([string]$contract.scope -eq 'root_only' -and -not [string]::Equals([string]$GovernanceScope, 'root', [System.StringComparison]::OrdinalIgnoreCase)) {
-            throw 'structured host specialist dispatch decision is currently supported only in root governance scope'
-        }
         $surfacedSkillIds = @($Recommendations | ForEach-Object {
             if ($null -ne $_ -and (Test-VibeObjectHasProperty -InputObject $_ -PropertyName 'skill_id')) { [string]$_.skill_id } else { '' }
         } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -261,6 +261,130 @@ function Get-VibeHostContinuationContext {
     return $context
 }
 
+function Get-VibeHostRevisionDelta {
+    param(
+        [AllowNull()] [object]$HostDecision = $null,
+        [AllowNull()] [object]$RuntimeInputPacket = $null
+    )
+
+    $items = @()
+    if ($null -ne $HostDecision) {
+        if (Test-VibeObjectHasProperty -InputObject $HostDecision -PropertyName 'revision_delta') {
+            $items += @(Get-VibeNormalizedStringList -Values (Get-VibePropertySafe -InputObject $HostDecision -PropertyName 'revision_delta'))
+        }
+        $continuationContext = Get-VibeHostContinuationContext -HostDecision $HostDecision
+        if ($null -ne $continuationContext -and (Test-VibeObjectHasProperty -InputObject $continuationContext -PropertyName 'revision_delta')) {
+            $items += @(Get-VibeNormalizedStringList -Values $continuationContext.revision_delta)
+        }
+    }
+    if ($null -ne $RuntimeInputPacket) {
+        if (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket -PropertyName 'host_revision_delta') {
+            $items += @(Get-VibeNormalizedStringList -Values $RuntimeInputPacket.host_revision_delta)
+        }
+        if (
+            (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket -PropertyName 'continuation_context') -and
+            $null -ne $RuntimeInputPacket.continuation_context -and
+            (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket.continuation_context -PropertyName 'revision_delta')
+        ) {
+            $items += @(Get-VibeNormalizedStringList -Values $RuntimeInputPacket.continuation_context.revision_delta)
+        }
+    }
+
+    return @($items | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } | Select-Object -Unique)
+}
+
+function Test-VibeRevisionDeltaRequestsAdvisoryOnlySpecialists {
+    param(
+        [AllowNull()] [object[]]$RevisionDelta = @()
+    )
+
+    $text = ([string]::Join(' ', @(Get-VibeNormalizedStringList -Values $RevisionDelta))).ToLowerInvariant()
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $false
+    }
+
+    return ($text -match 'advisory[- ]?only|do not (adopt|require)|not (adopt|required|require)|no forced (adopt|specialist)|不得.*强制|不强制.*专家|仅.*advisory|只.*advisory')
+}
+
+function Test-VibeRevisionDeltaRequestsTddNotApplicable {
+    param(
+        [AllowNull()] [object[]]$RevisionDelta = @()
+    )
+
+    $text = ([string]::Join(' ', @(Get-VibeNormalizedStringList -Values $RevisionDelta))).ToLowerInvariant()
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $false
+    }
+
+    return ($text -match 'tdd[^.;。]*not[_ -]?applicable|not[_ -]?applicable[^.;。]*tdd|tdd[^.;。]*(not required|not require|skip|disabled|off)|研究/设计阶段\s*tdd\s*not[_ -]?applicable')
+}
+
+function Split-VibeRequirementRevisionItems {
+    param(
+        [AllowEmptyString()] [string]$Text = ''
+    )
+
+    $normalized = ([string]$Text).Trim()
+    if ([string]::IsNullOrWhiteSpace($normalized)) {
+        return @()
+    }
+
+    $items = @($normalized -split '\s*;\s*' | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
+    if (@($items).Count -eq 0) {
+        return @($normalized)
+    }
+    return @($items)
+}
+
+function Get-VibeRequirementRevisionProjection {
+    param(
+        [AllowNull()] [object[]]$RevisionDelta = @()
+    )
+
+    $deliverable = ''
+    $acceptanceCriteria = @()
+    $productAcceptanceCriteria = @()
+    foreach ($item in @(Get-VibeNormalizedStringList -Values $RevisionDelta)) {
+        $text = ([string]$item).Trim()
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            continue
+        }
+
+        if ([string]::IsNullOrWhiteSpace($deliverable) -and $text -match '(?i)(?:^|[.]\s*)(?:the\s+)?deliverable(?:\s+field)?\s+must\s+(?:be|include)\s*[:：]\s*(.+)$') {
+            $deliverable = $Matches[1].Trim()
+            continue
+        }
+        if ([string]::IsNullOrWhiteSpace($deliverable) -and $text -match '(?i)deliverable\s*必须[^:：]*[:：]\s*(.+)$') {
+            $deliverable = $Matches[1].Trim()
+            continue
+        }
+        if (@($acceptanceCriteria).Count -eq 0 -and $text -match '(?i)acceptance\s+criteria(?:\s+field)?\s+must\s+(?:include|contain|be)\s*[:：]\s*(.+)$') {
+            $acceptanceCriteria = @(Split-VibeRequirementRevisionItems -Text $Matches[1])
+            continue
+        }
+        if (@($acceptanceCriteria).Count -eq 0 -and $text -match '(?i)acceptance\s+criteria\s*必须[^:：]*[:：]\s*(.+)$') {
+            $acceptanceCriteria = @(Split-VibeRequirementRevisionItems -Text $Matches[1])
+            continue
+        }
+        if (@($productAcceptanceCriteria).Count -eq 0 -and $text -match '(?i)product\s+acceptance(?:\s+criteria)?(?:\s+field)?\s+(?:must\s+(?:include|contain|be)|requires?)\s*[:：]?\s*(.+)$') {
+            $productAcceptanceCriteria = @(Split-VibeRequirementRevisionItems -Text $Matches[1])
+            continue
+        }
+        if (@($productAcceptanceCriteria).Count -eq 0 -and $text -match '(?i)product\s+acceptance\s+criteria\s*必须[^:：]*[:：]\s*(.+)$') {
+            $productAcceptanceCriteria = @(Split-VibeRequirementRevisionItems -Text $Matches[1])
+            continue
+        }
+    }
+
+    return [pscustomobject]@{
+        deliverable = $deliverable
+        acceptance_criteria = @($acceptanceCriteria | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } | Select-Object -Unique)
+        product_acceptance_criteria = @($productAcceptanceCriteria | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } | Select-Object -Unique)
+        specialist_advisory_only = [bool](Test-VibeRevisionDeltaRequestsAdvisoryOnlySpecialists -RevisionDelta $RevisionDelta)
+        tdd_not_applicable = [bool](Test-VibeRevisionDeltaRequestsTddNotApplicable -RevisionDelta $RevisionDelta)
+    }
+}
+
 function Test-VibeStructuredBoundedReentryContext {
     param(
         [AllowNull()] [object]$ContinuationContext = $null
@@ -556,6 +680,31 @@ function Resolve-VibeHostSpecialistDispatchDecision {
     if (-not [bool]$contract.enabled) {
         return $null
     }
+    $revisionDelta = @(Get-VibeHostRevisionDelta -HostDecision $HostDecision)
+    if (
+        ($null -eq $HostDecision -or -not (Test-VibeObjectHasProperty -InputObject $HostDecision -PropertyName 'specialist_dispatch_decision')) -and
+        (Test-VibeRevisionDeltaRequestsAdvisoryOnlySpecialists -RevisionDelta $revisionDelta)
+    ) {
+        if ([string]$contract.scope -eq 'root_only' -and -not [string]::Equals([string]$GovernanceScope, 'root', [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw 'structured host specialist dispatch decision is currently supported only in root governance scope'
+        }
+        $surfacedSkillIds = @($Recommendations | ForEach-Object {
+            if ($null -ne $_ -and (Test-VibeObjectHasProperty -InputObject $_ -PropertyName 'skill_id')) { [string]$_.skill_id } else { '' }
+        } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+        return [pscustomobject]@{
+            protocol_version = 'v1'
+            derived_by = 'host_revision_delta'
+            selection_mode = 'curated_only'
+            requested_selection_mode = 'curated_only'
+            approved_skill_ids = @()
+            deferred_skill_ids = @($surfacedSkillIds)
+            rejected_skill_ids = @()
+            surfaced_skill_ids = @($surfacedSkillIds)
+            stale_skill_ids = @()
+            reconciliation_state = 'current'
+            requires_recuration = $false
+        }
+    }
     if ($null -eq $HostDecision -or -not (Test-VibeObjectHasProperty -InputObject $HostDecision -PropertyName 'specialist_dispatch_decision')) {
         return $null
     }
@@ -711,6 +860,16 @@ function Resolve-VibeCodeTaskTddDecision {
     $hostDecisionProjection = Get-VibeCodeTaskTddDecisionFromHostDecision -HostDecision $HostDecision
     if ($null -ne $hostDecisionProjection) {
         return $hostDecisionProjection
+    }
+
+    $revisionDelta = @(Get-VibeHostRevisionDelta -HostDecision $HostDecision)
+    if (Test-VibeRevisionDeltaRequestsTddNotApplicable -RevisionDelta $revisionDelta) {
+        return [pscustomobject]@{
+            mode = 'not_applicable'
+            source = 'host_revision_delta'
+            reason = 'Host revision delta explicitly scoped this stage as not requiring code-task TDD evidence.'
+            exception = $null
+        }
     }
 
     if ($DocumentArtifactBaseline) {

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -372,6 +372,20 @@ $runtimeTaskType = if (
 } else {
     ''
 }
+$hostRevisionDeltaForRequirement = @(Get-VibeHostRevisionDelta -RuntimeInputPacket $runtimeInputPacket)
+$hostRequirementRevision = Get-VibeRequirementRevisionProjection -RevisionDelta $hostRevisionDeltaForRequirement
+if (-not [string]::IsNullOrWhiteSpace([string]$hostRequirementRevision.deliverable)) {
+    $intentContract | Add-Member -NotePropertyName deliverable -NotePropertyValue ([string]$hostRequirementRevision.deliverable) -Force
+}
+if (@($hostRequirementRevision.acceptance_criteria).Count -gt 0) {
+    $intentContract | Add-Member -NotePropertyName acceptance_criteria -NotePropertyValue ([object[]]@($hostRequirementRevision.acceptance_criteria)) -Force
+}
+if (@($hostRequirementRevision.product_acceptance_criteria).Count -gt 0) {
+    $productAcceptanceCriteria = @($hostRequirementRevision.product_acceptance_criteria)
+} else {
+    $productAcceptanceCriteria = Get-VibeProductAcceptanceCriteria -IntentContract $intentContract
+}
+$manualSpotChecks = Get-VibeManualSpotChecks -Task $Task -IntentContract $intentContract
 $needsDocumentArtifactBaseline = Test-VibeTaskNeedsDocumentArtifactBaseline -Task $Task -Deliverable ([string]$intentContract.deliverable)
 $heuristicRequiresCodeTaskTddEvidence = Test-VibeTaskNeedsCodeTaskTddEvidence -Task $Task -Deliverable ([string]$intentContract.deliverable)
 $packetCodeTaskTddDecision = if (
@@ -409,9 +423,17 @@ $codeTaskTddDecision = if ($packetCodeTaskTddDecision) {
         -HeuristicRequiresTdd $heuristicRequiresCodeTaskTddEvidence `
         -DocumentArtifactBaseline $needsDocumentArtifactBaseline
 }
+if ([bool]$hostRequirementRevision.tdd_not_applicable) {
+    $codeTaskTddDecision = [pscustomobject]@{
+        mode = 'not_applicable'
+        source = 'host_revision_delta'
+        reason = 'Host revision delta explicitly scoped this requirement/design stage as not requiring code-task TDD evidence.'
+        exception = $null
+    }
+}
 $hostExplicitTddNotApplicable = (
     $codeTaskTddDecision -and
-    [string]$codeTaskTddDecision.source -eq 'host_decision' -and
+    [string]$codeTaskTddDecision.source -in @('host_decision', 'host_revision_delta') -and
     [string]$codeTaskTddDecision.mode -eq 'not_applicable'
 )
 if (@($codeTaskTddEvidenceRequirements).Count -gt 0 -and -not $hostExplicitTddNotApplicable) {

--- a/scripts/runtime/Write-RequirementDoc.ps1
+++ b/scripts/runtime/Write-RequirementDoc.ps1
@@ -340,8 +340,6 @@ $docPath = if ($isChildScope) {
     Get-VibeRequirementDocPath -RepoRoot $runtime.repo_root -Task $Task -ArtifactRoot $ArtifactRoot
 }
 $antiDriftDraft = New-VgoAntiProxyGoalDriftDraft -PrimaryObjective $intentContract.goal
-$productAcceptanceCriteria = Get-VibeProductAcceptanceCriteria -IntentContract $intentContract
-$manualSpotChecks = Get-VibeManualSpotChecks -Task $Task -IntentContract $intentContract
 $completionLanguagePolicy = Get-VibeCompletionLanguagePolicy
 $deliveryTruthContract = Get-VibeDeliveryTruthContractLines
 $artifactReviewRequirements = Get-VibeOptionalFrozenItems -IntentContract $intentContract -PropertyNames @('artifact_review_requirements', 'artifactReviewRequirements')
@@ -423,7 +421,10 @@ $codeTaskTddDecision = if ($packetCodeTaskTddDecision) {
         -HeuristicRequiresTdd $heuristicRequiresCodeTaskTddEvidence `
         -DocumentArtifactBaseline $needsDocumentArtifactBaseline
 }
-if ([bool]$hostRequirementRevision.tdd_not_applicable) {
+if (
+    [bool]$hostRequirementRevision.tdd_not_applicable -and
+    ($null -eq $codeTaskTddDecision -or [string]$codeTaskTddDecision.source -ne 'host_decision')
+) {
     $codeTaskTddDecision = [pscustomobject]@{
         mode = 'not_applicable'
         source = 'host_revision_delta'

--- a/tests/runtime_neutral/test_structured_bounded_reentry_continuation.py
+++ b/tests/runtime_neutral/test_structured_bounded_reentry_continuation.py
@@ -88,6 +88,40 @@ def build_host_revision_decision_json() -> str:
     )
 
 
+def build_host_requirement_field_revision_decision_json() -> str:
+    revision_delta = [
+        "Replace the generic Deliverable field. The Deliverable must be: a router/runtime output field audit table; a compact host-facing route summary design; a field tiering rule that separates audit-only, runtime-required, and host-actionable fields; a migration compatibility strategy for existing consumers; and a minimal code-change plus targeted test plan.",
+        "Replace the generic Acceptance Criteria field. Acceptance Criteria must include: host AI can use the compact summary first for route, bounded re-entry, and specialist dispatch decisions; runtime-input-packet keeps the full audit payload; existing field consumers remain backward compatible; confirm_required, bounded re-entry, specialist dispatch, and delivery acceptance behavior do not regress.",
+        "Replace the generic Product Acceptance Criteria field. Product acceptance requires a concrete design and implementation plan that reduces host context burden without deleting audit evidence, without adding a second route authority, and without changing the canonical six-stage runtime.",
+        "Current-stage specialist decision must be advisory-only. Do not adopt or require tdd-guide, spreadsheet, ML, literature, or retrieval specialists at requirement freeze unless a later concrete code-change or evidence-lookup subtask explicitly needs them.",
+        "Code Task TDD Mode for this requirement/design stage must be not_applicable. TDD evidence becomes required only after execution enters actual code modification.",
+    ]
+    return json.dumps(
+        {
+            "decision_kind": "approval_response",
+            "decision_action": "revise_requirement",
+            "approval_decision": "revise",
+            "revision_delta": revision_delta,
+            "continuation_context": {
+                "structured_bounded_reentry": True,
+                "reentry_action": "revise",
+                "source_run_id": "prior-run",
+                "terminal_stage": "requirement_doc",
+                "next_stage": "xl_plan",
+                "revision_target_stage": "requirement_doc",
+                "revision_delta": revision_delta,
+                "prior_task": "router field simplification study compact host-facing summary minimal code-change test plan",
+                "prior_task_type": "planning",
+                "prior_goal": "router field simplification study compact host-facing summary",
+                "prior_deliverable": "Governed implementation artifacts, verification evidence, and cleanup receipts",
+                "prior_constraints": ["do not change runtime state machine"],
+                "control_only_prompt": True,
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
 def run_freeze(*, artifact_root: Path, host_decision_json: str) -> dict[str, object]:
     shell = resolve_powershell()
     if shell is None:
@@ -447,6 +481,68 @@ class StructuredBoundedReentryContinuationTests(unittest.TestCase):
                 packet["host_revision_delta"],
             )
             self.assertEqual("revise_requirement", packet["host_decision"]["decision_action"])
+
+    def test_revision_delta_can_make_specialists_advisory_and_tdd_not_applicable(self) -> None:
+        payload = run_common_script(
+            "$hostDecision = [pscustomobject]@{ "
+            "  decision_kind = 'approval_response'; "
+            "  decision_action = 'revise_requirement'; "
+            "  revision_delta = @("
+            "    'Current-stage specialist decision must be advisory-only. Do not adopt or require tdd-guide or spreadsheet.', "
+            "    'Code Task TDD Mode for this requirement/design stage must be not_applicable.'"
+            "  ) "
+            "}; "
+            "$recommendations = @("
+            "  [pscustomobject]@{ skill_id = 'tdd-guide' }, "
+            "  [pscustomobject]@{ skill_id = 'spreadsheet' }"
+            "); "
+            "$dispatch = Resolve-VibeHostSpecialistDispatchDecision "
+            "-HostDecision $hostDecision "
+            "-Recommendations $recommendations "
+            "-GovernanceScope 'root' "
+            "-Policy $null; "
+            "$tdd = Resolve-VibeCodeTaskTddDecision "
+            "-HostDecision $hostDecision "
+            "-Task 'router runtime minimal code-change test plan' "
+            "-TaskType 'coding' "
+            "-HeuristicRequiresTdd $true "
+            "-DocumentArtifactBaseline $false; "
+            "[pscustomobject]@{ dispatch = $dispatch; tdd = $tdd } | ConvertTo-Json -Depth 20 -Compress"
+        )
+
+        self.assertEqual("curated_only", payload["dispatch"]["selection_mode"])
+        self.assertEqual([], payload["dispatch"]["approved_skill_ids"])
+        self.assertEqual(["tdd-guide", "spreadsheet"], payload["dispatch"]["deferred_skill_ids"])
+        self.assertEqual("not_applicable", payload["tdd"]["mode"])
+        self.assertEqual("host_revision_delta", payload["tdd"]["source"])
+
+    def test_requirement_revision_delta_is_promoted_to_frozen_requirement_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir) / "artifacts"
+            payload = run_runtime(
+                artifact_root=artifact_root,
+                host_decision_json=build_host_requirement_field_revision_decision_json(),
+                requested_stage_stop="requirement_doc",
+            )
+            relative_artifacts = payload["summary"].get("artifacts_relative", {})
+            requirement_doc_path = artifact_root / Path(relative_artifacts["requirement_doc"])
+            runtime_input_packet_path = artifact_root / Path(relative_artifacts["runtime_input_packet"])
+            requirement_doc = requirement_doc_path.read_text(encoding="utf-8")
+            runtime_input_packet = json.loads(runtime_input_packet_path.read_text(encoding="utf-8"))
+
+            self.assertIn("## Deliverable", requirement_doc)
+            self.assertIn("router/runtime output field audit table", requirement_doc)
+            self.assertNotIn(
+                "## Deliverable\nGoverned implementation artifacts, verification evidence, and cleanup receipts",
+                requirement_doc,
+            )
+            self.assertIn("- host AI can use the compact summary first", requirement_doc)
+            self.assertIn("concrete design and implementation plan that reduces host context burden", requirement_doc)
+            self.assertIn("TDD mode: not_applicable", requirement_doc)
+            self.assertIn("Decision source: host_revision_delta", requirement_doc)
+            self.assertIn("No code-task TDD evidence requirements were frozen for this run.", requirement_doc)
+            self.assertEqual("not_applicable", runtime_input_packet["code_task_tdd_decision"]["mode"])
+            self.assertEqual([], runtime_input_packet["specialist_dispatch"]["approved_dispatch"])
 
     def test_stale_host_specialist_dispatch_decision_is_safely_shrunk(self) -> None:
         shell = resolve_powershell()

--- a/tests/runtime_neutral/test_structured_bounded_reentry_continuation.py
+++ b/tests/runtime_neutral/test_structured_bounded_reentry_continuation.py
@@ -91,7 +91,7 @@ def build_host_revision_decision_json() -> str:
 def build_host_requirement_field_revision_decision_json() -> str:
     revision_delta = [
         "Replace the generic Deliverable field. The Deliverable must be: a router/runtime output field audit table; a compact host-facing route summary design; a field tiering rule that separates audit-only, runtime-required, and host-actionable fields; a migration compatibility strategy for existing consumers; and a minimal code-change plus targeted test plan.",
-        "Replace the generic Acceptance Criteria field. Acceptance Criteria must include: host AI can use the compact summary first for route, bounded re-entry, and specialist dispatch decisions; runtime-input-packet keeps the full audit payload; existing field consumers remain backward compatible; confirm_required, bounded re-entry, specialist dispatch, and delivery acceptance behavior do not regress.",
+        "Replace the generic Acceptance Criteria field. Acceptance Criteria must include: host AI can use the compact summary first for route, bounded re-entry, and specialist dispatch decisions；runtime-input-packet keeps the full audit payload；existing field consumers remain backward compatible；confirm_required, bounded re-entry, specialist dispatch, and delivery acceptance behavior do not regress.",
         "Replace the generic Product Acceptance Criteria field. Product acceptance requires a concrete design and implementation plan that reduces host context burden without deleting audit evidence, without adding a second route authority, and without changing the canonical six-stage runtime.",
         "Current-stage specialist decision must be advisory-only. Do not adopt or require tdd-guide, spreadsheet, ML, literature, or retrieval specialists at requirement freeze unless a later concrete code-change or evidence-lookup subtask explicitly needs them.",
         "Code Task TDD Mode for this requirement/design stage must be not_applicable. TDD evidence becomes required only after execution enters actual code modification.",
@@ -115,6 +115,40 @@ def build_host_requirement_field_revision_decision_json() -> str:
                 "prior_goal": "router field simplification study compact host-facing summary",
                 "prior_deliverable": "Governed implementation artifacts, verification evidence, and cleanup receipts",
                 "prior_constraints": ["do not change runtime state machine"],
+                "control_only_prompt": True,
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
+def build_host_revision_with_explicit_tdd_required_json() -> str:
+    revision_delta = [
+        "Code Task TDD Mode for this requirement/design stage must be not_applicable.",
+    ]
+    return json.dumps(
+        {
+            "decision_kind": "approval_response",
+            "decision_action": "revise_requirement",
+            "approval_decision": "revise",
+            "code_task_tdd_decision": {
+                "mode": "required",
+                "reason": "Host explicitly requires TDD for this run.",
+            },
+            "revision_delta": revision_delta,
+            "continuation_context": {
+                "structured_bounded_reentry": True,
+                "reentry_action": "revise",
+                "source_run_id": "prior-run",
+                "terminal_stage": "requirement_doc",
+                "next_stage": "xl_plan",
+                "revision_target_stage": "requirement_doc",
+                "revision_delta": revision_delta,
+                "prior_task": "fix router runtime code path",
+                "prior_task_type": "coding",
+                "prior_goal": "fix router runtime code path",
+                "prior_deliverable": "code patch and tests",
+                "prior_constraints": [],
                 "control_only_prompt": True,
             },
         },
@@ -512,9 +546,50 @@ class StructuredBoundedReentryContinuationTests(unittest.TestCase):
 
         self.assertEqual("curated_only", payload["dispatch"]["selection_mode"])
         self.assertEqual([], payload["dispatch"]["approved_skill_ids"])
-        self.assertEqual(["tdd-guide", "spreadsheet"], payload["dispatch"]["deferred_skill_ids"])
+        self.assertEqual({"tdd-guide", "spreadsheet"}, set(payload["dispatch"]["deferred_skill_ids"]))
         self.assertEqual("not_applicable", payload["tdd"]["mode"])
         self.assertEqual("host_revision_delta", payload["tdd"]["source"])
+
+    def test_revision_delta_helpers_avoid_broad_matches_and_split_cjk_separators(self) -> None:
+        payload = run_common_script(
+            "$split = Split-VibeRequirementRevisionItems -Text 'first item；second item; third item'; "
+            "$result = [ordered]@{ "
+            "  split = @($split); "
+            "  tdd_day_off = Test-VibeRevisionDeltaRequestsTddNotApplicable -RevisionDelta @('TDD schedule has a day off after documentation review.'); "
+            "  tdd_turned_off = Test-VibeRevisionDeltaRequestsTddNotApplicable -RevisionDelta @('TDD is turned off for this requirement/design stage.'); "
+            "  advisory_generic_not_require = Test-VibeRevisionDeltaRequestsAdvisoryOnlySpecialists -RevisionDelta @('Do not require a separate approval reply.'); "
+            "  advisory_specialist = Test-VibeRevisionDeltaRequestsAdvisoryOnlySpecialists -RevisionDelta @('Specialist decision must be advisory-only for this stage.'); "
+            "}; "
+            "$result | ConvertTo-Json -Depth 20 -Compress"
+        )
+
+        self.assertEqual(["first item", "second item", "third item"], payload["split"])
+        self.assertFalse(payload["tdd_day_off"])
+        self.assertTrue(payload["tdd_turned_off"])
+        self.assertFalse(payload["advisory_generic_not_require"])
+        self.assertTrue(payload["advisory_specialist"])
+
+    def test_revision_delta_helpers_ignore_malformed_runtime_context_and_child_advisory_scope(self) -> None:
+        payload = run_common_script(
+            "$runtimePacket = [pscustomobject]@{ "
+            "  host_revision_delta = @('Add concrete acceptance.'); "
+            "  continuation_context = 'not-an-object' "
+            "}; "
+            "$delta = Get-VibeHostRevisionDelta -RuntimeInputPacket $runtimePacket; "
+            "$hostDecision = [pscustomobject]@{ "
+            "  revision_delta = @('Specialist decision must be advisory-only for this stage.') "
+            "}; "
+            "$recommendations = @([pscustomobject]@{ skill_id = 'tdd-guide' }); "
+            "$childDecision = Resolve-VibeHostSpecialistDispatchDecision "
+            "-HostDecision $hostDecision "
+            "-Recommendations $recommendations "
+            "-GovernanceScope 'child' "
+            "-Policy $null; "
+            "[pscustomobject]@{ delta = @($delta); child_is_null = ($null -eq $childDecision) } | ConvertTo-Json -Depth 20 -Compress"
+        )
+
+        self.assertEqual(["Add concrete acceptance."], payload["delta"])
+        self.assertTrue(payload["child_is_null"])
 
     def test_requirement_revision_delta_is_promoted_to_frozen_requirement_fields(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -524,7 +599,9 @@ class StructuredBoundedReentryContinuationTests(unittest.TestCase):
                 host_decision_json=build_host_requirement_field_revision_decision_json(),
                 requested_stage_stop="requirement_doc",
             )
-            relative_artifacts = payload["summary"].get("artifacts_relative", {})
+            relative_artifacts = payload["summary"]["artifacts_relative"]
+            self.assertIn("requirement_doc", relative_artifacts)
+            self.assertIn("runtime_input_packet", relative_artifacts)
             requirement_doc_path = artifact_root / Path(relative_artifacts["requirement_doc"])
             runtime_input_packet_path = artifact_root / Path(relative_artifacts["runtime_input_packet"])
             requirement_doc = requirement_doc_path.read_text(encoding="utf-8")
@@ -543,6 +620,25 @@ class StructuredBoundedReentryContinuationTests(unittest.TestCase):
             self.assertIn("No code-task TDD evidence requirements were frozen for this run.", requirement_doc)
             self.assertEqual("not_applicable", runtime_input_packet["code_task_tdd_decision"]["mode"])
             self.assertEqual([], runtime_input_packet["specialist_dispatch"]["approved_dispatch"])
+
+    def test_requirement_revision_delta_does_not_downgrade_explicit_host_tdd_decision(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir) / "artifacts"
+            payload = run_runtime(
+                artifact_root=artifact_root,
+                host_decision_json=build_host_revision_with_explicit_tdd_required_json(),
+                requested_stage_stop="requirement_doc",
+            )
+            relative_artifacts = payload["summary"]["artifacts_relative"]
+            requirement_doc_path = artifact_root / Path(relative_artifacts["requirement_doc"])
+            runtime_input_packet_path = artifact_root / Path(relative_artifacts["runtime_input_packet"])
+            requirement_doc = requirement_doc_path.read_text(encoding="utf-8")
+            runtime_input_packet = json.loads(runtime_input_packet_path.read_text(encoding="utf-8"))
+
+            self.assertIn("TDD mode: required", requirement_doc)
+            self.assertIn("Decision source: host_decision", requirement_doc)
+            self.assertEqual("required", runtime_input_packet["code_task_tdd_decision"]["mode"])
+            self.assertEqual("host_decision", runtime_input_packet["code_task_tdd_decision"]["source"])
 
     def test_stale_host_specialist_dispatch_decision_is_safely_shrunk(self) -> None:
         shell = resolve_powershell()


### PR DESCRIPTION
## Summary
- Promote structured requirement revision delta into frozen Deliverable, Acceptance Criteria, and Product Acceptance Criteria instead of leaving it only under Host Revision Delta.
- Let explicit revision-delta instructions keep specialists advisory-only and mark requirement/design-stage TDD as not_applicable.
- Add structured bounded re-entry tests covering advisory-only specialist handling and requirement-field promotion.

## Verification
- `py -3 -m pytest tests\runtime_neutral\test_structured_bounded_reentry_continuation.py -q` -> 14 passed
- `py -3 -m pytest tests\runtime_neutral\test_governed_runtime_bridge.py -q` -> 16 passed

## Note
- While checking broader specialist promotion behavior, `tests\runtime_neutral\test_skill_promotion_destructive_gate.py::SkillPromotionDestructiveGateTests::test_destructive_match_is_blocked_with_artifact_backed_outcome` still fails because the current destructive prompt produces no specialist recommendation to block. That appears separate from this requirement-revision fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-provided revision guidance can mark requests as advisory-only or declare TDD "not applicable", influencing specialist dispatch and TDD gating.
  * Requirement documents now accept host-driven overrides for deliverables, acceptance criteria, and product acceptance, and refresh manual spot checks accordingly.

* **Tests**
  * Added tests validating host-driven decision behavior, field projection into requirement docs, and TDD provisioning precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->