### PR TITLE
Use elegant SVG install CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Install VibeSkills, type `vibe`, and let the harness handle the busy work: under
 <br/><br/>
 
 <a href="docs/install/one-click-install-release-copy.en.md">
-  <img src="https://img.shields.io/badge/⚡_Click_to_Install-7B61FF?style=for-the-badge" width="327" height="56" alt="Click to Install">
+  <img src="docs/assets/install-cta-en.svg" width="327" height="56" alt="Click to Install">
 </a>
 
 <br/><br/>

--- a/README.zh.md
+++ b/README.zh.md
@@ -67,7 +67,7 @@
 <br/><br/>
 
 <a href="docs/install/one-click-install-release-copy.md">
-  <img src="https://img.shields.io/badge/⚡_点击立即安装-7B61FF?style=for-the-badge" width="214" height="56" alt="点击立即安装">
+  <img src="docs/assets/install-cta-cn.svg" width="214" height="56" alt="点击立即安装">
 </a>
 
 <br/><br/>

--- a/docs/assets/install-cta-cn.svg
+++ b/docs/assets/install-cta-cn.svg
@@ -1,0 +1,19 @@
+<svg width="214" height="56" viewBox="0 0 214 56" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">点击立即安装</title>
+  <desc id="desc">VibeSkills install call to action button</desc>
+  <defs>
+    <linearGradient id="bg" x1="16" y1="4" x2="202" y2="54" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6E56CF"/>
+      <stop offset="1" stop-color="#8B5CF6"/>
+    </linearGradient>
+    <filter id="shadow" x="-6" y="-4" width="226" height="70" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="6" stdDeviation="5" flood-color="#3B1F8F" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+  <g filter="url(#shadow)">
+    <rect x="1" y="1" width="212" height="54" rx="10" fill="url(#bg)"/>
+    <rect x="1.5" y="1.5" width="211" height="53" rx="9.5" stroke="#C4B5FD" stroke-opacity="0.48"/>
+  </g>
+  <path d="M43.9 15L32.8 30.1H42L38.4 42L51.7 24.9H42.3L43.9 15Z" fill="#FFF8CC"/>
+  <text x="122" y="36" text-anchor="middle" fill="#FFFFFF" font-size="21" font-weight="650" letter-spacing="0" font-family="Inter, Segoe UI, PingFang SC, Noto Sans SC, Microsoft YaHei UI, sans-serif">点击立即安装</text>
+</svg>

--- a/docs/assets/install-cta-en.svg
+++ b/docs/assets/install-cta-en.svg
@@ -1,0 +1,19 @@
+<svg width="327" height="56" viewBox="0 0 327 56" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Click to Install</title>
+  <desc id="desc">VibeSkills install call to action button</desc>
+  <defs>
+    <linearGradient id="bg" x1="24" y1="4" x2="305" y2="55" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6E56CF"/>
+      <stop offset="1" stop-color="#8B5CF6"/>
+    </linearGradient>
+    <filter id="shadow" x="-8" y="-4" width="343" height="70" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="6" stdDeviation="5" flood-color="#3B1F8F" flood-opacity="0.18"/>
+    </filter>
+  </defs>
+  <g filter="url(#shadow)">
+    <rect x="1" y="1" width="325" height="54" rx="10" fill="url(#bg)"/>
+    <rect x="1.5" y="1.5" width="324" height="53" rx="9.5" stroke="#C4B5FD" stroke-opacity="0.48"/>
+  </g>
+  <path d="M91.9 15L80.8 30.1H90L86.4 42L99.7 24.9H90.3L91.9 15Z" fill="#FFF8CC"/>
+  <text x="179" y="36" text-anchor="middle" fill="#FFFFFF" font-size="22" font-weight="650" letter-spacing="0" font-family="Inter, Segoe UI, Helvetica Neue, Arial, sans-serif">Click to Install</text>
+</svg>


### PR DESCRIPTION
## Summary
- replace the homepage install CTA shields badge with local SVG buttons
- keep the 2x proportional dimensions: Chinese 214x56, English 327x56
- use an elegant system font stack and vector lightning icon instead of badge/emoji font rendering

## Verification
- `git diff --check`
- `python -m pytest tests/runtime_neutral/test_docs_readme_encoding.py tests/runtime_neutral/test_docs_source_neutral_links.py`
- parsed both SVG files as XML
- previewed both SVG buttons through a local HTTP server in Chrome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the install call-to-action button appearance in both English and Chinese README files with refreshed visual assets while maintaining installation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->