### PR TITLE
feat(verify): add OrcaRouter as a named provider type in the router AI connectivity probe

### DIFF
--- a/packages/verification-core/src/vgo_verify/router_ai_probe_advice.py
+++ b/packages/verification-core/src/vgo_verify/router_ai_probe_advice.py
@@ -6,6 +6,8 @@ from .router_ai_probe_support import (
     INTENT_ADVICE_API_KEY_ENV,
     INTENT_ADVICE_BASE_URL_ENV,
     INTENT_ADVICE_MODEL_ENV,
+    ORCAROUTER_API_KEY_ENV,
+    ORCAROUTER_BASE_URL,
     ProbeContext,
     TransportFn,
     anthropic_messages_base_url,
@@ -19,12 +21,17 @@ from .router_ai_probe_support import (
     resolve_first_value,
 )
 
+# OpenAI-compatible provider types the advice probe can drive directly.
+OPENAI_COMPATIBLE_PROVIDER_TYPES = {"openai", "openai-compatible", "orcarouter"}
+
 
 def provider_credential_env(provider_type: str, provider_cfg: dict[str, Any] | None = None) -> str:
     if isinstance(provider_cfg, dict):
         configured = non_empty(provider_cfg.get("api_key_env"))
         if configured:
             return configured
+    if provider_type.strip().lower() == "orcarouter":
+        return ORCAROUTER_API_KEY_ENV
     return INTENT_ADVICE_API_KEY_ENV
 
 
@@ -46,6 +53,8 @@ def resolve_advice_base_url(provider_type: str, provider_cfg: dict[str, Any], se
         INTENT_ADVICE_BASE_URL_ENV
     ]
     normalized = provider_type.strip().lower()
+    if normalized == "orcarouter":
+        return resolve_first_value(base_url_names, settings_values) or ORCAROUTER_BASE_URL
     if normalized in {"openai", "openai-compatible", "mock"}:
         return resolve_first_value(base_url_names, settings_values) or "https://api.openai.com/v1"
     return resolve_first_value(base_url_names, settings_values)
@@ -315,7 +324,7 @@ def probe_advice_connectivity(
             result["endpoint_used"] = endpoint_used
         return result
 
-    if provider_type_normalized not in {"openai", "openai-compatible"}:
+    if provider_type_normalized not in OPENAI_COMPATIBLE_PROVIDER_TYPES:
         return {
             "status": "provider_rejected_request",
             "provider_type": provider_type,

--- a/packages/verification-core/src/vgo_verify/router_ai_probe_support.py
+++ b/packages/verification-core/src/vgo_verify/router_ai_probe_support.py
@@ -23,6 +23,10 @@ VECTOR_DIFF_API_KEY_ENV = "VCO_VECTOR_DIFF_API_KEY"
 VECTOR_DIFF_BASE_URL_ENV = "VCO_VECTOR_DIFF_BASE_URL"
 VECTOR_DIFF_MODEL_ENV = "VCO_VECTOR_DIFF_MODEL"
 
+# Named OpenAI-compatible gateway defaults.
+ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+ORCAROUTER_API_KEY_ENV = "ORCAROUTER_API_KEY"
+
 
 @dataclass
 class ProbeContext:

--- a/packages/verification-core/src/vgo_verify/router_ai_probe_vector.py
+++ b/packages/verification-core/src/vgo_verify/router_ai_probe_vector.py
@@ -8,12 +8,17 @@ from .router_ai_probe_support import (
     VECTOR_DIFF_API_KEY_ENV,
     VECTOR_DIFF_BASE_URL_ENV,
     VECTOR_DIFF_MODEL_ENV,
+    ORCAROUTER_API_KEY_ENV,
+    ORCAROUTER_BASE_URL,
     extract_vectors,
     non_empty,
     openai_v1_base_url,
     resolve_env_value,
     resolve_first_value,
 )
+
+# OpenAI-compatible provider types the vector-diff probe can drive directly.
+OPENAI_COMPATIBLE_EMBEDDING_PROVIDER_TYPES = {"openai", "openai-compatible", "orcarouter"}
 
 
 def resolve_vector_base_url(provider_type: str, provider_cfg: dict[str, Any], settings_values: dict[str, str]) -> str | None:
@@ -27,6 +32,8 @@ def resolve_vector_base_url(provider_type: str, provider_cfg: dict[str, Any], se
     normalized = provider_type.strip().lower()
     if normalized in {"openai", "openai-compatible"}:
         return resolve_first_value(base_url_names, settings_values) or "https://api.openai.com/v1"
+    if normalized == "orcarouter":
+        return resolve_first_value(base_url_names, settings_values) or ORCAROUTER_BASE_URL
     return None
 
 
@@ -58,7 +65,10 @@ def probe_vector_diff(
             "attempts": [],
         }
 
-    credential_env = non_empty(provider_cfg.get("api_key_env")) or VECTOR_DIFF_API_KEY_ENV
+    if provider_type.strip().lower() == "orcarouter":
+        credential_env = non_empty(provider_cfg.get("api_key_env")) or ORCAROUTER_API_KEY_ENV
+    else:
+        credential_env = non_empty(provider_cfg.get("api_key_env")) or VECTOR_DIFF_API_KEY_ENV
     api_key = resolve_env_value(credential_env, settings_values)
     if not api_key:
         return {
@@ -83,7 +93,7 @@ def probe_vector_diff(
 
     timeout_ms = int(provider_cfg.get("timeout_ms", 6000) or 6000)
     provider_type_normalized = provider_type.lower()
-    if provider_type_normalized in {"openai", "openai-compatible"}:
+    if provider_type_normalized in OPENAI_COMPATIBLE_EMBEDDING_PROVIDER_TYPES:
         endpoint = f"{openai_v1_base_url(base_url)}/embeddings"
     else:
         return {

--- a/tests/runtime_neutral/test_router_ai_connectivity_probe.py
+++ b/tests/runtime_neutral/test_router_ai_connectivity_probe.py
@@ -319,6 +319,58 @@ class RouterAiConnectivityProbeTests(unittest.TestCase):
             [attempt["endpoint_kind"] for attempt in artifact["advice"]["attempts"]],
         )
 
+    def test_orcarouter_provider_defaults_to_orcarouter_endpoint(self) -> None:
+        policy = self._policy()
+        policy["provider"]["type"] = "orcarouter"
+        policy["provider"]["base_url"] = ""
+        policy["provider"]["base_url_env_candidates"] = []
+        policy["provider"]["api_key_env"] = ""
+        self._write_policy(policy)
+        self._write_settings({"ORCAROUTER_API_KEY": "sk-orca-test"})
+
+        seen_urls: list[str] = []
+
+        def transport(req: dict) -> dict:
+            seen_urls.append(req["url"])
+            return {
+                "ok": True,
+                "status_code": 200,
+                "error_kind": None,
+                "error": None,
+                "body_text": '{"choices":[{"message":{"content":"{\\"ok\\":true}"}}]}',
+                "json": {"choices": [{"message": {"content": '{"ok":true}'}}]},
+                "latency_ms": 6,
+            }
+
+        with mock.patch.dict(os.environ, {"ORCAROUTER_API_KEY": "sk-orca-test"}, clear=True):
+            artifact = self.module.evaluate(
+                self.root,
+                self.target_root,
+                probe_context=self.module.ProbeContext(prefix_detected=True),
+                transport=transport,
+            )
+
+        self.assertEqual("ok", artifact["summary"]["advice_status"])
+        self.assertTrue(any(url.startswith("https://api.orcarouter.ai/v1") for url in seen_urls))
+        self.assertEqual("ORCAROUTER_API_KEY", artifact["advice"].get("credential_env"))
+
+    def test_orcarouter_missing_credentials_abstains_offline(self) -> None:
+        policy = self._policy()
+        policy["provider"]["type"] = "orcarouter"
+        policy["provider"]["api_key_env"] = ""
+        self._write_policy(policy)
+        self._write_settings({})
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            artifact = self.module.evaluate(
+                self.root,
+                self.target_root,
+                probe_context=self.module.ProbeContext(prefix_detected=True),
+            )
+
+        self.assertEqual("missing_credentials", artifact["summary"]["advice_status"])
+        self.assertEqual("ORCAROUTER_API_KEY", artifact["advice"].get("credential_env"))
+
     def test_parse_error_is_classified(self) -> None:
         self._write_settings({"VCO_INTENT_ADVICE_API_KEY": "sk-test"})
 


### PR DESCRIPTION
## Why

VibeSkills routes local Skills and orchestrates harness workflows, and its
router already leans on an OpenAI-compatible advice provider for route advice,
candidate rerank, and shadow evaluation. Today that provider layer is fully
generic: users point `VCO_INTENT_ADVICE_BASE_URL` at any OpenAI-compatible
endpoint, but nothing in the codebase recognizes a named gateway the way it
recognizes `openai`, `openai-compatible`, or `anthropic-compatible`.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway
built for both models and agents. Like OpenRouter, it exposes a
provider/model namespace across many models — but it also combines adaptive
routing, automatic failover, zero-markup inference, observability,
guardrails, and agent-tool governance behind the same endpoint. Adding
`orcarouter` as a first-class provider type means this project's users can
point the router's connectivity probe at that stack directly, without
treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same
endpoint — screening every prompt/response and governing every tool call on a
default-deny basis, with no application code changes.

## What

This change teaches the router AI connectivity probe
(`vgo_verify.router_ai_probe_advice` / `router_ai_probe_vector`) about
`orcarouter` as a named provider type, mirroring how it already drives
`openai-compatible`:

- `provider.type = "orcarouter"` is accepted on the same OpenAI-compatible
  path (`/responses`, `/chat/completions`, `/embeddings`).
- When no `base_url` is configured, the probe defaults to
  `https://api.orcarouter.ai/v1` instead of `https://api.openai.com/v1`.
- The probe looks up the key in `ORCAROUTER_API_KEY` by default, matching the
  env-var convention the project already uses for its VCO_* provider keys.
- The advice and vector-diff credential/env resolution both honor the
  orcarouter defaults.

## Verification

- Added two unit tests in `tests/runtime_neutral/test_router_ai_connectivity_probe.py`
  covering the orcarouter endpoint default and the offline abstain path.
- `pytest tests/runtime_neutral/test_router_ai_connectivity_probe.py` → 17 passed.
- Full CI python validation surface (`config/python-validation-targets.txt`) → 95 passed, 70 skipped.
- Live probe against `https://api.orcarouter.ai/v1` with an OrcaRouter key →
  `advice_status=ok`, `gate_result=PASS`, `status=200` on `/responses`.

No router behavior changes: the canonical router remains provider-neutral and
single-authority; this only extends what the verification probe can
recognize.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OrcaRouter as an OpenAI-compatible provider for AI advice and embedding connectivity checks.
  * OrcaRouter connections now use the appropriate default endpoint and API key configuration.

* **Bug Fixes**
  * Corrected credential detection and endpoint routing for OrcaRouter providers.

* **Tests**
  * Added coverage for successful OrcaRouter connectivity and missing-credential scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->