### PR TITLE
Enlarge homepage install CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Install VibeSkills, type `vibe`, and let the harness handle the busy work: under
 <br/><br/>
 
 <a href="docs/install/one-click-install-release-copy.en.md">
-  <img src="https://img.shields.io/badge/⚡_Click_to_Install-7B61FF?style=for-the-badge" height="56" alt="Click to Install">
+  <img src="https://img.shields.io/badge/⚡_Click_to_Install-7B61FF?style=for-the-badge" width="981" height="112" alt="Click to Install">
 </a>
 
 <br/><br/>

--- a/README.zh.md
+++ b/README.zh.md
@@ -67,7 +67,7 @@
 <br/><br/>
 
 <a href="docs/install/one-click-install-release-copy.md">
-  <img src="https://img.shields.io/badge/⚡_点击立即安装-7B61FF?style=for-the-badge" height="56" alt="点击立即安装">
+  <img src="https://img.shields.io/badge/⚡_点击立即安装-7B61FF?style=for-the-badge" width="642" height="112" alt="点击立即安装">
 </a>
 
 <br/><br/>


### PR DESCRIPTION
## Summary
- Enlarge the standalone homepage install CTA in both README files.
- Set explicit width and height so the button length, height, and text scale together.
- Keep quick-start and language buttons on the secondary row.

## Verification
- git diff --check
- README CTA dimensions verified locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Adjusted the installation badge image dimensions in both English and Chinese README files to enhance visual presentation and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->