### PR TITLE
Fix check.sh empty projection loops under set -u

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1128,22 +1128,24 @@ fi
 if [[ "${HOST_ID}" == "codex" && "${ADAPTER_CHECK_MODE}" == "governed" && "${PROFILE}" == "full" ]]; then
   PROJECTED_SKILL_NAMES=()
   load_projected_skill_names_for_check "compatibility_skill_projections"
-  projected_wrapper_skill_names=("${PROJECTED_SKILL_NAMES[@]}")
-  for n in "${projected_wrapper_skill_names[@]}"; do
-    check_path "skill/${n}" "$(resolve_skill_descriptor_path "${n}")"
-  done
+  if [[ ${#PROJECTED_SKILL_NAMES[@]} -gt 0 ]]; then
+    for n in "${PROJECTED_SKILL_NAMES[@]}"; do
+      check_path "skill/${n}" "$(resolve_skill_descriptor_path "${n}")"
+    done
+  fi
 fi
 if [[ "${HOST_ID}" == "codex" && "${ADAPTER_CHECK_MODE}" == "governed" ]]; then
   PROJECTED_SKILL_NAMES=()
   load_projected_skill_names_for_check "public_skill_surface"
-  codex_command_names=("${PROJECTED_SKILL_NAMES[@]}")
-  for n in "${codex_command_names[@]}"; do
-    if [[ "${n}" == "vibe-upgrade" ]]; then
-      check_path "skill/${n}" "${TARGET_ROOT}/skills/${n}/SKILL.md"
-    else
-      check_path "codex command/${n}" "${TARGET_ROOT}/commands/${n}.md" false
-    fi
-  done
+  if [[ ${#PROJECTED_SKILL_NAMES[@]} -gt 0 ]]; then
+    for n in "${PROJECTED_SKILL_NAMES[@]}"; do
+      if [[ "${n}" == "vibe-upgrade" ]]; then
+        check_path "skill/${n}" "${TARGET_ROOT}/skills/${n}/SKILL.md"
+      else
+        check_path "codex command/${n}" "${TARGET_ROOT}/commands/${n}.md" false
+      fi
+    done
+  fi
 fi
 if [[ "${HOST_ID}" == "opencode" ]]; then
   if [[ "${ADAPTER_CHECK_MODE}" != "preview-guidance" ]]; then


### PR DESCRIPTION
Fixes #235.
Supersedes #236 with the requested unprefixed branch name: `fix-check-empty-projections`.

## Summary

`check.sh` can abort under Bash `set -u` when a manifest-backed projection list is valid but empty. The previous implementation copied `PROJECTED_SKILL_NAMES` into intermediate arrays and then iterated those arrays unconditionally, which can surface as an `unbound variable` abort on macOS Bash before the deep health check finishes.

This PR keeps the projection source manifest-driven and strict, but only enters each projection validation loop when the loaded array has entries. Non-empty projection lists still validate every projected skill or Codex command.

## Verification

```bash
bash -n check.sh install.sh scripts/bootstrap/one-shot-setup.sh
git diff --check -- check.sh
CODEX_HOME="$HOME/.codex" bash ./scripts/bootstrap/one-shot-setup.sh --host codex --profile full --skip-external-install
```

The full Codex one-shot setup completed after the fix:

- installed runtime freshness gate: `844 passed, 0 failed`
- deep health check: `69 passed, 0 failed`

## Notes

The PR intentionally does not change `.gitignore` or local `.omx/` state handling. It is scoped to the `check.sh` strict-mode empty projection edge case only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated health-check validation logic to properly handle empty projection lists and maintain correct routing for different entry types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foryourhealth111-pixel/Vibe-Skills/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->