### PR TITLE
Double homepage install CTA proportionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Install VibeSkills, type `vibe`, and let the harness handle the busy work: under
 <br/><br/>
 
 <a href="docs/install/one-click-install-release-copy.en.md">
-  <img src="https://img.shields.io/badge/⚡_Click_to_Install-7B61FF?style=for-the-badge" height="56" alt="Click to Install">
+  <img src="https://img.shields.io/badge/⚡_Click_to_Install-7B61FF?style=for-the-badge" width="327" height="56" alt="Click to Install">
 </a>
 
 <br/><br/>

--- a/README.zh.md
+++ b/README.zh.md
@@ -67,7 +67,7 @@
 <br/><br/>
 
 <a href="docs/install/one-click-install-release-copy.md">
-  <img src="https://img.shields.io/badge/⚡_点击立即安装-7B61FF?style=for-the-badge" height="56" alt="点击立即安装">
+  <img src="https://img.shields.io/badge/⚡_点击立即安装-7B61FF?style=for-the-badge" width="214" height="56" alt="点击立即安装">
 </a>
 
 <br/><br/>


### PR DESCRIPTION
## Summary
- make the homepage install CTA badges exactly 2x their original badge dimensions
- use explicit proportional width + height so GitHub renders the enlargement clearly
- keep the centered install entry and current button text

## Verification
- `git diff --check origin/main..HEAD`
- `python -m pytest tests/runtime_neutral/test_docs_readme_encoding.py`
- confirmed README.zh.md uses `width="214" height="56"`
- confirmed README.md uses `width="327" height="56"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined installation badge specifications in README documentation files with explicit width attributes to ensure consistent visual rendering across different language versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->