### PR TITLE
Highlight homepage install entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ Install VibeSkills, type `vibe`, and let the harness handle the busy work: under
 
 🧠 Planning · 🛠️ Engineering · 🤖 AI · 🔬 Research · 🎨 Creation
 
-<br/>
+<br/><br/>
 
 <a href="docs/install/one-click-install-release-copy.en.md">
-  <img src="https://img.shields.io/badge/⚡_Get_Started-7B61FF?style=for-the-badge" alt="Install">
+  <img src="https://img.shields.io/badge/⚡_Click_to_Install-7B61FF?style=for-the-badge" height="56" alt="Click to Install">
 </a>
-&nbsp;
+
+<br/><br/>
+
 <a href="docs/quick-start.en.md">
   <img src="https://img.shields.io/badge/📖_Quick_Start-2d3748?style=for-the-badge" alt="Docs">
 </a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -64,12 +64,14 @@
 
 🧠 规划 · 🛠️ 工程 · 🤖 AI · 🔬 科研 · 🎨 创作
 
-<br/>
+<br/><br/>
 
 <a href="docs/install/one-click-install-release-copy.md">
-  <img src="https://img.shields.io/badge/⚡_立即安装-7B61FF?style=for-the-badge" alt="安装">
+  <img src="https://img.shields.io/badge/⚡_点击立即安装-7B61FF?style=for-the-badge" height="56" alt="点击立即安装">
 </a>
-&nbsp;
+
+<br/><br/>
+
 <a href="docs/quick-start.md">
   <img src="https://img.shields.io/badge/📖_快速上手-2d3748?style=for-the-badge" alt="文档">
 </a>


### PR DESCRIPTION
## Summary
- Make the homepage install CTA a standalone centered button.
- Enlarge the install badge and change the Chinese copy to 点击立即安装.
- Keep the English README aligned with Click to Install.

## Verification
- git diff --check
- README CTA text verified locally with ripgrep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved layout spacing in the install call-to-action section across English and Chinese documentation versions.
  * Updated install badge label text and added standardized height attribute for consistent visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->