### PR TITLE
Release Vibe Skills 3.1.1

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -228,7 +228,7 @@ Read these references only after canonical launch or when maintaining the repo:
 ## Maintenance
 
 - Runtime family: governed-runtime-first
-- Version: 3.1.0
-- Updated: 2026-04-25
+- Version: 3.1.1
+- Updated: 2026-05-06
 - Internal specialist recommendation router: `scripts/router/resolve-pack-route.ps1`
 - Primary contract metadata: `core/skill-contracts/v1/vibe.json`

--- a/apps/vgo-cli/pyproject.toml
+++ b/apps/vgo-cli/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-cli"
-version = "3.1.0"
+version = "3.1.1"
 description = "Thin CLI launcher for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/config/version-governance.json
+++ b/config/version-governance.json
@@ -1,10 +1,10 @@
 {
     "schema_version":  2,
     "release":  {
-                    "version":  "3.1.0",
-                    "updated":  "2026-04-25",
+                    "version":  "3.1.1",
+                    "updated":  "2026-05-06",
                     "channel":  "stable",
-                    "notes":  "Phoenix release: unified vibe entry surface, structured host routing, bounded continuation, specialist truth gates, install/runtime path hardening, public vibe-upgrade, and package metadata alignment"
+                    "notes":  "Current routing contract hardening, specialist execution lock closure, runtime-neutral verification stabilization, and release-surface refresh on the latest mainline"
                 },
     "source_of_truth":  {
                             "canonical_root":  ".",

--- a/dist/core/manifest.json
+++ b/dist/core/manifest.json
@@ -4,8 +4,8 @@
   "lane_kind": "universal-core",
   "stability": "preview",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "summary": "Universal contracts only. No install/check runtime closure is promised by this lane.",
   "runtime_ownership": {

--- a/dist/host-claude-code/manifest.json
+++ b/dist/host-claude-code/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "claude-code",
   "stability": "supported-with-constraints",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "summary": "Claude Code host adapter lane with bounded managed closure. The repo can write and verify a managed Claude settings surface, while still keeping broader host behavior outside repo ownership.",
   "runtime_ownership": {

--- a/dist/host-codex/manifest.json
+++ b/dist/host-codex/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "codex",
   "stability": "supported-with-constraints",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "summary": "Codex host adapter lane. Uses the official runtime entrypoints, but remains honest about host-managed plugin and credential surfaces.",
   "runtime_ownership": {

--- a/dist/host-cursor/manifest.json
+++ b/dist/host-cursor/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "cursor",
   "stability": "preview",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "summary": "Cursor host adapter preview. The repository can expose runtime-core payload and preview health checks, but does not claim full governed closure yet.",
   "runtime_ownership": {

--- a/dist/host-openclaw/manifest.json
+++ b/dist/host-openclaw/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "openclaw",
   "stability": "preview",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "summary": "OpenClaw host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/host-opencode/manifest.json
+++ b/dist/host-opencode/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "opencode",
   "stability": "preview",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "summary": "OpenCode host adapter preview. The repo can install runtime-core plus OpenCode-native command and agent wrapper payload into OpenCode roots, but final host config and platform closure remain incomplete.",
   "runtime_ownership": {

--- a/dist/host-windsurf/manifest.json
+++ b/dist/host-windsurf/manifest.json
@@ -5,8 +5,8 @@
   "host_id": "windsurf",
   "stability": "preview",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "summary": "Windsurf host adapter preview. Uses the shared runtime-core installer and host-root payloads without claiming governed closure.",
   "runtime_ownership": {

--- a/dist/manifests/vibeskills-claude-code.json
+++ b/dist/manifests/vibeskills-claude-code.json
@@ -48,8 +48,8 @@
   },
   "summary": "Claude Code now has a bounded managed install/check lane that writes and verifies a Claude settings surface, but it still does not become the Codex official runtime or full platform-parity lane.",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-codex.json
+++ b/dist/manifests/vibeskills-codex.json
@@ -53,8 +53,8 @@
   },
   "summary": "Codex is the current strongest practical reference lane for the governed runtime payload, but some key surfaces remain host-managed and certain platforms are degraded.",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-core.json
+++ b/dist/manifests/vibeskills-core.json
@@ -46,8 +46,8 @@
   },
   "summary": "Host-agnostic contracts and schemas that stabilize skill metadata without claiming a governed runtime on any host.",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "truth_sources": [
     "docs/universalization/core-contract.md",

--- a/dist/manifests/vibeskills-cursor.json
+++ b/dist/manifests/vibeskills-cursor.json
@@ -50,8 +50,8 @@
   },
   "summary": "Cursor exposes preview adapter entrypoints and truthful readiness boundaries, but this repository does not claim governed or host-native closure for it.",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-generic.json
+++ b/dist/manifests/vibeskills-generic.json
@@ -45,8 +45,8 @@
   },
   "summary": "Generic hosts may consume canonical contracts and a repo-provided runtime-core payload in a neutral target root, but the repository still makes no host closure claim.",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-openclaw.json
+++ b/dist/manifests/vibeskills-openclaw.json
@@ -50,8 +50,8 @@
   },
   "summary": "OpenClaw may consume the shared runtime-core payload through a documented host root, but this repository does not claim host-native governed closure for it.",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-opencode.json
+++ b/dist/manifests/vibeskills-opencode.json
@@ -53,8 +53,8 @@
   },
   "summary": "OpenCode now has a truthful preview adapter lane with bounded install/check entrypoints, skills payload, and wrapper scaffolds, but the repository still avoids claiming full host closure or platform parity.",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/manifests/vibeskills-windsurf.json
+++ b/dist/manifests/vibeskills-windsurf.json
@@ -50,8 +50,8 @@
   },
   "summary": "Windsurf may consume the shared runtime-core payload through a documented host root, but this repository does not claim host-native governed closure for it.",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "truth_sources": [
     "docs/universalization/host-capability-matrix.md",

--- a/dist/official-runtime/manifest.json
+++ b/dist/official-runtime/manifest.json
@@ -4,8 +4,8 @@
   "lane_kind": "tier-1-official-runtime",
   "stability": "tier-1",
   "source_release": {
-    "version": "3.1.0",
-    "updated": "2026-04-25"
+    "version": "3.1.1",
+    "updated": "2026-05-06"
   },
   "summary": "Reference lane for the current governed official runtime. This dist pack points to it and must not rewrite it.",
   "runtime_ownership": {

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -10,7 +10,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ### Current Release Surface
 
-- [`v3.1.0.md`](v3.1.0.md): Phoenix release for unified `vibe` / `vibe-upgrade` public surfaces, structured host routing, bounded continuation, specialist truth gates, TDD applicability, install/runtime path hardening, and package metadata alignment
+- [`v3.1.1.md`](v3.1.1.md): current routing contract hardening / specialist execution lock closure / runtime-neutral verification stabilization / docs and install-surface refresh
 
 ### Release Runtime / Proof Handoff
 
@@ -24,6 +24,7 @@ This directory stores governed VCO release notes and the minimum runtime-facing 
 
 ## Recent Governed Releases
 
+- [`v3.1.1.md`](v3.1.1.md) - 2026-05-06 - current routing contract hardening / specialist execution lock closure / runtime-neutral verification stabilization / docs and install-surface refresh
 - [`v3.1.0.md`](v3.1.0.md) - 2026-04-25 - unified public vibe surfaces / structured host routing / bounded continuation / specialist truth gates / TDD applicability / install-runtime path hardening / package metadata alignment
 - [`v3.0.4.md`](v3.0.4.md) - 2026-04-19 - Windows verification gate Python resolution / direct in-session specialist routing / canonical entry truth hardening / release-train telemetry seeding / upgrade truth and empty-upgrade repair
 - [`v3.0.3.md`](v3.0.3.md) - 2026-04-15 - host-global bootstrap lifecycle / specialist decision truth / upgrade metadata hardening / installed runtime payload coverage repair

--- a/docs/releases/v3.1.1.md
+++ b/docs/releases/v3.1.1.md
@@ -1,0 +1,67 @@
+# VCO Release v3.1.1
+
+- Date: 2026-05-06
+- Commit(base): cdc5a71
+- Previous public release: `v3.1.0`
+- Previous public release commit: `67e709e`
+
+## Highlights
+
+- This patch release cuts from the latest `main` baseline after the post-`v3.1.0` routing cleanup train, review follow-up fixes, and runtime-neutral verification stabilization work landed on GitHub.
+- The current routing contract is tighter and easier to trust. Canonical-entry truth now stays aligned with the current skill-routing surface, older consultation/debt vocabulary is pruned more aggressively, and public outputs lean harder on the current contract instead of compatibility-era field names.
+- Specialist execution closure is more explicit. The runtime now freezes and enforces specialist execution lock state across re-entry, reconciles routed skills with execution-time dispatch more carefully, and keeps current-session execution accounting clearer when handoff is pending versus actually resolved.
+- Several routing packs were simplified or retired across the release line: zero-authority leftovers were cleaned further, domain-owner boundaries were hardened, and stale packs such as cold-platform / quantum / lab-automation legacy surfaces were reduced or removed instead of lingering as noisy router hits.
+- The release surface is cleaner for operators. Source-neutral docs, practice demos, and homepage install-entry refreshes landed after `v3.1.0`, so the public repository now points users at a clearer install and evaluation path without changing the governed runtime authority model.
+- Repository metadata is aligned again at `3.1.1`, including Python package versions, release governance, changelog, release notes, and generated dist manifests.
+
+## What Changed Since v3.1.0
+
+### Current Routing Contract And Vocabulary
+
+- Hardened canonical-entry truth so current routing outputs, specialist projections, and visible execution wording stay aligned instead of leaking retired consultation-era terminology.
+- Simplified active routing fields, current policy helper names, and output vocabulary so current receipts speak in one contract dialect rather than mixing new and legacy routing labels.
+- Compressed or retired older routing documentation where the current contract already supersedes it, reducing drift between docs, runtime outputs, and tests.
+
+### Specialist Execution Lock And Delivery Truth
+
+- Added and then enforced specialist execution lock helpers so selected specialists remain frozen across re-entry and `plan_execute`.
+- Reconciled routed skills with execution-time dispatch more carefully, which reduces confusion between "routed", "disclosed for execution", and "materially used".
+- Tightened delivery-acceptance and runtime proof paths around current-session specialist execution state so pending handoff is reported honestly.
+
+### Routing Pack Cleanup And Boundary Hardening
+
+- Continued multi-pack cleanup across zero-authority, bio-science, code-quality, finance, medical-imaging, longtail-science-ml, research-design, and related routing surfaces.
+- Removed or shrank stale packs and stage-assistant surfaces that no longer deserved direct routing authority.
+- Added targeted docs/tests around the cleanup so the repo documents which route owners remain active and why.
+
+### Verification And Review Follow-Through
+
+- Stabilized the runtime-neutral verification baseline after the PR226 review cycle and the later combined PR228 follow-up merge.
+- Added review-driven fixes for current routing helpers, direct-call validation, and specialist execution lock behavior.
+- Kept the release line grounded in regression checks instead of shipping on docs-only metadata updates.
+
+### README And Install Surface Refresh
+
+- Added practice demos that make the governed `vibe` workflow easier to evaluate from openable outputs instead of only abstract description.
+- Made internal docs links source-neutral so the same docs survive GitHub, mirrors, local checkouts, and release archives.
+- Iterated the homepage install CTA and install-entry presentation to make the public entry path more obvious.
+
+## Validation Notes
+
+- `python -m pytest tests/runtime_neutral/test_release_v3_1_1_surface.py -q` -> failing-first evidence captured before the release metadata updates; expected failures showed the repo was still advertising `3.1.0`.
+- `python scripts/build/sync_dist_release_manifests.py --repo-root .` -> regenerated all release-facing `dist` manifests from `config/version-governance.json`.
+- `python -m pytest tests/runtime_neutral/test_release_v3_1_1_surface.py -q` -> `2 passed`.
+- `python -m pytest tests/unit/test_vgo_cli_upgrade_service.py -q` -> `19 passed`.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-version-consistency-gate.ps1` -> PASS, 10 assertions.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-release-notes-quality-gate.ps1` -> PASS.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-version-packaging-gate.ps1` -> PASS, 9 assertions.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-dist-manifest-gate.ps1` -> PASS.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-release-install-runtime-coherence-gate.ps1` -> PASS.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-config-parity-gate.ps1` -> PASS, 45 config pairs matched.
+- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-bom-frontmatter-gate.ps1` -> PASS for canonical/governance surfaces, with bundled and installed targets skipped as not applicable in this release workspace.
+
+## Migration Notes
+
+- Public Vibe entry skills remain `vibe` and `vibe-upgrade`; this patch release does not widen the public entry surface.
+- Hosts and operators should keep treating routed skills, disclosed-for-execution skills, and materially used skills as separate truth layers.
+- The install and evaluation path is easier to discover, but host-managed plugin, MCP, and credential surfaces remain outside repo ownership unless a host-specific proof lane says otherwise.

--- a/packages/adapter-sdk/pyproject.toml
+++ b/packages/adapter-sdk/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-adapters"
-version = "3.1.0"
+version = "3.1.1"
 description = "Adapter SDK for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/contracts/pyproject.toml
+++ b/packages/contracts/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-contracts"
-version = "3.1.0"
+version = "3.1.1"
 description = "Authoritative contracts for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/installer-core/pyproject.toml
+++ b/packages/installer-core/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-installer"
-version = "3.1.0"
+version = "3.1.1"
 description = "Installer core for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/runtime-core/pyproject.toml
+++ b/packages/runtime-core/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-runtime"
-version = "3.1.0"
+version = "3.1.1"
 description = "Runtime core for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/skill-catalog/pyproject.toml
+++ b/packages/skill-catalog/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-skill-catalog"
-version = "3.1.0"
+version = "3.1.1"
 description = "Detached skill catalog package for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/packages/verification-core/pyproject.toml
+++ b/packages/verification-core/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vgo-verify"
-version = "3.1.0"
+version = "3.1.1"
 description = "Verification core for Vibe-Skills clean architecture"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vibe-skills-workspace"
-version = "3.1.0"
+version = "3.1.1"
 description = "Clean architecture workspace scaffold for Vibe-Skills"
 requires-python = ">=3.10"

--- a/references/changelog.md
+++ b/references/changelog.md
@@ -1,5 +1,13 @@
 # VCO Changelog
 
+## v3.1.1 (2026-05-06)
+
+- Hardened the current routing release line around specialist execution lock enforcement, current-session execution accounting, and canonical-entry truth alignment for the latest `main` baseline.
+- Consolidated and simplified routing ownership across multiple packs, retired more stale compatibility surfaces, and stabilized the runtime-neutral verification baseline after the PR226/PR228 review cycle.
+- Refreshed the public release surface with source-neutral docs, practice demos, and clearer install-entry presentation while keeping governed release metadata, package versions, and dist manifests aligned at `3.1.1`.
+- Detailed release notes: `docs/releases/v3.1.1.md`.
+
+
 ## v3.1.0 (2026-04-25)
 
 - Rebuilt the public Vibe surface around one canonical `vibe` entry plus public `vibe-upgrade`, while demoting legacy want/how/do wrapper names to compatibility metadata only.

--- a/references/release-ledger.jsonl
+++ b/references/release-ledger.jsonl
@@ -34,3 +34,4 @@
 {"recorded_at":"2026-04-18T13:34:12","version":"3.0.4","updated":"2026-04-18","git_head":"c0618d0","actor":null}
 {"recorded_at":"2026-04-19T04:28:17","version":"3.0.4","updated":"2026-04-19","git_head":"eeb09f3","actor":null}
 {"recorded_at":"2026-04-25T20:27:19","version":"3.1.0","updated":"2026-04-25","git_head":"6d6630b","actor":"羽裳"}
+{"recorded_at":"2026-05-06T15:10:00","version":"3.1.1","updated":"2026-05-06","git_head":"cdc5a71","actor":"codex"}

--- a/tests/runtime_neutral/test_release_v3_1_1_surface.py
+++ b/tests/runtime_neutral/test_release_v3_1_1_surface.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXPECTED_VERSION = "3.1.1"
+EXPECTED_UPDATED = "2026-05-06"
+EXPECTED_BASE_COMMIT = "cdc5a71"
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+class ReleaseV311SurfaceTests(unittest.TestCase):
+    def test_authoritative_release_surface_is_aligned(self) -> None:
+        governance = load_json(REPO_ROOT / "config/version-governance.json")
+        self.assertEqual(governance["release"]["version"], EXPECTED_VERSION)
+        self.assertEqual(governance["release"]["updated"], EXPECTED_UPDATED)
+
+        pyproject_paths = [
+            REPO_ROOT / "pyproject.toml",
+            REPO_ROOT / "apps" / "vgo-cli" / "pyproject.toml",
+            REPO_ROOT / "packages" / "adapter-sdk" / "pyproject.toml",
+            REPO_ROOT / "packages" / "contracts" / "pyproject.toml",
+            REPO_ROOT / "packages" / "installer-core" / "pyproject.toml",
+            REPO_ROOT / "packages" / "runtime-core" / "pyproject.toml",
+            REPO_ROOT / "packages" / "skill-catalog" / "pyproject.toml",
+            REPO_ROOT / "packages" / "verification-core" / "pyproject.toml",
+        ]
+        for path in pyproject_paths:
+            self.assertIn(f'version = "{EXPECTED_VERSION}"', path.read_text(encoding="utf-8"))
+
+        skill_text = (REPO_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn(f"- Version: {EXPECTED_VERSION}", skill_text)
+        self.assertIn(f"- Updated: {EXPECTED_UPDATED}", skill_text)
+
+        changelog_text = (REPO_ROOT / "references/changelog.md").read_text(encoding="utf-8")
+        self.assertIn(f"## v{EXPECTED_VERSION} ({EXPECTED_UPDATED})", changelog_text)
+        self.assertIn(f"docs/releases/v{EXPECTED_VERSION}.md", changelog_text)
+
+        release_readme_text = (REPO_ROOT / "docs/releases/README.md").read_text(encoding="utf-8")
+        self.assertIn(f"[`v{EXPECTED_VERSION}.md`](v{EXPECTED_VERSION}.md)", release_readme_text)
+
+        release_note_text = (REPO_ROOT / "docs/releases" / f"v{EXPECTED_VERSION}.md").read_text(encoding="utf-8")
+        self.assertIn(f"# VCO Release v{EXPECTED_VERSION}", release_note_text)
+        self.assertIn(f"- Date: {EXPECTED_UPDATED}", release_note_text)
+        self.assertIn(f"- Commit(base): {EXPECTED_BASE_COMMIT}", release_note_text)
+
+        ledger_lines = [
+            json.loads(line)
+            for line in (REPO_ROOT / "references/release-ledger.jsonl").read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        self.assertIn(
+            {
+                "version": EXPECTED_VERSION,
+                "updated": EXPECTED_UPDATED,
+                "git_head": EXPECTED_BASE_COMMIT,
+                "actor": "codex",
+            },
+            [
+                {
+                    "version": entry.get("version"),
+                    "updated": entry.get("updated"),
+                    "git_head": entry.get("git_head"),
+                    "actor": entry.get("actor"),
+                }
+                for entry in ledger_lines
+            ],
+        )
+
+    def test_dist_release_manifests_point_at_v311(self) -> None:
+        source_config = load_json(REPO_ROOT / "config/distribution-manifest-sources.json")
+        manifest_paths = [
+            REPO_ROOT / item["output_path"]
+            for item in source_config.get("lane_manifests", []) + source_config.get("public_manifests", [])
+        ]
+        for path in manifest_paths:
+            manifest = load_json(path)
+            self.assertEqual(manifest["source_release"]["version"], EXPECTED_VERSION, str(path))
+            self.assertEqual(manifest["source_release"]["updated"], EXPECTED_UPDATED, str(path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_vgo_cli_upgrade_service.py
+++ b/tests/unit/test_vgo_cli_upgrade_service.py
@@ -482,7 +482,7 @@ def test_upgrade_runtime_uses_managed_source_when_started_from_installed_runtime
         "refresh_upstream_status",
         lambda repo_root_arg, target_root_arg, status, **kwargs: {
             **status,
-            "remote_latest_version": "3.1.0",
+            "remote_latest_version": "3.1.1",
             "remote_latest_commit": "new-install",
             "update_available": True,
         },
@@ -502,7 +502,7 @@ def test_upgrade_runtime_uses_managed_source_when_started_from_installed_runtime
         upgrade_service,
         "refresh_installed_status",
         lambda repo_root_arg, target_root_arg, host_id, **kwargs: {
-            "installed_version": "3.1.0",
+            "installed_version": "3.1.1",
             "installed_commit": "new-install",
         },
     )
@@ -523,7 +523,7 @@ def test_upgrade_runtime_uses_managed_source_when_started_from_installed_runtime
     assert recorded["repo_root"] == managed_source
     assert steps == [f"reset:{managed_source}:new-install", "reinstall", "check"]
     assert result["changed"] is True
-    assert result["after"]["installed_version"] == "3.1.0"
+    assert result["after"]["installed_version"] == "3.1.1"
 
 
 def test_upgrade_runtime_raises_clear_error_when_no_canonical_git_repo_exists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Release Vibe Skills `3.1.1` from latest `main`.

- bump authoritative version markers and package metadata to `3.1.1`
- add governed release notes and changelog/ledger updates
- sync release-facing dist manifests from version governance
- add a targeted release-surface regression test and update upgrade-service expectations

## Validation

- `python -m pytest tests/runtime_neutral/test_release_v3_1_1_surface.py -q`
- `python -m pytest tests/unit/test_vgo_cli_upgrade_service.py -q`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-version-consistency-gate.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-release-notes-quality-gate.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-version-packaging-gate.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-dist-manifest-gate.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-release-install-runtime-coherence-gate.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-config-parity-gate.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\verify\vibe-bom-frontmatter-gate.ps1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added complete release notes for v3.1.1 documenting all changes since v3.1.0.
  * Updated changelog and release registry.

* **Chores**
  * Bumped all package versions to 3.1.1.
  * Updated release metadata and governance records.

* **Tests**
  * Added validation tests for v3.1.1 release surface consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->