### PR TITLE
Preserve specialist execution locks across re-entry

### DIFF
--- a/docs/governance/current-routing-contract.md
+++ b/docs/governance/current-routing-contract.md
@@ -14,22 +14,25 @@ enter the six-stage work and become a real usage claim?
 The current Vibe-Skills routing model is:
 
 ```text
-skill_candidates -> skill_routing.selected -> selected_skill_execution -> skill_usage.used / skill_usage.unused
+skill_candidates -> skill_routing.selected -> skill_execution_lock -> selected_skill_execution -> skill_usage.used / skill_usage.unused
 ```
 
 This is the only model current user-facing docs and generated runtime outputs
 should teach.
 
-The model has no extra current states between selection and usage. A skill is
-either selected into the work, then later recorded as used or unused.
+The model separates selection, approved-plan execution obligation, execution,
+and material-use evidence. A skill can be selected and locked for execution
+without being materially used yet.
 
 ## Operating Rules
 
 1. Routing may list possible skills in `skill_candidates`.
 2. The plan may choose skills through `skill_routing.selected`.
-3. Execution may only treat selected skills as work inputs through
+3. Plan approval may preserve selected skills across bounded re-entry through
+   `skill_execution_lock`.
+4. Execution may only treat selected or locked skills as work inputs through
    `selected_skill_execution`.
-4. Completion may only claim a skill was used through `skill_usage.used` with
+5. Completion may only claim a skill was used through `skill_usage.used` with
    matching `skill_usage.evidence`.
 
 For compound tasks, split the work into bounded task segments and select the
@@ -43,11 +46,18 @@ states.
 | --- | --- |
 | `candidate` | A skill was considered by routing. This is not a use claim. |
 | `selected` | A skill was chosen into the work surface through `skill_routing.selected`. This is not a use claim. |
+| `skill_execution_lock` | The approved-plan execution lock that preserves selected specialists across bounded re-entry. It is not a use claim. |
 | `selected_skill_execution` | The selected skill list frozen into execution. This connects routing to actual work; it is still not a use claim. |
 | `used` | A selected or loaded skill shaped an artifact and appears in `skill_usage.used` with evidence. |
 | `unused` | A selected or loaded skill did not shape an artifact and appears in `skill_usage.unused`. |
 | `evidence` | A stage, artifact reference, and impact summary proving material skill use. |
 | `retired old-format fields` | Old routing, consultation, and dispatch fields are not current inputs, current outputs, or maintained compatibility targets. |
+
+`skill_execution_lock` exists because bounded re-entry reruns the router. Once
+a plan is approved, selected specialists become execution obligations and must
+be executed, marked not applicable, deferred, or failed before delivery
+acceptance can pass. The lock does not prove material skill use;
+`skill_usage.used` remains the only material-use truth.
 
 ## Usage Proof
 
@@ -57,8 +67,8 @@ A skill may be reported as used only when all of these are true:
 2. The skill has at least one `skill_usage.evidence` record.
 3. The evidence names a concrete stage and artifact impact.
 
-Routing, selection, old consultation receipts, and old dispatch records are not
-usage proof.
+Routing, selection, execution locks, old consultation receipts, and old dispatch
+records are not usage proof.
 
 ## Current Output Rules
 
@@ -67,6 +77,7 @@ Current runtime outputs should use these names:
 ```text
 skill_candidates
 skill_routing.selected
+skill_execution_lock
 selected_skill_execution
 skill_usage.used
 skill_usage.unused
@@ -95,8 +106,8 @@ planning_consultation
 ```
 
 When current and retired fields are both present in an old artifact, current
-runtime code should prefer `skill_routing` and `skill_usage` and ignore retired
-fields for current behavior.
+runtime code should prefer `skill_routing`, `skill_execution_lock`, and
+`skill_usage` and ignore retired fields for current behavior.
 
 ## Non-Goals
 

--- a/docs/governance/current-runtime-field-contract.md
+++ b/docs/governance/current-runtime-field-contract.md
@@ -9,7 +9,7 @@ This document defines the current Vibe-Skills runtime field vocabulary.
 The current routing and usage model is:
 
 ```text
-skill_candidates -> skill_routing.selected -> selected_skill_execution -> skill_usage.used / skill_usage.unused
+skill_candidates -> skill_routing.selected -> skill_execution_lock -> selected_skill_execution -> skill_usage.used / skill_usage.unused
 ```
 
 Current docs, runtime packets, generated plans, tests, and gates should use
@@ -60,17 +60,24 @@ Final used claims require `skill_usage.used` plus matching
 Preferred current execution vocabulary:
 
 ```text
+skill_execution_lock
 selected_skill_execution
 skill_execution_units
 execution_skill_outcomes
 ```
 
-Execution anchors: `selected_skill_execution`, `skill_execution_units`, and
-`execution_skill_outcomes`.
+Execution anchors: `skill_execution_lock`, `selected_skill_execution`,
+`skill_execution_units`, and `execution_skill_outcomes`.
+
+### `skill_execution_lock`
+
+`skill_execution_lock` records specialists that crossed the approved-plan boundary and therefore require execution resolution. It contains `locked_skill_ids`, `locked_dispatch`, `source_run_id`, and `resolution_required`. It is an execution-obligation field, not a material-use field.
 
 `selected_skill_execution` is the execution-side copy of
-`skill_routing.selected`. It connects selected skills to real work, but it is
-not material-use proof by itself.
+the active execution source. When `skill_execution_lock` is active, execution
+uses the locked dispatch; otherwise it uses `skill_routing.selected`. It
+connects selected skills to real work, but it is not material-use proof by
+itself.
 
 Current root runtime packets should not expose retired dispatch fields as a
 routing contract surface.
@@ -105,9 +112,10 @@ narrow execution-internal allowlists with an explicit scan reason.
 ## Current Behavior Rule
 
 Current runtime behavior must derive selected skills from
-`skill_routing.selected`, carry them into `selected_skill_execution`, and record
-material use in `skill_usage.used`, `skill_usage.unused`, and
-`skill_usage.evidence`.
+`skill_routing.selected`, preserve approved-plan obligations in
+`skill_execution_lock`, carry the active execution source into
+`selected_skill_execution`, and record material use in `skill_usage.used`,
+`skill_usage.unused`, and `skill_usage.evidence`.
 
 Old routing, old consultation, old recommendation, and old stage-assistant
 fields are not maintained compatibility inputs.

--- a/docs/governance/terminology-governance.md
+++ b/docs/governance/terminology-governance.md
@@ -1,6 +1,6 @@
 # Terminology Governance
 
-> Historical / Retired Note: This document records prior terminology cleanup. The current routing model is `skill_candidates -> skill_routing.selected -> selected_skill_execution -> skill_usage`.
+> Historical / Retired Note: This document records prior terminology cleanup. The current routing model is `skill_candidates -> skill_routing.selected -> skill_execution_lock -> selected_skill_execution -> skill_usage`.
 
 Current readers should use:
 
@@ -17,6 +17,7 @@ messages:
 | --- | --- |
 | `skill_candidates` | Candidate skills available to a pack or route decision. |
 | `skill_routing.selected` | The selected skill decisions produced by routing. |
+| `skill_execution_lock` | Current execution-obligation field that preserves approved specialists across bounded re-entry; not evidence of material skill use. |
 | `selected_skill_execution` | The current execution-intent projection shown to users and hosts. |
 | `skill_usage.used` | Skills materially used in the run. |
 | `skill_usage.unused` | Candidate or selected skills that were not materially used. |

--- a/docs/superpowers/plans/2026-05-02-current-routing-debt-erasure.md
+++ b/docs/superpowers/plans/2026-05-02-current-routing-debt-erasure.md
@@ -4,7 +4,7 @@
 > retired routing terminology as cleanup targets. The current routing model is
 > `skill_candidates -> skill_routing.selected -> selected_skill_execution -> skill_usage`;
 > old terms here are debt targets, not current runtime states.
-
+>
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Build an executable current-routing debt audit and cleanup pass that removes retired routing fields from current paths and keeps any old-field support isolated as retired compatibility.
@@ -15,7 +15,7 @@
 
 ---
 
-### Task 1: Add The Current Routing Debt Policy
+## Task 1: Add The Current Routing Debt Policy
 
 **Files:**
 - Create: `config/current-routing-debt-erasure.json`
@@ -265,7 +265,7 @@ git add config/current-routing-debt-erasure.json tests/runtime_neutral/test_curr
 git commit -m "test: define current routing debt policy"
 ```
 
-### Task 2: Add The Debt Gate Tests
+## Task 2: Add The Debt Gate Tests
 
 **Files:**
 - Create: `tests/runtime_neutral/test_current_routing_debt_gate.py`
@@ -384,7 +384,7 @@ git add tests/runtime_neutral/test_current_routing_debt_gate.py
 git commit -m "test: require current routing debt gate"
 ```
 
-### Task 3: Implement The Current Routing Debt Gate
+## Task 3: Implement The Current Routing Debt Gate
 
 **Files:**
 - Create: `scripts/verify/vibe-current-routing-debt-gate.ps1`
@@ -755,7 +755,7 @@ git commit -m "feat: add current routing debt gate"
 
 If Step 2 fails with P1 findings, leave the script uncommitted and continue to Task 4 so the first passing commit contains the gate plus the cleanup that makes it true.
 
-### Task 4: Move Retired Consultation Readers Out Of Current Runtime
+## Task 4: Move Retired Consultation Readers Out Of Current Runtime
 
 **Files:**
 - Create: `scripts/runtime/legacy/VibeRetiredConsultation.Common.ps1`
@@ -879,7 +879,7 @@ git add scripts/runtime/VibeRuntime.Common.ps1 scripts/runtime/legacy/VibeRetire
 git commit -m "refactor: isolate retired consultation runtime readers"
 ```
 
-### Task 5: Clean Current Test Fixtures That Still Emit Retired Fields
+## Task 5: Clean Current Test Fixtures That Still Emit Retired Fields
 
 **Files:**
 - Modify: `tests/unit/test_canonical_vibe_entry_launcher.py`
@@ -1063,7 +1063,7 @@ git add tests/unit/test_canonical_vibe_entry_launcher.py tests/integration/test_
 git commit -m "test: retire old routing fields from current fixtures"
 ```
 
-### Task 6: Wire The Gate Into Verify Documentation
+## Task 6: Wire The Gate Into Verify Documentation
 
 **Files:**
 - Modify: `scripts/verify/README.md`
@@ -1119,13 +1119,13 @@ In `scripts/verify/README.md`, add this command to the Common Verify Sequence af
 
 Add this note under High-Frequency Quick Starts:
 
-```markdown
+````markdown
 Current routing debt:
 
 ```powershell
 & ".\vibe-current-routing-debt-gate.ps1" -WriteArtifacts
 ```
-```
+````
 
 - [ ] **Step 4: Update gate family index**
 
@@ -1154,7 +1154,7 @@ git add scripts/verify/README.md scripts/verify/gate-family-index.md tests/runti
 git commit -m "docs: add current routing debt gate to verify flow"
 ```
 
-### Task 7: Run The Gate, Review The Audit, And Commit Generated Evidence Policy
+## Task 7: Run The Gate, Review The Audit, And Commit Generated Evidence Policy
 
 **Files:**
 - Produces untracked or modified generated outputs under `outputs/verify/`
@@ -1237,7 +1237,7 @@ git commit -m "docs: add current routing debt audit"
 
 If `docs/audits` has no tracked audit reports, leave the generated Markdown uncommitted and mention its path in the implementation closeout.
 
-### Task 8: Full Verification
+## Task 8: Full Verification
 
 **Files:**
 - No file edits expected.
@@ -1293,7 +1293,7 @@ git status --short
 
 Expected: only intentionally generated `outputs/verify/*` files may remain uncommitted. Source, tests, docs, and policy changes are committed.
 
-### Task 9: Closeout Commit And Evidence Summary
+## Task 9: Closeout Commit And Evidence Summary
 
 **Files:**
 - No new files unless Task 7 tracks the Markdown audit.

--- a/docs/superpowers/plans/2026-05-05-vibe-specialist-execution-lock.md
+++ b/docs/superpowers/plans/2026-05-05-vibe-specialist-execution-lock.md
@@ -1,0 +1,1620 @@
+# Vibe Specialist Execution Lock Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve approved Vibe specialist execution obligations across bounded re-entry so final execution cannot silently drop specialists selected in the approved plan.
+
+**Architecture:** Add a durable `skill_execution_lock` projection to runtime packets, feed it into plan execution before current router-only selection, and make delivery acceptance account for unresolved locked specialists. Keep `skill_usage.used` as the only material-use truth; the lock is execution obligation, not usage evidence.
+
+**Tech Stack:** PowerShell runtime scripts, Python `pytest` runtime-neutral tests, Vibe verification-core delivery acceptance module, Markdown governance docs.
+
+---
+
+## Scope And File Structure
+
+This plan implements the approved spec at `docs/superpowers/specs/2026-05-05-vibe-specialist-execution-lock-design.md`.
+
+Modify:
+
+- `scripts/runtime/VibeRuntime.Common.ps1`: add lock helpers and previous-packet loading.
+- `scripts/runtime/VibeSkillRouting.Common.ps1`: convert active locks into dispatch rows.
+- `scripts/runtime/Freeze-RuntimeInputPacket.ps1`: construct `skill_execution_lock` during packet freeze.
+- `scripts/runtime/Invoke-PlanExecute.ps1`: prefer active lock dispatch over current router-only selection and emit lock accounting.
+- `packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py`: evaluate lock resolution as a delivery truth layer.
+- `tests/runtime_neutral/test_skill_execution_lock_contract.py`: new focused PowerShell/Python tests for the lock model.
+- `tests/runtime_neutral/test_runtime_delivery_acceptance.py`: delivery acceptance fixture and assertions for unresolved/resolved locks.
+- `docs/governance/current-routing-contract.md`: document the new authority chain.
+- `docs/governance/current-runtime-field-contract.md`: document runtime fields for `skill_execution_lock`.
+- `docs/governance/terminology-governance.md`: define current terms.
+- `tests/runtime_neutral/test_current_routing_docs_entrypoint.py`: update current model assertions.
+- `tests/runtime_neutral/test_terminology_field_simplification.py`: update terminology assertions.
+
+Do not change router ranking logic, pack manifests, or historical archived docs in this slice.
+
+## Preflight
+
+- [ ] **Step 1: Confirm branch and cleanliness**
+
+Run:
+
+```powershell
+git status --short
+git branch --show-current
+```
+
+Expected:
+
+```text
+pr226-followup-review-fixes
+```
+
+`git status --short` may show this plan file or task files created by the current implementation. Do not revert unrelated user changes.
+
+- [ ] **Step 2: Run the focused baseline tests**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_simplified_skill_routing_contract.py tests/runtime_neutral/test_skill_promotion_freeze_contract.py tests/runtime_neutral/test_runtime_delivery_acceptance.py::RuntimeDeliveryAcceptanceTests::test_runtime_delivery_acceptance_passes_when_current_session_specialist_execution_is_recorded -q
+```
+
+Expected:
+
+```text
+passed
+```
+
+If this fails before edits, stop and record the failing test names and messages before continuing.
+
+---
+
+### Task 1: Add Failing Lock Contract Tests
+
+**Files:**
+
+- Create: `tests/runtime_neutral/test_skill_execution_lock_contract.py`
+- No runtime implementation files are modified in this task.
+
+- [ ] **Step 1: Create the failing test file**
+
+Create `tests/runtime_neutral/test_skill_execution_lock_contract.py` with this content:
+
+```python
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_COMMON = REPO_ROOT / "scripts" / "runtime" / "VibeRuntime.Common.ps1"
+SKILL_ROUTING_COMMON = REPO_ROOT / "scripts" / "runtime" / "VibeSkillRouting.Common.ps1"
+FREEZE_SCRIPT = REPO_ROOT / "scripts" / "runtime" / "Freeze-RuntimeInputPacket.ps1"
+
+
+def resolve_powershell() -> str | None:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("pwsh.exe"),
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        shutil.which("powershell"),
+        shutil.which("powershell.exe"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
+def ps_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def run_ps_json(script: str) -> dict[str, object]:
+    shell = resolve_powershell()
+    if shell is None:
+        raise unittest.SkipTest("PowerShell executable not available")
+    completed = subprocess.run(
+        [shell, "-NoLogo", "-NoProfile", "-Command", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def as_list(value: object) -> list[object]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+class SkillExecutionLockContractTests(unittest.TestCase):
+    def test_lock_projection_preserves_previous_selected_when_current_router_differs(self) -> None:
+        payload = run_ps_json(
+            "& { "
+            f". {ps_quote(str(RUNTIME_COMMON))}; "
+            f". {ps_quote(str(SKILL_ROUTING_COMMON))}; "
+            "$previous = [pscustomobject]@{ "
+            "  run_id = 'pytest-plan-run'; "
+            "  skill_routing = [pscustomobject]@{ "
+            "    selected = @([pscustomobject]@{ "
+            "      skill_id = 'scientific-reporting'; "
+            "      task_slice = 'write paper'; "
+            "      native_skill_entrypoint = 'C:/skills/scientific-reporting/SKILL.md'; "
+            "      skill_md_path = 'C:/skills/scientific-reporting/SKILL.md'; "
+            "      dispatch_phase = 'post_execution'; "
+            "      write_scope = 'specialist:scientific-reporting'; "
+            "      verification_expectation = 'report evidence' "
+            "    }) "
+            "  } "
+            "}; "
+            "$current = [pscustomobject]@{ "
+            "  selected = @([pscustomobject]@{ "
+            "    skill_id = 'latex-submission-pipeline'; "
+            "    task_slice = 'compile pdf'; "
+            "    native_skill_entrypoint = 'C:/skills/latex-submission-pipeline/SKILL.md'; "
+            "    skill_md_path = 'C:/skills/latex-submission-pipeline/SKILL.md'; "
+            "    dispatch_phase = 'post_execution'; "
+            "    write_scope = 'specialist:latex-submission-pipeline'; "
+            "    verification_expectation = 'build pdf' "
+            "  }); "
+            "  candidates = @(); rejected = @() "
+            "}; "
+            "$lock = New-VibeSkillExecutionLockProjection "
+            "-PreviousRuntimeInputPacket $previous "
+            "-CurrentSkillRouting $current "
+            "-SourceRunId 'pytest-plan-run' "
+            "-Source 'approved_plan_reentry'; "
+            "$lock | ConvertTo-Json -Depth 20 "
+            "}"
+        )
+
+        self.assertEqual("v1", payload["schema_version"])
+        self.assertEqual("active", payload["state"])
+        self.assertEqual("approved_plan_reentry", payload["source"])
+        self.assertEqual("pytest-plan-run", payload["source_run_id"])
+        self.assertIn("scientific-reporting", as_list(payload["locked_skill_ids"]))
+        locked_dispatch = as_list(payload["locked_dispatch"])
+        self.assertEqual("scientific-reporting", locked_dispatch[0]["skill_id"])
+        self.assertEqual("inherited_not_currently_surfaced", locked_dispatch[0]["reconciliation_state"])
+        self.assertTrue(payload["resolution_required"])
+
+    def test_lock_projection_prefers_explicit_host_decision(self) -> None:
+        payload = run_ps_json(
+            "& { "
+            f". {ps_quote(str(RUNTIME_COMMON))}; "
+            f". {ps_quote(str(SKILL_ROUTING_COMMON))}; "
+            "$previous = [pscustomobject]@{ "
+            "  skill_routing = [pscustomobject]@{ "
+            "    selected = @([pscustomobject]@{ skill_id = 'scientific-reporting'; task_slice = 'prior plan' }) "
+            "  } "
+            "}; "
+            "$current = [pscustomobject]@{ "
+            "  selected = @([pscustomobject]@{ skill_id = 'latex-submission-pipeline'; task_slice = 'current pdf'; dispatch_phase = 'post_execution' }); "
+            "  candidates = @([pscustomobject]@{ skill_id = 'designing-experiments'; task_slice = 'explicit design'; dispatch_phase = 'pre_execution' }); "
+            "  rejected = @() "
+            "}; "
+            "$decision = [pscustomobject]@{ approved_skill_ids = @('designing-experiments') }; "
+            "$lock = New-VibeSkillExecutionLockProjection "
+            "-PreviousRuntimeInputPacket $previous "
+            "-CurrentSkillRouting $current "
+            "-HostSpecialistDispatchDecision $decision "
+            "-SourceRunId 'pytest-plan-run' "
+            "-Source 'approved_plan_reentry'; "
+            "$lock | ConvertTo-Json -Depth 20 "
+            "}"
+        )
+
+        self.assertEqual(["designing-experiments"], as_list(payload["locked_skill_ids"]))
+        dispatch = as_list(payload["locked_dispatch"])[0]
+        self.assertEqual("designing-experiments", dispatch["skill_id"])
+        self.assertEqual("host_decision", dispatch["lock_source"])
+        self.assertEqual("current_surfaced", dispatch["reconciliation_state"])
+
+    def test_convert_lock_to_dispatch_preserves_dispatch_fields(self) -> None:
+        payload = run_ps_json(
+            "& { "
+            f". {ps_quote(str(RUNTIME_COMMON))}; "
+            f". {ps_quote(str(SKILL_ROUTING_COMMON))}; "
+            "$lock = [pscustomobject]@{ "
+            "  schema_version = 'v1'; state = 'active'; resolution_required = $true; "
+            "  locked_dispatch = @([pscustomobject]@{ "
+            "    skill_id = 'literature-review'; "
+            "    task_slice = 'review authoritative literature'; "
+            "    native_skill_entrypoint = 'C:/skills/literature-review/SKILL.md'; "
+            "    skill_md_path = 'C:/skills/literature-review/SKILL.md'; "
+            "    dispatch_phase = 'pre_execution'; "
+            "    parallelizable_in_root_xl = $true; "
+            "    write_scope = 'specialist:literature-review'; "
+            "    verification_expectation = 'citation notes'; "
+            "    lock_source = 'previous_skill_routing_selected' "
+            "  }) "
+            "}; "
+            "$dispatch = Convert-VibeSkillExecutionLockToDispatch -SkillExecutionLock $lock; "
+            "[pscustomobject]@{ dispatch = $dispatch } | ConvertTo-Json -Depth 20 "
+            "}"
+        )
+
+        dispatch = as_list(payload["dispatch"])[0]
+        self.assertEqual("literature-review", dispatch["skill_id"])
+        self.assertEqual("pre_execution", dispatch["dispatch_phase"])
+        self.assertEqual("specialist:literature-review", dispatch["write_scope"])
+        self.assertEqual("citation notes", dispatch["verification_expectation"])
+        self.assertTrue(dispatch["locked_for_execution"])
+
+    def test_freeze_inherits_previous_plan_selection_into_execution_lock(self) -> None:
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available")
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir) / "artifacts"
+            prior_session = artifact_root / "outputs" / "runtime" / "vibe-sessions" / "pytest-plan-run"
+            prior_session.mkdir(parents=True)
+            (prior_session / "runtime-input-packet.json").write_text(
+                json.dumps(
+                    {
+                        "run_id": "pytest-plan-run",
+                        "requested_stage_stop": "xl_plan",
+                        "skill_routing": {
+                            "schema_version": "simplified_skill_routing_v1",
+                            "selected": [
+                                {
+                                    "skill_id": "scientific-reporting",
+                                    "task_slice": "write a scientific report",
+                                    "native_skill_entrypoint": "C:/skills/scientific-reporting/SKILL.md",
+                                    "skill_md_path": "C:/skills/scientific-reporting/SKILL.md",
+                                    "dispatch_phase": "post_execution",
+                                    "write_scope": "specialist:scientific-reporting",
+                                    "verification_expectation": "report evidence",
+                                }
+                            ],
+                            "candidates": [],
+                            "rejected": [],
+                        },
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            host_decision = {
+                "decision_kind": "approval_response",
+                "decision_action": "approve_plan",
+                "approval_decision": "approve",
+                "continuation_context": {
+                    "structured_bounded_reentry": True,
+                    "source_run_id": "pytest-plan-run",
+                    "reentry_action": "approve_plan",
+                    "prior_task_type": "research",
+                    "control_only_prompt": True,
+                },
+            }
+            completed = subprocess.run(
+                [
+                    shell,
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-File",
+                    str(FREEZE_SCRIPT),
+                    "-Task",
+                    "Continue approved plan and compile the LaTeX paper.",
+                    "-Mode",
+                    "interactive_governed",
+                    "-RunId",
+                    "pytest-execute-run",
+                    "-ArtifactRoot",
+                    str(artifact_root),
+                    "-HostDecisionJson",
+                    json.dumps(host_decision),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=True,
+            )
+            self.assertIn("packet_path", completed.stdout)
+            packet_path = next((artifact_root / "outputs" / "runtime" / "vibe-sessions" / "pytest-execute-run").rglob("runtime-input-packet.json"))
+            packet = json.loads(packet_path.read_text(encoding="utf-8"))
+
+        lock = packet["skill_execution_lock"]
+        self.assertEqual("active", lock["state"])
+        self.assertIn("scientific-reporting", as_list(lock["locked_skill_ids"]))
+        self.assertTrue(lock["resolution_required"])
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail before implementation**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_skill_execution_lock_contract.py -q
+```
+
+Expected:
+
+```text
+FAILED
+```
+
+At least one failure should mention that `New-VibeSkillExecutionLockProjection` or `Convert-VibeSkillExecutionLockToDispatch` is not recognized.
+
+- [ ] **Step 3: Commit the failing tests**
+
+Run:
+
+```powershell
+git add tests/runtime_neutral/test_skill_execution_lock_contract.py
+git commit -m "test: add specialist execution lock contract coverage"
+```
+
+Expected:
+
+```text
+Commit succeeds and prints subject `test: add specialist execution lock contract coverage`.
+```
+
+---
+
+### Task 2: Implement Runtime Lock Helpers
+
+**Files:**
+
+- Modify: `scripts/runtime/VibeRuntime.Common.ps1`
+- Test: `tests/runtime_neutral/test_skill_execution_lock_contract.py`
+
+- [ ] **Step 1: Add lock helper functions**
+
+In `scripts/runtime/VibeRuntime.Common.ps1`, add these functions after `Resolve-VibeHostSkillExecutionDecision`:
+
+```powershell
+function Get-VibeRuntimeInputPacketFromSessionRunId {
+    param(
+        [AllowEmptyString()] [string]$ArtifactRoot = '',
+        [AllowEmptyString()] [string]$SourceRunId = ''
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ArtifactRoot) -or [string]::IsNullOrWhiteSpace($SourceRunId)) {
+        return $null
+    }
+
+    $candidatePath = Join-Path (Join-Path (Join-Path (Join-Path $ArtifactRoot 'outputs') 'runtime') 'vibe-sessions') (Join-Path $SourceRunId 'runtime-input-packet.json')
+    if (-not (Test-Path -LiteralPath $candidatePath)) {
+        return $null
+    }
+
+    try {
+        return Get-Content -LiteralPath $candidatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+}
+
+function Get-VibeSkillExecutionLockFromRuntimeInputPacket {
+    param(
+        [AllowNull()] [object]$RuntimeInputPacket = $null
+    )
+
+    if (
+        $null -eq $RuntimeInputPacket -or
+        -not (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket -PropertyName 'skill_execution_lock') -or
+        $null -eq $RuntimeInputPacket.skill_execution_lock
+    ) {
+        return $null
+    }
+
+    return $RuntimeInputPacket.skill_execution_lock
+}
+
+function Test-VibeSkillExecutionLockActive {
+    param(
+        [AllowNull()] [object]$SkillExecutionLock = $null
+    )
+
+    if ($null -eq $SkillExecutionLock) {
+        return $false
+    }
+    $state = if (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'state') { [string]$SkillExecutionLock.state } else { '' }
+    $lockedDispatch = if (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'locked_dispatch') { @($SkillExecutionLock.locked_dispatch) } else { @() }
+    $lockedSkillIds = if (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'locked_skill_ids') { @($SkillExecutionLock.locked_skill_ids) } else { @() }
+    return [bool]([string]::Equals($state, 'active', [System.StringComparison]::OrdinalIgnoreCase) -and ((@($lockedDispatch).Count -gt 0) -or (@($lockedSkillIds).Count -gt 0)))
+}
+
+function Copy-VibeSkillExecutionLockDispatchRecord {
+    param(
+        [AllowNull()] [object]$Record = $null,
+        [AllowEmptyString()] [string]$LockSource = '',
+        [AllowEmptyString()] [string]$ReconciliationState = ''
+    )
+
+    if ($null -eq $Record) {
+        return $null
+    }
+    $copy = Copy-VibeRecordObject -InputObject $Record
+    $skillId = if (Test-VibeObjectHasProperty -InputObject $copy -PropertyName 'skill_id') { [string]$copy.skill_id } else { '' }
+    if ([string]::IsNullOrWhiteSpace($skillId)) {
+        return $null
+    }
+    if (-not (Test-VibeObjectHasProperty -InputObject $copy -PropertyName 'task_slice') -or [string]::IsNullOrWhiteSpace([string]$copy.task_slice)) {
+        $copy | Add-Member -NotePropertyName task_slice -NotePropertyValue ('Resolve locked specialist execution for {0}.' -f $skillId) -Force
+    }
+    if (-not (Test-VibeObjectHasProperty -InputObject $copy -PropertyName 'dispatch_phase') -or [string]::IsNullOrWhiteSpace([string]$copy.dispatch_phase)) {
+        $copy | Add-Member -NotePropertyName dispatch_phase -NotePropertyValue 'in_execution' -Force
+    }
+    if (-not (Test-VibeObjectHasProperty -InputObject $copy -PropertyName 'write_scope') -or [string]::IsNullOrWhiteSpace([string]$copy.write_scope)) {
+        $copy | Add-Member -NotePropertyName write_scope -NotePropertyValue ('specialist:{0}' -f $skillId) -Force
+    }
+    if (-not (Test-VibeObjectHasProperty -InputObject $copy -PropertyName 'verification_expectation') -or [string]::IsNullOrWhiteSpace([string]$copy.verification_expectation)) {
+        $copy | Add-Member -NotePropertyName verification_expectation -NotePropertyValue 'Resolve locked specialist execution before delivery acceptance.' -Force
+    }
+    $copy | Add-Member -NotePropertyName locked_for_execution -NotePropertyValue $true -Force
+    $copy | Add-Member -NotePropertyName lock_source -NotePropertyValue $(if ([string]::IsNullOrWhiteSpace($LockSource)) { 'unknown' } else { [string]$LockSource }) -Force
+    $copy | Add-Member -NotePropertyName reconciliation_state -NotePropertyValue $(if ([string]::IsNullOrWhiteSpace($ReconciliationState)) { 'current_surfaced' } else { [string]$ReconciliationState }) -Force
+    $copy | Add-Member -NotePropertyName requires_resolution -NotePropertyValue $true -Force
+    return $copy
+}
+
+function New-VibeMinimalSkillExecutionLockDispatchRecord {
+    param(
+        [Parameter(Mandatory)] [string]$SkillId,
+        [AllowEmptyString()] [string]$LockSource = '',
+        [AllowEmptyString()] [string]$ReconciliationState = ''
+    )
+
+    return Copy-VibeSkillExecutionLockDispatchRecord `
+        -Record ([pscustomobject]@{
+            skill_id = [string]$SkillId
+            task_slice = ('Resolve locked specialist execution for {0}.' -f [string]$SkillId)
+            dispatch_phase = 'in_execution'
+            write_scope = ('specialist:{0}' -f [string]$SkillId)
+            verification_expectation = 'Resolve locked specialist execution before delivery acceptance.'
+        }) `
+        -LockSource $LockSource `
+        -ReconciliationState $ReconciliationState
+}
+
+function Add-VibeSkillExecutionLockRecord {
+    param(
+        [Parameter(Mandatory)] [System.Collections.Generic.List[object]]$Rows,
+        [Parameter(Mandatory)] [hashtable]$Seen,
+        [AllowNull()] [object]$Record = $null
+    )
+
+    if ($null -eq $Record -or -not (Test-VibeObjectHasProperty -InputObject $Record -PropertyName 'skill_id')) {
+        return
+    }
+    $skillId = [string]$Record.skill_id
+    if ([string]::IsNullOrWhiteSpace($skillId) -or $Seen.ContainsKey($skillId)) {
+        return
+    }
+    $Rows.Add($Record) | Out-Null
+    $Seen[$skillId] = $true
+}
+
+function Get-VibeSkillExecutionLockCandidateRecords {
+    param(
+        [AllowNull()] [object]$SkillRouting = $null
+    )
+
+    if ($null -eq $SkillRouting) {
+        return @()
+    }
+    $rows = @()
+    foreach ($propertyName in @('selected', 'candidates', 'rejected')) {
+        if (Test-VibeObjectHasProperty -InputObject $SkillRouting -PropertyName $propertyName) {
+            $rows += @($SkillRouting.$propertyName)
+        }
+    }
+    return @($rows | Where-Object { $null -ne $_ })
+}
+
+function New-VibeSkillExecutionLockProjection {
+    param(
+        [AllowNull()] [object]$PreviousRuntimeInputPacket = $null,
+        [AllowNull()] [object]$CurrentSkillRouting = $null,
+        [AllowNull()] [object]$HostSpecialistDispatchDecision = $null,
+        [AllowEmptyString()] [string]$SourceRunId = '',
+        [AllowEmptyString()] [string]$Source = 'current_skill_routing_selected'
+    )
+
+    $rows = New-Object System.Collections.Generic.List[object]
+    $seen = @{}
+    $currentRecords = @(Get-VibeSkillExecutionLockCandidateRecords -SkillRouting $CurrentSkillRouting)
+    $currentSkillIds = @($currentRecords | ForEach-Object {
+        if (Test-VibeObjectHasProperty -InputObject $_ -PropertyName 'skill_id') { [string]$_.skill_id } else { '' }
+    } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+
+    $hostApproved = if ($null -ne $HostSpecialistDispatchDecision -and (Test-VibeObjectHasProperty -InputObject $HostSpecialistDispatchDecision -PropertyName 'approved_skill_ids')) {
+        @(Get-VibeNormalizedStringList -Values $HostSpecialistDispatchDecision.approved_skill_ids)
+    } else {
+        @()
+    }
+    if (@($hostApproved).Count -gt 0) {
+        foreach ($skillId in @($hostApproved)) {
+            $sourceRecord = @($currentRecords | Where-Object {
+                (Test-VibeObjectHasProperty -InputObject $_ -PropertyName 'skill_id') -and
+                [string]::Equals([string]$_.skill_id, [string]$skillId, [System.StringComparison]::OrdinalIgnoreCase)
+            } | Select-Object -First 1)
+            $record = if (@($sourceRecord).Count -gt 0) {
+                Copy-VibeSkillExecutionLockDispatchRecord -Record $sourceRecord[0] -LockSource 'host_decision' -ReconciliationState 'current_surfaced'
+            } else {
+                New-VibeMinimalSkillExecutionLockDispatchRecord -SkillId $skillId -LockSource 'host_decision' -ReconciliationState 'host_approved_not_currently_surfaced'
+            }
+            Add-VibeSkillExecutionLockRecord -Rows $rows -Seen $seen -Record $record
+        }
+    } else {
+        $previousLock = Get-VibeSkillExecutionLockFromRuntimeInputPacket -RuntimeInputPacket $PreviousRuntimeInputPacket
+        if (Test-VibeSkillExecutionLockActive -SkillExecutionLock $previousLock) {
+            foreach ($entry in @($previousLock.locked_dispatch)) {
+                $skillId = if (Test-VibeObjectHasProperty -InputObject $entry -PropertyName 'skill_id') { [string]$entry.skill_id } else { '' }
+                $state = if ($skillId -in @($currentSkillIds)) { 'current_surfaced' } else { 'inherited_not_currently_surfaced' }
+                Add-VibeSkillExecutionLockRecord -Rows $rows -Seen $seen -Record (Copy-VibeSkillExecutionLockDispatchRecord -Record $entry -LockSource 'previous_skill_execution_lock' -ReconciliationState $state)
+            }
+        } elseif ($null -ne $PreviousRuntimeInputPacket -and (Test-VibeObjectHasProperty -InputObject $PreviousRuntimeInputPacket -PropertyName 'skill_routing') -and $null -ne $PreviousRuntimeInputPacket.skill_routing) {
+            foreach ($entry in @(Get-VibeSkillRoutingSelected -RuntimeInputPacket $PreviousRuntimeInputPacket)) {
+                $skillId = if (Test-VibeObjectHasProperty -InputObject $entry -PropertyName 'skill_id') { [string]$entry.skill_id } else { '' }
+                $state = if ($skillId -in @($currentSkillIds)) { 'current_surfaced' } else { 'inherited_not_currently_surfaced' }
+                Add-VibeSkillExecutionLockRecord -Rows $rows -Seen $seen -Record (Copy-VibeSkillExecutionLockDispatchRecord -Record $entry -LockSource 'previous_skill_routing_selected' -ReconciliationState $state)
+            }
+        }
+        if (@($rows.ToArray()).Count -eq 0 -and $null -ne $CurrentSkillRouting) {
+            foreach ($entry in @(Get-VibeSkillRoutingSelected -SkillRouting $CurrentSkillRouting)) {
+                Add-VibeSkillExecutionLockRecord -Rows $rows -Seen $seen -Record (Copy-VibeSkillExecutionLockDispatchRecord -Record $entry -LockSource 'current_skill_routing_selected' -ReconciliationState 'current_surfaced')
+            }
+        }
+    }
+
+    $lockedDispatch = [object[]]$rows.ToArray()
+    $lockedSkillIds = [object[]]@($lockedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $state = if (@($lockedSkillIds).Count -gt 0) { 'active' } else { 'inactive' }
+    return [pscustomobject]@{
+        schema_version = 'v1'
+        state = $state
+        source = if ([string]::IsNullOrWhiteSpace($Source)) { 'current_skill_routing_selected' } else { [string]$Source }
+        source_run_id = if ([string]::IsNullOrWhiteSpace($SourceRunId)) { $null } else { [string]$SourceRunId }
+        locked_skill_ids = @($lockedSkillIds)
+        locked_dispatch = @($lockedDispatch)
+        resolution_required = [bool](@($lockedSkillIds).Count -gt 0)
+        resolution_states = @('executed', 'not_applicable', 'deferred', 'failed')
+    }
+}
+
+function New-VibeSkillExecutionLockSummaryProjection {
+    param(
+        [AllowNull()] [object]$SkillExecutionLock = $null
+    )
+
+    $active = Test-VibeSkillExecutionLockActive -SkillExecutionLock $SkillExecutionLock
+    $lockedSkillIds = if ($active -and (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'locked_skill_ids')) { @($SkillExecutionLock.locked_skill_ids) } else { @() }
+    return [pscustomobject]@{
+        active = [bool]$active
+        locked_skill_count = @($lockedSkillIds).Count
+        locked_skill_ids = @($lockedSkillIds)
+        source = if ($active -and (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'source')) { [string]$SkillExecutionLock.source } else { $null }
+        source_run_id = if ($active -and (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'source_run_id')) { [string]$SkillExecutionLock.source_run_id } else { $null }
+        resolution_required = if ($active -and (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'resolution_required')) { [bool]$SkillExecutionLock.resolution_required } else { $false }
+    }
+}
+```
+
+- [ ] **Step 2: Run the helper tests**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_skill_execution_lock_contract.py::SkillExecutionLockContractTests::test_lock_projection_preserves_previous_selected_when_current_router_differs tests/runtime_neutral/test_skill_execution_lock_contract.py::SkillExecutionLockContractTests::test_lock_projection_prefers_explicit_host_decision -q
+```
+
+Expected:
+
+```text
+2 passed
+```
+
+- [ ] **Step 3: Commit helper implementation**
+
+Run:
+
+```powershell
+git add scripts/runtime/VibeRuntime.Common.ps1 tests/runtime_neutral/test_skill_execution_lock_contract.py
+git commit -m "feat: add specialist execution lock helpers"
+```
+
+Expected:
+
+```text
+Commit succeeds and prints subject `feat: add specialist execution lock helpers`.
+```
+
+---
+
+### Task 3: Add Lock-To-Dispatch Conversion
+
+**Files:**
+
+- Modify: `scripts/runtime/VibeSkillRouting.Common.ps1`
+- Test: `tests/runtime_neutral/test_skill_execution_lock_contract.py`
+
+- [ ] **Step 1: Add conversion helper**
+
+In `scripts/runtime/VibeSkillRouting.Common.ps1`, add this function after `Convert-VibeSkillRoutingSelectedToDispatch`:
+
+```powershell
+function Convert-VibeSkillExecutionLockToDispatch {
+    param(
+        [AllowNull()] [object]$SkillExecutionLock = $null
+    )
+
+    if ($null -eq $SkillExecutionLock) {
+        return @()
+    }
+
+    $state = [string](Get-VibeSkillRoutingProperty -InputObject $SkillExecutionLock -PropertyName 'state' -DefaultValue '')
+    if (-not [string]::Equals($state, 'active', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return @()
+    }
+
+    $lockedDispatch = [object[]]@(Get-VibeSkillRoutingProperty -InputObject $SkillExecutionLock -PropertyName 'locked_dispatch' -DefaultValue @())
+    return [object[]]@($lockedDispatch | ForEach-Object {
+        $entry = $_
+        $skillId = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'skill_id' -DefaultValue '')
+        if ([string]::IsNullOrWhiteSpace($skillId)) {
+            return
+        }
+        [pscustomobject]@{
+            skill_id = $skillId
+            phase_id = Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'phase_id' -DefaultValue $null
+            reason = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'reason' -DefaultValue '')
+            task_slice = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'task_slice' -DefaultValue ('Resolve locked specialist execution for {0}.' -f $skillId))
+            native_skill_entrypoint = Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'native_skill_entrypoint' -DefaultValue $null
+            skill_md_path = Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'skill_md_path' -DefaultValue $null
+            dispatch_phase = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'dispatch_phase' -DefaultValue 'in_execution')
+            parallelizable_in_root_xl = [bool](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'parallelizable_in_root_xl' -DefaultValue $false)
+            native_usage_required = [bool](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'native_usage_required' -DefaultValue $true)
+            usage_required = [bool](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'usage_required' -DefaultValue (Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'native_usage_required' -DefaultValue $true))
+            skill_root = Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'skill_root' -DefaultValue $null
+            bounded_role = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'bounded_role' -DefaultValue 'selected_skill')
+            must_preserve_workflow = [bool](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'must_preserve_workflow' -DefaultValue $true)
+            binding_profile = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'binding_profile' -DefaultValue 'selected_skill')
+            lane_policy = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'lane_policy' -DefaultValue 'native_contract')
+            write_scope = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'write_scope' -DefaultValue ('specialist:{0}' -f $skillId))
+            review_mode = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'review_mode' -DefaultValue 'native_contract')
+            execution_priority = [int](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'execution_priority' -DefaultValue 50)
+            required_inputs = [object[]]@(Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'required_inputs' -DefaultValue @())
+            expected_outputs = [object[]]@(Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'expected_outputs' -DefaultValue @())
+            verification_expectation = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'verification_expectation' -DefaultValue 'Resolve locked specialist execution before completion.')
+            progressive_load_policy = [object[]]@(Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'progressive_load_policy' -DefaultValue @())
+            locked_for_execution = $true
+            lock_source = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'lock_source' -DefaultValue 'skill_execution_lock')
+            reconciliation_state = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'reconciliation_state' -DefaultValue 'current_surfaced')
+            requires_resolution = [bool](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'requires_resolution' -DefaultValue $true)
+        }
+    } | Where-Object { $null -ne $_ })
+}
+```
+
+- [ ] **Step 2: Run conversion tests**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_skill_execution_lock_contract.py::SkillExecutionLockContractTests::test_convert_lock_to_dispatch_preserves_dispatch_fields -q
+```
+
+Expected:
+
+```text
+1 passed
+```
+
+- [ ] **Step 3: Commit conversion helper**
+
+Run:
+
+```powershell
+git add scripts/runtime/VibeSkillRouting.Common.ps1
+git commit -m "feat: convert specialist execution locks to dispatch"
+```
+
+Expected:
+
+```text
+Commit succeeds and prints subject `feat: convert specialist execution locks to dispatch`.
+```
+
+---
+
+### Task 4: Create Lock During Runtime Packet Freeze
+
+**Files:**
+
+- Modify: `scripts/runtime/Freeze-RuntimeInputPacket.ps1`
+- Test: `tests/runtime_neutral/test_skill_execution_lock_contract.py`
+
+- [ ] **Step 1: Load previous runtime packet before packet projection**
+
+In `scripts/runtime/Freeze-RuntimeInputPacket.ps1`, after the multiline assignment that starts with `$hostSpecialistDispatchDecision = Resolve-VibeHostSkillExecutionDecision`, add:
+
+```powershell
+$lockSourceRunId = if (
+    $null -ne $continuationContext -and
+    (Test-VibeObjectHasProperty -InputObject $continuationContext -PropertyName 'source_run_id') -and
+    -not [string]::IsNullOrWhiteSpace([string]$continuationContext.source_run_id)
+) {
+    [string]$continuationContext.source_run_id
+} else {
+    ''
+}
+$previousRuntimeInputPacket = Get-VibeRuntimeInputPacketFromSessionRunId `
+    -ArtifactRoot $ArtifactRoot `
+    -SourceRunId $lockSourceRunId
+```
+
+- [ ] **Step 2: Construct lock after current `$skillRouting` is built**
+
+In `scripts/runtime/Freeze-RuntimeInputPacket.ps1`, immediately after the multiline assignment that starts with `$skillRouting = New-VibeSkillRoutingFromLegacy`, add:
+
+```powershell
+$lockSource = if (-not [string]::IsNullOrWhiteSpace($lockSourceRunId)) {
+    'approved_plan_reentry'
+} else {
+    'current_skill_routing_selected'
+}
+$skillExecutionLock = New-VibeSkillExecutionLockProjection `
+    -PreviousRuntimeInputPacket $previousRuntimeInputPacket `
+    -CurrentSkillRouting $skillRouting `
+    -HostSpecialistDispatchDecision $hostSpecialistDispatchDecision `
+    -SourceRunId $lockSourceRunId `
+    -Source $lockSource
+```
+
+- [ ] **Step 3: Pass the lock into the runtime packet projection**
+
+In the `New-VibeRuntimeInputPacketProjection` call in `scripts/runtime/Freeze-RuntimeInputPacket.ps1`, add:
+
+```powershell
+    -SkillExecutionLock $skillExecutionLock `
+```
+
+- [ ] **Step 4: Add the projection parameter and output field**
+
+In `New-VibeRuntimeInputPacketProjection` in `scripts/runtime/VibeRuntime.Common.ps1`, add a parameter:
+
+```powershell
+[AllowNull()] [object]$SkillExecutionLock = $null,
+```
+
+Then add this field in the returned packet object near `skill_routing`:
+
+```powershell
+skill_execution_lock = if ($null -ne $SkillExecutionLock) { $SkillExecutionLock } else { $null }
+skill_execution_lock_summary = New-VibeSkillExecutionLockSummaryProjection -SkillExecutionLock $SkillExecutionLock
+```
+
+- [ ] **Step 5: Run freeze inheritance test**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_skill_execution_lock_contract.py::SkillExecutionLockContractTests::test_freeze_inherits_previous_plan_selection_into_execution_lock -q
+```
+
+Expected:
+
+```text
+1 passed
+```
+
+- [ ] **Step 6: Run existing freeze contract tests**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_simplified_skill_routing_contract.py tests/runtime_neutral/test_skill_promotion_freeze_contract.py tests/runtime_neutral/test_structured_bounded_reentry_continuation.py -q
+```
+
+Expected:
+
+```text
+passed
+```
+
+- [ ] **Step 7: Commit freeze integration**
+
+Run:
+
+```powershell
+git add scripts/runtime/Freeze-RuntimeInputPacket.ps1 scripts/runtime/VibeRuntime.Common.ps1 tests/runtime_neutral/test_skill_execution_lock_contract.py
+git commit -m "feat: freeze specialist execution lock across reentry"
+```
+
+Expected:
+
+```text
+Commit succeeds and prints subject `feat: freeze specialist execution lock across reentry`.
+```
+
+---
+
+### Task 5: Prefer Lock Dispatch During Plan Execution
+
+**Files:**
+
+- Modify: `scripts/runtime/Invoke-PlanExecute.ps1`
+- Test: `tests/runtime_neutral/test_skill_execution_lock_contract.py`
+- Test: `tests/runtime_neutral/test_l_xl_native_execution_topology.py`
+
+- [ ] **Step 1: Add plan-execute lock contract test**
+
+Append this test method to `SkillExecutionLockContractTests` in `tests/runtime_neutral/test_skill_execution_lock_contract.py`:
+
+```python
+    def test_lock_dispatch_is_preferred_over_current_router_selection_projection(self) -> None:
+        payload = run_ps_json(
+            "& { "
+            f". {ps_quote(str(RUNTIME_COMMON))}; "
+            f". {ps_quote(str(SKILL_ROUTING_COMMON))}; "
+            "$runtimePacket = [pscustomobject]@{ "
+            "  skill_execution_lock = [pscustomobject]@{ "
+            "    schema_version = 'v1'; state = 'active'; resolution_required = $true; "
+            "    locked_dispatch = @([pscustomobject]@{ "
+            "      skill_id = 'scientific-reporting'; task_slice = 'locked report'; dispatch_phase = 'post_execution'; "
+            "      write_scope = 'specialist:scientific-reporting'; verification_expectation = 'report evidence' "
+            "    }) "
+            "  }; "
+            "  skill_routing = [pscustomobject]@{ "
+            "    selected = @([pscustomobject]@{ skill_id = 'latex-submission-pipeline'; task_slice = 'current pdf'; dispatch_phase = 'post_execution' }) "
+            "  } "
+            "}; "
+            "$lockDispatch = Convert-VibeSkillExecutionLockToDispatch -SkillExecutionLock $runtimePacket.skill_execution_lock; "
+            "$currentDispatch = Convert-VibeSkillRoutingSelectedToDispatch -RuntimeInputPacket $runtimePacket -SkillRouting $runtimePacket.skill_routing; "
+            "[pscustomobject]@{ lock_dispatch = $lockDispatch; current_dispatch = $currentDispatch } | ConvertTo-Json -Depth 20 "
+            "}"
+        )
+
+        self.assertEqual(["scientific-reporting"], [item["skill_id"] for item in as_list(payload["lock_dispatch"])])
+        self.assertEqual(["latex-submission-pipeline"], [item["skill_id"] for item in as_list(payload["current_dispatch"])])
+```
+
+- [ ] **Step 2: Change plan execution dispatch source order**
+
+In `scripts/runtime/Invoke-PlanExecute.ps1`, after `$skillRouting` is resolved and before the current `$selectedSkills = @(Convert-VibeSkillRoutingSelectedToDispatch -RuntimeInputPacket $runtimeInputPacket -SkillRouting $skillRouting)` assignment, add:
+
+```powershell
+$skillExecutionLock = Get-VibeSkillExecutionLockFromRuntimeInputPacket -RuntimeInputPacket $runtimeInputPacket
+$lockSelectedSkills = @(Convert-VibeSkillExecutionLockToDispatch -SkillExecutionLock $skillExecutionLock)
+$hasActiveSkillExecutionLock = Test-VibeSkillExecutionLockActive -SkillExecutionLock $skillExecutionLock
+```
+
+Replace:
+
+```powershell
+$selectedSkills = @(Convert-VibeSkillRoutingSelectedToDispatch -RuntimeInputPacket $runtimeInputPacket -SkillRouting $skillRouting)
+```
+
+with:
+
+```powershell
+$selectedSkills = if ($hasActiveSkillExecutionLock -and @($lockSelectedSkills).Count -gt 0) {
+    @($lockSelectedSkills)
+} else {
+    @(Convert-VibeSkillRoutingSelectedToDispatch -RuntimeInputPacket $runtimeInputPacket -SkillRouting $skillRouting)
+}
+```
+
+Replace:
+
+```powershell
+$hasCanonicalSelectedSkills = $null -ne $skillRouting -and $skillRouting.PSObject.Properties.Name -contains 'selected' -and @($skillRouting.selected).Count -gt 0
+```
+
+with:
+
+```powershell
+$hasCanonicalSelectedSkills = (
+    ($hasActiveSkillExecutionLock -and @($selectedSkills).Count -gt 0) -or
+    ($null -ne $skillRouting -and $skillRouting.PSObject.Properties.Name -contains 'selected' -and @($skillRouting.selected).Count -gt 0)
+)
+```
+
+Inside the `$specialistDispatchResolution = [pscustomobject]@{` block used when `$hasCanonicalSelectedSkills` is true, replace:
+
+```powershell
+reason = 'skill_routing_selected_is_authority'
+```
+
+with:
+
+```powershell
+reason = if ($hasActiveSkillExecutionLock) { 'skill_execution_lock_is_authority' } else { 'skill_routing_selected_is_authority' }
+```
+
+- [ ] **Step 3: Emit lock accounting into execution manifest**
+
+Before the `$executionManifest = [pscustomobject]@{` assignment, compute:
+
+```powershell
+$lockedSkillIds = if ($hasActiveSkillExecutionLock -and $skillExecutionLock.PSObject.Properties.Name -contains 'locked_skill_ids') { @($skillExecutionLock.locked_skill_ids) } else { @() }
+$executedLockedSkillIds = @($verifiedSpecialistUnits | ForEach-Object {
+    if ($_.PSObject.Properties.Name -contains 'skill_id') { [string]$_.skill_id } else { '' }
+} | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and $_ -in @($lockedSkillIds) } | Select-Object -Unique)
+$failedLockedSkillIds = @($failedLiveSpecialistUnits | ForEach-Object {
+    if ($_.PSObject.Properties.Name -contains 'skill_id') { [string]$_.skill_id } else { '' }
+} | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and $_ -in @($lockedSkillIds) } | Select-Object -Unique)
+$resolvedLockedSkillIds = @(@($executedLockedSkillIds) + @($failedLockedSkillIds) | Select-Object -Unique)
+$unresolvedLockedSkillIds = @($lockedSkillIds | Where-Object { $_ -notin @($resolvedLockedSkillIds) })
+$specialistLockResolution = [pscustomobject]@{
+    active = [bool]$hasActiveSkillExecutionLock
+    locked_skill_ids = @($lockedSkillIds)
+    executed_skill_ids = @($executedLockedSkillIds)
+    not_applicable_skill_ids = @()
+    deferred_skill_ids = @()
+    failed_skill_ids = @($failedLockedSkillIds)
+    unresolved_skill_ids = @($unresolvedLockedSkillIds)
+    delivery_blocking = [bool](@($unresolvedLockedSkillIds).Count -gt 0 -or @($failedLockedSkillIds).Count -gt 0)
+}
+```
+
+Add these fields to `specialist_accounting` in the execution manifest:
+
+```powershell
+skill_execution_lock = $skillExecutionLock
+skill_execution_lock_active = [bool]$hasActiveSkillExecutionLock
+skill_execution_lock_summary = New-VibeSkillExecutionLockSummaryProjection -SkillExecutionLock $skillExecutionLock
+specialist_lock_resolution = $specialistLockResolution
+```
+
+Also add top-level:
+
+```powershell
+skill_execution_lock = $skillExecutionLock
+specialist_lock_resolution = $specialistLockResolution
+```
+
+- [ ] **Step 4: Run focused plan-execute tests**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_skill_execution_lock_contract.py tests/runtime_neutral/test_l_xl_native_execution_topology.py::NativeExecutionTopologyTests::test_approved_specialist_dispatch_requires_executable_native_units -q
+```
+
+Expected:
+
+```text
+passed
+```
+
+- [ ] **Step 5: Commit plan-execute integration**
+
+Run:
+
+```powershell
+git add scripts/runtime/Invoke-PlanExecute.ps1 tests/runtime_neutral/test_skill_execution_lock_contract.py
+git commit -m "feat: prefer specialist execution lock in plan execute"
+```
+
+Expected:
+
+```text
+Commit succeeds and prints subject `feat: prefer specialist execution lock in plan execute`.
+```
+
+---
+
+### Task 6: Enforce Lock Resolution In Delivery Acceptance
+
+**Files:**
+
+- Modify: `packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py`
+- Modify: `tests/runtime_neutral/test_runtime_delivery_acceptance.py`
+
+- [ ] **Step 1: Extend delivery acceptance test fixture**
+
+In `RuntimeDeliveryAcceptanceTests._build_session` in `tests/runtime_neutral/test_runtime_delivery_acceptance.py`, add parameters:
+
+```python
+        skill_execution_lock: dict[str, object] | None = None,
+        specialist_lock_resolution: dict[str, object] | None = None,
+```
+
+After `execution_manifest_payload` is initialized, add:
+
+```python
+        if specialist_lock_resolution is not None:
+            execution_manifest_payload["specialist_lock_resolution"] = specialist_lock_resolution
+```
+
+After `runtime_input_packet_payload` is initialized, add:
+
+```python
+        if skill_execution_lock is not None:
+            runtime_input_packet_payload["skill_execution_lock"] = skill_execution_lock
+```
+
+- [ ] **Step 2: Add delivery acceptance tests**
+
+Append these tests to `RuntimeDeliveryAcceptanceTests`:
+
+```python
+    def test_runtime_delivery_acceptance_fails_when_locked_specialist_is_unresolved(self) -> None:
+        skill_path = "/tmp/scientific-reporting/SKILL.md"
+        session_root = self._build_session(
+            approved_dispatch=[
+                {
+                    "skill_id": "scientific-reporting",
+                    "native_skill_entrypoint": skill_path,
+                }
+            ],
+            phase_execute_specialist_user_disclosure={
+                "scope": "selected_skill_execution_only",
+                "timing": "before_execution",
+                "path_source": "native_skill_entrypoint",
+                "routed_skills": [
+                    {
+                        "skill_id": "scientific-reporting",
+                        "native_skill_entrypoint": skill_path,
+                        "entrypoint_requirement_satisfied": True,
+                    }
+                ],
+            },
+            skill_execution_lock={
+                "schema_version": "v1",
+                "state": "active",
+                "locked_skill_ids": ["scientific-reporting"],
+                "locked_dispatch": [{"skill_id": "scientific-reporting", "native_skill_entrypoint": skill_path}],
+                "resolution_required": True,
+            },
+            specialist_lock_resolution={
+                "active": True,
+                "locked_skill_ids": ["scientific-reporting"],
+                "executed_skill_ids": [],
+                "not_applicable_skill_ids": [],
+                "deferred_skill_ids": [],
+                "failed_skill_ids": [],
+                "unresolved_skill_ids": ["scientific-reporting"],
+                "delivery_blocking": True,
+            },
+            phase_execute_specialist_decision={
+                "decision_state": "approved_dispatch",
+                "resolution_mode": "approved_dispatch",
+                "approved_dispatch_skill_ids": ["scientific-reporting"],
+            },
+        )
+
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("FAIL", report["summary"]["gate_result"])
+        self.assertIn("specialist_lock_resolution_truth", report["truth_results"])
+        self.assertEqual("failing", report["truth_results"]["specialist_lock_resolution_truth"]["state"])
+        self.assertIn("scientific-reporting", report["execution_context"]["specialist_lock_unresolved_skill_ids"])
+
+    def test_runtime_delivery_acceptance_passes_when_locked_specialist_is_executed(self) -> None:
+        skill_path = "/tmp/scientific-reporting/SKILL.md"
+        session_root = self._build_session(
+            run_id="pytest-specialist-lock-pass",
+            approved_dispatch=[
+                {
+                    "skill_id": "scientific-reporting",
+                    "native_skill_entrypoint": skill_path,
+                }
+            ],
+            phase_execute_specialist_user_disclosure={
+                "scope": "selected_skill_execution_only",
+                "timing": "before_execution",
+                "path_source": "native_skill_entrypoint",
+                "routed_skills": [
+                    {
+                        "skill_id": "scientific-reporting",
+                        "native_skill_entrypoint": skill_path,
+                        "entrypoint_requirement_satisfied": True,
+                    }
+                ],
+            },
+            specialist_accounting={
+                "selected_skill_execution": [
+                    {
+                        "skill_id": "scientific-reporting",
+                        "native_skill_entrypoint": skill_path,
+                    }
+                ],
+                "selected_skill_execution_count": 1,
+                "effective_execution_status": "direct_current_session_routed",
+                "direct_routed_skill_execution_units": [
+                    {
+                        "unit_id": "unit-1",
+                        "skill_id": "scientific-reporting",
+                        "result_path": "specialist-results/scientific-reporting.json",
+                    }
+                ],
+            },
+            skill_execution_lock={
+                "schema_version": "v1",
+                "state": "active",
+                "locked_skill_ids": ["scientific-reporting"],
+                "locked_dispatch": [{"skill_id": "scientific-reporting", "native_skill_entrypoint": skill_path}],
+                "resolution_required": True,
+            },
+            specialist_lock_resolution={
+                "active": True,
+                "locked_skill_ids": ["scientific-reporting"],
+                "executed_skill_ids": ["scientific-reporting"],
+                "not_applicable_skill_ids": [],
+                "deferred_skill_ids": [],
+                "failed_skill_ids": [],
+                "unresolved_skill_ids": [],
+                "delivery_blocking": False,
+            },
+            phase_execute_specialist_decision={
+                "decision_state": "approved_dispatch",
+                "resolution_mode": "approved_dispatch",
+                "approved_dispatch_skill_ids": ["scientific-reporting"],
+            },
+            sidecar_specialist_execution={
+                "protocol_version": "v1",
+                "source_run_id": "pytest-specialist-lock-pass",
+                "resolution_mode": "current_session_host_execution",
+                "evidence_paths": ["/tmp/pytest-specialist-lock-pass.md"],
+                "units": [
+                    {
+                        "unit_id": "unit-1",
+                        "skill_id": "scientific-reporting",
+                        "resolution_state": "executed",
+                        "native_skill_entrypoint": skill_path,
+                        "evidence_paths": ["/tmp/pytest-scientific-reporting.txt"],
+                    }
+                ],
+            },
+        )
+
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("PASS", report["summary"]["gate_result"])
+        self.assertEqual("passing", report["truth_results"]["specialist_lock_resolution_truth"]["state"])
+        self.assertEqual([], report["execution_context"]["specialist_lock_unresolved_skill_ids"])
+```
+
+- [ ] **Step 3: Run tests and confirm they fail before evaluator changes**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_runtime_delivery_acceptance.py::RuntimeDeliveryAcceptanceTests::test_runtime_delivery_acceptance_fails_when_locked_specialist_is_unresolved tests/runtime_neutral/test_runtime_delivery_acceptance.py::RuntimeDeliveryAcceptanceTests::test_runtime_delivery_acceptance_passes_when_locked_specialist_is_executed -q
+```
+
+Expected:
+
+```text
+FAILED
+```
+
+The failure should show missing `specialist_lock_resolution_truth` or missing execution context fields.
+
+- [ ] **Step 4: Add delivery evaluator logic**
+
+In `packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py`, add helper functions near the existing specialist helper section:
+
+```python
+def _normalize_string_list(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        raw_values = value
+    else:
+        raw_values = [value]
+    result: list[str] = []
+    for item in raw_values:
+        text = str(item or "").strip()
+        if text and text not in result:
+            result.append(text)
+    return result
+
+
+def _load_skill_execution_lock(runtime_packet: dict[str, object], execution_manifest: dict[str, object]) -> dict[str, object]:
+    manifest_lock = execution_manifest.get("skill_execution_lock")
+    if isinstance(manifest_lock, dict):
+        return manifest_lock
+    accounting = execution_manifest.get("specialist_accounting")
+    if isinstance(accounting, dict):
+        accounting_lock = accounting.get("skill_execution_lock")
+        if isinstance(accounting_lock, dict):
+            return accounting_lock
+    packet_lock = runtime_packet.get("skill_execution_lock")
+    if isinstance(packet_lock, dict):
+        return packet_lock
+    return {}
+
+
+def _load_specialist_lock_resolution(execution_manifest: dict[str, object]) -> dict[str, object]:
+    manifest_resolution = execution_manifest.get("specialist_lock_resolution")
+    if isinstance(manifest_resolution, dict):
+        return manifest_resolution
+    accounting = execution_manifest.get("specialist_accounting")
+    if isinstance(accounting, dict):
+        accounting_resolution = accounting.get("specialist_lock_resolution")
+        if isinstance(accounting_resolution, dict):
+            return accounting_resolution
+    return {}
+
+
+def _evaluate_specialist_lock_resolution(
+    skill_execution_lock: dict[str, object],
+    specialist_lock_resolution: dict[str, object],
+) -> tuple[str, list[str], dict[str, list[str]]]:
+    state = str(skill_execution_lock.get("state") or "").strip().lower()
+    locked_skill_ids = _normalize_string_list(skill_execution_lock.get("locked_skill_ids"))
+    active = state == "active" and bool(locked_skill_ids)
+    if not active:
+        return "passing", ["No active specialist execution lock was present."], {
+            "locked": [],
+            "executed": [],
+            "not_applicable": [],
+            "deferred": [],
+            "failed": [],
+            "unresolved": [],
+        }
+
+    executed = _normalize_string_list(specialist_lock_resolution.get("executed_skill_ids"))
+    not_applicable = _normalize_string_list(specialist_lock_resolution.get("not_applicable_skill_ids"))
+    deferred = _normalize_string_list(specialist_lock_resolution.get("deferred_skill_ids"))
+    failed = _normalize_string_list(specialist_lock_resolution.get("failed_skill_ids"))
+    explicitly_unresolved = _normalize_string_list(specialist_lock_resolution.get("unresolved_skill_ids"))
+    resolved = set(executed) | set(not_applicable) | set(deferred) | set(failed)
+    unresolved = [skill_id for skill_id in locked_skill_ids if skill_id not in resolved]
+    for skill_id in explicitly_unresolved:
+        if skill_id not in unresolved:
+            unresolved.append(skill_id)
+
+    if failed:
+        return "failing", [f"Locked specialist execution failed for: {', '.join(failed)}."], {
+            "locked": locked_skill_ids,
+            "executed": executed,
+            "not_applicable": not_applicable,
+            "deferred": deferred,
+            "failed": failed,
+            "unresolved": unresolved,
+        }
+    if unresolved:
+        return "failing", [f"Locked specialist execution is unresolved for: {', '.join(unresolved)}."], {
+            "locked": locked_skill_ids,
+            "executed": executed,
+            "not_applicable": not_applicable,
+            "deferred": deferred,
+            "failed": failed,
+            "unresolved": unresolved,
+        }
+    if deferred:
+        return "manual_review_required", [f"Locked specialist execution was deferred for: {', '.join(deferred)}."], {
+            "locked": locked_skill_ids,
+            "executed": executed,
+            "not_applicable": not_applicable,
+            "deferred": deferred,
+            "failed": failed,
+            "unresolved": unresolved,
+        }
+    return "passing", ["All locked specialist execution obligations were resolved."], {
+        "locked": locked_skill_ids,
+        "executed": executed,
+        "not_applicable": not_applicable,
+        "deferred": deferred,
+        "failed": failed,
+        "unresolved": unresolved,
+    }
+```
+
+In `evaluate`, after `runtime_packet` and `execution_manifest` are loaded, call:
+
+```python
+skill_execution_lock = _load_skill_execution_lock(runtime_packet, execution_manifest)
+specialist_lock_resolution = _load_specialist_lock_resolution(execution_manifest)
+specialist_lock_state, specialist_lock_notes, specialist_lock_lists = _evaluate_specialist_lock_resolution(
+    skill_execution_lock,
+    specialist_lock_resolution,
+)
+```
+
+Add a truth layer:
+
+```python
+"specialist_lock_resolution_truth": {
+    "state": _normalize_truth_state(specialist_lock_state),
+    "evidence": [],
+    "notes": " ".join(specialist_lock_notes).strip(),
+},
+```
+
+Add execution context fields:
+
+```python
+"specialist_lock_active": bool(specialist_lock_lists["locked"]),
+"specialist_lock_skill_ids": specialist_lock_lists["locked"],
+"specialist_lock_executed_skill_ids": specialist_lock_lists["executed"],
+"specialist_lock_not_applicable_skill_ids": specialist_lock_lists["not_applicable"],
+"specialist_lock_deferred_skill_ids": specialist_lock_lists["deferred"],
+"specialist_lock_failed_skill_ids": specialist_lock_lists["failed"],
+"specialist_lock_unresolved_skill_ids": specialist_lock_lists["unresolved"],
+```
+
+- [ ] **Step 5: Run delivery acceptance lock tests**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_runtime_delivery_acceptance.py::RuntimeDeliveryAcceptanceTests::test_runtime_delivery_acceptance_fails_when_locked_specialist_is_unresolved tests/runtime_neutral/test_runtime_delivery_acceptance.py::RuntimeDeliveryAcceptanceTests::test_runtime_delivery_acceptance_passes_when_locked_specialist_is_executed -q
+```
+
+Expected:
+
+```text
+2 passed
+```
+
+- [ ] **Step 6: Run delivery acceptance suite**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_runtime_delivery_acceptance.py -q
+```
+
+Expected:
+
+```text
+passed
+```
+
+- [ ] **Step 7: Commit delivery acceptance enforcement**
+
+Run:
+
+```powershell
+git add packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py tests/runtime_neutral/test_runtime_delivery_acceptance.py
+git commit -m "feat: enforce specialist execution lock resolution"
+```
+
+Expected:
+
+```text
+Commit succeeds and prints subject `feat: enforce specialist execution lock resolution`.
+```
+
+---
+
+### Task 7: Update Current Routing Documentation
+
+**Files:**
+
+- Modify: `docs/governance/current-routing-contract.md`
+- Modify: `docs/governance/current-runtime-field-contract.md`
+- Modify: `docs/governance/terminology-governance.md`
+- Modify: `tests/runtime_neutral/test_current_routing_docs_entrypoint.py`
+- Modify: `tests/runtime_neutral/test_terminology_field_simplification.py`
+- Modify: `tests/runtime_neutral/test_current_routing_contract_cleanup.py`
+
+- [ ] **Step 1: Update current routing docs assertions first**
+
+In `tests/runtime_neutral/test_current_routing_docs_entrypoint.py`, replace the chain assertions with:
+
+```python
+    assert (
+        "skill_candidates -> skill_routing.selected -> skill_execution_lock -> "
+        "selected_skill_execution -> skill_usage.used / skill_usage.unused"
+    ) in text
+    assert "`skill_execution_lock` | The approved-plan execution lock that preserves selected specialists across bounded re-entry. It is not a use claim." in text
+```
+
+In the runtime field test in the same file, assert:
+
+```python
+    assert (
+        "skill_candidates -> skill_routing.selected -> skill_execution_lock -> "
+        "selected_skill_execution -> skill_usage.used / skill_usage.unused"
+    ) in text
+    assert "`skill_execution_lock` records specialists that crossed the approved-plan boundary" in text
+```
+
+In `tests/runtime_neutral/test_terminology_field_simplification.py`, replace the active model assertion with:
+
+```python
+    assert "skill_candidates -> skill_routing.selected -> skill_execution_lock -> selected_skill_execution -> skill_usage" in text
+    assert "`skill_execution_lock`" in text
+```
+
+In `tests/runtime_neutral/test_current_routing_contract_cleanup.py`, update the expected model string to:
+
+```python
+"skill_candidates -> skill_routing.selected -> skill_execution_lock -> selected_skill_execution -> skill_usage.used / skill_usage.unused"
+```
+
+- [ ] **Step 2: Run doc tests and confirm they fail**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_current_routing_docs_entrypoint.py tests/runtime_neutral/test_terminology_field_simplification.py tests/runtime_neutral/test_current_routing_contract_cleanup.py -q
+```
+
+Expected:
+
+```text
+FAILED
+```
+
+Failures should point to missing `skill_execution_lock` text in docs.
+
+- [ ] **Step 3: Update `current-routing-contract.md`**
+
+In `docs/governance/current-routing-contract.md`, change the current chain to:
+
+```text
+skill_candidates -> skill_routing.selected -> skill_execution_lock -> selected_skill_execution -> skill_usage.used / skill_usage.unused
+```
+
+Add or update the field table row:
+
+```markdown
+| `skill_execution_lock` | The approved-plan execution lock that preserves selected specialists across bounded re-entry. It is not a use claim. |
+```
+
+Add this paragraph near the field definitions:
+
+```markdown
+`skill_execution_lock` exists because bounded re-entry reruns the router. Once a plan is approved, selected specialists become execution obligations and must be executed, marked not applicable, deferred, or failed before delivery acceptance can pass. The lock does not prove material skill use; `skill_usage.used` remains the only material-use truth.
+```
+
+- [ ] **Step 4: Update `current-runtime-field-contract.md`**
+
+In `docs/governance/current-runtime-field-contract.md`, change the current chain to:
+
+```text
+skill_candidates -> skill_routing.selected -> skill_execution_lock -> selected_skill_execution -> skill_usage.used / skill_usage.unused
+```
+
+Add this field definition:
+
+```markdown
+### `skill_execution_lock`
+
+`skill_execution_lock` records specialists that crossed the approved-plan boundary and therefore require execution resolution. It contains `locked_skill_ids`, `locked_dispatch`, `source_run_id`, and `resolution_required`. It is an execution-obligation field, not a material-use field.
+```
+
+- [ ] **Step 5: Update `terminology-governance.md`**
+
+In `docs/governance/terminology-governance.md`, change the active model sentence to:
+
+```text
+skill_candidates -> skill_routing.selected -> skill_execution_lock -> selected_skill_execution -> skill_usage
+```
+
+Add this term row:
+
+```markdown
+| `skill_execution_lock` | Current execution-obligation field that preserves approved specialists across bounded re-entry; not evidence of material skill use. |
+```
+
+- [ ] **Step 6: Run doc tests**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_current_routing_docs_entrypoint.py tests/runtime_neutral/test_terminology_field_simplification.py tests/runtime_neutral/test_current_routing_contract_cleanup.py -q
+```
+
+Expected:
+
+```text
+passed
+```
+
+- [ ] **Step 7: Commit docs**
+
+Run:
+
+```powershell
+git add docs/governance/current-routing-contract.md docs/governance/current-runtime-field-contract.md docs/governance/terminology-governance.md tests/runtime_neutral/test_current_routing_docs_entrypoint.py tests/runtime_neutral/test_terminology_field_simplification.py tests/runtime_neutral/test_current_routing_contract_cleanup.py
+git commit -m "docs: document specialist execution lock contract"
+```
+
+Expected:
+
+```text
+Commit succeeds and prints subject `docs: document specialist execution lock contract`.
+```
+
+---
+
+### Task 8: Run Full Verification Slice And Install Check
+
+**Files:**
+
+- No new source files.
+- Verification covers files changed by Tasks 1-7.
+
+- [ ] **Step 1: Run focused Python tests**
+
+Run:
+
+```powershell
+python -m pytest tests/runtime_neutral/test_skill_execution_lock_contract.py tests/runtime_neutral/test_simplified_skill_routing_contract.py tests/runtime_neutral/test_skill_promotion_freeze_contract.py tests/runtime_neutral/test_structured_bounded_reentry_continuation.py tests/runtime_neutral/test_runtime_delivery_acceptance.py tests/runtime_neutral/test_current_routing_docs_entrypoint.py tests/runtime_neutral/test_terminology_field_simplification.py tests/runtime_neutral/test_current_routing_contract_cleanup.py -q
+```
+
+Expected:
+
+```text
+passed
+```
+
+- [ ] **Step 2: Run runtime check script**
+
+Run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\check.ps1
+```
+
+Expected:
+
+```text
+failed 0
+```
+
+or an equivalent summary showing zero failing checks.
+
+- [ ] **Step 3: Verify final git state**
+
+Run:
+
+```powershell
+git status --short
+git log -6 --oneline
+```
+
+Expected:
+
+```text
+```
+
+`git status --short` should be empty after all task commits. `git log -6 --oneline` should show the specialist execution lock commits.
+
+- [ ] **Step 4: Report implementation evidence**
+
+In the final implementation report, include:
+
+```text
+Changed files:
+- scripts/runtime/VibeRuntime.Common.ps1
+- scripts/runtime/VibeSkillRouting.Common.ps1
+- scripts/runtime/Freeze-RuntimeInputPacket.ps1
+- scripts/runtime/Invoke-PlanExecute.ps1
+- packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py
+- tests/runtime_neutral/test_skill_execution_lock_contract.py
+- tests/runtime_neutral/test_runtime_delivery_acceptance.py
+- docs/governance/current-routing-contract.md
+- docs/governance/current-runtime-field-contract.md
+- docs/governance/terminology-governance.md
+
+Verification:
+- python -m pytest tests/runtime_neutral/test_skill_execution_lock_contract.py tests/runtime_neutral/test_simplified_skill_routing_contract.py tests/runtime_neutral/test_skill_promotion_freeze_contract.py tests/runtime_neutral/test_structured_bounded_reentry_continuation.py tests/runtime_neutral/test_runtime_delivery_acceptance.py tests/runtime_neutral/test_current_routing_docs_entrypoint.py tests/runtime_neutral/test_terminology_field_simplification.py tests/runtime_neutral/test_current_routing_contract_cleanup.py -q
+- powershell -ExecutionPolicy Bypass -File .\check.ps1
+```
+
+Do not claim the installed Codex runtime has changed unless a separate deployment step explicitly installs this branch into `C:\Users\羽裳\.codex`.
+
+---
+
+## Implementation Notes For Workers
+
+- Keep `skill_usage.used` unchanged. The lock is not a use claim.
+- Preserve current `skill_routing.selected` for audit even when execution uses the lock.
+- Prefer additive fields over renaming existing fields in this slice.
+- Keep old runtime packets readable when `skill_execution_lock` is absent.
+- Do not update historical docs unless a current test requires a narrow current-model note.
+- If an exact test name differs from this plan because the upstream file changed, use `python -m pytest <file> -k "<term>" -q` to locate the nearest existing focused test, then record the actual test name in the implementation report.

--- a/docs/superpowers/specs/2026-05-05-vibe-specialist-execution-lock-design.md
+++ b/docs/superpowers/specs/2026-05-05-vibe-specialist-execution-lock-design.md
@@ -1,0 +1,390 @@
+# Vibe Specialist Execution Lock Design
+
+Date: 2026-05-05
+
+## Goal
+
+Make Vibe preserve approved specialist execution intent across bounded
+re-entry. A skill that is selected into the approved plan must not disappear
+from the final execution topology merely because a later re-entry reruns the
+router and produces a narrower current route.
+
+The design keeps the current honest usage model:
+
+```text
+candidate -> selected -> locked_for_execution -> executed / not_applicable / deferred
+```
+
+This does not mean every candidate skill must execute. It means every skill
+that crosses the approved-plan boundary must be either executed or explicitly
+resolved before the delivery gate can pass.
+
+## Problem
+
+The current runtime has the right pieces, but their authority is scoped too
+narrowly to the current re-entry:
+
+- `Freeze-RuntimeInputPacket.ps1` reruns the router on each bounded re-entry.
+- `Freeze-RuntimeInputPacket.ps1` rebuilds `skill_routing` from the current
+  router result, current recommendations, and current dispatch split.
+- `Invoke-PlanExecute.ps1` converts only the current packet's
+  `skill_routing.selected` into `selected_skill_execution`.
+- If the current packet has any `skill_routing.selected`, plan execution treats
+  that current selection as authoritative and disables auto absorption.
+- `VibeRuntime.Common.ps1` already supports a host
+  `skill_execution_decision`, but an ordinary plan approval does not
+  automatically create a durable execution decision from the previously
+  selected specialists.
+
+The user-visible failure mode is easy to explain:
+
+1. Requirement re-entry routes literature and research skills.
+2. Plan re-entry routes experiment or reporting skills.
+3. Final execution re-entry routes only a LaTeX skill.
+4. The final execution topology contains only the LaTeX skill.
+5. Earlier skills may have influenced requirement or plan artifacts, but they
+   were not preserved as final execution work units.
+
+That behavior is not a truthful multi-specialist execution model. It blurs
+planned selection, approved dispatch, and material execution.
+
+## Non-Goals
+
+This change must not:
+
+- execute every routed candidate skill;
+- treat routing, loading, or dispatch alone as material skill use;
+- weaken the existing `skill_usage.used` evidence standard;
+- bypass destructive or incomplete skill dispatch checks;
+- remove compatibility readers for old runtime packets;
+- make child lanes self-approve new root specialists;
+- require a public host to expose every internal bundled skill as a top-level
+  host-visible skill.
+
+## Design Summary
+
+Add a durable execution lock between plan approval and plan execution.
+
+The lock is a runtime-packet field that records which selected or approved
+specialists have crossed the approved-plan boundary and therefore require
+resolution in execution.
+
+Recommended field:
+
+```json
+{
+  "skill_execution_lock": {
+    "schema_version": "v1",
+    "state": "active",
+    "source": "approved_plan_reentry",
+    "source_run_id": "20260505T044250Z-609dce9c",
+    "locked_skill_ids": [
+      "scientific-reporting",
+      "latex-submission-pipeline"
+    ],
+    "locked_dispatch": [],
+    "resolution_required": true,
+    "resolution_states": [
+      "executed",
+      "not_applicable",
+      "deferred"
+    ]
+  }
+}
+```
+
+The lock is not a usage claim. It is an execution obligation. A locked skill
+can become `executed`, `not_applicable`, or `deferred`, but it cannot silently
+vanish from accounting.
+
+## Authority Model
+
+The current authority chain should become:
+
+```text
+router ranked candidates
+-> skill_routing.selected
+-> approved plan boundary
+-> skill_execution_lock
+-> selected_skill_execution
+-> specialist-execution.json
+-> skill_usage.used / skill_usage.unused
+```
+
+Meaning:
+
+- `candidate`: considered by routing or recommendation.
+- `selected`: chosen into the current work surface.
+- `locked_for_execution`: approved-plan boundary preserved the skill as an
+  execution obligation.
+- `executed`: native workflow was actually invoked and evidence exists.
+- `not_applicable`: the lock was intentionally resolved without execution
+  because the skill was no longer applicable, with a concrete reason.
+- `deferred`: execution was intentionally postponed, with a concrete reason.
+- `used`: material artifact-impact truth from `skill_usage.used`, not from the
+  lock.
+
+## Data Flow
+
+### Requirement And Plan Stages
+
+Requirement and plan generation continue to use the current packet's
+`skill_routing.selected` and `skill_usage` behavior.
+
+The XL plan should surface the specialists selected into the plan and label
+them as pending execution resolution, not as already used.
+
+### Plan Approval Re-Entry
+
+When the host decision approves the plan and the runtime moves toward
+`plan_execute`, `Freeze-RuntimeInputPacket.ps1` should construct or inherit a
+`skill_execution_lock`.
+
+The initial source order should be:
+
+1. Explicit `host_decision.skill_execution_decision.approved_skill_ids`.
+2. Previous run's `skill_execution_lock.locked_dispatch`, if present.
+3. Previous run's `skill_routing.selected`, when the previous bounded stage was
+   `xl_plan` or equivalent plan approval context.
+4. Current run's `skill_routing.selected`.
+
+This order preserves explicit host decisions first while keeping ordinary
+approve-plan flows useful.
+
+### Runtime Packet Freeze
+
+`Freeze-RuntimeInputPacket.ps1` should add a normalized
+`skill_execution_lock` projection to the new packet.
+
+The lock should store dispatch records, not only ids, whenever dispatch records
+are available. That avoids losing native entrypoint paths, write scopes,
+dispatch phases, and verification expectations.
+
+If a previous locked skill is no longer surfaced by the current router, the
+runtime should still preserve it as locked, but mark reconciliation:
+
+```json
+{
+  "skill_id": "literature-review",
+  "reconciliation_state": "inherited_not_currently_surfaced",
+  "requires_resolution": true
+}
+```
+
+This prevents the current router from erasing approved-plan obligations.
+
+### Plan Execution
+
+`Invoke-PlanExecute.ps1` should build `selected_skill_execution` from the lock
+when the lock is active. Current `skill_routing.selected` remains useful for
+audit, but it no longer overrides the lock at execution time.
+
+Execution dispatch order:
+
+1. Active `skill_execution_lock.locked_dispatch`.
+2. Explicit host `skill_execution_decision` dispatch if no lock exists.
+3. Current `skill_routing.selected`.
+4. Existing auto-absorb behavior for local suggestions, only when no canonical
+   selected skills or active lock exist.
+
+The existing destructive, degraded, and blocked dispatch handling remains
+mandatory.
+
+### Resolution Accounting
+
+Each locked skill must be resolved before delivery acceptance can pass.
+
+Accepted states:
+
+```text
+executed
+not_applicable
+deferred
+failed
+```
+
+Delivery should pass only when there are no unresolved locked skills and no
+failed locked skills, unless an explicit manual-review exception is recorded.
+
+Recommended artifact fields:
+
+```json
+{
+  "specialist_lock_resolution": {
+    "locked_skill_ids": [],
+    "executed_skill_ids": [],
+    "not_applicable_skill_ids": [],
+    "deferred_skill_ids": [],
+    "failed_skill_ids": [],
+    "unresolved_skill_ids": [],
+    "delivery_blocking": true
+  }
+}
+```
+
+## Components
+
+### `VibeRuntime.Common.ps1`
+
+Add helper functions:
+
+- `Get-VibeSkillExecutionLockFromRuntimeInputPacket`
+- `New-VibeSkillExecutionLockProjection`
+- `Merge-VibeSkillExecutionLock`
+- `Resolve-VibeSkillExecutionLockSource`
+- `New-VibeSkillExecutionLockSummaryProjection`
+
+These helpers should normalize lock shape, preserve old packets safely, and
+avoid putting re-entry inheritance logic directly into every stage script.
+
+### `Freeze-RuntimeInputPacket.ps1`
+
+Add lock construction during packet freeze.
+
+Inputs:
+
+- current host decision;
+- continuation context;
+- current `skill_routing`;
+- previous runtime packet, when continuing from a bounded run;
+- previous execution plan metadata, when available.
+
+Outputs:
+
+- `skill_execution_lock`;
+- `specialist_dispatch.lock_applied`;
+- explicit reconciliation metadata for inherited skills.
+
+### `VibeSkillRouting.Common.ps1`
+
+Add a single conversion path from selected or locked skill records to dispatch
+records.
+
+This avoids duplicating dispatch conversion in both freeze and execution.
+
+Suggested helper:
+
+```powershell
+Convert-VibeSkillExecutionLockToDispatch
+```
+
+### `Invoke-PlanExecute.ps1`
+
+Use the active lock as the first source of `selected_skill_execution`.
+
+Add lock resolution accounting to:
+
+- `execution-manifest.json`;
+- `execution-topology.json`;
+- `specialist-execution.json`;
+- delivery acceptance inputs.
+
+### Documentation
+
+Update current docs that explain skill state to include:
+
+```text
+candidate -> selected -> locked_for_execution -> executed / not_applicable / deferred
+```
+
+The docs must still say that `used` requires `skill_usage.used` evidence.
+
+## Error Handling
+
+If a locked skill lacks a native entrypoint path:
+
+- keep the lock;
+- mark the dispatch as degraded;
+- require explicit `not_applicable` or `deferred` resolution if it cannot run.
+
+If a locked skill becomes destructive or contract-incomplete:
+
+- do not auto-execute it;
+- mark it blocked;
+- require explicit resolution before delivery.
+
+If the previous runtime packet cannot be read:
+
+- continue with current `skill_routing.selected`;
+- record `lock_source_state = previous_packet_unavailable`;
+- do not claim inherited specialists were preserved.
+
+If an explicit host decision rejects a previously locked skill:
+
+- keep the lock entry for audit;
+- resolve it as `not_applicable` or `deferred` with
+  `resolution_source = host_decision`;
+- do not execute it.
+
+## Testing Plan
+
+Add focused tests that cover the actual failure mode.
+
+### Unit Tests
+
+1. Lock creation from previous `skill_routing.selected`.
+2. Lock preservation when current router selects a different skill.
+3. Explicit host `skill_execution_decision` overrides inherited lock.
+4. Rejected or deferred host decisions resolve inherited lock entries.
+5. Locked dispatch preserves `native_skill_entrypoint`, `dispatch_phase`,
+   `write_scope`, and `verification_expectation`.
+
+### Runtime Simulation
+
+Create a bounded re-entry fixture:
+
+1. requirement run selects `literature-review`;
+2. revised requirement run selects `hypothesis-generation`;
+3. plan run selects `scientific-reporting`;
+4. final execution run router selects only `latex-submission-pipeline`.
+
+Expected result:
+
+- final runtime packet has active `skill_execution_lock`;
+- execution topology includes locked specialists, not only the final router
+  skill;
+- every locked skill is `executed`, `not_applicable`, `deferred`, or `failed`;
+- unresolved locked skills block delivery acceptance.
+
+### Regression Tests
+
+Existing behavior should remain valid when:
+
+- no previous selected specialists exist;
+- the task is single-skill;
+- the current router and previous selected skill are the same;
+- old runtime packets do not contain `skill_execution_lock`;
+- child governance scope receives root-approved specialists only.
+
+## Acceptance Criteria
+
+The implementation is complete only when:
+
+1. A plan-approval re-entry preserves previous selected specialists into an
+   active `skill_execution_lock`.
+2. `Invoke-PlanExecute.ps1` prefers the lock over current router-only
+   `skill_routing.selected`.
+3. Final `execution-topology.json` exposes locked specialist units.
+4. Final accounting distinguishes `selected`, `locked_for_execution`,
+   `executed`, `not_applicable`, `deferred`, `failed`, `used`, and `unused`.
+5. Delivery acceptance fails or requires manual review when locked specialists
+   remain unresolved.
+6. Existing binary `skill_usage` semantics remain unchanged.
+7. Focused PowerShell tests pass.
+8. A live or fixture run reproduces the original failure pattern and shows the
+   lock preserving specialists across re-entry.
+
+## Open Implementation Notes
+
+The safest first implementation slice is intentionally narrow:
+
+1. Add lock model helpers.
+2. Inherit prior selected specialists on approve-plan re-entry.
+3. Feed lock dispatch into plan execution.
+4. Add unresolved-lock delivery accounting.
+5. Add focused tests for the previous-loss failure mode.
+
+Do not broaden this slice into router ranking changes or pack consolidation.
+The problem is not that the router picked LaTeX in the final run. The problem
+is that the final run was allowed to erase previously approved specialist
+execution obligations.

--- a/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py
+++ b/packages/verification-core/src/vgo_verify/runtime_delivery_acceptance_runtime.py
@@ -164,6 +164,90 @@ def _evaluate_skill_usage_truth(
     }
 
 
+def _normalize_unique_string_list(value: object) -> list[str]:
+    result: list[str] = []
+    for item in _normalize_string_list(value):
+        if item not in result:
+            result.append(item)
+    return result
+
+
+def _load_skill_execution_lock(
+    runtime_packet: dict[str, Any],
+    execution_manifest: dict[str, Any],
+) -> dict[str, Any]:
+    manifest_lock = execution_manifest.get("skill_execution_lock")
+    if isinstance(manifest_lock, dict):
+        return manifest_lock
+    accounting = execution_manifest.get("specialist_accounting")
+    if isinstance(accounting, dict):
+        accounting_lock = accounting.get("skill_execution_lock")
+        if isinstance(accounting_lock, dict):
+            return accounting_lock
+    packet_lock = runtime_packet.get("skill_execution_lock")
+    if isinstance(packet_lock, dict):
+        return packet_lock
+    return {}
+
+
+def _load_specialist_lock_resolution(execution_manifest: dict[str, Any]) -> dict[str, Any]:
+    manifest_resolution = execution_manifest.get("specialist_lock_resolution")
+    if isinstance(manifest_resolution, dict):
+        return manifest_resolution
+    accounting = execution_manifest.get("specialist_accounting")
+    if isinstance(accounting, dict):
+        accounting_resolution = accounting.get("specialist_lock_resolution")
+        if isinstance(accounting_resolution, dict):
+            return accounting_resolution
+    return {}
+
+
+def _evaluate_specialist_lock_resolution(
+    skill_execution_lock: dict[str, Any],
+    specialist_lock_resolution: dict[str, Any],
+) -> tuple[str, list[str], dict[str, list[str]]]:
+    state = str(skill_execution_lock.get("state") or "").strip().lower()
+    locked_skill_ids = _normalize_unique_string_list(skill_execution_lock.get("locked_skill_ids"))
+    active = state == "active" and bool(locked_skill_ids)
+    empty_lists = {
+        "locked": [],
+        "executed": [],
+        "not_applicable": [],
+        "deferred": [],
+        "failed": [],
+        "unresolved": [],
+    }
+    if not active:
+        return "passing", ["No active specialist execution lock was present."], empty_lists
+
+    executed = _normalize_unique_string_list(specialist_lock_resolution.get("executed_skill_ids"))
+    not_applicable = _normalize_unique_string_list(specialist_lock_resolution.get("not_applicable_skill_ids"))
+    deferred = _normalize_unique_string_list(specialist_lock_resolution.get("deferred_skill_ids"))
+    failed = _normalize_unique_string_list(specialist_lock_resolution.get("failed_skill_ids"))
+    explicitly_unresolved = _normalize_unique_string_list(specialist_lock_resolution.get("unresolved_skill_ids"))
+    resolved = set(executed) | set(not_applicable) | set(deferred) | set(failed)
+    unresolved = [skill_id for skill_id in locked_skill_ids if skill_id not in resolved]
+    for skill_id in explicitly_unresolved:
+        if skill_id not in unresolved:
+            unresolved.append(skill_id)
+
+    lock_lists = {
+        "locked": locked_skill_ids,
+        "executed": executed,
+        "not_applicable": not_applicable,
+        "deferred": deferred,
+        "failed": failed,
+        "unresolved": unresolved,
+    }
+    if failed:
+        return "failing", [f"Locked specialist execution failed for: {', '.join(failed)}."], lock_lists
+    if unresolved:
+        return "failing", [f"Locked specialist execution is unresolved for: {', '.join(unresolved)}."], lock_lists
+    if deferred:
+        return "manual_review_required", [f"Locked specialist execution was deferred for: {', '.join(deferred)}."], lock_lists
+    return "passing", ["All locked specialist execution obligations were resolved."], lock_lists
+
+
 def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[str, Any]:
     contract = load_json(repo_root / "config" / "project-delivery-acceptance-contract.json")
     execute_receipt_path = session_root / "phase-execute.json"
@@ -184,6 +268,12 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
     skill_routing = runtime_input_packet.get("skill_routing") or {}
     specialist_accounting = execution_manifest.get("specialist_accounting") or {}
     skill_usage = _load_skill_usage(session_root, runtime_input_packet, execution_manifest, execute_receipt)
+    skill_execution_lock = _load_skill_execution_lock(runtime_input_packet, execution_manifest)
+    specialist_lock_resolution = _load_specialist_lock_resolution(execution_manifest)
+    specialist_lock_state, specialist_lock_notes, specialist_lock_lists = _evaluate_specialist_lock_resolution(
+        skill_execution_lock,
+        specialist_lock_resolution,
+    )
 
     product_acceptance_criteria = _extract_bullets(requirement_text, "Product Acceptance Criteria")
     manual_spot_checks, manual_section_missing = _manual_spot_checks_from_requirement(requirement_text)
@@ -998,6 +1088,15 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
             "evidence": specialist_decision_evidence,
             "notes": " ".join(specialist_decision_notes).strip(),
         },
+        "specialist_lock_resolution_truth": {
+            "state": _normalize_truth_state(specialist_lock_state),
+            "evidence": [
+                str(path)
+                for path in (runtime_input_packet_path, execution_manifest_path)
+                if path.exists()
+            ],
+            "notes": " ".join(specialist_lock_notes).strip(),
+        },
         "skill_usage_truth": {
             "state": str(skill_usage_truth.get("truth_state") or "passing"),
             "evidence": list(skill_usage_truth.get("evidence_paths") or []),
@@ -1089,6 +1188,12 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
         residual_risks.append("Specialist decision truth is missing required fallback or dispatch detail.")
     if specialist_decision_state == "degraded":
         residual_risks.append("Specialist decision recorded a traceable but non-green specialist fallback path.")
+    if specialist_lock_lists["failed"]:
+        residual_risks.append("Locked specialist execution failed for: " + ", ".join(specialist_lock_lists["failed"]) + ".")
+    if specialist_lock_lists["unresolved"]:
+        residual_risks.append("Locked specialist execution remains unresolved for: " + ", ".join(specialist_lock_lists["unresolved"]) + ".")
+    if specialist_lock_lists["deferred"]:
+        residual_risks.append("Locked specialist execution was deferred for: " + ", ".join(specialist_lock_lists["deferred"]) + ".")
     if str(skill_usage_truth.get("state") or "") == "FAIL":
         residual_risks.append("Binary skill usage truth is missing full-load or artifact-impact evidence.")
     if specialist_host_continuation_pending:
@@ -1208,6 +1313,13 @@ def evaluate_delivery_acceptance(repo_root: Path, session_root: Path) -> dict[st
             "direct_routed_skill_execution_unit_ids": direct_routed_unit_ids,
             "direct_routed_skill_execution_skill_ids": direct_routed_skill_ids,
             "direct_routed_skill_execution_units": direct_routed_skill_execution_units,
+            "specialist_lock_active": bool(specialist_lock_lists["locked"]),
+            "specialist_lock_skill_ids": specialist_lock_lists["locked"],
+            "specialist_lock_executed_skill_ids": specialist_lock_lists["executed"],
+            "specialist_lock_not_applicable_skill_ids": specialist_lock_lists["not_applicable"],
+            "specialist_lock_deferred_skill_ids": specialist_lock_lists["deferred"],
+            "specialist_lock_failed_skill_ids": specialist_lock_lists["failed"],
+            "specialist_lock_unresolved_skill_ids": specialist_lock_lists["unresolved"],
             "specialist_host_resolution_state": specialist_host_resolution_state,
             "specialist_host_executed_unit_count": specialist_host_executed_unit_count,
             "specialist_host_degraded_unit_count": specialist_host_degraded_unit_count,

--- a/scripts/runtime/Freeze-RuntimeInputPacket.ps1
+++ b/scripts/runtime/Freeze-RuntimeInputPacket.ps1
@@ -1146,6 +1146,18 @@ $hostSpecialistDispatchDecision = Resolve-VibeHostSkillExecutionDecision `
     -Recommendations @($specialistRecommendations) `
     -GovernanceScope ([string]$hierarchyState.governance_scope) `
     -Policy $policy
+$lockSourceRunId = if (
+    $null -ne $continuationContext -and
+    (Test-VibeObjectHasProperty -InputObject $continuationContext -PropertyName 'source_run_id') -and
+    -not [string]::IsNullOrWhiteSpace([string]$continuationContext.source_run_id)
+) {
+    [string]$continuationContext.source_run_id
+} else {
+    ''
+}
+$previousRuntimeInputPacket = Get-VibeRuntimeInputPacketFromSessionRunId `
+    -ArtifactRoot $ArtifactRoot `
+    -SourceRunId $lockSourceRunId
 $codeTaskTddDecision = Resolve-VibeCodeTaskTddDecision `
     -HostDecision $hostDecision `
     -Task $Task `
@@ -1168,6 +1180,17 @@ $skillRouting = New-VibeSkillRoutingFromLegacy `
     -Recommendations @($specialistRecommendations) `
     -StageAssistantHints @($stageAssistantHints) `
     -SpecialistDispatch $specialistDispatch
+$lockSource = if (-not [string]::IsNullOrWhiteSpace($lockSourceRunId)) {
+    'approved_plan_reentry'
+} else {
+    'current_skill_routing_selected'
+}
+$skillExecutionLock = New-VibeSkillExecutionLockProjection `
+    -PreviousRuntimeInputPacket $previousRuntimeInputPacket `
+    -CurrentSkillRouting $skillRouting `
+    -HostSpecialistDispatchDecision $hostSpecialistDispatchDecision `
+    -SourceRunId $lockSourceRunId `
+    -Source $lockSource
 $selectedSkillLoads = @()
 foreach ($selectedSkill in @(Get-VibeSkillRoutingSelected -SkillRouting $skillRouting)) {
     $selectedSkillId = [string]$selectedSkill.skill_id
@@ -1225,6 +1248,7 @@ $packet = New-VibeRuntimeInputPacketProjection `
     -StageAssistantHints @($stageAssistantHints) `
     -SkillUsage $skillUsage `
     -SkillRouting $skillRouting `
+    -SkillExecutionLock $skillExecutionLock `
     -SpecialistDispatch $specialistDispatch `
     -OverlayDecisions @($overlayDecisions) `
     -Policy $policy

--- a/scripts/runtime/Invoke-PlanExecute.ps1
+++ b/scripts/runtime/Invoke-PlanExecute.ps1
@@ -1209,7 +1209,14 @@ $skillRouting = if ($runtimeInputPacket -and $runtimeInputPacket.PSObject.Proper
 } else {
     $null
 }
-$selectedSkills = @(Convert-VibeSkillRoutingSelectedToDispatch -RuntimeInputPacket $runtimeInputPacket -SkillRouting $skillRouting)
+$skillExecutionLock = Get-VibeSkillExecutionLockFromRuntimeInputPacket -RuntimeInputPacket $runtimeInputPacket
+$lockSelectedSkills = @(Convert-VibeSkillExecutionLockToDispatch -SkillExecutionLock $skillExecutionLock)
+$hasActiveSkillExecutionLock = Test-VibeSkillExecutionLockActive -SkillExecutionLock $skillExecutionLock
+$selectedSkills = if ($hasActiveSkillExecutionLock -and @($lockSelectedSkills).Count -gt 0) {
+    @($lockSelectedSkills)
+} else {
+    @(Convert-VibeSkillRoutingSelectedToDispatch -RuntimeInputPacket $runtimeInputPacket -SkillRouting $skillRouting)
+}
 $frozenApprovedDispatch = @($selectedSkills)
 $frozenLocalSuggestions = @()
 $frozenBlockedDispatch = if ($runtimeSelectedSkillExecution -and $runtimeSelectedSkillExecution.PSObject.Properties.Name -contains 'blocked_skill_execution' -and $null -ne $runtimeSelectedSkillExecution.blocked_skill_execution) { @($runtimeSelectedSkillExecution.blocked_skill_execution) } else { @() }
@@ -1257,7 +1264,10 @@ if (@($nonExecutableSelectedSkillIds).Count -gt 0) {
         })
     $frozenApprovedDispatch = @($selectedSkills)
 }
-$hasCanonicalSelectedSkills = $null -ne $skillRouting -and $skillRouting.PSObject.Properties.Name -contains 'selected' -and @($skillRouting.selected).Count -gt 0
+$hasCanonicalSelectedSkills = (
+    ($hasActiveSkillExecutionLock -and @($selectedSkills).Count -gt 0) -or
+    ($null -ne $skillRouting -and $skillRouting.PSObject.Properties.Name -contains 'selected' -and @($skillRouting.selected).Count -gt 0)
+)
 if ($hasCanonicalSelectedSkills) {
     $specialistDispatchResolution = [pscustomobject]@{
         selected_skill_execution = @($selectedSkills)
@@ -1266,7 +1276,7 @@ if ($hasCanonicalSelectedSkills) {
         auto_absorb_gate = [pscustomobject]@{
             enabled = $false
             receipt_path = $null
-            reason = 'skill_routing_selected_is_authority'
+            reason = if ($hasActiveSkillExecutionLock) { 'skill_execution_lock_is_authority' } else { 'skill_routing_selected_is_authority' }
         }
         escalation_required = $false
         approval_owner = 'root'
@@ -1946,6 +1956,25 @@ $skillExecutionResolutionPath = if ($specialistDispatchResolution.auto_absorb_ga
 } else {
     $null
 }
+$lockedSkillIds = if ($hasActiveSkillExecutionLock -and $skillExecutionLock.PSObject.Properties.Name -contains 'locked_skill_ids') { @($skillExecutionLock.locked_skill_ids) } else { @() }
+$executedLockedSkillIds = @($verifiedSpecialistUnits | ForEach-Object {
+    if ($_.PSObject.Properties.Name -contains 'skill_id') { [string]$_.skill_id } else { '' }
+} | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and $_ -in @($lockedSkillIds) } | Select-Object -Unique)
+$failedLockedSkillIds = @($failedLiveSpecialistUnits | ForEach-Object {
+    if ($_.PSObject.Properties.Name -contains 'skill_id') { [string]$_.skill_id } else { '' }
+} | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and $_ -in @($lockedSkillIds) } | Select-Object -Unique)
+$resolvedLockedSkillIds = @(@($executedLockedSkillIds) + @($failedLockedSkillIds) | Select-Object -Unique)
+$unresolvedLockedSkillIds = @($lockedSkillIds | Where-Object { $_ -notin @($resolvedLockedSkillIds) })
+$specialistLockResolution = [pscustomobject]@{
+    active = [bool]$hasActiveSkillExecutionLock
+    locked_skill_ids = @($lockedSkillIds)
+    executed_skill_ids = @($executedLockedSkillIds)
+    not_applicable_skill_ids = @()
+    deferred_skill_ids = @()
+    failed_skill_ids = @($failedLockedSkillIds)
+    unresolved_skill_ids = @($unresolvedLockedSkillIds)
+    delivery_blocking = [bool](@($unresolvedLockedSkillIds).Count -gt 0 -or @($failedLockedSkillIds).Count -gt 0)
+}
 $executionManifest = [pscustomobject]@{
     stage = 'plan_execute'
     run_id = $RunId
@@ -1961,6 +1990,8 @@ $executionManifest = [pscustomobject]@{
     skill_usage = $skillUsage
     skill_routing_path = $runtimeInputPath
     skill_routing_summary = New-VibeSkillRoutingSummary -SkillRouting $skillRouting -SkillUsage $skillUsage
+    skill_execution_lock = $skillExecutionLock
+    specialist_lock_resolution = $specialistLockResolution
     selected_skill_ids = @(Get-VibeSkillRoutingSelectedSkillIds -RuntimeInputPacket $runtimeInputPacket -SkillRouting $skillRouting)
     execution_memory_context_path = if ([string]::IsNullOrWhiteSpace($ExecutionMemoryContextPath)) { $null } else { $ExecutionMemoryContextPath }
     generated_at = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
@@ -2030,6 +2061,10 @@ $executionManifest = [pscustomobject]@{
         frozen_selected_skill_execution = @($frozenSelectedSkillExecution)
         auto_selected_skill_execution_count = [int]$autoSelectedSkillExecutionCount
         auto_selected_skill_execution = @($autoSelectedSkillExecution)
+        skill_execution_lock = $skillExecutionLock
+        skill_execution_lock_active = [bool]$hasActiveSkillExecutionLock
+        skill_execution_lock_summary = New-VibeSkillExecutionLockSummaryProjection -SkillExecutionLock $skillExecutionLock
+        specialist_lock_resolution = $specialistLockResolution
         requested_host_adapter_id = $runtimePacketHostAdapterIdentity.requested_host_id
         effective_host_adapter_id = $runtimePacketHostAdapterIdentity.effective_host_id
         phase_binding_counts = [pscustomobject]@{

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -791,6 +791,243 @@ function Resolve-VibeHostSkillExecutionDecision {
     }
 }
 
+function Get-VibeRuntimeInputPacketFromSessionRunId {
+    param(
+        [AllowEmptyString()] [string]$ArtifactRoot = '',
+        [AllowEmptyString()] [string]$SourceRunId = ''
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ArtifactRoot) -or [string]::IsNullOrWhiteSpace($SourceRunId)) {
+        return $null
+    }
+
+    $candidatePath = Join-Path (Join-Path (Join-Path (Join-Path $ArtifactRoot 'outputs') 'runtime') 'vibe-sessions') (Join-Path $SourceRunId 'runtime-input-packet.json')
+    if (-not (Test-Path -LiteralPath $candidatePath)) {
+        return $null
+    }
+
+    try {
+        return Get-Content -LiteralPath $candidatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+}
+
+function Get-VibeSkillExecutionLockFromRuntimeInputPacket {
+    param(
+        [AllowNull()] [object]$RuntimeInputPacket = $null
+    )
+
+    if (
+        $null -eq $RuntimeInputPacket -or
+        -not (Test-VibeObjectHasProperty -InputObject $RuntimeInputPacket -PropertyName 'skill_execution_lock') -or
+        $null -eq $RuntimeInputPacket.skill_execution_lock
+    ) {
+        return $null
+    }
+
+    return $RuntimeInputPacket.skill_execution_lock
+}
+
+function Test-VibeSkillExecutionLockActive {
+    param(
+        [AllowNull()] [object]$SkillExecutionLock = $null
+    )
+
+    if ($null -eq $SkillExecutionLock) {
+        return $false
+    }
+
+    $state = if (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'state') { [string]$SkillExecutionLock.state } else { '' }
+    $lockedDispatch = if (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'locked_dispatch') { @($SkillExecutionLock.locked_dispatch) } else { @() }
+    $lockedSkillIds = if (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'locked_skill_ids') { @($SkillExecutionLock.locked_skill_ids) } else { @() }
+    return [bool]([string]::Equals($state, 'active', [System.StringComparison]::OrdinalIgnoreCase) -and ((@($lockedDispatch).Count -gt 0) -or (@($lockedSkillIds).Count -gt 0)))
+}
+
+function Copy-VibeSkillExecutionLockDispatchRecord {
+    param(
+        [AllowNull()] [object]$Record = $null,
+        [AllowEmptyString()] [string]$LockSource = '',
+        [AllowEmptyString()] [string]$ReconciliationState = ''
+    )
+
+    if ($null -eq $Record) {
+        return $null
+    }
+
+    $copy = Copy-VibeRecordObject -InputObject $Record
+    $skillId = if (Test-VibeObjectHasProperty -InputObject $copy -PropertyName 'skill_id') { [string]$copy.skill_id } else { '' }
+    if ([string]::IsNullOrWhiteSpace($skillId)) {
+        return $null
+    }
+
+    if (-not (Test-VibeObjectHasProperty -InputObject $copy -PropertyName 'task_slice') -or [string]::IsNullOrWhiteSpace([string]$copy.task_slice)) {
+        $copy | Add-Member -NotePropertyName task_slice -NotePropertyValue ('Resolve locked specialist execution for {0}.' -f $skillId) -Force
+    }
+    if (-not (Test-VibeObjectHasProperty -InputObject $copy -PropertyName 'dispatch_phase') -or [string]::IsNullOrWhiteSpace([string]$copy.dispatch_phase)) {
+        $copy | Add-Member -NotePropertyName dispatch_phase -NotePropertyValue 'in_execution' -Force
+    }
+    if (-not (Test-VibeObjectHasProperty -InputObject $copy -PropertyName 'write_scope') -or [string]::IsNullOrWhiteSpace([string]$copy.write_scope)) {
+        $copy | Add-Member -NotePropertyName write_scope -NotePropertyValue ('specialist:{0}' -f $skillId) -Force
+    }
+    if (-not (Test-VibeObjectHasProperty -InputObject $copy -PropertyName 'verification_expectation') -or [string]::IsNullOrWhiteSpace([string]$copy.verification_expectation)) {
+        $copy | Add-Member -NotePropertyName verification_expectation -NotePropertyValue 'Resolve locked specialist execution before delivery acceptance.' -Force
+    }
+
+    $copy | Add-Member -NotePropertyName locked_for_execution -NotePropertyValue $true -Force
+    $copy | Add-Member -NotePropertyName lock_source -NotePropertyValue $(if ([string]::IsNullOrWhiteSpace($LockSource)) { 'unknown' } else { [string]$LockSource }) -Force
+    $copy | Add-Member -NotePropertyName reconciliation_state -NotePropertyValue $(if ([string]::IsNullOrWhiteSpace($ReconciliationState)) { 'current_surfaced' } else { [string]$ReconciliationState }) -Force
+    $copy | Add-Member -NotePropertyName requires_resolution -NotePropertyValue $true -Force
+    return $copy
+}
+
+function New-VibeMinimalSkillExecutionLockDispatchRecord {
+    param(
+        [Parameter(Mandatory)] [string]$SkillId,
+        [AllowEmptyString()] [string]$LockSource = '',
+        [AllowEmptyString()] [string]$ReconciliationState = ''
+    )
+
+    return Copy-VibeSkillExecutionLockDispatchRecord `
+        -Record ([pscustomobject]@{
+            skill_id = [string]$SkillId
+            task_slice = ('Resolve locked specialist execution for {0}.' -f [string]$SkillId)
+            dispatch_phase = 'in_execution'
+            write_scope = ('specialist:{0}' -f [string]$SkillId)
+            verification_expectation = 'Resolve locked specialist execution before delivery acceptance.'
+        }) `
+        -LockSource $LockSource `
+        -ReconciliationState $ReconciliationState
+}
+
+function Add-VibeSkillExecutionLockRecord {
+    param(
+        [Parameter(Mandatory)] [object]$Rows,
+        [Parameter(Mandatory)] [hashtable]$Seen,
+        [AllowNull()] [object]$Record = $null
+    )
+
+    if ($null -eq $Record -or -not (Test-VibeObjectHasProperty -InputObject $Record -PropertyName 'skill_id')) {
+        return
+    }
+
+    $skillId = [string]$Record.skill_id
+    if ([string]::IsNullOrWhiteSpace($skillId) -or $Seen.ContainsKey($skillId)) {
+        return
+    }
+
+    $Rows.Add($Record) | Out-Null
+    $Seen[$skillId] = $true
+}
+
+function Get-VibeSkillExecutionLockCandidateRecords {
+    param(
+        [AllowNull()] [object]$SkillRouting = $null
+    )
+
+    if ($null -eq $SkillRouting) {
+        return @()
+    }
+
+    $rows = @()
+    foreach ($propertyName in @('selected', 'candidates', 'rejected')) {
+        if (Test-VibeObjectHasProperty -InputObject $SkillRouting -PropertyName $propertyName) {
+            $rows += @($SkillRouting.$propertyName)
+        }
+    }
+    return @($rows | Where-Object { $null -ne $_ })
+}
+
+function New-VibeSkillExecutionLockProjection {
+    param(
+        [AllowNull()] [object]$PreviousRuntimeInputPacket = $null,
+        [AllowNull()] [object]$CurrentSkillRouting = $null,
+        [AllowNull()] [object]$HostSpecialistDispatchDecision = $null,
+        [AllowEmptyString()] [string]$SourceRunId = '',
+        [AllowEmptyString()] [string]$Source = 'current_skill_routing_selected'
+    )
+
+    $rows = New-Object System.Collections.Generic.List[object]
+    $seen = @{}
+    $currentRecords = @(Get-VibeSkillExecutionLockCandidateRecords -SkillRouting $CurrentSkillRouting)
+    $currentSkillIds = @($currentRecords | ForEach-Object {
+        if (Test-VibeObjectHasProperty -InputObject $_ -PropertyName 'skill_id') { [string]$_.skill_id } else { '' }
+    } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+
+    $hostApproved = if ($null -ne $HostSpecialistDispatchDecision -and (Test-VibeObjectHasProperty -InputObject $HostSpecialistDispatchDecision -PropertyName 'approved_skill_ids')) {
+        @(Get-VibeNormalizedStringList -Values $HostSpecialistDispatchDecision.approved_skill_ids)
+    } else {
+        @()
+    }
+
+    if (@($hostApproved).Count -gt 0) {
+        foreach ($skillId in @($hostApproved)) {
+            $sourceRecord = @($currentRecords | Where-Object {
+                (Test-VibeObjectHasProperty -InputObject $_ -PropertyName 'skill_id') -and
+                [string]::Equals([string]$_.skill_id, [string]$skillId, [System.StringComparison]::OrdinalIgnoreCase)
+            } | Select-Object -First 1)
+            $record = if (@($sourceRecord).Count -gt 0) {
+                Copy-VibeSkillExecutionLockDispatchRecord -Record $sourceRecord[0] -LockSource 'host_decision' -ReconciliationState 'current_surfaced'
+            } else {
+                New-VibeMinimalSkillExecutionLockDispatchRecord -SkillId $skillId -LockSource 'host_decision' -ReconciliationState 'host_approved_not_currently_surfaced'
+            }
+            Add-VibeSkillExecutionLockRecord -Rows $rows -Seen $seen -Record $record
+        }
+    } else {
+        $previousLock = Get-VibeSkillExecutionLockFromRuntimeInputPacket -RuntimeInputPacket $PreviousRuntimeInputPacket
+        if (Test-VibeSkillExecutionLockActive -SkillExecutionLock $previousLock) {
+            foreach ($entry in @($previousLock.locked_dispatch)) {
+                $skillId = if (Test-VibeObjectHasProperty -InputObject $entry -PropertyName 'skill_id') { [string]$entry.skill_id } else { '' }
+                $state = if ($skillId -in @($currentSkillIds)) { 'current_surfaced' } else { 'inherited_not_currently_surfaced' }
+                Add-VibeSkillExecutionLockRecord -Rows $rows -Seen $seen -Record (Copy-VibeSkillExecutionLockDispatchRecord -Record $entry -LockSource 'previous_skill_execution_lock' -ReconciliationState $state)
+            }
+        } elseif ($null -ne $PreviousRuntimeInputPacket -and (Test-VibeObjectHasProperty -InputObject $PreviousRuntimeInputPacket -PropertyName 'skill_routing') -and $null -ne $PreviousRuntimeInputPacket.skill_routing) {
+            foreach ($entry in @(Get-VibeSkillRoutingSelected -RuntimeInputPacket $PreviousRuntimeInputPacket)) {
+                $skillId = if (Test-VibeObjectHasProperty -InputObject $entry -PropertyName 'skill_id') { [string]$entry.skill_id } else { '' }
+                $state = if ($skillId -in @($currentSkillIds)) { 'current_surfaced' } else { 'inherited_not_currently_surfaced' }
+                Add-VibeSkillExecutionLockRecord -Rows $rows -Seen $seen -Record (Copy-VibeSkillExecutionLockDispatchRecord -Record $entry -LockSource 'previous_skill_routing_selected' -ReconciliationState $state)
+            }
+        }
+
+        if (@($rows.ToArray()).Count -eq 0 -and $null -ne $CurrentSkillRouting) {
+            foreach ($entry in @(Get-VibeSkillRoutingSelected -SkillRouting $CurrentSkillRouting)) {
+                Add-VibeSkillExecutionLockRecord -Rows $rows -Seen $seen -Record (Copy-VibeSkillExecutionLockDispatchRecord -Record $entry -LockSource 'current_skill_routing_selected' -ReconciliationState 'current_surfaced')
+            }
+        }
+    }
+
+    $lockedDispatch = [object[]]$rows.ToArray()
+    $lockedSkillIds = [object[]]@($lockedDispatch | ForEach-Object { [string]$_.skill_id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $state = if (@($lockedSkillIds).Count -gt 0) { 'active' } else { 'inactive' }
+    return [pscustomobject]@{
+        schema_version = 'v1'
+        state = $state
+        source = if ([string]::IsNullOrWhiteSpace($Source)) { 'current_skill_routing_selected' } else { [string]$Source }
+        source_run_id = if ([string]::IsNullOrWhiteSpace($SourceRunId)) { $null } else { [string]$SourceRunId }
+        locked_skill_ids = @($lockedSkillIds)
+        locked_dispatch = @($lockedDispatch)
+        resolution_required = [bool](@($lockedSkillIds).Count -gt 0)
+        resolution_states = @('executed', 'not_applicable', 'deferred', 'failed')
+    }
+}
+
+function New-VibeSkillExecutionLockSummaryProjection {
+    param(
+        [AllowNull()] [object]$SkillExecutionLock = $null
+    )
+
+    $active = Test-VibeSkillExecutionLockActive -SkillExecutionLock $SkillExecutionLock
+    $lockedSkillIds = if ($active -and (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'locked_skill_ids')) { @($SkillExecutionLock.locked_skill_ids) } else { @() }
+    return [pscustomobject]@{
+        active = [bool]$active
+        locked_skill_count = @($lockedSkillIds).Count
+        locked_skill_ids = @($lockedSkillIds)
+        source = if ($active -and (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'source')) { [string]$SkillExecutionLock.source } else { $null }
+        source_run_id = if ($active -and (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'source_run_id')) { [string]$SkillExecutionLock.source_run_id } else { $null }
+        resolution_required = if ($active -and (Test-VibeObjectHasProperty -InputObject $SkillExecutionLock -PropertyName 'resolution_required')) { [bool]$SkillExecutionLock.resolution_required } else { $false }
+    }
+}
+
 function Normalize-VibeCodeTaskTddMode {
     param(
         [AllowNull()] [object]$Value = $null

--- a/scripts/runtime/VibeRuntime.Common.ps1
+++ b/scripts/runtime/VibeRuntime.Common.ps1
@@ -2217,6 +2217,7 @@ function New-VibeRuntimeInputPacketProjection {
         [AllowNull()] [object[]]$StageAssistantHints = @(),
         [AllowNull()] [object]$SkillUsage = $null,
         [AllowNull()] [object]$SkillRouting = $null,
+        [AllowNull()] [object]$SkillExecutionLock = $null,
         [Parameter(Mandatory)] [object]$SpecialistDispatch,
         [AllowNull()] [object[]]$OverlayDecisions = @(),
         [Parameter(Mandatory)] [object]$Policy
@@ -2360,6 +2361,8 @@ function New-VibeRuntimeInputPacketProjection {
         execution_phase_decomposition = $ExecutionPhaseDecomposition
         code_task_tdd_decision = $CodeTaskTddDecision
         host_skill_execution_decision = $HostSpecialistDispatchDecision
+        skill_execution_lock = if ($null -ne $SkillExecutionLock) { $SkillExecutionLock } else { $null }
+        skill_execution_lock_summary = New-VibeSkillExecutionLockSummaryProjection -SkillExecutionLock $SkillExecutionLock
         skill_routing = if ($null -ne $SkillRouting) {
             $SkillRouting
         } else {

--- a/scripts/runtime/VibeSkillRouting.Common.ps1
+++ b/scripts/runtime/VibeSkillRouting.Common.ps1
@@ -215,6 +215,72 @@ function Convert-VibeSkillRoutingSelectedToDispatch {
     })
 }
 
+function Convert-VibeSkillExecutionLockToDispatch {
+    param(
+        [AllowNull()] [object]$SkillExecutionLock = $null
+    )
+
+    if ($null -eq $SkillExecutionLock) {
+        return @()
+    }
+
+    $state = [string](Get-VibeSkillRoutingProperty -InputObject $SkillExecutionLock -PropertyName 'state' -DefaultValue '')
+    if (-not [string]::Equals($state, 'active', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return @()
+    }
+
+    $lockedDispatch = @()
+    if ($SkillExecutionLock.PSObject.Properties.Name -contains 'locked_dispatch') {
+        $lockedDispatch = @($SkillExecutionLock.locked_dispatch)
+    }
+
+    if (@($lockedDispatch).Count -eq 0 -and $SkillExecutionLock.PSObject.Properties.Name -contains 'locked_skill_ids') {
+        $lockedDispatch = @($SkillExecutionLock.locked_skill_ids | ForEach-Object {
+            $skillId = [string]$_
+            if (-not [string]::IsNullOrWhiteSpace($skillId)) {
+                [pscustomobject]@{ skill_id = $skillId }
+            }
+        })
+    }
+
+    return [object[]]@($lockedDispatch | Where-Object { $null -ne $_ } | ForEach-Object {
+        $entry = $_
+        $skillId = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'skill_id' -DefaultValue '')
+        if ([string]::IsNullOrWhiteSpace($skillId)) {
+            return
+        }
+
+        [pscustomobject]@{
+            skill_id = $skillId
+            phase_id = Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'phase_id' -DefaultValue $null
+            reason = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'reason' -DefaultValue '')
+            task_slice = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'task_slice' -DefaultValue ('Resolve locked specialist execution for {0}.' -f $skillId))
+            native_skill_entrypoint = Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'native_skill_entrypoint' -DefaultValue $null
+            skill_md_path = Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'skill_md_path' -DefaultValue $null
+            dispatch_phase = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'dispatch_phase' -DefaultValue 'in_execution')
+            parallelizable_in_root_xl = [bool](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'parallelizable_in_root_xl' -DefaultValue $false)
+            native_usage_required = [bool](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'native_usage_required' -DefaultValue $true)
+            usage_required = [bool](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'usage_required' -DefaultValue (Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'native_usage_required' -DefaultValue $true))
+            skill_root = Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'skill_root' -DefaultValue $null
+            bounded_role = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'bounded_role' -DefaultValue 'selected_skill')
+            must_preserve_workflow = [bool](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'must_preserve_workflow' -DefaultValue $true)
+            binding_profile = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'binding_profile' -DefaultValue 'selected_skill')
+            lane_policy = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'lane_policy' -DefaultValue 'native_contract')
+            write_scope = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'write_scope' -DefaultValue ('specialist:{0}' -f $skillId))
+            review_mode = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'review_mode' -DefaultValue 'native_contract')
+            execution_priority = [int](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'execution_priority' -DefaultValue 50)
+            required_inputs = [object[]]@(Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'required_inputs' -DefaultValue @())
+            expected_outputs = [object[]]@(Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'expected_outputs' -DefaultValue @())
+            verification_expectation = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'verification_expectation' -DefaultValue 'Resolve locked specialist execution before delivery acceptance.')
+            progressive_load_policy = [object[]]@(Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'progressive_load_policy' -DefaultValue @())
+            locked_for_execution = $true
+            lock_source = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'lock_source' -DefaultValue 'unknown')
+            reconciliation_state = [string](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'reconciliation_state' -DefaultValue 'current_surfaced')
+            requires_resolution = [bool](Get-VibeSkillRoutingProperty -InputObject $entry -PropertyName 'requires_resolution' -DefaultValue $true)
+        }
+    })
+}
+
 function New-VibeSkillRoutingSummary {
     param(
         [AllowNull()] [object]$SkillRouting = $null,

--- a/scripts/verify/vibe-current-routing-debt-gate.ps1
+++ b/scripts/verify/vibe-current-routing-debt-gate.ps1
@@ -347,6 +347,8 @@ if ($WriteArtifacts) {
     New-Item -ItemType Directory -Force -Path $verifyDir | Out-Null
     New-Item -ItemType Directory -Force -Path $auditDir | Out-Null
 
+    # Keep both filenames: gate consumers read the gate report, while audit
+    # consumers use the historical audit JSON path for generated evidence.
     Write-VgoUtf8NoBomText -Path (Join-Path $verifyDir 'current-routing-debt-gate.json') -Content ($report | ConvertTo-Json -Depth 50)
     Write-VgoUtf8NoBomText -Path (Join-Path $verifyDir 'current-routing-debt-audit.json') -Content ($report | ConvertTo-Json -Depth 50)
 

--- a/scripts/verify/vibe-current-routing-debt-gate.ps1
+++ b/scripts/verify/vibe-current-routing-debt-gate.ps1
@@ -1,8 +1,8 @@
 param(
     [switch]$Json,
     [switch]$WriteArtifacts,
-    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path,
-    [string]$ArtifactRoot = $RepoRoot
+    [AllowEmptyString()] [string]$RepoRoot = '',
+    [AllowEmptyString()] [string]$ArtifactRoot = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -139,10 +139,6 @@ function Get-LineCommentAndStringFragments {
 function Test-LineIsGuardAssertion {
     param([Parameter(Mandatory)] [string]$Line)
 
-    $trimmed = $Line.TrimStart()
-    if ($trimmed.StartsWith('assert ', [System.StringComparison]::OrdinalIgnoreCase) -and $Line.IndexOf(' not in ', [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
-        return $true
-    }
     foreach ($needle in @('assertNotIn', 'self.assertNotIn', 'assertNotRegex')) {
         if ($Line.IndexOf($needle, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
             return $true
@@ -150,7 +146,7 @@ function Test-LineIsGuardAssertion {
     }
     foreach ($fragment in @(Get-LineCommentAndStringFragments -Line $Line)) {
         $fragmentText = [string]$fragment.text
-        foreach ($needle in @('assert "not in"', ' not in ', 'NotIn')) {
+        foreach ($needle in @('assert "not in"', 'NotIn')) {
             if ($fragmentText.IndexOf($needle, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
                 return $true
             }
@@ -235,7 +231,16 @@ function New-DebtFinding {
 }
 
 $context = Get-VgoGovernanceContext -ScriptPath $PSCommandPath -EnforceExecutionContext
-$RepoRoot = $context.repoRoot
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = [string]$context.repoRoot
+}
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+if ([string]::IsNullOrWhiteSpace($ArtifactRoot)) {
+    $ArtifactRoot = $RepoRoot
+}
+else {
+    $ArtifactRoot = [System.IO.Path]::GetFullPath($ArtifactRoot)
+}
 $policyPath = Join-Path $RepoRoot 'config\current-routing-debt-erasure.json'
 if (-not (Test-Path -LiteralPath $policyPath -PathType Leaf)) {
     throw "current routing debt policy not found: $policyPath"

--- a/scripts/verify/vibe-current-routing-debt-gate.ps1
+++ b/scripts/verify/vibe-current-routing-debt-gate.ps1
@@ -17,7 +17,13 @@ function ConvertTo-RepoRelativePath {
     $rootFull = [System.IO.Path]::GetFullPath($Root).TrimEnd('\', '/')
     $pathFull = [System.IO.Path]::GetFullPath($Path)
     if ($pathFull.StartsWith($rootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
-        return $pathFull.Substring($rootFull.Length).TrimStart('\', '/').Replace('\', '/')
+        if ($pathFull.Length -eq $rootFull.Length) {
+            return ''
+        }
+        $boundary = $pathFull[$rootFull.Length]
+        if ($boundary -eq [System.IO.Path]::DirectorySeparatorChar -or $boundary -eq [System.IO.Path]::AltDirectorySeparatorChar) {
+            return $pathFull.Substring($rootFull.Length).TrimStart('\', '/').Replace('\', '/')
+        }
     }
     return $pathFull.Replace('\', '/')
 }
@@ -146,7 +152,7 @@ function Test-LineIsGuardAssertion {
     }
     foreach ($fragment in @(Get-LineCommentAndStringFragments -Line $Line)) {
         $fragmentText = [string]$fragment.text
-        foreach ($needle in @('assert "not in"', 'NotIn')) {
+        foreach ($needle in @('assert "not in"', 'assertNotIn', 'self.assertNotIn', 'assertNotRegex', 'assert.NotIn')) {
             if ($fragmentText.IndexOf($needle, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
                 return $true
             }

--- a/tests/runtime_neutral/test_current_routing_contract_cleanup.py
+++ b/tests/runtime_neutral/test_current_routing_contract_cleanup.py
@@ -312,7 +312,7 @@ class CurrentRoutingContractCleanupTests(unittest.TestCase):
         text = path.read_text(encoding="utf-8")
 
         self.assertIn(
-            "skill_candidates -> skill_routing.selected -> selected_skill_execution -> skill_usage.used / skill_usage.unused",
+            "skill_candidates -> skill_routing.selected -> skill_execution_lock -> selected_skill_execution -> skill_usage.used / skill_usage.unused",
             text,
         )
         for required in [

--- a/tests/runtime_neutral/test_current_routing_debt_gate.py
+++ b/tests/runtime_neutral/test_current_routing_debt_gate.py
@@ -74,9 +74,33 @@ def copy_debt_gate_fixture(tmp_path: Path, *, current_paths: list[str]) -> Path:
     return verify_dir / GATE.name
 
 
+def copy_debt_gate_policy_fixture(repo_root: Path, *, current_paths: list[str]) -> None:
+    config_dir = repo_root / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (repo_root / ".git").mkdir(exist_ok=True)
+
+    policy_payload = json.loads(POLICY.read_text(encoding="utf-8"))
+    policy_payload["scan_scopes"]["current_paths"] = current_paths
+    policy_payload["scan_scopes"]["legacy_allowed_paths"] = []
+    (config_dir / POLICY.name).write_text(json.dumps(policy_payload, indent=2) + "\n", encoding="utf-8")
+    shutil.copy2(REPO_ROOT / "config" / "version-governance.json", config_dir / "version-governance.json")
+    shutil.copy2(REPO_ROOT / "config" / "runtime-script-manifest.json", config_dir / "runtime-script-manifest.json")
+    shutil.copy2(REPO_ROOT / "config" / "runtime-config-manifest.json", config_dir / "runtime-config-manifest.json")
+
+
 def run_fixture_gate(gate: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [powershell(), "-NoLogo", "-NoProfile", "-File", str(gate), "-Json"],
+        cwd=gate.parents[2],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+def run_fixture_gate_with_args(gate: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [powershell(), "-NoLogo", "-NoProfile", "-File", str(gate), *args],
         cwd=gate.parents[2],
         capture_output=True,
         text=True,
@@ -173,6 +197,8 @@ def test_gate_scopes_retired_explanation_and_not_in_allowance_to_comments_or_str
     assert "$Line.IndexOf($needle" not in retired_body
     assert "Get-LineCommentAndStringFragments -Line $Line" in guard_body
     assert "foreach ($needle in @('assertNotIn', 'self.assertNotIn', 'assertNotRegex', 'assert \"not in\"', ' not in ', 'NotIn'))" not in guard_body
+    assert "StartsWith('assert '" not in guard_body
+    assert "$Line.IndexOf(' not in '" not in guard_body
 
 
 def test_gate_does_not_treat_legacy_identifier_as_retired_explanation(tmp_path: Path) -> None:
@@ -203,6 +229,51 @@ def test_gate_does_not_treat_non_assert_not_in_code_as_guard_assertion(tmp_path:
     assert payload["status"] == "fail"
     assert payload["summary"]["P1"] == 1
     assert payload["findings"][0]["term"] == "legacy_skill_routing"
+
+
+def test_gate_treats_assert_not_in_retired_string_as_current_test_dependency(tmp_path: Path) -> None:
+    gate = copy_debt_gate_fixture(tmp_path, current_paths=["tests/runtime_neutral"])
+    test_dir = tmp_path / "tests" / "runtime_neutral"
+    test_dir.mkdir(parents=True, exist_ok=True)
+    (test_dir / "test_example.py").write_text('assert "stage_assistant_hints" not in payload\n', encoding="utf-8")
+
+    result = run_fixture_gate(gate)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["status"] == "fail"
+    assert payload["summary"]["P1"] == 1
+    assert payload["findings"][0]["term"] == "stage_assistant_hints"
+
+
+def test_gate_honors_explicit_repo_root_when_script_lives_elsewhere(tmp_path: Path) -> None:
+    gate = copy_debt_gate_fixture(tmp_path / "script_repo", current_paths=["scripts/runtime"])
+    scan_root = tmp_path / "scan_repo"
+    copy_debt_gate_policy_fixture(scan_root, current_paths=["scripts/runtime"])
+    runtime_dir = scan_root / "scripts" / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    (runtime_dir / "example.ps1").write_text("$payload = @{ stage_assistant_hints = 'legacy' }\n", encoding="utf-8")
+
+    result = run_fixture_gate_with_args(gate, "-Json", "-RepoRoot", str(scan_root))
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["status"] == "fail"
+    assert payload["repo_root"].replace("\\", "/") == scan_root.as_posix()
+    assert payload["summary"]["P1"] == 1
+    assert payload["findings"][0]["path"] == "scripts/runtime/example.ps1"
+    assert payload["findings"][0]["term"] == "stage_assistant_hints"
+
+
+def test_current_routing_debt_plan_uses_markdownlint_safe_structure() -> None:
+    text = (REPO_ROOT / "docs" / "superpowers" / "plans" / "2026-05-02-current-routing-debt-erasure.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "\n### Task " not in text
+    assert "> old terms here are debt targets, not current runtime states.\n>\n> **For agentic workers:**" in text
+    assert "````markdown\nCurrent routing debt:" in text
+    assert "\n```markdown\nCurrent routing debt:" not in text
 
 
 def test_gate_fails_when_configured_current_path_is_missing(tmp_path: Path) -> None:

--- a/tests/runtime_neutral/test_current_routing_debt_gate.py
+++ b/tests/runtime_neutral/test_current_routing_debt_gate.py
@@ -108,6 +108,10 @@ def run_fixture_gate_with_args(gate: Path, *args: str) -> subprocess.CompletedPr
     )
 
 
+def powershell_single_quoted(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
 def test_gate_reports_json_and_clean_current_surfaces() -> None:
     result = run_gate("-Json")
     assert result.returncode == 0, result.stdout + result.stderr
@@ -244,6 +248,54 @@ def test_gate_treats_assert_not_in_retired_string_as_current_test_dependency(tmp
     assert payload["status"] == "fail"
     assert payload["summary"]["P1"] == 1
     assert payload["findings"][0]["term"] == "stage_assistant_hints"
+
+
+def test_gate_does_not_treat_generic_notin_text_as_guard_assertion(tmp_path: Path) -> None:
+    gate = copy_debt_gate_fixture(tmp_path, current_paths=["tests/runtime_neutral"])
+    test_dir = tmp_path / "tests" / "runtime_neutral"
+    test_dir.mkdir(parents=True, exist_ok=True)
+    (test_dir / "test_example.py").write_text('VALUE = "stage_assistant_hints NotInitialized"\n', encoding="utf-8")
+
+    result = run_fixture_gate(gate)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["status"] == "fail"
+    assert payload["summary"]["P1"] == 1
+    assert payload["findings"][0]["term"] == "stage_assistant_hints"
+
+
+def test_repo_relative_path_requires_path_segment_boundary(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    sibling_file = tmp_path / "repo-tools" / "example.txt"
+    sibling_file.parent.mkdir(parents=True, exist_ok=True)
+    sibling_file.write_text("outside sibling\n", encoding="utf-8")
+
+    function_source = function_body(GATE.read_text(encoding="utf-8"), "ConvertTo-RepoRelativePath")
+    expected = str(sibling_file).replace("\\", "/")
+    script = tmp_path / "check_repo_relative_boundary.ps1"
+    script.write_text(
+        "\n".join(
+            [
+                function_source,
+                f"$result = ConvertTo-RepoRelativePath -Path {powershell_single_quoted(str(sibling_file))} -Root {powershell_single_quoted(str(root))}",
+                f"$expected = {powershell_single_quoted(expected)}",
+                'if ($result -ne $expected) { throw "Expected $expected but got $result" }',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [powershell(), "-NoLogo", "-NoProfile", "-File", str(script)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_gate_honors_explicit_repo_root_when_script_lives_elsewhere(tmp_path: Path) -> None:

--- a/tests/runtime_neutral/test_current_routing_docs_entrypoint.py
+++ b/tests/runtime_neutral/test_current_routing_docs_entrypoint.py
@@ -15,10 +15,11 @@ def test_current_routing_contract_teaches_selection_execution_usage_chain() -> N
     text = read_doc("current-routing-contract.md")
 
     assert (
-        "skill_candidates -> skill_routing.selected -> selected_skill_execution -> "
+        "skill_candidates -> skill_routing.selected -> skill_execution_lock -> "
+        "selected_skill_execution -> "
         "skill_usage.used / skill_usage.unused"
     ) in text
-    assert "`selected_skill_execution` | The selected skill list frozen into execution." in text
+    assert "`skill_execution_lock` | The approved-plan execution lock that preserves selected specialists across bounded re-entry. It is not a use claim." in text
     assert "skill_routing.selected -> skill_usage.used" not in text
 
 
@@ -26,10 +27,11 @@ def test_runtime_field_contract_matches_current_routing_contract_chain() -> None
     text = read_doc("current-runtime-field-contract.md")
 
     assert (
-        "skill_candidates -> skill_routing.selected -> selected_skill_execution -> "
+        "skill_candidates -> skill_routing.selected -> skill_execution_lock -> "
+        "selected_skill_execution -> "
         "skill_usage.used / skill_usage.unused"
     ) in text
-    assert "`selected_skill_execution` is the execution-side copy of" in text
+    assert "`skill_execution_lock` records specialists that crossed the approved-plan boundary" in text
     assert "skill_routing.selected -> skill_usage.used" not in text
 
 

--- a/tests/runtime_neutral/test_runtime_delivery_acceptance.py
+++ b/tests/runtime_neutral/test_runtime_delivery_acceptance.py
@@ -64,6 +64,8 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
         omit_default_specialist_decision: bool = False,
         skill_usage: dict[str, object] | None = None,
         skill_routing: dict[str, object] | None = None,
+        skill_execution_lock: dict[str, object] | None = None,
+        specialist_lock_resolution: dict[str, object] | None = None,
     ) -> Path:
         tempdir = tempfile.TemporaryDirectory()
         self.addCleanup(tempdir.cleanup)
@@ -163,6 +165,8 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
             "failed_unit_count": failed_unit_count,
             "timed_out_unit_count": 0,
         }
+        if specialist_lock_resolution is not None:
+            execution_manifest_payload["specialist_lock_resolution"] = specialist_lock_resolution
         selected_skill_execution_payload = list(approved_dispatch or [])
         if approved_dispatch is not None or specialist_accounting is not None:
             default_specialist_accounting = {
@@ -186,6 +190,8 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
                 "explicit_runtime_skill": "vibe",
             }
         }
+        if skill_execution_lock is not None:
+            runtime_input_packet_payload["skill_execution_lock"] = skill_execution_lock
         if skill_routing is not None:
             runtime_input_packet_payload["skill_routing"] = skill_routing
         if approved_dispatch is not None:
@@ -793,6 +799,142 @@ class RuntimeDeliveryAcceptanceTests(unittest.TestCase):
             str(session_root / "specialist-execution.json"),
             report["truth_results"]["workflow_completion_truth"]["evidence"],
         )
+
+    def test_runtime_delivery_acceptance_fails_when_locked_specialist_is_unresolved(self) -> None:
+        skill_path = "/tmp/scientific-reporting/SKILL.md"
+        session_root = self._build_session(
+            approved_dispatch=[
+                {
+                    "skill_id": "scientific-reporting",
+                    "native_skill_entrypoint": skill_path,
+                }
+            ],
+            phase_execute_specialist_user_disclosure={
+                "scope": "selected_skill_execution_only",
+                "timing": "before_execution",
+                "path_source": "native_skill_entrypoint",
+                "routed_skills": [
+                    {
+                        "skill_id": "scientific-reporting",
+                        "native_skill_entrypoint": skill_path,
+                        "entrypoint_requirement_satisfied": True,
+                    }
+                ],
+            },
+            skill_execution_lock={
+                "schema_version": "v1",
+                "state": "active",
+                "locked_skill_ids": ["scientific-reporting"],
+                "locked_dispatch": [{"skill_id": "scientific-reporting", "native_skill_entrypoint": skill_path}],
+                "resolution_required": True,
+            },
+            specialist_lock_resolution={
+                "active": True,
+                "locked_skill_ids": ["scientific-reporting"],
+                "executed_skill_ids": [],
+                "not_applicable_skill_ids": [],
+                "deferred_skill_ids": [],
+                "failed_skill_ids": [],
+                "unresolved_skill_ids": ["scientific-reporting"],
+                "delivery_blocking": True,
+            },
+            phase_execute_specialist_decision={
+                "decision_state": "approved_dispatch",
+                "resolution_mode": "approved_dispatch",
+                "approved_dispatch_skill_ids": ["scientific-reporting"],
+            },
+        )
+
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("FAIL", report["summary"]["gate_result"])
+        self.assertIn("specialist_lock_resolution_truth", report["truth_results"])
+        self.assertEqual("failing", report["truth_results"]["specialist_lock_resolution_truth"]["state"])
+        self.assertIn("scientific-reporting", report["execution_context"]["specialist_lock_unresolved_skill_ids"])
+
+    def test_runtime_delivery_acceptance_passes_when_locked_specialist_is_executed(self) -> None:
+        skill_path = "/tmp/scientific-reporting/SKILL.md"
+        session_root = self._build_session(
+            run_id="pytest-specialist-lock-pass",
+            approved_dispatch=[
+                {
+                    "skill_id": "scientific-reporting",
+                    "native_skill_entrypoint": skill_path,
+                }
+            ],
+            phase_execute_specialist_user_disclosure={
+                "scope": "selected_skill_execution_only",
+                "timing": "before_execution",
+                "path_source": "native_skill_entrypoint",
+                "routed_skills": [
+                    {
+                        "skill_id": "scientific-reporting",
+                        "native_skill_entrypoint": skill_path,
+                        "entrypoint_requirement_satisfied": True,
+                    }
+                ],
+            },
+            specialist_accounting={
+                "selected_skill_execution": [
+                    {
+                        "skill_id": "scientific-reporting",
+                        "native_skill_entrypoint": skill_path,
+                    }
+                ],
+                "selected_skill_execution_count": 1,
+                "effective_execution_status": "direct_current_session_routed",
+                "direct_routed_skill_execution_units": [
+                    {
+                        "unit_id": "unit-1",
+                        "skill_id": "scientific-reporting",
+                        "result_path": "specialist-results/scientific-reporting.json",
+                    }
+                ],
+            },
+            skill_execution_lock={
+                "schema_version": "v1",
+                "state": "active",
+                "locked_skill_ids": ["scientific-reporting"],
+                "locked_dispatch": [{"skill_id": "scientific-reporting", "native_skill_entrypoint": skill_path}],
+                "resolution_required": True,
+            },
+            specialist_lock_resolution={
+                "active": True,
+                "locked_skill_ids": ["scientific-reporting"],
+                "executed_skill_ids": ["scientific-reporting"],
+                "not_applicable_skill_ids": [],
+                "deferred_skill_ids": [],
+                "failed_skill_ids": [],
+                "unresolved_skill_ids": [],
+                "delivery_blocking": False,
+            },
+            phase_execute_specialist_decision={
+                "decision_state": "approved_dispatch",
+                "resolution_mode": "approved_dispatch",
+                "approved_dispatch_skill_ids": ["scientific-reporting"],
+            },
+            sidecar_specialist_execution={
+                "protocol_version": "v1",
+                "source_run_id": "pytest-specialist-lock-pass",
+                "resolution_mode": "current_session_host_execution",
+                "evidence_paths": ["/tmp/pytest-specialist-lock-pass.md"],
+                "units": [
+                    {
+                        "unit_id": "unit-1",
+                        "skill_id": "scientific-reporting",
+                        "resolution_state": "executed",
+                        "native_skill_entrypoint": skill_path,
+                        "evidence_paths": ["/tmp/pytest-scientific-reporting.txt"],
+                    }
+                ],
+            },
+        )
+
+        report = evaluate(REPO_ROOT, session_root)
+
+        self.assertEqual("PASS", report["summary"]["gate_result"])
+        self.assertEqual("passing", report["truth_results"]["specialist_lock_resolution_truth"]["state"])
+        self.assertEqual([], report["execution_context"]["specialist_lock_unresolved_skill_ids"])
 
     def test_runtime_delivery_acceptance_does_not_pass_incomplete_workflow_with_executed_sidecar(self) -> None:
         approved_dispatch = [

--- a/tests/runtime_neutral/test_science_lab_automation_pack_consolidation.py
+++ b/tests/runtime_neutral/test_science_lab_automation_pack_consolidation.py
@@ -25,6 +25,7 @@ DELETED_SKILLS = [
 OUT_OF_SCOPE_SKILLS = [
     "latchbio-integration",
 ]
+ASSERTIONS = unittest.TestCase()
 
 
 def load_json(path: Path) -> dict[str, object]:
@@ -80,8 +81,8 @@ def manifest_skill_ids() -> set[str]:
         values = pack.get("skill_candidates") or []
         assert isinstance(values, list), pack
         skill_ids.update(str(value) for value in values)
-        assert "route_authority_candidates" not in pack, pack
-        assert "stage_assistant_candidates" not in pack, pack
+        ASSERTIONS.assertNotIn("route_authority_candidates", pack, str(pack))
+        ASSERTIONS.assertNotIn("stage_assistant_candidates", pack, str(pack))
         defaults = pack.get("defaults_by_task") or {}
         assert isinstance(defaults, dict), pack
         skill_ids.update(str(value) for value in defaults.values())

--- a/tests/runtime_neutral/test_skill_execution_lock_contract.py
+++ b/tests/runtime_neutral/test_skill_execution_lock_contract.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_COMMON = REPO_ROOT / "scripts" / "runtime" / "VibeRuntime.Common.ps1"
+SKILL_ROUTING_COMMON = REPO_ROOT / "scripts" / "runtime" / "VibeSkillRouting.Common.ps1"
+FREEZE_SCRIPT = REPO_ROOT / "scripts" / "runtime" / "Freeze-RuntimeInputPacket.ps1"
+
+
+def resolve_powershell() -> str | None:
+    candidates = [
+        shutil.which("pwsh"),
+        shutil.which("pwsh.exe"),
+        r"C:\Program Files\PowerShell\7\pwsh.exe",
+        shutil.which("powershell"),
+        shutil.which("powershell.exe"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
+def ps_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def run_ps_json(script: str) -> dict[str, object]:
+    shell = resolve_powershell()
+    if shell is None:
+        raise unittest.SkipTest("PowerShell executable not available")
+    completed = subprocess.run(
+        [shell, "-NoLogo", "-NoProfile", "-Command", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def as_list(value: object) -> list[object]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+class SkillExecutionLockContractTests(unittest.TestCase):
+    def test_lock_projection_preserves_previous_selected_when_current_router_differs(self) -> None:
+        payload = run_ps_json(
+            "& { "
+            f". {ps_quote(str(RUNTIME_COMMON))}; "
+            f". {ps_quote(str(SKILL_ROUTING_COMMON))}; "
+            "$previous = [pscustomobject]@{ "
+            "  run_id = 'pytest-plan-run'; "
+            "  skill_routing = [pscustomobject]@{ "
+            "    selected = @([pscustomobject]@{ "
+            "      skill_id = 'scientific-reporting'; "
+            "      task_slice = 'write paper'; "
+            "      native_skill_entrypoint = 'C:/skills/scientific-reporting/SKILL.md'; "
+            "      skill_md_path = 'C:/skills/scientific-reporting/SKILL.md'; "
+            "      dispatch_phase = 'post_execution'; "
+            "      write_scope = 'specialist:scientific-reporting'; "
+            "      verification_expectation = 'report evidence' "
+            "    }) "
+            "  } "
+            "}; "
+            "$current = [pscustomobject]@{ "
+            "  selected = @([pscustomobject]@{ "
+            "    skill_id = 'latex-submission-pipeline'; "
+            "    task_slice = 'compile pdf'; "
+            "    native_skill_entrypoint = 'C:/skills/latex-submission-pipeline/SKILL.md'; "
+            "    skill_md_path = 'C:/skills/latex-submission-pipeline/SKILL.md'; "
+            "    dispatch_phase = 'post_execution'; "
+            "    write_scope = 'specialist:latex-submission-pipeline'; "
+            "    verification_expectation = 'build pdf' "
+            "  }); "
+            "  candidates = @(); rejected = @() "
+            "}; "
+            "$lock = New-VibeSkillExecutionLockProjection "
+            "-PreviousRuntimeInputPacket $previous "
+            "-CurrentSkillRouting $current "
+            "-SourceRunId 'pytest-plan-run' "
+            "-Source 'approved_plan_reentry'; "
+            "$lock | ConvertTo-Json -Depth 20 "
+            "}"
+        )
+
+        self.assertEqual("v1", payload["schema_version"])
+        self.assertEqual("active", payload["state"])
+        self.assertEqual("approved_plan_reentry", payload["source"])
+        self.assertEqual("pytest-plan-run", payload["source_run_id"])
+        self.assertIn("scientific-reporting", as_list(payload["locked_skill_ids"]))
+        locked_dispatch = as_list(payload["locked_dispatch"])
+        self.assertEqual("scientific-reporting", locked_dispatch[0]["skill_id"])
+        self.assertEqual("inherited_not_currently_surfaced", locked_dispatch[0]["reconciliation_state"])
+        self.assertTrue(payload["resolution_required"])
+
+    def test_lock_projection_prefers_explicit_host_decision(self) -> None:
+        payload = run_ps_json(
+            "& { "
+            f". {ps_quote(str(RUNTIME_COMMON))}; "
+            f". {ps_quote(str(SKILL_ROUTING_COMMON))}; "
+            "$previous = [pscustomobject]@{ "
+            "  skill_routing = [pscustomobject]@{ "
+            "    selected = @([pscustomobject]@{ skill_id = 'scientific-reporting'; task_slice = 'prior plan' }) "
+            "  } "
+            "}; "
+            "$current = [pscustomobject]@{ "
+            "  selected = @([pscustomobject]@{ skill_id = 'latex-submission-pipeline'; task_slice = 'current pdf'; dispatch_phase = 'post_execution' }); "
+            "  candidates = @([pscustomobject]@{ skill_id = 'designing-experiments'; task_slice = 'explicit design'; dispatch_phase = 'pre_execution' }); "
+            "  rejected = @() "
+            "}; "
+            "$decision = [pscustomobject]@{ approved_skill_ids = @('designing-experiments') }; "
+            "$lock = New-VibeSkillExecutionLockProjection "
+            "-PreviousRuntimeInputPacket $previous "
+            "-CurrentSkillRouting $current "
+            "-HostSpecialistDispatchDecision $decision "
+            "-SourceRunId 'pytest-plan-run' "
+            "-Source 'approved_plan_reentry'; "
+            "$lock | ConvertTo-Json -Depth 20 "
+            "}"
+        )
+
+        self.assertEqual(["designing-experiments"], as_list(payload["locked_skill_ids"]))
+        dispatch = as_list(payload["locked_dispatch"])[0]
+        self.assertEqual("designing-experiments", dispatch["skill_id"])
+        self.assertEqual("host_decision", dispatch["lock_source"])
+        self.assertEqual("current_surfaced", dispatch["reconciliation_state"])
+
+    def test_convert_lock_to_dispatch_preserves_dispatch_fields(self) -> None:
+        payload = run_ps_json(
+            "& { "
+            f". {ps_quote(str(RUNTIME_COMMON))}; "
+            f". {ps_quote(str(SKILL_ROUTING_COMMON))}; "
+            "$lock = [pscustomobject]@{ "
+            "  schema_version = 'v1'; state = 'active'; resolution_required = $true; "
+            "  locked_dispatch = @([pscustomobject]@{ "
+            "    skill_id = 'literature-review'; "
+            "    task_slice = 'review authoritative literature'; "
+            "    native_skill_entrypoint = 'C:/skills/literature-review/SKILL.md'; "
+            "    skill_md_path = 'C:/skills/literature-review/SKILL.md'; "
+            "    dispatch_phase = 'pre_execution'; "
+            "    parallelizable_in_root_xl = $true; "
+            "    write_scope = 'specialist:literature-review'; "
+            "    verification_expectation = 'citation notes'; "
+            "    lock_source = 'previous_skill_routing_selected' "
+            "  }) "
+            "}; "
+            "$dispatch = Convert-VibeSkillExecutionLockToDispatch -SkillExecutionLock $lock; "
+            "[pscustomobject]@{ dispatch = $dispatch } | ConvertTo-Json -Depth 20 "
+            "}"
+        )
+
+        dispatch = as_list(payload["dispatch"])[0]
+        self.assertEqual("literature-review", dispatch["skill_id"])
+        self.assertEqual("pre_execution", dispatch["dispatch_phase"])
+        self.assertEqual("specialist:literature-review", dispatch["write_scope"])
+        self.assertEqual("citation notes", dispatch["verification_expectation"])
+        self.assertTrue(dispatch["locked_for_execution"])
+
+    def test_freeze_inherits_previous_plan_selection_into_execution_lock(self) -> None:
+        shell = resolve_powershell()
+        if shell is None:
+            self.skipTest("PowerShell executable not available")
+        with tempfile.TemporaryDirectory() as tempdir:
+            artifact_root = Path(tempdir) / "artifacts"
+            prior_session = artifact_root / "outputs" / "runtime" / "vibe-sessions" / "pytest-plan-run"
+            prior_session.mkdir(parents=True)
+            (prior_session / "runtime-input-packet.json").write_text(
+                json.dumps(
+                    {
+                        "run_id": "pytest-plan-run",
+                        "requested_stage_stop": "xl_plan",
+                        "skill_routing": {
+                            "schema_version": "simplified_skill_routing_v1",
+                            "selected": [
+                                {
+                                    "skill_id": "scientific-reporting",
+                                    "task_slice": "write a scientific report",
+                                    "native_skill_entrypoint": "C:/skills/scientific-reporting/SKILL.md",
+                                    "skill_md_path": "C:/skills/scientific-reporting/SKILL.md",
+                                    "dispatch_phase": "post_execution",
+                                    "write_scope": "specialist:scientific-reporting",
+                                    "verification_expectation": "report evidence",
+                                }
+                            ],
+                            "candidates": [],
+                            "rejected": [],
+                        },
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            host_decision = {
+                "decision_kind": "approval_response",
+                "decision_action": "approve_plan",
+                "approval_decision": "approve",
+                "continuation_context": {
+                    "structured_bounded_reentry": True,
+                    "source_run_id": "pytest-plan-run",
+                    "reentry_action": "approve_plan",
+                    "prior_task_type": "research",
+                    "control_only_prompt": True,
+                },
+            }
+            completed = subprocess.run(
+                [
+                    shell,
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-File",
+                    str(FREEZE_SCRIPT),
+                    "-Task",
+                    "Continue approved plan and compile the LaTeX paper.",
+                    "-Mode",
+                    "interactive_governed",
+                    "-RunId",
+                    "pytest-execute-run",
+                    "-ArtifactRoot",
+                    str(artifact_root),
+                    "-HostDecisionJson",
+                    json.dumps(host_decision),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=True,
+            )
+            self.assertIn("packet_path", completed.stdout)
+            packet_path = next(
+                (artifact_root / "outputs" / "runtime" / "vibe-sessions" / "pytest-execute-run").rglob(
+                    "runtime-input-packet.json"
+                )
+            )
+            packet = json.loads(packet_path.read_text(encoding="utf-8"))
+
+        lock = packet["skill_execution_lock"]
+        self.assertEqual("active", lock["state"])
+        self.assertIn("scientific-reporting", as_list(lock["locked_skill_ids"]))
+        self.assertTrue(lock["resolution_required"])

--- a/tests/runtime_neutral/test_skill_execution_lock_contract.py
+++ b/tests/runtime_neutral/test_skill_execution_lock_contract.py
@@ -251,3 +251,29 @@ class SkillExecutionLockContractTests(unittest.TestCase):
         self.assertEqual("active", lock["state"])
         self.assertIn("scientific-reporting", as_list(lock["locked_skill_ids"]))
         self.assertTrue(lock["resolution_required"])
+
+    def test_lock_dispatch_is_preferred_over_current_router_selection_projection(self) -> None:
+        payload = run_ps_json(
+            "& { "
+            f". {ps_quote(str(RUNTIME_COMMON))}; "
+            f". {ps_quote(str(SKILL_ROUTING_COMMON))}; "
+            "$runtimePacket = [pscustomobject]@{ "
+            "  skill_execution_lock = [pscustomobject]@{ "
+            "    schema_version = 'v1'; state = 'active'; resolution_required = $true; "
+            "    locked_dispatch = @([pscustomobject]@{ "
+            "      skill_id = 'scientific-reporting'; task_slice = 'locked report'; dispatch_phase = 'post_execution'; "
+            "      write_scope = 'specialist:scientific-reporting'; verification_expectation = 'report evidence' "
+            "    }) "
+            "  }; "
+            "  skill_routing = [pscustomobject]@{ "
+            "    selected = @([pscustomobject]@{ skill_id = 'latex-submission-pipeline'; task_slice = 'current pdf'; dispatch_phase = 'post_execution' }) "
+            "  } "
+            "}; "
+            "$lockDispatch = Convert-VibeSkillExecutionLockToDispatch -SkillExecutionLock $runtimePacket.skill_execution_lock; "
+            "$currentDispatch = Convert-VibeSkillRoutingSelectedToDispatch -RuntimeInputPacket $runtimePacket -SkillRouting $runtimePacket.skill_routing; "
+            "[pscustomobject]@{ lock_dispatch = $lockDispatch; current_dispatch = $currentDispatch } | ConvertTo-Json -Depth 20 "
+            "}"
+        )
+
+        self.assertEqual(["scientific-reporting"], [item["skill_id"] for item in as_list(payload["lock_dispatch"])])
+        self.assertEqual(["latex-submission-pipeline"], [item["skill_id"] for item in as_list(payload["current_dispatch"])])

--- a/tests/runtime_neutral/test_terminology_field_simplification.py
+++ b/tests/runtime_neutral/test_terminology_field_simplification.py
@@ -68,9 +68,10 @@ def test_pack_defaults_point_to_skill_candidates() -> None:
 
 def test_terminology_governance_doc_exists_and_defines_active_model() -> None:
     text = TERMINOLOGY_DOC.read_text(encoding="utf-8")
-    assert "skill_candidates -> skill_routing.selected -> selected_skill_execution -> skill_usage" in text
+    assert "skill_candidates -> skill_routing.selected -> skill_execution_lock -> selected_skill_execution -> skill_usage" in text
     assert "`skill_candidates`" in text
     assert "`skill_routing.selected`" in text
+    assert "`skill_execution_lock`" in text
     assert "`selected_skill_execution`" in text
     assert "`skill_usage.used`" in text
     assert "`skill_usage.unused`" in text

--- a/tests/unit/test_router_contract_selection_guards.py
+++ b/tests/unit/test_router_contract_selection_guards.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+import unittest
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -10,6 +11,9 @@ if str(RUNTIME_SRC) not in sys.path:
     sys.path.insert(0, str(RUNTIME_SRC))
 
 from vgo_runtime.router_contract_selection import get_pack_skill_candidates, select_pack_candidate
+
+
+ASSERTIONS = unittest.TestCase()
 
 
 def _selection(prompt: str, *, requested: str | None = None) -> dict[str, object]:
@@ -82,7 +86,7 @@ def test_requested_subagent_bypasses_guard() -> None:
 
     assert selection["selected"] == "subagent-driven-development"
     assert selection["reason"] == "requested_skill"
-    assert "_legacy_stage_assistant_candidates" not in selection
+    ASSERTIONS.assertNotIn("_legacy_stage_assistant_candidates", selection)
 
 
 def test_pack_skill_candidates_prefer_unified_field_over_old_role_fixture_fields() -> None:
@@ -134,8 +138,8 @@ def test_active_skill_candidates_use_current_fields_only() -> None:
     )
 
     assert selection["selected"] == "helper"
-    assert "legacy_role" not in selection["ranking"][0]
-    assert "_legacy_role" not in selection["ranking"][0]
-    assert "route_authority_eligible" not in selection["ranking"][0]
-    assert "_legacy_stage_assistant_candidates" not in selection
+    ASSERTIONS.assertNotIn("legacy_role", selection["ranking"][0])
+    ASSERTIONS.assertNotIn("_legacy_role", selection["ranking"][0])
+    ASSERTIONS.assertNotIn("route_authority_eligible", selection["ranking"][0])
+    ASSERTIONS.assertNotIn("_legacy_stage_assistant_candidates", selection)
     assert "routing_role" not in selection["ranking"][0]


### PR DESCRIPTION
## Summary
- Add `skill_execution_lock` helpers and freeze-time projection so approved specialist obligations survive bounded re-entry.
- Prefer active execution locks during plan execution, while keeping `skill_usage.used` as the only material-use evidence.
- Enforce unresolved/failed locked specialists in runtime delivery acceptance, with updated governance docs and regression coverage.

## Test Plan
- [x] `python -m pytest tests/runtime_neutral/test_skill_execution_lock_contract.py tests/runtime_neutral/test_simplified_skill_routing_contract.py tests/runtime_neutral/test_skill_promotion_freeze_contract.py tests/runtime_neutral/test_structured_bounded_reentry_continuation.py tests/runtime_neutral/test_runtime_delivery_acceptance.py tests/runtime_neutral/test_current_routing_docs_entrypoint.py tests/runtime_neutral/test_terminology_field_simplification.py tests/runtime_neutral/test_current_routing_contract_cleanup.py -q` -> `95 passed`
- [x] `powershell -ExecutionPolicy Bypass -File .\check.ps1 -SkipRuntimeFreshnessGate` -> `58 passed, 0 failed, 1 warnings`
- [x] `powershell -ExecutionPolicy Bypass -File .\check.ps1` -> expected local install parity failure: `830 passed, 14 failed`; the source branch changed runtime files but this PR has not deployed them into `C:\Users\羽裳\.codex\skills\vibe`

## Deployment Note
This PR updates the source worktree only. It does not modify the live Codex runtime installed under `C:\Users\羽裳\.codex`.