### PR TITLE
docs: center documentation summary tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ It selects suitable Skills for the task, assigns them to the relevant work, and 
 <a id="more-documentation"></a>
 <h2 align="center">More Documentation</h2>
 
-<table>
+<table align="center" width="90%">
   <thead>
     <tr>
       <th width="50%" align="center">Need</th>

--- a/README.zh.md
+++ b/README.zh.md
@@ -427,7 +427,7 @@ VibeSkills 会扫描 Skills 安装目录，以及你配置的其他本地 Skill 
 <a id="more-documentation"></a>
 <h2 align="center">更多文档</h2>
 
-<table>
+<table align="center" width="90%">
   <thead>
     <tr>
       <th width="50%" align="center">你想做什么</th>


### PR DESCRIPTION
## What changed

- Centered the English and Chinese `More Documentation` tables.
- Set the tables to `90%` width so the centered placement is visually clear instead of stretching or sitting against the left edge.

## Why

The cells were centered, but the table element itself did not have an explicit centered width. GitHub therefore rendered the documentation summary without the intended page balance.

## Impact

README presentation only. Links and table contents are unchanged.

## Verification

- `py -3 -m pytest -q tests/runtime_neutral/test_docs_readme_encoding.py tests/runtime_neutral/test_docs_source_neutral_links.py` (`5 passed`)
- GitHub GFM rendering preserved `align="center"` and `width="90%"` on the documentation table.
- `git diff --check`