### PR TITLE
contracts: define live document registry and artifact sink

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,3 +39,23 @@ _Avoid_: Snapshot of current wording, implementation freeze, repository grep
 **TDD Test Intent**:
 The discipline that a test should state the capability promise first, then drive the implementation toward satisfying that promise with the smallest necessary proof.
 _Avoid_: After-the-fact assertion pile, historical cleanup lock, style policing by test
+
+**Live Contract**:
+A stable, undated normative contract that defines current repository behavior and may be consumed by the runtime or default verification.
+_Avoid_: Current plan, dated status page, historical proof
+
+**Entry Document**:
+A human-facing navigation or operating guide that points readers to live contracts without owning runtime truth.
+_Avoid_: Canonical contract, executable policy
+
+**Release Artifact**:
+Run-specific requirements, plans, status, and proof retained with CI or a release instead of the tracked live documentation surface.
+_Avoid_: Live documentation, permanent repository status page
+
+**Historical Record**:
+Completed or superseded governance material preserved through Git history or release artifacts and excluded from the live control plane.
+_Avoid_: Current contract, default verification dependency
+
+**Live Documentation Budget**:
+The bounded set of tracked human-facing Markdown documents maintained as current repository guidance, capped at thirty documents across the root, `docs`, and `references` surfaces.
+_Avoid_: Unbounded archive, dated worklog collection

--- a/config/live-document-contract.json
+++ b/config/live-document-contract.json
@@ -1,0 +1,121 @@
+{
+  "schema_version": 1,
+  "max_live_documents": 30,
+  "governed_roots": [
+    ".",
+    "docs",
+    "references"
+  ],
+  "excluded_paths": [
+    "THIRD_PARTY_LICENSES.md"
+  ],
+  "excluded_prefixes": [
+    "references/provenance/"
+  ],
+  "documents": [
+    {
+      "id": "project-readme",
+      "path": "README.md",
+      "owner": "project-entry",
+      "lifecycle": "live"
+    },
+    {
+      "id": "project-readme-zh",
+      "path": "README.zh.md",
+      "owner": "project-entry",
+      "lifecycle": "live"
+    },
+    {
+      "id": "contributor-entry",
+      "path": "CONTRIBUTING.md",
+      "owner": "contributor-experience",
+      "lifecycle": "live"
+    },
+    {
+      "id": "verification-language",
+      "path": "CONTEXT.md",
+      "owner": "verification",
+      "lifecycle": "live"
+    },
+    {
+      "id": "docs-entry",
+      "path": "docs/README.md",
+      "owner": "project-entry",
+      "lifecycle": "live"
+    },
+    {
+      "id": "governance-entry",
+      "path": "docs/governance/README.md",
+      "owner": "governance",
+      "lifecycle": "live"
+    },
+    {
+      "id": "runtime-field-contract",
+      "path": "docs/governance/current-runtime-field-contract.md",
+      "owner": "runtime-contracts",
+      "lifecycle": "live"
+    },
+    {
+      "id": "routing-contract",
+      "path": "docs/governance/current-routing-contract.md",
+      "owner": "routing",
+      "lifecycle": "live"
+    },
+    {
+      "id": "skill-admission-contract",
+      "path": "docs/governance/skill-admission-hardening.md",
+      "owner": "skill-catalog",
+      "lifecycle": "live"
+    },
+    {
+      "id": "bundled-retention-contract",
+      "path": "docs/governance/bundled-skill-retention-matrix.md",
+      "owner": "skill-catalog",
+      "lifecycle": "live"
+    },
+    {
+      "id": "developer-change-contract",
+      "path": "docs/developer-change-governance.md",
+      "owner": "governance",
+      "lifecycle": "live"
+    },
+    {
+      "id": "governance-history-decision",
+      "path": "docs/adr/0001-externalize-governance-history.md",
+      "owner": "governance",
+      "lifecycle": "retained"
+    },
+    {
+      "id": "contributor-zone-contract",
+      "path": "references/contributor-zone-decision-table.md",
+      "owner": "contributor-experience",
+      "lifecycle": "live"
+    },
+    {
+      "id": "change-proof-contract",
+      "path": "references/change-proof-matrix.md",
+      "owner": "verification",
+      "lifecycle": "live"
+    },
+    {
+      "id": "developer-entry-contract",
+      "path": "references/developer-entry-contract.md",
+      "owner": "contributor-experience",
+      "lifecycle": "live"
+    }
+  ],
+  "artifact_sink": {
+    "schema_version": 1,
+    "root": ".vibeskills/runs",
+    "required_artifacts": [
+      "requirement",
+      "plan",
+      "status",
+      "proof"
+    ],
+    "required_metadata": [
+      "commit_sha",
+      "execution_environment"
+    ]
+  }
+}

--- a/config/runtime-config-manifest.json
+++ b/config/runtime-config-manifest.json
@@ -24,6 +24,7 @@
     "config/gsd-overlay.json",
     "config/heartbeat-policy.json",
     "config/implementation-guardrails.json",
+    "config/live-document-contract.json",
     "config/llm-acceleration-policy.json",
     "config/memory-backend-adapters.json",
     "config/memory-disclosure-policy.json",
@@ -87,6 +88,7 @@
       "runtime_governance_files": [
         "config/fallback-governance.json",
         "config/implementation-guardrails.json",
+        "config/live-document-contract.json",
         "config/operator-preview-contract.json",
         "config/phase-cleanup-policy.json",
         "config/plan-execution-policy.json",

--- a/docs/adr/0001-externalize-governance-history.md
+++ b/docs/adr/0001-externalize-governance-history.md
@@ -1,0 +1,9 @@
+---
+status: accepted
+---
+
+# Externalize governance history
+
+Vibe-Skills will keep at most thirty live Markdown documents across the root, `docs`, and `references` surfaces, with executable contracts owning runtime truth and a single machine-readable index naming the live documents. Generated requirements, plans, status snapshots, and proof bundles will be retained as CI or release artifacts; completed historical material will be removed from the main branch after one explicit release-cycle compatibility window because reducing continuing maintenance cost outweighs keeping a browsable in-tree governance archive.
+
+PR proof artifacts are retained for 30 days, main-branch and scheduled-audit artifacts for 90 days, and formal release proof with the corresponding GitHub Release. The tracked `current-state.md` summary will be retired in favor of CI, release metadata, and live `check` output.

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -12,6 +12,10 @@ If you are reading old consolidation, cleanup, or hard-removal passes, go to [`.
 
 current runtime truth and routing compatibility contracts live here first.
 
+- [`../../config/live-document-contract.json`](../../config/live-document-contract.json)
+  is the executable inventory for the bounded live-document surface and the
+  shared requirement, plan, status, and proof artifact sink. Manifest artifact
+  paths resolve relative to the declared per-run artifact root.
 - [`current-runtime-field-contract.md`](current-runtime-field-contract.md)
   defines the current runtime truth vocabulary and the work-first artifact order.
 - [`current-routing-contract.md`](current-routing-contract.md)

--- a/packages/contracts/src/vgo_contracts/__init__.py
+++ b/packages/contracts/src/vgo_contracts/__init__.py
@@ -25,6 +25,19 @@ from .discoverable_entry_surface import (
 from .governance_runtime_roles import RUNTIME_PAYLOAD_ROLE_NOTES, derive_runtime_payload_roles
 from .host_launch_receipt import HostLaunchReceipt, write_host_launch_receipt
 from .install_ledger import InstallLedger
+from .live_governance_contract import (
+    LIVE_GOVERNANCE_CONTRACT_RELPATH,
+    MAX_LIVE_MARKDOWN_DOCUMENTS,
+    ArtifactSinkContract,
+    LiveDocumentEntry,
+    LiveGovernanceContract,
+    RunArtifactManifest,
+    load_live_governance_contract,
+    load_live_governance_contract_file,
+    resolve_live_governance_contract_path,
+    validate_live_document_workspace,
+    validate_run_artifact_workspace,
+)
 from .mirror_topology_contract import (
     DEFAULT_CANONICAL_TARGET_ID,
     DEFAULT_NESTED_MATERIALIZATION_MODE,
@@ -80,6 +93,17 @@ __all__ = [
     'HostLaunchReceipt',
     'write_host_launch_receipt',
     'InstallLedger',
+    'LIVE_GOVERNANCE_CONTRACT_RELPATH',
+    'MAX_LIVE_MARKDOWN_DOCUMENTS',
+    'ArtifactSinkContract',
+    'LiveDocumentEntry',
+    'LiveGovernanceContract',
+    'RunArtifactManifest',
+    'load_live_governance_contract',
+    'load_live_governance_contract_file',
+    'resolve_live_governance_contract_path',
+    'validate_live_document_workspace',
+    'validate_run_artifact_workspace',
     'DEFAULT_CANONICAL_TARGET_ID',
     'DEFAULT_NESTED_MATERIALIZATION_MODE',
     'resolve_canonical_mirror_relpath',

--- a/packages/contracts/src/vgo_contracts/live_governance_contract.py
+++ b/packages/contracts/src/vgo_contracts/live_governance_contract.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+LIVE_GOVERNANCE_CONTRACT_RELPATH = Path("config/live-document-contract.json")
+MAX_LIVE_MARKDOWN_DOCUMENTS = 30
+REQUIRED_ARTIFACT_KINDS: tuple[str, ...] = (
+    "requirement",
+    "plan",
+    "status",
+    "proof",
+)
+REQUIRED_ARTIFACT_METADATA: tuple[str, ...] = (
+    "commit_sha",
+    "execution_environment",
+)
+REQUIRED_GOVERNED_ROOTS = frozenset({".", "docs", "references"})
+ALLOWED_DOCUMENT_LIFECYCLES = frozenset({"live", "transitional", "retained"})
+
+_SLUG_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_WINDOWS_DRIVE_PATTERN = re.compile(r"^[A-Za-z]:")
+
+
+def _normalize_relative_path(value: Any, field_name: str, *, allow_dot: bool = False) -> str:
+    normalized = str(value or "").replace("\\", "/").strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be a non-empty relative path")
+    if normalized == ".":
+        if allow_dot:
+            return normalized
+        raise ValueError(f"{field_name} must name a relative path below '.'")
+    if normalized.startswith("/") or _WINDOWS_DRIVE_PATTERN.match(normalized):
+        raise ValueError(f"{field_name} must be relative: {normalized}")
+    normalized = normalized.rstrip("/")
+    path = PurePosixPath(normalized)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"{field_name} must be a safe relative path: {normalized}")
+    return path.as_posix()
+
+
+def _normalize_slug(value: Any, field_name: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not _SLUG_PATTERN.fullmatch(normalized):
+        raise ValueError(f"{field_name} must be a lowercase identifier: {value}")
+    return normalized
+
+
+def _normalize_unique_strings(values: Any, field_name: str) -> tuple[str, ...]:
+    if not isinstance(values, list):
+        raise ValueError(f"{field_name} must be a list")
+    normalized = tuple(str(item or "").strip() for item in values)
+    if any(not item for item in normalized):
+        raise ValueError(f"{field_name} must not contain empty values")
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(f"{field_name} must not contain duplicates")
+    return normalized
+
+
+@dataclass(slots=True, frozen=True)
+class LiveDocumentEntry:
+    document_id: str
+    path: str
+    owner: str
+    lifecycle: str
+
+    @classmethod
+    def model_validate(cls, payload: dict[str, Any]) -> "LiveDocumentEntry":
+        lifecycle = str(payload.get("lifecycle") or "").strip().lower()
+        if lifecycle not in ALLOWED_DOCUMENT_LIFECYCLES:
+            raise ValueError(f"unsupported document lifecycle: {lifecycle}")
+        path = _normalize_relative_path(payload.get("path"), "document path")
+        if not path.casefold().endswith(".md"):
+            raise ValueError(f"live document path must be Markdown: {path}")
+        return cls(
+            document_id=_normalize_slug(payload.get("id"), "document id"),
+            path=path,
+            owner=_normalize_slug(payload.get("owner"), "document owner"),
+            lifecycle=lifecycle,
+        )
+
+    def model_dump(self) -> dict[str, str]:
+        return {
+            "id": self.document_id,
+            "path": self.path,
+            "owner": self.owner,
+            "lifecycle": self.lifecycle,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class ArtifactSinkContract:
+    schema_version: int
+    root: str
+    required_artifacts: tuple[str, ...]
+    required_metadata: tuple[str, ...]
+
+    @classmethod
+    def model_validate(cls, payload: dict[str, Any]) -> "ArtifactSinkContract":
+        schema_version = int(payload.get("schema_version") or 0)
+        if schema_version <= 0:
+            raise ValueError("artifact sink schema_version must be positive")
+        required_artifacts = _normalize_unique_strings(
+            payload.get("required_artifacts"),
+            "artifact sink required_artifacts",
+        )
+        missing_artifacts = set(REQUIRED_ARTIFACT_KINDS) - set(required_artifacts)
+        if missing_artifacts:
+            raise ValueError(
+                "artifact sink is missing required artifact kinds: "
+                + ", ".join(sorted(missing_artifacts))
+            )
+        required_metadata = _normalize_unique_strings(
+            payload.get("required_metadata"),
+            "artifact sink required_metadata",
+        )
+        missing_metadata = set(REQUIRED_ARTIFACT_METADATA) - set(required_metadata)
+        if missing_metadata:
+            raise ValueError(
+                "artifact sink is missing required metadata: "
+                + ", ".join(sorted(missing_metadata))
+            )
+        return cls(
+            schema_version=schema_version,
+            root=_normalize_relative_path(payload.get("root"), "artifact sink root"),
+            required_artifacts=required_artifacts,
+            required_metadata=required_metadata,
+        )
+
+    def model_dump(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "root": self.root,
+            "required_artifacts": list(self.required_artifacts),
+            "required_metadata": list(self.required_metadata),
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class RunArtifactManifest:
+    schema_version: int
+    run_id: str
+    artifact_root: str
+    artifacts: dict[str, str]
+    commit_sha: str
+    execution_environment: dict[str, str]
+
+    @classmethod
+    def model_validate(
+        cls,
+        payload: dict[str, Any],
+        artifact_sink: ArtifactSinkContract,
+    ) -> "RunArtifactManifest":
+        schema_version = int(payload.get("schema_version") or 0)
+        if schema_version != artifact_sink.schema_version:
+            raise ValueError(
+                "run artifact schema_version does not match the artifact sink contract"
+            )
+        run_id = str(payload.get("run_id") or "").strip()
+        if not run_id:
+            raise ValueError("run artifact manifest requires run_id")
+        raw_artifacts = payload.get("artifacts")
+        if not isinstance(raw_artifacts, dict):
+            raise ValueError("run artifact manifest artifacts must be an object")
+        artifacts = {
+            str(key): _normalize_relative_path(value, f"artifact path for {key}")
+            for key, value in raw_artifacts.items()
+        }
+        missing_artifacts = set(artifact_sink.required_artifacts) - set(artifacts)
+        if missing_artifacts:
+            raise ValueError(
+                "run artifact manifest is missing artifacts: "
+                + ", ".join(sorted(missing_artifacts))
+            )
+        if len(set(artifacts.values())) != len(artifacts):
+            raise ValueError("run artifact paths must be unique")
+        commit_sha = str(payload.get("commit_sha") or "").strip()
+        if not commit_sha:
+            raise ValueError("run artifact manifest requires commit_sha")
+        raw_environment = payload.get("execution_environment")
+        if not isinstance(raw_environment, dict) or not raw_environment:
+            raise ValueError(
+                "run artifact manifest requires execution_environment metadata"
+            )
+        execution_environment = {
+            str(key).strip(): str(value).strip()
+            for key, value in raw_environment.items()
+            if str(key).strip() and str(value).strip()
+        }
+        if not execution_environment:
+            raise ValueError(
+                "run artifact manifest requires execution_environment metadata"
+            )
+        artifact_root = _normalize_relative_path(
+            payload.get("artifact_root"),
+            "run artifact root",
+        )
+        artifact_sink_prefix = artifact_sink.root.rstrip("/") + "/"
+        if not artifact_root.startswith(artifact_sink_prefix):
+            raise ValueError(
+                "run artifact root must be a child of the artifact sink root: "
+                f"{artifact_sink.root}"
+            )
+        return cls(
+            schema_version=schema_version,
+            run_id=run_id,
+            artifact_root=artifact_root,
+            artifacts=artifacts,
+            commit_sha=commit_sha,
+            execution_environment=execution_environment,
+        )
+
+    def model_dump(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "artifact_root": self.artifact_root,
+            "artifacts": dict(self.artifacts),
+            "commit_sha": self.commit_sha,
+            "execution_environment": dict(self.execution_environment),
+        }
+
+    def resolve_artifact_paths(
+        self,
+        workspace_root: str | Path,
+    ) -> dict[str, Path]:
+        workspace = Path(workspace_root).resolve()
+        run_root = (workspace / Path(self.artifact_root)).resolve()
+        if not run_root.is_relative_to(workspace):
+            raise ValueError(
+                "run artifact root resolves outside the governed workspace"
+            )
+        resolved_paths: dict[str, Path] = {}
+        for artifact_kind, artifact_relpath in self.artifacts.items():
+            artifact_path = (run_root / Path(artifact_relpath)).resolve()
+            if not artifact_path.is_relative_to(run_root):
+                raise ValueError(
+                    f"artifact path resolves outside the run root: {artifact_kind}"
+                )
+            resolved_paths[artifact_kind] = artifact_path
+        return resolved_paths
+
+
+@dataclass(slots=True, frozen=True)
+class LiveGovernanceContract:
+    schema_version: int
+    max_live_documents: int
+    governed_roots: tuple[str, ...]
+    excluded_paths: tuple[str, ...]
+    excluded_prefixes: tuple[str, ...]
+    documents: tuple[LiveDocumentEntry, ...]
+    artifact_sink: ArtifactSinkContract
+
+    @classmethod
+    def model_validate(cls, payload: dict[str, Any]) -> "LiveGovernanceContract":
+        schema_version = int(payload.get("schema_version") or 0)
+        if schema_version <= 0:
+            raise ValueError("live governance schema_version must be positive")
+        max_live_documents = int(payload.get("max_live_documents") or 0)
+        if max_live_documents <= 0 or max_live_documents > MAX_LIVE_MARKDOWN_DOCUMENTS:
+            raise ValueError(
+                f"max_live_documents must be between 1 and {MAX_LIVE_MARKDOWN_DOCUMENTS}"
+            )
+        raw_roots = payload.get("governed_roots")
+        if not isinstance(raw_roots, list) or not raw_roots:
+            raise ValueError("governed_roots must be a non-empty list")
+        governed_roots = tuple(
+            _normalize_relative_path(root, "governed root", allow_dot=True)
+            for root in raw_roots
+        )
+        missing_roots = REQUIRED_GOVERNED_ROOTS - set(governed_roots)
+        if missing_roots:
+            raise ValueError(
+                "missing required governed roots: "
+                + ", ".join(sorted(missing_roots))
+            )
+        excluded_paths = tuple(
+            _normalize_relative_path(path, "excluded path")
+            for path in list(payload.get("excluded_paths") or [])
+        )
+        excluded_prefixes = tuple(
+            _normalize_relative_path(path, "excluded prefix").rstrip("/") + "/"
+            for path in list(payload.get("excluded_prefixes") or [])
+        )
+        raw_documents = payload.get("documents")
+        if not isinstance(raw_documents, list):
+            raise ValueError("documents must be a list")
+        if not raw_documents:
+            raise ValueError("documents must contain at least one live document")
+        documents = tuple(
+            LiveDocumentEntry.model_validate(dict(document))
+            for document in raw_documents
+            if isinstance(document, dict)
+        )
+        if len(documents) != len(raw_documents):
+            raise ValueError("every live document entry must be an object")
+        if len(documents) > max_live_documents:
+            raise ValueError(
+                f"live document registry contains {len(documents)} entries; "
+                f"the configured budget is {max_live_documents}"
+            )
+        document_ids = [document.document_id for document in documents]
+        document_paths = [document.path for document in documents]
+        if len(set(document_ids)) != len(document_ids):
+            raise ValueError("live document ids must be unique")
+        if len(set(document_paths)) != len(document_paths):
+            raise ValueError("live document paths must be unique")
+        for document in documents:
+            if document.path in excluded_paths or any(
+                document.path.startswith(prefix) for prefix in excluded_prefixes
+            ):
+                raise ValueError(
+                    f"excluded document cannot be registered as live: {document.path}"
+                )
+            if not _is_path_under_governed_roots(document.path, governed_roots):
+                raise ValueError(
+                    f"live document is outside governed roots: {document.path}"
+                )
+        raw_artifact_sink = payload.get("artifact_sink")
+        if not isinstance(raw_artifact_sink, dict):
+            raise ValueError("artifact_sink must be an object")
+        return cls(
+            schema_version=schema_version,
+            max_live_documents=max_live_documents,
+            governed_roots=governed_roots,
+            excluded_paths=excluded_paths,
+            excluded_prefixes=excluded_prefixes,
+            documents=documents,
+            artifact_sink=ArtifactSinkContract.model_validate(raw_artifact_sink),
+        )
+
+    def validate_run_artifact_manifest(
+        self,
+        payload: dict[str, Any],
+    ) -> RunArtifactManifest:
+        return RunArtifactManifest.model_validate(payload, self.artifact_sink)
+
+    def model_dump(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "max_live_documents": self.max_live_documents,
+            "governed_roots": list(self.governed_roots),
+            "excluded_paths": list(self.excluded_paths),
+            "excluded_prefixes": list(self.excluded_prefixes),
+            "documents": [document.model_dump() for document in self.documents],
+            "artifact_sink": self.artifact_sink.model_dump(),
+        }
+
+
+def _is_path_under_governed_roots(
+    document_path: str,
+    governed_roots: tuple[str, ...],
+) -> bool:
+    for root in governed_roots:
+        if root == "." and "/" not in document_path:
+            return True
+        if root != "." and document_path.startswith(root.rstrip("/") + "/"):
+            return True
+    return False
+
+
+def resolve_live_governance_contract_path(start_path: str | Path) -> Path:
+    current = Path(start_path).resolve()
+    if current.is_file():
+        current = current.parent
+    while True:
+        candidate = current / LIVE_GOVERNANCE_CONTRACT_RELPATH
+        if candidate.exists():
+            return candidate
+        if current.parent == current:
+            break
+        current = current.parent
+    raise RuntimeError(
+        f"live governance contract not found from start path: {start_path}"
+    )
+
+
+def load_live_governance_contract_file(
+    contract_path: str | Path,
+) -> LiveGovernanceContract:
+    payload = json.loads(
+        Path(contract_path).read_text(encoding="utf-8-sig")
+    )
+    if not isinstance(payload, dict):
+        raise ValueError("live governance contract must be a JSON object")
+    return LiveGovernanceContract.model_validate(payload)
+
+
+def load_live_governance_contract(
+    start_path: str | Path,
+) -> LiveGovernanceContract:
+    return load_live_governance_contract_file(
+        resolve_live_governance_contract_path(start_path)
+    )
+
+
+def validate_live_document_workspace(
+    contract: LiveGovernanceContract,
+    repo_root: str | Path,
+) -> list[Path]:
+    root = Path(repo_root).resolve()
+    validated_paths: list[Path] = []
+    for document in contract.documents:
+        path = root / Path(document.path)
+        if not path.is_file():
+            raise ValueError(f"registered live document does not exist: {document.path}")
+        validated_paths.append(path)
+    return validated_paths
+
+
+def validate_run_artifact_workspace(
+    manifest: RunArtifactManifest,
+    workspace_root: str | Path,
+) -> dict[str, Path]:
+    artifact_paths = manifest.resolve_artifact_paths(workspace_root)
+    missing_artifacts = [
+        artifact_kind
+        for artifact_kind, artifact_path in artifact_paths.items()
+        if not artifact_path.is_file()
+    ]
+    if missing_artifacts:
+        raise ValueError(
+            "run artifact files are missing: "
+            + ", ".join(sorted(missing_artifacts))
+        )
+    return artifact_paths

--- a/tests/unit/test_live_governance_contract.py
+++ b/tests/unit/test_live_governance_contract.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACTS_SRC = REPO_ROOT / "packages" / "contracts" / "src"
+if str(CONTRACTS_SRC) not in sys.path:
+    sys.path.insert(0, str(CONTRACTS_SRC))
+
+import vgo_contracts  # noqa: E402
+from vgo_contracts.live_governance_contract import (  # noqa: E402
+    LiveGovernanceContract,
+    load_live_governance_contract,
+    validate_live_document_workspace,
+    validate_run_artifact_workspace,
+)
+
+
+def _write(path: Path, text: str = "# Contract\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _contract_payload(
+    *,
+    documents: list[dict[str, str]] | None = None,
+) -> dict:
+    return {
+        "schema_version": 1,
+        "max_live_documents": 30,
+        "governed_roots": [".", "docs", "references"],
+        "excluded_paths": ["THIRD_PARTY_LICENSES.md"],
+        "excluded_prefixes": ["references/provenance/"],
+        "documents": documents
+        if documents is not None
+        else [
+            {
+                "id": "project-entry",
+                "path": "README.md",
+                "owner": "project-entry",
+                "lifecycle": "live",
+            },
+            {
+                "id": "runtime-contract",
+                "path": "docs/runtime-contract.md",
+                "owner": "runtime-contracts",
+                "lifecycle": "live",
+            },
+            {
+                "id": "proof-policy",
+                "path": "references/proof-policy.md",
+                "owner": "verification",
+                "lifecycle": "live",
+            },
+        ],
+        "artifact_sink": {
+            "schema_version": 1,
+            "root": ".vibeskills/runs",
+            "required_artifacts": ["requirement", "plan", "status", "proof"],
+            "required_metadata": ["commit_sha", "execution_environment"],
+        },
+    }
+
+
+def _run_manifest_payload() -> dict:
+    return {
+        "schema_version": 1,
+        "run_id": "run-001",
+        "artifact_root": ".vibeskills/runs/run-001",
+        "artifacts": {
+            "requirement": "requirement.json",
+            "plan": "plan.json",
+            "status": "status.json",
+            "proof": "proof.json",
+        },
+        "commit_sha": "0123456789abcdef",
+        "execution_environment": {
+            "os": "windows",
+            "python": "3.10",
+        },
+    }
+
+
+def test_minimal_live_contract_workspace_emits_a_complete_run_artifact_manifest(tmp_path: Path) -> None:
+    contract_payload = _contract_payload()
+    _write(
+        tmp_path / "config" / "live-document-contract.json",
+        json.dumps(contract_payload, indent=2) + "\n",
+    )
+    for document in contract_payload["documents"]:
+        _write(tmp_path / document["path"])
+
+    contract = load_live_governance_contract(tmp_path / "docs")
+    validated_paths = validate_live_document_workspace(contract, tmp_path)
+    manifest = contract.validate_run_artifact_manifest(_run_manifest_payload())
+    artifact_paths = manifest.resolve_artifact_paths(tmp_path)
+    for artifact_kind, artifact_path in artifact_paths.items():
+        _write(
+            artifact_path,
+            json.dumps({"artifact_kind": artifact_kind}) + "\n",
+        )
+    validated_artifact_paths = validate_run_artifact_workspace(
+        manifest,
+        tmp_path,
+    )
+
+    assert validated_paths == [
+        tmp_path / "README.md",
+        tmp_path / "docs" / "runtime-contract.md",
+        tmp_path / "references" / "proof-policy.md",
+    ]
+    assert manifest.artifacts["proof"] == "proof.json"
+    assert manifest.commit_sha == "0123456789abcdef"
+    assert manifest.execution_environment == {"os": "windows", "python": "3.10"}
+    assert validated_artifact_paths == artifact_paths
+    assert all(path.is_file() for path in validated_artifact_paths.values())
+    assert artifact_paths["proof"] == (
+        tmp_path / ".vibeskills" / "runs" / "run-001" / "proof.json"
+    )
+    assert not (tmp_path / "docs" / "requirements").exists()
+    assert not (tmp_path / "docs" / "plans").exists()
+
+
+def test_repo_ships_a_valid_live_governance_contract() -> None:
+    contract = load_live_governance_contract(REPO_ROOT)
+
+    validated_paths = validate_live_document_workspace(contract, REPO_ROOT)
+
+    assert len(validated_paths) <= 30
+    assert validated_paths
+    assert all(path.suffix.casefold() == ".md" for path in validated_paths)
+    assert contract.artifact_sink.required_artifacts == (
+        "requirement",
+        "plan",
+        "status",
+        "proof",
+    )
+    assert contract.artifact_sink.required_metadata == (
+        "commit_sha",
+        "execution_environment",
+    )
+
+
+def test_runtime_config_manifest_packages_live_governance_contract() -> None:
+    manifest = json.loads(
+        (REPO_ROOT / "config" / "runtime-config-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    relpath = vgo_contracts.LIVE_GOVERNANCE_CONTRACT_RELPATH.as_posix()
+
+    assert relpath in manifest["files"]
+    assert relpath in manifest["role_groups"]["files"]["runtime_governance_files"]
+
+
+def test_live_governance_contract_is_a_public_package_interface() -> None:
+    assert (
+        vgo_contracts.LIVE_GOVERNANCE_CONTRACT_RELPATH.as_posix()
+        == "config/live-document-contract.json"
+    )
+    assert vgo_contracts.load_live_governance_contract is load_live_governance_contract
+    assert (
+        vgo_contracts.validate_live_document_workspace
+        is validate_live_document_workspace
+    )
+    assert (
+        vgo_contracts.validate_run_artifact_workspace
+        is validate_run_artifact_workspace
+    )
+
+
+@pytest.mark.parametrize(
+    "document_path",
+    [
+        "/docs/runtime-contract.md",
+        "C:/docs/runtime-contract.md",
+        "C:docs/runtime-contract.md",
+    ],
+)
+def test_live_governance_contract_rejects_non_relative_document_paths(
+    document_path: str,
+) -> None:
+    payload = _contract_payload(
+        documents=[
+            {
+                "id": "runtime-contract",
+                "path": document_path,
+                "owner": "runtime-contracts",
+                "lifecycle": "live",
+            }
+        ]
+    )
+
+    with pytest.raises(ValueError, match="relative"):
+        LiveGovernanceContract.model_validate(payload)
+
+
+def test_live_governance_contract_requires_all_governed_document_roots() -> None:
+    payload = _contract_payload()
+    payload["governed_roots"] = ["docs", "references"]
+
+    with pytest.raises(ValueError, match="missing required governed roots"):
+        LiveGovernanceContract.model_validate(payload)
+
+
+def test_live_governance_contract_rejects_more_than_thirty_registered_documents() -> None:
+    documents = [
+        {
+            "id": f"document-{index}",
+            "path": f"docs/document-{index}.md",
+            "owner": "governance",
+            "lifecycle": "live",
+        }
+        for index in range(31)
+    ]
+
+    with pytest.raises(ValueError, match="configured budget is 30"):
+        LiveGovernanceContract.model_validate(_contract_payload(documents=documents))
+
+
+def test_live_document_budget_counts_every_maintained_registry_entry() -> None:
+    documents = [
+        {
+            "id": f"document-{index}",
+            "path": f"docs/document-{index}.md",
+            "owner": "governance",
+            "lifecycle": "live",
+        }
+        for index in range(30)
+    ]
+    documents.append(
+        {
+            "id": "retained-decision",
+            "path": "docs/adr/retained-decision.md",
+            "owner": "governance",
+            "lifecycle": "retained",
+        }
+    )
+
+    with pytest.raises(ValueError, match="configured budget is 30"):
+        LiveGovernanceContract.model_validate(_contract_payload(documents=documents))
+
+
+@pytest.mark.parametrize("field", ["owner", "lifecycle"])
+def test_live_governance_contract_requires_document_metadata(field: str) -> None:
+    document = {
+        "id": "runtime-contract",
+        "path": "docs/runtime-contract.md",
+        "owner": "runtime-contracts",
+        "lifecycle": "live",
+    }
+    document.pop(field)
+
+    with pytest.raises(ValueError, match=field):
+        LiveGovernanceContract.model_validate(
+            _contract_payload(documents=[document])
+        )
+
+
+def test_live_governance_contract_rejects_an_empty_registry() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        LiveGovernanceContract.model_validate(_contract_payload(documents=[]))
+
+
+def test_run_artifact_manifest_requires_complete_artifact_set() -> None:
+    contract = LiveGovernanceContract.model_validate(_contract_payload())
+    manifest_payload = _run_manifest_payload()
+    manifest_payload["artifacts"].pop("proof")
+
+    with pytest.raises(ValueError, match="proof"):
+        contract.validate_run_artifact_manifest(manifest_payload)
+
+
+def test_run_artifact_manifest_requires_distinct_artifact_paths() -> None:
+    contract = LiveGovernanceContract.model_validate(_contract_payload())
+    manifest_payload = _run_manifest_payload()
+    manifest_payload["artifacts"]["proof"] = "status.json"
+
+    with pytest.raises(ValueError, match="unique"):
+        contract.validate_run_artifact_manifest(manifest_payload)
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("commit_sha", "commit_sha"),
+        ("execution_environment", "execution_environment"),
+    ],
+)
+def test_run_artifact_manifest_requires_attribution_metadata(
+    field: str,
+    message: str,
+) -> None:
+    contract = LiveGovernanceContract.model_validate(_contract_payload())
+    manifest_payload = _run_manifest_payload()
+    manifest_payload.pop(field)
+
+    with pytest.raises(ValueError, match=message):
+        contract.validate_run_artifact_manifest(manifest_payload)
+
+
+def test_run_artifact_manifest_must_use_the_declared_artifact_sink() -> None:
+    contract = LiveGovernanceContract.model_validate(_contract_payload())
+    manifest_payload = _run_manifest_payload()
+    manifest_payload["artifact_root"] = "outputs/runtime/run-001"
+
+    with pytest.raises(ValueError, match="artifact sink root"):
+        contract.validate_run_artifact_manifest(manifest_payload)
+
+
+@pytest.mark.parametrize(
+    "artifact_path",
+    ["/tmp/proof.json", "../proof.json", "C:proof.json", "."],
+)
+def test_run_artifact_manifest_rejects_artifacts_outside_the_run_root(
+    artifact_path: str,
+) -> None:
+    contract = LiveGovernanceContract.model_validate(_contract_payload())
+    manifest_payload = _run_manifest_payload()
+    manifest_payload["artifacts"]["proof"] = artifact_path
+
+    with pytest.raises(ValueError, match="relative"):
+        contract.validate_run_artifact_manifest(manifest_payload)


### PR DESCRIPTION
## Summary

- add a machine-readable registry for the bounded live-document surface, including capability ownership and lifecycle metadata
- add package-owned validation for the thirty-document budget, governed roots, safe paths, artifact schema, commit identity, execution environment, and per-run artifact containment
- package the contract through `config/runtime-config-manifest.json` and document the executable governance entry point
- add minimal-workspace behavior coverage that emits and validates requirement, plan, status, and proof artifacts without historical governance documents

## Scope and governance

- Governing issue: #265
- Parent program: #264
- Z0 guarded surfaces touched: none
- Packaging-sensitive surface touched: `config/runtime-config-manifest.json`
- Existing untracked `build/` and `*.egg-info/` directories were left untouched

## Proof bundle

- `py -3 -m pytest tests/unit/test_live_governance_contract.py tests/unit/test_runtime_surface_contract.py tests/runtime_neutral/test_bundled_runtime_mirror.py tests/integration/test_runtime_payload_dependency_coverage.py tests/integration/test_runtime_config_manifest_roles.py -q`
  - Output: `35 passed`
  - Claim: the live-document contract, runtime packaging projection, and adjacent manifest roles behave coherently.
- `py -3 -m mypy packages/contracts/src/vgo_contracts/live_governance_contract.py packages/contracts/src/vgo_contracts/__init__.py`
  - Output: success, no issues
  - Claim: the public Python contract surface type-checks.
- `pyright packages/contracts/src/vgo_contracts/live_governance_contract.py`
  - Output: `0 errors, 0 warnings`
  - Claim: the new contract module passes independent static analysis.
- `ruff check packages/contracts/src/vgo_contracts/live_governance_contract.py packages/contracts/src/vgo_contracts/__init__.py tests/unit/test_live_governance_contract.py`
  - Output: all checks passed
  - Claim: changed Python and test surfaces satisfy lint checks.
- `py -3 -m pytest --maxfail=1 -q`
  - Output before the first failure: `368 passed, 4 skipped`; first failure is `tests/runtime_neutral/test_docs_readme_encoding.py::DocsReadmeNavigationTests::test_docs_landing_page_has_readable_install_navigation`
  - Claim: the remaining failure is the pre-existing mojibake in `docs/README.md`; that file is unchanged from fixed point `755822f9`.

Closes #265
Part of #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added governance controls for tracking live documents, ownership, lifecycle, and document limits.
  - Added validation for required release artifacts, metadata, workspace paths, and artifact locations.
  - Added machine-readable governance configuration and runtime discovery.

- **Documentation**
  - Documented governance terminology, live-document requirements, artifact retention, and externalized governance history.
  - Updated governance guidance to reference the live document contract and generated artifacts.

- **Tests**
  - Added comprehensive coverage for document, workspace, registry, and artifact validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->