### PR TITLE
docs: clarify v4 install and update steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,30 +499,32 @@ The runtime core behind **VibeSkills** is **VCO**. It keeps workflow control in 
 
 ## ⚙️ Installation & Skills Management
 
-Public installation starts from the [GitHub Releases page](https://github.com/foryourhealth111-pixel/Vibe-Skills/releases). Download the release zip, extract it, and run the wrappers from that extracted directory.
+Public installation starts from a published release, not a repository checkout. Download the current [vibe-skills-4.0.0-public.zip](https://github.com/foryourhealth111-pixel/Vibe-Skills/releases/download/v4.0.0/vibe-skills-4.0.0-public.zip), extract it outside the managed Skills directory, and open a terminal in the extracted folder.
 
 The v4 public asset is the host-neutral, SkillsDir-centered bundle `vibe-skills-4.0.0-public.zip`. The installer writes Vibe-owned files under `<SkillsDir>/vibe`. The public release installs the `vibe` runtime itself. It does not add a separate built-in skill catalog. After install, the only public runtime entry is `vibe`, and additional Skills are discovered separately from that shared skills directory and any configured local skill roots.
 
-The default target is `~/.agents/skills`, so the shortest Windows install from a published release zip is:
+The default target is `~/.agents/skills`. Install and verify it with:
 
 ```powershell
-.\install.ps1
-.\check.ps1
+pwsh -NoProfile -File .\install.ps1 -SkillsDir "$HOME\.agents\skills"
+pwsh -NoProfile -File .\check.ps1 -SkillsDir "$HOME\.agents\skills"
 ```
 
-To install into a specific skills directory, pass it directly from the extracted release copy:
+For a Codex-only install, use Codex's Skills directory instead:
 
 ```powershell
-.\install.ps1 -SkillsDir C:\Users\you\.agents\skills
-.\check.ps1 -SkillsDir C:\Users\you\.agents\skills
+pwsh -NoProfile -File .\install.ps1 -SkillsDir "$HOME\.codex\skills"
+pwsh -NoProfile -File .\check.ps1 -SkillsDir "$HOME\.codex\skills"
 ```
 
-Update and uninstall use the same boundary. For updates, download the newer published release zip first, extract it, and then run `update` from that newer release copy against the same `SkillsDir`:
+To update, download and extract the newer release, then run `update` and `check` from that newer copy against the same `SkillsDir`:
 
 ```powershell
-.\update.ps1 -SkillsDir C:\Users\you\.agents\skills
-.\uninstall.ps1 -SkillsDir C:\Users\you\.agents\skills
+pwsh -NoProfile -File .\update.ps1 -SkillsDir "$HOME\.agents\skills"
+pwsh -NoProfile -File .\check.ps1 -SkillsDir "$HOME\.agents\skills"
 ```
+
+Uninstall is a separate operation: `pwsh -NoProfile -File .\uninstall.ps1 -SkillsDir "$HOME\.agents\skills"`.
 
 When upgrading from v3 to v4, keep the same `SkillsDir`, run the v4 `update` wrapper, then run `check`. Retired legacy entry names are not part of the v4 public runtime; use `vibe` for governed work.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -496,15 +496,15 @@ _这一节用来帮助你快速判断：`vibe` 适合组织哪些类型的任务
 
 ## ⚙️ 安装与 Skills 管理
 
-公开安装从 [GitHub Releases 页面](https://github.com/foryourhealth111-pixel/Vibe-Skills/releases) 开始。下载公开 release 里的 zip，解压后再从这个目录运行安装脚本。
+公开安装应从已发布的 Release 开始，不要直接从仓库 checkout 安装。下载当前的 [vibe-skills-4.0.0-public.zip](https://github.com/foryourhealth111-pixel/Vibe-Skills/releases/download/v4.0.0/vibe-skills-4.0.0-public.zip)，解压到受管 Skills 目录之外，然后在解压目录中打开终端。
 
 默认目录是 `~/.agents/skills`。如果某个宿主或你自己的工作流需要别的 skills 目录，就显式传入那个路径。
 
 PowerShell：
 
 ```powershell
-.\install.ps1 -SkillsDir C:\Users\you\.agents\skills
-.\check.ps1 -SkillsDir C:\Users\you\.agents\skills
+pwsh -NoProfile -File .\install.ps1 -SkillsDir "$HOME\.agents\skills"
+pwsh -NoProfile -File .\check.ps1 -SkillsDir "$HOME\.agents\skills"
 ```
 
 Shell：
@@ -514,17 +514,26 @@ bash ./install.sh --skills-dir "$HOME/.agents/skills"
 bash ./check.sh --skills-dir "$HOME/.agents/skills"
 ```
 
-更新和卸载使用同一个边界：
+如果只给 Codex 安装，则显式使用 Codex 的 Skills 目录：
 
 ```powershell
-.\update.ps1 -SkillsDir C:\Users\you\.agents\skills
-.\uninstall.ps1 -SkillsDir C:\Users\you\.agents\skills
+pwsh -NoProfile -File .\install.ps1 -SkillsDir "$HOME\.codex\skills"
+pwsh -NoProfile -File .\check.ps1 -SkillsDir "$HOME\.codex\skills"
+```
+
+更新时，先下载并解压新版 Release，再从新的解压目录对原来的 `SkillsDir` 运行 `update` 和 `check`：
+
+```powershell
+pwsh -NoProfile -File .\update.ps1 -SkillsDir "$HOME\.agents\skills"
+pwsh -NoProfile -File .\check.ps1 -SkillsDir "$HOME\.agents\skills"
 ```
 
 ```bash
 bash ./update.sh --skills-dir "$HOME/.agents/skills"
-bash ./uninstall.sh --skills-dir "$HOME/.agents/skills"
+bash ./check.sh --skills-dir "$HOME/.agents/skills"
 ```
+
+卸载是单独操作：`pwsh -NoProfile -File .\uninstall.ps1 -SkillsDir "$HOME\.agents\skills"`。
 
 v4 公开发布物是 host-neutral、以 SkillsDir 为中心的 `vibe-skills-4.0.0-public.zip`。安装器只把 Vibe 自己拥有的文件写到 `<SkillsDir>/vibe`。公开发布包安装的是 `vibe` 运行时本体，不会额外安装一套内置 skill 目录。安装完成后，唯一公开运行时入口是 `vibe`；额外 Skills 则由共享 skills 目录和额外声明的本地根目录提供。
 

--- a/docs/install/README.en.md
+++ b/docs/install/README.en.md
@@ -1,14 +1,16 @@
 # Simple Install
 
-The public install path starts from the [GitHub Releases page](https://github.com/foryourhealth111-pixel/Vibe-Skills/releases). The v4.0.0 asset is named `vibe-skills-4.0.0-public.zip`. Download and extract it, then run the wrappers from that release directory. The installer does one thing: it installs `vibe` into a skills directory.
+The public install path starts from a published release, not a repository checkout. Download the current [vibe-skills-4.0.0-public.zip](https://github.com/foryourhealth111-pixel/Vibe-Skills/releases/download/v4.0.0/vibe-skills-4.0.0-public.zip), extract it outside the managed Skills directory, and run the wrappers from the extracted folder.
+
+The published ZIP SHA-256 is `0b16a5f615a485b8d082407d458cc5c4ffe2cee443c6211fc941cd6678987dc9`.
 
 The default directory is `~/.agents/skills`. If a host or your own workflow needs a different skills directory, pass it explicitly, for example `~/.codex/skills` or `~/.claude/skills`.
+
+## Install
 
 ```powershell
 pwsh -NoProfile -File .\install.ps1 -SkillsDir "$HOME\.agents\skills"
 pwsh -NoProfile -File .\check.ps1 -SkillsDir "$HOME\.agents\skills"
-pwsh -NoProfile -File .\update.ps1 -SkillsDir "$HOME\.agents\skills"
-pwsh -NoProfile -File .\uninstall.ps1 -SkillsDir "$HOME\.agents\skills"
 ```
 
 For a Codex-only install, target the Codex skills directory explicitly:
@@ -21,16 +23,42 @@ pwsh -NoProfile -File .\check.ps1 -SkillsDir "$HOME\.codex\skills"
 ```bash
 bash ./install.sh --skills-dir "$HOME/.agents/skills"
 bash ./check.sh --skills-dir "$HOME/.agents/skills"
-bash ./update.sh --skills-dir "$HOME/.agents/skills"
-bash ./uninstall.sh --skills-dir "$HOME/.agents/skills"
 ```
 
 After installation, the managed directory is `<SkillsDir>/vibe`. The install receipt lives at `<SkillsDir>/vibe/.vibeskills/install-receipt.json`.
 
-`check` verifies the files recorded in the receipt. `update` refuses to overwrite user edits when drift is detected. `uninstall` removes only files recorded in the receipt and keeps user-added files.
+`check` verifies the files recorded in the receipt.
 `check` proves `installed locally`. It does not prove `runtime coherent` or `delivery accepted`.
 
-To update, download the newer published release zip first, extract it, run `update` from that newer release copy against the same `SkillsDir`, and then run `check`. Do not extract the new release inside the managed `<SkillsDir>/vibe` directory.
+## Update An Existing Install
+
+Download the newer published release ZIP first, extract it, and run these commands from that newer release copy against the same `SkillsDir`:
+
+```powershell
+pwsh -NoProfile -File .\update.ps1 -SkillsDir "$HOME\.agents\skills"
+pwsh -NoProfile -File .\check.ps1 -SkillsDir "$HOME\.agents\skills"
+```
+
+```bash
+bash ./update.sh --skills-dir "$HOME/.agents/skills"
+bash ./check.sh --skills-dir "$HOME/.agents/skills"
+```
+
+Do not extract the new release inside the managed `<SkillsDir>/vibe` directory. `update` refuses to overwrite receipt-owned files when drift is detected.
+
+## Uninstall
+
+Uninstall is not part of the install or update sequence. Run it only when you intend to remove VibeSkills:
+
+```powershell
+pwsh -NoProfile -File .\uninstall.ps1 -SkillsDir "$HOME\.agents\skills"
+```
+
+```bash
+bash ./uninstall.sh --skills-dir "$HOME/.agents/skills"
+```
+
+`uninstall` removes only files recorded in the receipt and keeps user-added files.
 
 ## Upgrading From v3 To v4
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,14 +1,16 @@
 # 简化安装
 
-公开安装从 [GitHub Releases 页面](https://github.com/foryourhealth111-pixel/Vibe-Skills/releases) 开始。v4.0.0 的发布文件名是 `vibe-skills-4.0.0-public.zip`。下载并解压后，在这个发布目录里运行脚本。安装器随后只做一件事：把 `vibe` 安装到一个 skills 目录下。
+公开安装应从已发布的 Release 开始，不要直接从仓库 checkout 安装。下载当前的 [vibe-skills-4.0.0-public.zip](https://github.com/foryourhealth111-pixel/Vibe-Skills/releases/download/v4.0.0/vibe-skills-4.0.0-public.zip)，解压到受管 Skills 目录之外，然后从解压目录运行脚本。
+
+已发布 ZIP 的 SHA-256 是 `0b16a5f615a485b8d082407d458cc5c4ffe2cee443c6211fc941cd6678987dc9`。
 
 默认目录是 `~/.agents/skills`。如果某个宿主或你自己的工作流需要别的 skills 目录，也可以显式传入，例如 `~/.codex/skills` 或 `~/.claude/skills`。
+
+## 安装
 
 ```powershell
 pwsh -NoProfile -File .\install.ps1 -SkillsDir "$HOME\.agents\skills"
 pwsh -NoProfile -File .\check.ps1 -SkillsDir "$HOME\.agents\skills"
-pwsh -NoProfile -File .\update.ps1 -SkillsDir "$HOME\.agents\skills"
-pwsh -NoProfile -File .\uninstall.ps1 -SkillsDir "$HOME\.agents\skills"
 ```
 
 只在 Codex 中使用时，可以显式安装到 Codex 的 skills 目录：
@@ -21,16 +23,42 @@ pwsh -NoProfile -File .\check.ps1 -SkillsDir "$HOME\.codex\skills"
 ```bash
 bash ./install.sh --skills-dir "$HOME/.agents/skills"
 bash ./check.sh --skills-dir "$HOME/.agents/skills"
-bash ./update.sh --skills-dir "$HOME/.agents/skills"
-bash ./uninstall.sh --skills-dir "$HOME/.agents/skills"
 ```
 
 安装后，受管目录是 `<SkillsDir>/vibe`。安装收据位于 `<SkillsDir>/vibe/.vibeskills/install-receipt.json`。
 
-`check` 只检查收据登记的文件是否仍然完整。`update` 会在发现用户改动时拒绝覆盖。`uninstall` 只删除收据登记的文件，保留用户额外添加的文件。
+`check` 只检查收据登记的文件是否仍然完整。
 `check` 证明的是 `installed locally`。它不证明 `runtime coherent`，也不证明 `delivery accepted`。
 
-如果要更新，先下载更新版本的发布版本 zip，再解压，然后在新的发布目录里对同一个 `SkillsDir` 运行 `update`，最后运行 `check`。不要把新版本解压到受管目录 `<SkillsDir>/vibe` 里面。
+## 更新已安装版本
+
+先下载更新的已发布 ZIP，解压后，从新的发布目录对同一个 `SkillsDir` 运行：
+
+```powershell
+pwsh -NoProfile -File .\update.ps1 -SkillsDir "$HOME\.agents\skills"
+pwsh -NoProfile -File .\check.ps1 -SkillsDir "$HOME\.agents\skills"
+```
+
+```bash
+bash ./update.sh --skills-dir "$HOME/.agents/skills"
+bash ./check.sh --skills-dir "$HOME/.agents/skills"
+```
+
+不要把新版本解压到受管目录 `<SkillsDir>/vibe` 里面。`update` 发现收据登记文件被修改时会拒绝覆盖。
+
+## 卸载
+
+卸载不属于安装或更新步骤。只在你确实要移除 VibeSkills 时运行：
+
+```powershell
+pwsh -NoProfile -File .\uninstall.ps1 -SkillsDir "$HOME\.agents\skills"
+```
+
+```bash
+bash ./uninstall.sh --skills-dir "$HOME/.agents/skills"
+```
+
+`uninstall` 只删除收据登记的文件，保留用户额外添加的文件。
 
 ## 从 v3 升级到 v4
 


### PR DESCRIPTION
## Outcome

- links the current v4 public ZIP directly from both root READMEs and both install guides
- separates install, update, and uninstall so users are not shown `uninstall` as part of a copy-paste install sequence
- makes `update` followed by `check` explicit for existing installs
- adds the verified published ZIP SHA-256 to the detailed install guides
- keeps the Codex-only target path visible without changing installer behavior

## Verification

- downloaded the published `vibe-skills-4.0.0-public.zip`
- verified SHA-256 `0b16a5f615a485b8d082407d458cc5c4ffe2cee443c6211fc941cd6678987dc9`
- clean temporary install completed successfully
- temporary `check` reported zero missing and zero drifted receipt-owned files
- `py -3 -m pytest tests/runtime_neutral/test_documentation_surface_alignment.py tests/runtime_neutral/test_simple_install_docs_contract.py tests/runtime_neutral/test_release_v4_0_0_surface.py -q`
  - `47 passed`
- `git diff --check`
  - passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance to use the published release ZIP with SHA-256 verification.
  * Added clearer PowerShell commands for installation, validation, updates, and uninstall.
  * Clarified supported skills directory locations and Codex-specific installation.
  * Documented safe update practices, including extracting releases outside managed directories.
  * Explained validation coverage, managed files, and preservation of user-added files during uninstall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->