### PR TITLE
docs: close v4 release publication gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ Update and uninstall use the same boundary. For updates, download the newer publ
 .\uninstall.ps1 -SkillsDir C:\Users\you\.agents\skills
 ```
 
-When upgrading from v3 to v4, keep the same `SkillsDir`, run the v4 `update` wrapper, then run `check`. Legacy `vibe-what-do-i-want`, `vibe-how-do-we-do`, `vibe-do-it`, and `vibe-upgrade` entry names are retired; use `vibe` for the governed runtime.
+When upgrading from v3 to v4, keep the same `SkillsDir`, run the v4 `update` wrapper, then run `check`. Retired legacy entry names are not part of the v4 public runtime; use `vibe` for governed work.
 
 The installer writes only Vibe-owned files under `<SkillsDir>/vibe`. It does not edit Codex, Claude, Agents, host settings, command wrappers, or global prompt files. Re-running install or update preserves user-added files and refuses unowned path conflicts instead of deleting the directory.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -538,7 +538,7 @@ v4 公开发布物是 host-neutral、以 SkillsDir 为中心的 `vibe-skills-4.0
 - 卸载入口：`uninstall.ps1 -SkillsDir <skills-dir>`
 - 详细说明：[`docs/install/README.md`](docs/install/README.md)
 
-从 v3 升级到 v4 时，继续使用原来的 `SkillsDir`，运行 v4 发布包里的 `update`，再运行 `check`。旧的 `vibe-what-do-i-want`、`vibe-how-do-we-do`、`vibe-do-it` 和 `vibe-upgrade` 入口已经退役，统一使用 `vibe`。
+从 v3 升级到 v4 时，继续使用原来的 `SkillsDir`，运行 v4 发布包里的 `update`，再运行 `check`。已退役的旧入口不再属于 v4 的公开运行时，后续统一使用 `vibe`。
 
 ### 需要时再展开更多文档
 

--- a/docs/install/README.en.md
+++ b/docs/install/README.en.md
@@ -38,7 +38,7 @@ To update, download the newer published release zip first, extract it, run `upda
 2. Download and extract `vibe-skills-4.0.0-public.zip`.
 3. Run the v4 `update` wrapper against the existing `SkillsDir`.
 4. Run `check` and confirm that receipt-owned missing and drifted file counts are both `0`.
-5. Use `vibe` for subsequent governed runs. The legacy `vibe-what-do-i-want`, `vibe-how-do-we-do`, `vibe-do-it`, and `vibe-upgrade` entry names are not part of the v4 public runtime.
+5. Use `vibe` for subsequent governed runs. Retired legacy entry names are not part of the v4 public runtime.
 
 v4 does not automatically install or recommend the `chrome`, `chrome-devtools`, `playwright`, `context7`, or `claude-flow` MCPs. The installer also does not modify their host configuration.
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -38,7 +38,7 @@ bash ./uninstall.sh --skills-dir "$HOME/.agents/skills"
 2. 下载并解压 `vibe-skills-4.0.0-public.zip`。
 3. 从 v4 解压目录对原来的 `SkillsDir` 运行 `update`。
 4. 运行 `check`，确认收据登记文件缺失为 `0`、漂移为 `0`。
-5. 后续统一调用 `vibe`。旧的 `vibe-what-do-i-want`、`vibe-how-do-we-do`、`vibe-do-it` 和 `vibe-upgrade` 入口不再属于 v4 公开运行时。
+5. 后续统一调用 `vibe`。已退役的旧入口不再属于 v4 公开运行时。
 
 v4 不会自动安装或推荐 `chrome`、`chrome-devtools`、`playwright`、`context7` 或 `claude-flow` MCP。安装器也不会替用户修改这些 MCP 的主机配置。
 

--- a/docs/releases/v4.0.0.md
+++ b/docs/releases/v4.0.0.md
@@ -2,6 +2,7 @@
 
 - Date: 2026-07-17
 - Commit(base): c1665ba7
+- Published tag: `v4.0.0` at `9cf0dcbf7c6e377806c00b2e0d2ffe75cb612d35`
 
 ## Highlights
 
@@ -18,7 +19,7 @@ v4 changes the public execution and migration boundary. It removes legacy entry 
 
 ## Installation And Upgrade
 
-- Download `vibe-skills-4.0.0-public.zip` from the [GitHub Releases page](https://github.com/foryourhealth111-pixel/Vibe-Skills/releases) after the release is published.
+- Download `vibe-skills-4.0.0-public.zip` from the [GitHub Releases page](https://github.com/foryourhealth111-pixel/Vibe-Skills/releases).
 - For a shared user-level install, run `install` or `update` against `~/.agents/skills`.
 - For a Codex-only install, target `~/.codex/skills` explicitly.
 - Upgrade an existing v3 install by running the v4 `update` wrapper against the same `SkillsDir`, then run `check`.
@@ -41,4 +42,4 @@ v4 changes the public execution and migration boundary. It removes legacy entry 
 - Do not expect Vibe to execute a hidden native specialist lane after planning. The Agent named in the handoff owns the module work and must return the declared module result.
 - Do not infer success from artifact presence alone. Required failed, blocked, or incomplete modules keep delivery acceptance closed.
 - Keep additional domain Skills in the shared skills directory or configured local skill roots; the public v4 package installs the runtime, not a separate bundled skill catalog.
-- The release note prepares the governed `v4.0.0` surface. The GitHub tag, release object, and downloadable asset are separate publication steps after PR merge.
+- The governed `v4.0.0` surface is published: the GitHub tag, release object, and downloadable asset all point to the release commit above.


### PR DESCRIPTION
## Outcome

Bring the live installation and release notes into alignment with the published v4.0.0 release.

- Remove retired entry names from active public install and README surfaces, leaving `vibe` as the only public runtime entry.
- Record the actual published v4.0.0 tag and replace pre-publication wording in the v4 release note.

## Verification

- `py -3 -m pytest tests/runtime_neutral/test_release_v4_0_0_surface.py tests/runtime_neutral/test_simple_install_docs_contract.py tests/runtime_neutral/test_documentation_surface_alignment.py tests/runtime_neutral/test_release_notes_quality.py tests/integration/test_public_install_uninstall_guidance.py`
  - `55 passed`
- Downloaded the published `vibe-skills-4.0.0-public.zip`; SHA-256 matched the GitHub asset digest.
- Installed, checked, updated, and rechecked the downloaded release in an isolated temporary skills directory; every check reported zero missing and zero drifted files.