### PR TITLE
Fix check.sh empty projection loops under set -u

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1128,22 +1128,24 @@ fi
 if [[ "${HOST_ID}" == "codex" && "${ADAPTER_CHECK_MODE}" == "governed" && "${PROFILE}" == "full" ]]; then
   PROJECTED_SKILL_NAMES=()
   load_projected_skill_names_for_check "compatibility_skill_projections"
-  projected_wrapper_skill_names=("${PROJECTED_SKILL_NAMES[@]}")
-  for n in "${projected_wrapper_skill_names[@]}"; do
-    check_path "skill/${n}" "$(resolve_skill_descriptor_path "${n}")"
-  done
+  if [[ ${#PROJECTED_SKILL_NAMES[@]} -gt 0 ]]; then
+    for n in "${PROJECTED_SKILL_NAMES[@]}"; do
+      check_path "skill/${n}" "$(resolve_skill_descriptor_path "${n}")"
+    done
+  fi
 fi
 if [[ "${HOST_ID}" == "codex" && "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   PROJECTED_SKILL_NAMES=()
   load_projected_skill_names_for_check "public_skill_surface"
-  codex_command_names=("${PROJECTED_SKILL_NAMES[@]}")
-  for n in "${codex_command_names[@]}"; do
-    if [[ "${n}" == "vibe-upgrade" ]]; then
-      check_path "skill/${n}" "${TARGET_ROOT}/skills/${n}/SKILL.md"
-    else
-      check_path "codex command/${n}" "${TARGET_ROOT}/commands/${n}.md" false
-    fi
-  done
+  if [[ ${#PROJECTED_SKILL_NAMES[@]} -gt 0 ]]; then
+    for n in "${PROJECTED_SKILL_NAMES[@]}"; do
+      if [[ "${n}" == "vibe-upgrade" ]]; then
+        check_path "skill/${n}" "${TARGET_ROOT}/skills/${n}/SKILL.md"
+      else
+        check_path "codex command/${n}" "${TARGET_ROOT}/commands/${n}.md" false
+      fi
+    done
+  fi
 fi
 if [[ "${HOST_ID}" == "opencode" ]]; then
   if [[ "${ADAPTER_CHECK_MODE}" != "preview-guidance" ]]; then


### PR DESCRIPTION
Superseded by a replacement PR from the same commit using the requested unprefixed branch name `fix-check-empty-projections` instead of `codex/fix-check-empty-projections`.

Original summary:

Fixes #235.

`check.sh` can abort under Bash `set -u` when a manifest-backed projection list is valid but empty. The previous implementation copied `PROJECTED_SKILL_NAMES` into intermediate arrays and then iterated those arrays unconditionally, which can surface as an `unbound variable` abort on macOS Bash before the deep health check finishes.

This PR keeps the projection source manifest-driven and strict, but only enters each projection validation loop when the loaded array has entries. Non-empty projection lists still validate every projected skill or Codex command.

Verification:

```bash
bash -n check.sh install.sh scripts/bootstrap/one-shot-setup.sh
git diff --check -- check.sh
CODEX_HOME="$HOME/.codex" bash ./scripts/bootstrap/one-shot-setup.sh --host codex --profile full --skip-external-install
```

The full Codex one-shot setup completed after the fix:

- installed runtime freshness gate: `844 passed, 0 failed`
- deep health check: `69 passed, 0 failed`