### PR TITLE
installer: recover partial uninstalls and type CLI exits

### DIFF
--- a/apps/vgo-cli/src/vgo_cli/commands.py
+++ b/apps/vgo-cli/src/vgo_cli/commands.py
@@ -14,6 +14,7 @@ from .errors import (
     CliMissingResourceError,
     CliPermissionError,
     CliStateError,
+    CliUnavailableError,
 )
 from .output import print_json_payload
 from .process import print_process_output, run_powershell_file, run_subprocess
@@ -24,11 +25,13 @@ from .workspace import extend_workspace_package_path
 PROJECT_URL = "https://github.com/foryourhealth111-pixel/Vibe-Skills"
 
 
-def _installer_cli_error(exc: RuntimeError | OSError) -> CliError:
+def _installer_cli_error(exc: RuntimeError | OSError | ValueError) -> CliError:
     if isinstance(exc, PermissionError):
         return CliPermissionError(str(exc))
     if isinstance(exc, FileNotFoundError):
         return CliMissingResourceError(str(exc))
+    if isinstance(exc, TimeoutError):
+        return CliUnavailableError(str(exc))
     if isinstance(exc, OSError):
         return CliIoError(str(exc))
     return CliStateError(str(exc))
@@ -66,10 +69,35 @@ def _load_public_release_bundle(source_root: Path) -> dict[str, object] | None:
     bundle_path = source_root / "release-bundle.json"
     if not bundle_path.is_file():
         return None
-    payload = json.loads(bundle_path.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(bundle_path.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        raise CliStateError(f"Unreadable public release bundle: {bundle_path}") from exc
     if not isinstance(payload, dict):
-        raise CliError(f"Expected JSON object: {bundle_path}")
+        raise CliStateError(f"Expected JSON object: {bundle_path}")
     return payload
+
+
+def _bundle_mapping(
+    bundle: dict[str, object],
+    field_name: str,
+    bundle_path: Path,
+) -> dict[str, object]:
+    value = bundle.get(field_name)
+    if not isinstance(value, dict):
+        raise CliStateError(f"Public release bundle field '{field_name}' must be an object: {bundle_path}")
+    return value
+
+
+def _bundle_required_text(
+    mapping: dict[str, object],
+    field_name: str,
+    bundle_path: Path,
+) -> str:
+    value = mapping.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise CliStateError(f"Public release bundle field '{field_name}' must be non-empty text: {bundle_path}")
+    return value.strip()
 
 
 def _local_release_version(source_root: Path) -> str:
@@ -82,15 +110,34 @@ def _local_release_version(source_root: Path) -> str:
 def _install_source_kwargs(source_root: Path) -> dict[str, object]:
     bundle = _load_public_release_bundle(source_root)
     if bundle is not None:
-        public_install = bundle.get("public_install") or {}
-        if str(public_install.get("source_kind") or "").strip() == "public_release":
-            release = bundle.get("release") or {}
-            asset = bundle.get("asset") or {}
-            version = str(release.get("version") or "").strip()
-            asset_name = str(asset.get("file_name") or "").strip()
-            if not version or not asset_name:
-                raise CliError("Public release bundle is missing release version or asset name.")
-            digest = str(asset.get("payload_digest_sha256") or "").strip()
+        public_install_value = bundle.get("public_install")
+        if public_install_value is None:
+            public_install: dict[str, object] = {}
+        elif isinstance(public_install_value, dict):
+            public_install = public_install_value
+        else:
+            raise CliStateError(
+                f"Public release bundle field 'public_install' must be an object: "
+                f"{source_root / 'release-bundle.json'}"
+            )
+        source_kind = public_install.get("source_kind")
+        if source_kind is not None and not isinstance(source_kind, str):
+            raise CliStateError(
+                f"Public release bundle field 'source_kind' must be text: "
+                f"{source_root / 'release-bundle.json'}"
+            )
+        if str(source_kind or "").strip() == "public_release":
+            bundle_path = source_root / "release-bundle.json"
+            release = _bundle_mapping(bundle, "release", bundle_path)
+            asset = _bundle_mapping(bundle, "asset", bundle_path)
+            version = _bundle_required_text(release, "version", bundle_path)
+            asset_name = _bundle_required_text(asset, "file_name", bundle_path)
+            digest_value = asset.get("payload_digest_sha256")
+            if digest_value is not None and not isinstance(digest_value, str):
+                raise CliStateError(
+                    f"Public release bundle field 'payload_digest_sha256' must be text: {bundle_path}"
+                )
+            digest = str(digest_value or "").strip()
             return {
                 "source_kind": "public_release",
                 "release_version": version,
@@ -124,7 +171,7 @@ def install_command(args: argparse.Namespace) -> int:
             installed_at_utc=datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z'),
             **_install_source_kwargs(repo_root),
         )
-    except (RuntimeError, OSError) as exc:
+    except (RuntimeError, OSError, ValueError) as exc:
         raise _installer_cli_error(exc) from exc
     print_json_payload(receipt)
     return 0
@@ -138,11 +185,16 @@ def uninstall_command(args: argparse.Namespace) -> int:
 
     try:
         result = uninstall_vibe_skill(skills_dir=skills_dir)
-    except (RuntimeError, OSError) as exc:
+    except (RuntimeError, OSError, ValueError) as exc:
         raise _installer_cli_error(exc) from exc
     print_json_payload(result)
     if not result.get("ok"):
-        raise CliIoError("Vibe uninstall is incomplete; retry after resolving the reported failures.")
+        message = "Vibe uninstall is incomplete; retry after resolving the reported failures."
+        if result.get("unavailable_files") or result.get("unavailable_directories"):
+            raise CliUnavailableError(message)
+        if result.get("permission_denied_files") or result.get("permission_denied_directories"):
+            raise CliPermissionError(message)
+        raise CliIoError(message)
     return 0
 
 
@@ -159,7 +211,7 @@ def update_command(args: argparse.Namespace) -> int:
             installed_at_utc=datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z'),
             **_install_source_kwargs(repo_root),
         )
-    except (RuntimeError, OSError) as exc:
+    except (RuntimeError, OSError, ValueError) as exc:
         raise _installer_cli_error(exc) from exc
     print_json_payload(receipt)
     return 0
@@ -173,7 +225,7 @@ def check_command(args: argparse.Namespace) -> int:
 
     try:
         result = check_vibe_skill(skills_dir=skills_dir)
-    except (RuntimeError, OSError) as exc:
+    except (RuntimeError, OSError, ValueError) as exc:
         raise _installer_cli_error(exc) from exc
     result["current_state"] = {
         "local_runtime": {

--- a/apps/vgo-cli/src/vgo_cli/commands.py
+++ b/apps/vgo-cli/src/vgo_cli/commands.py
@@ -8,7 +8,13 @@ import subprocess
 import sys
 
 from .core_bridge import run_canonical_entry_core, run_compatibility_exit_core, run_entry_locator_core, run_inspect_run_core, run_local_kernel_core, run_router_core, run_skill_index_core
-from .errors import CliError
+from .errors import (
+    CliError,
+    CliIoError,
+    CliMissingResourceError,
+    CliPermissionError,
+    CliStateError,
+)
 from .output import print_json_payload
 from .process import print_process_output, run_powershell_file, run_subprocess
 from .repo import get_installed_runtime_config, get_local_release_metadata
@@ -16,6 +22,16 @@ from .workspace import extend_workspace_package_path
 
 
 PROJECT_URL = "https://github.com/foryourhealth111-pixel/Vibe-Skills"
+
+
+def _installer_cli_error(exc: RuntimeError | OSError) -> CliError:
+    if isinstance(exc, PermissionError):
+        return CliPermissionError(str(exc))
+    if isinstance(exc, FileNotFoundError):
+        return CliMissingResourceError(str(exc))
+    if isinstance(exc, OSError):
+        return CliIoError(str(exc))
+    return CliStateError(str(exc))
 
 
 def _resolve_skills_dir(raw_value: str) -> Path:
@@ -101,12 +117,15 @@ def install_command(args: argparse.Namespace) -> int:
     extend_workspace_package_path(repo_root)
     from vgo_installer.simple_skill_installer import install_vibe_skill
 
-    receipt = install_vibe_skill(
-        repo_root=repo_root,
-        skills_dir=skills_dir,
-        installed_at_utc=datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z'),
-        **_install_source_kwargs(repo_root),
-    )
+    try:
+        receipt = install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc=datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z'),
+            **_install_source_kwargs(repo_root),
+        )
+    except (RuntimeError, OSError) as exc:
+        raise _installer_cli_error(exc) from exc
     print_json_payload(receipt)
     return 0
 
@@ -117,7 +136,13 @@ def uninstall_command(args: argparse.Namespace) -> int:
     extend_workspace_package_path(repo_root)
     from vgo_installer.simple_skill_installer import uninstall_vibe_skill
 
-    print_json_payload(uninstall_vibe_skill(skills_dir=skills_dir))
+    try:
+        result = uninstall_vibe_skill(skills_dir=skills_dir)
+    except (RuntimeError, OSError) as exc:
+        raise _installer_cli_error(exc) from exc
+    print_json_payload(result)
+    if not result.get("ok"):
+        raise CliIoError("Vibe uninstall is incomplete; retry after resolving the reported failures.")
     return 0
 
 
@@ -127,12 +152,15 @@ def update_command(args: argparse.Namespace) -> int:
     extend_workspace_package_path(repo_root)
     from vgo_installer.simple_skill_installer import update_vibe_skill
 
-    receipt = update_vibe_skill(
-        repo_root=repo_root,
-        skills_dir=skills_dir,
-        installed_at_utc=datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z'),
-        **_install_source_kwargs(repo_root),
-    )
+    try:
+        receipt = update_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc=datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z'),
+            **_install_source_kwargs(repo_root),
+        )
+    except (RuntimeError, OSError) as exc:
+        raise _installer_cli_error(exc) from exc
     print_json_payload(receipt)
     return 0
 
@@ -143,7 +171,10 @@ def check_command(args: argparse.Namespace) -> int:
     extend_workspace_package_path(repo_root)
     from vgo_installer.simple_skill_installer import check_vibe_skill
 
-    result = check_vibe_skill(skills_dir=skills_dir)
+    try:
+        result = check_vibe_skill(skills_dir=skills_dir)
+    except (RuntimeError, OSError) as exc:
+        raise _installer_cli_error(exc) from exc
     result["current_state"] = {
         "local_runtime": {
             "result": "PASS" if result.get("ok") else "FAIL",

--- a/apps/vgo-cli/src/vgo_cli/errors.py
+++ b/apps/vgo-cli/src/vgo_cli/errors.py
@@ -1,5 +1,37 @@
 from __future__ import annotations
 
+from enum import IntEnum
+
+
+class CliExitCode(IntEnum):
+    FAILURE = 1
+    USAGE = 2
+    INVALID_STATE = 3
+    MISSING_RESOURCE = 4
+    PERMISSION_DENIED = 5
+    UNAVAILABLE = 6
+    IO_ERROR = 7
+
 
 class CliError(RuntimeError):
-    pass
+    exit_code = CliExitCode.FAILURE
+
+
+class CliStateError(CliError):
+    exit_code = CliExitCode.INVALID_STATE
+
+
+class CliMissingResourceError(CliError):
+    exit_code = CliExitCode.MISSING_RESOURCE
+
+
+class CliPermissionError(CliError):
+    exit_code = CliExitCode.PERMISSION_DENIED
+
+
+class CliUnavailableError(CliError):
+    exit_code = CliExitCode.UNAVAILABLE
+
+
+class CliIoError(CliError):
+    exit_code = CliExitCode.IO_ERROR

--- a/apps/vgo-cli/src/vgo_cli/hosts.py
+++ b/apps/vgo-cli/src/vgo_cli/hosts.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from pathlib import Path
 from types import ModuleType
 
-from .errors import CliError
+from .errors import CliError, CliUnavailableError
 from .workspace import extend_workspace_package_path
 
 
@@ -59,7 +59,9 @@ def _resolve_host_entry(host_id: str | None) -> tuple[str, dict[str, object]]:
         try:
             entry = dict(registry_module.resolve_adapter_entry(registry, normalized))
         except ValueError as exc:
-            raise CliError(f'Unable to resolve host registry entry for: {host_id}') from exc
+            raise CliUnavailableError(
+                f'Unable to resolve host registry entry for: {host_id}'
+            ) from exc
     return normalized, entry
 
 

--- a/apps/vgo-cli/src/vgo_cli/main.py
+++ b/apps/vgo-cli/src/vgo_cli/main.py
@@ -146,7 +146,7 @@ def main(argv: list[str] | None = None) -> int:
         if message:
             for line in message.splitlines():
                 print(f'[FAIL] {line}', file=sys.stderr)
-        return 1
+        return int(exc.exit_code)
 
 
 if __name__ == '__main__':

--- a/apps/vgo-cli/src/vgo_cli/process.py
+++ b/apps/vgo-cli/src/vgo_cli/process.py
@@ -11,7 +11,7 @@ import sys
 from typing import Any, Callable, Sequence
 import warnings
 
-from .errors import CliError
+from .errors import CliUnavailableError
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -259,7 +259,7 @@ def run_powershell_file(script_path: Path, *args: str) -> subprocess.CompletedPr
         if checked:
             detail_parts.append(f"candidates checked: {', '.join(checked)}")
         detail = f"; {'; '.join(detail_parts)}" if detail_parts else ""
-        raise CliError(f"PowerShell is required to run: {script_path}{detail}")
+        raise CliUnavailableError(f"PowerShell is required to run: {script_path}{detail}")
     shell_path = str(resolution["host_path"])
     leaf = Path(shell_path).name.lower()
     command = [shell_path, '-NoProfile']

--- a/packages/installer-core/src/vgo_installer/simple_skill_installer.py
+++ b/packages/installer-core/src/vgo_installer/simple_skill_installer.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
+import errno
+from functools import wraps
 import hashlib
 import json
-from pathlib import Path
+import os
+import secrets
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath, PureWindowsPath
 import shutil
+import stat
+import tempfile
+import threading
+import time
+from typing import Callable, Iterator, NoReturn, ParamSpec, TypeVar, cast
 
 from ._bootstrap import ensure_contracts_src_on_path
 
@@ -40,21 +51,283 @@ PACKAGE_RUNTIME_TEST_ENTRYPOINTS = {
     "packages/verification-core/src/vgo_verify/test_baseline_audit.py",
 }
 RECEIPT_RELPATH = ".vibeskills/install-receipt.json"
-UNINSTALL_STATE_RELPATH = ".vibeskills/uninstall-state.json"
+OPERATION_LOCK_RELPATH = ".vibeskills/vibe-operation.lock"
+OPERATION_LOCK_TIMEOUT_SECONDS = 30.0
+INSTALL_STATE_RELPATH = ".vibeskills/vibe-install-state.json"
+INSTALL_STATE_KIND = "vibe-skill-install-transaction"
+INSTALL_STATE_PREPARING = "preparing"
+INSTALL_STATE_PREPARED = "prepared"
+INSTALL_RECOVERY_COMMITTED = "committed"
+INSTALL_RECOVERY_ROLLED_BACK = "rolled_back"
+UNINSTALL_STATE_RELPATH = ".vibeskills/vibe-uninstall-state.json"
 UNINSTALL_STATE_KIND = "vibe-skill-uninstall-state"
+UNINSTALL_STATE_MANAGED_FILES_REMOVED = "managed_files_removed"
+UNINSTALL_COMPLETE_RELPATH = ".vibeskills/vibe-uninstall-complete.json"
+UNINSTALL_COMPLETE_KIND = "vibe-skill-uninstall-completion"
+UNINSTALL_COMPLETE_STATUS = "completed"
+
+
+@dataclass
+class _InstallFileChange:
+    relpath: str
+    destination: Path
+    staged_path: Path | None
+    backup_path: Path | None = None
+    destination_existed: bool = False
+    old_sha256: str = ""
+    new_sha256: str = ""
+
+
+@dataclass(frozen=True)
+class _InstallRecovery:
+    disposition: str
+    receipt_existed: bool
+
+
+@dataclass(frozen=True)
+class _InstallOperationFailure:
+    detail: str
+    error: Exception
+
+
+@dataclass(frozen=True)
+class _InstallTreeEntry:
+    path: Path
+    is_directory: bool
+    is_link: bool
+
+
+@dataclass(frozen=True)
+class _UninstallCompletionCommitFailure:
+    relpath: str
+    error: OSError
+
+
+class _FileChangedDuringReadError(RuntimeError):
+    pass
+
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+_PROCESS_OPERATION_LOCK = threading.RLock()
+_PROCESS_OPERATION_LOCK_DEPTH = 0
+_PROCESS_OPERATION_LOCK_PATH: Path | None = None
+
+
+def _open_windows_file_no_follow(path: Path) -> int:
+    import ctypes
+    from ctypes import wintypes
+    import msvcrt
+
+    class _FileAttributeTagInfo(ctypes.Structure):
+        _fields_ = [
+            ("file_attributes", wintypes.DWORD),
+            ("reparse_tag", wintypes.DWORD),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    get_file_information = kernel32.GetFileInformationByHandleEx
+    get_file_information.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    get_file_information.restype = wintypes.BOOL
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+
+    generic_read = 0x80000000
+    share_read_write_delete = 0x00000001 | 0x00000002 | 0x00000004
+    open_existing = 3
+    file_attribute_normal = 0x00000080
+    file_attribute_directory = 0x00000010
+    file_attribute_reparse_point = 0x00000400
+    file_flag_backup_semantics = 0x02000000
+    file_flag_open_reparse_point = 0x00200000
+    file_attribute_tag_info = 9
+    invalid_handle = ctypes.c_void_p(-1).value
+
+    handle = create_file(
+        str(path),
+        generic_read,
+        share_read_write_delete,
+        None,
+        open_existing,
+        file_attribute_normal | file_flag_backup_semantics | file_flag_open_reparse_point,
+        None,
+    )
+    if handle == invalid_handle:
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    try:
+        file_info = _FileAttributeTagInfo()
+        if not get_file_information(
+            handle,
+            file_attribute_tag_info,
+            ctypes.byref(file_info),
+            ctypes.sizeof(file_info),
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+        if file_info.file_attributes & (
+            file_attribute_directory | file_attribute_reparse_point
+        ):
+            raise _FileChangedDuringReadError(
+                f"File changed to a link, junction, or non-file before hashing: {path}"
+            )
+        file_descriptor = msvcrt.open_osfhandle(
+            int(handle),
+            os.O_RDONLY | os.O_BINARY,
+        )
+    except BaseException:
+        close_handle(handle)
+        raise
+    return file_descriptor
+
+
+def _open_file_no_follow(path: Path) -> int:
+    if os.name == "nt":
+        return _open_windows_file_no_follow(path)
+
+    no_follow = getattr(os, "O_NOFOLLOW", 0)
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | no_follow
+    try:
+        return os.open(path, flags)
+    except OSError as exc:
+        if no_follow and exc.errno == errno.ELOOP:
+            raise _FileChangedDuringReadError(
+                f"File changed to a symbolic link before hashing: {path}"
+            ) from exc
+        raise
+
+
+def _hash_path_status(path: Path) -> os.stat_result:
+    try:
+        return path.stat(follow_symlinks=False)
+    except FileNotFoundError as exc:
+        raise _FileChangedDuringReadError(
+            f"File disappeared while preparing to hash it: {path}"
+        ) from exc
+
+
+def _validate_hash_file_identity(
+    path: Path,
+    *,
+    descriptor_status: os.stat_result,
+    path_status: os.stat_result,
+) -> None:
+    if (
+        _is_link_or_reparse_point(path_status)
+        or not stat.S_ISREG(descriptor_status.st_mode)
+        or not stat.S_ISREG(path_status.st_mode)
+        or not os.path.samestat(descriptor_status, path_status)
+    ):
+        raise _FileChangedDuringReadError(
+            f"File changed identity or type while hashing: {path}"
+        )
 
 
 def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+    file_descriptor = _open_file_no_follow(path)
+    try:
+        initial_descriptor_status = os.fstat(file_descriptor)
+        _validate_hash_file_identity(
+            path,
+            descriptor_status=initial_descriptor_status,
+            path_status=_hash_path_status(path),
+        )
+        digest = hashlib.sha256()
+        for chunk in iter(lambda: os.read(file_descriptor, 1024 * 1024), b""):
             digest.update(chunk)
-    return digest.hexdigest()
+        final_descriptor_status = os.fstat(file_descriptor)
+        _validate_hash_file_identity(
+            path,
+            descriptor_status=final_descriptor_status,
+            path_status=_hash_path_status(path),
+        )
+        initial_snapshot = (
+            initial_descriptor_status.st_size,
+            initial_descriptor_status.st_mtime_ns,
+            initial_descriptor_status.st_ctime_ns,
+        )
+        final_snapshot = (
+            final_descriptor_status.st_size,
+            final_descriptor_status.st_mtime_ns,
+            final_descriptor_status.st_ctime_ns,
+        )
+        if initial_snapshot != final_snapshot:
+            raise _FileChangedDuringReadError(f"File changed while hashing: {path}")
+        return digest.hexdigest()
+    finally:
+        os.close(file_descriptor)
 
 
 def _write_json(path: Path, payload: dict[str, object]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary_path = _stage_text_file(_json_content(payload), path)
+    try:
+        os.replace(temporary_path, path)
+    except BaseException:
+        try:
+            temporary_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _temporary_file_prefix(destination: Path, transaction_id: str = "") -> str:
+    transaction_segment = f"{transaction_id}." if transaction_id else ""
+    return f".{destination.name}.{transaction_segment}"
+
+
+def _stage_text_file(
+    content: str,
+    destination: Path,
+    *,
+    transaction_id: str = "",
+) -> Path:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        dir=destination.parent,
+        prefix=_temporary_file_prefix(destination, transaction_id),
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(file_descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        try:
+            os.close(file_descriptor)
+        except OSError:
+            pass
+        try:
+            temporary_path.unlink()
+        except OSError:
+            pass
+        raise
+    return temporary_path
+
+
+def _json_content(payload: dict[str, object]) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
 def _read_json(path: Path) -> dict[str, object]:
@@ -64,9 +337,72 @@ def _read_json(path: Path) -> dict[str, object]:
     return payload
 
 
-def _copy_file(source: Path, destination: Path) -> None:
+def _raise_install_operation_failures(
+    summary: str,
+    failures: list[_InstallOperationFailure],
+) -> NoReturn:
+    if not failures:
+        raise RuntimeError(summary)
+
+    message = f"{summary}: {'; '.join(failure.detail for failure in failures)}"
+    timeout_failure = next(
+        (
+            failure.error
+            for failure in failures
+            if isinstance(failure.error, TimeoutError)
+        ),
+        None,
+    )
+    if timeout_failure is not None:
+        raise TimeoutError(message) from timeout_failure
+
+    permission_failure = next(
+        (
+            failure.error
+            for failure in failures
+            if isinstance(failure.error, PermissionError)
+        ),
+        None,
+    )
+    if permission_failure is not None:
+        raise PermissionError(message) from permission_failure
+
+    io_failure = next(
+        (
+            failure.error
+            for failure in failures
+            if isinstance(failure.error, OSError)
+        ),
+        None,
+    )
+    if io_failure is not None:
+        raise OSError(message) from io_failure
+    raise RuntimeError(message) from failures[0].error
+
+
+def _stage_file_copy(
+    source: Path,
+    destination: Path,
+    *,
+    transaction_id: str = "",
+) -> Path:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(source, destination)
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        dir=destination.parent,
+        prefix=_temporary_file_prefix(destination, transaction_id),
+        suffix=".tmp",
+    )
+    os.close(file_descriptor)
+    temporary_path = Path(temporary_name)
+    try:
+        shutil.copy2(source, temporary_path)
+    except BaseException:
+        try:
+            temporary_path.unlink()
+        except OSError:
+            pass
+        raise
+    return temporary_path
 
 
 def _matches_surface_prefix(relpath: str) -> bool:
@@ -94,42 +430,112 @@ def _should_copy_runtime_surface_file(relpath: str) -> bool:
     return _matches_surface_prefix(normalized)
 
 
-def _copy_tree(source_root: Path, install_root: Path, relpath: str) -> None:
-    source = source_root / relpath
-    if not source.exists():
+def _validate_packaging_paths(
+    governance: dict[str, object],
+    *,
+    source_root: Path,
+    governance_path: Path,
+) -> None:
+    raw_packaging = governance.get("packaging")
+    if raw_packaging is None:
         return
-    if source.is_file():
-        _copy_file(source, install_root / relpath)
+    if not isinstance(raw_packaging, dict):
+        raise RuntimeError(f"Invalid runtime packaging contract: {governance_path}")
+
+    raw_payload = raw_packaging.get("runtime_payload")
+    if raw_payload is None:
+        raw_payload = raw_packaging.get("mirror")
+    if raw_payload is not None:
+        if not isinstance(raw_payload, dict):
+            raise RuntimeError(f"Invalid runtime packaging payload: {governance_path}")
+        for field_name in ("files", "directories"):
+            raw_paths = raw_payload.get(field_name)
+            if raw_paths is None:
+                continue
+            if not isinstance(raw_paths, list):
+                raise RuntimeError(f"Invalid runtime packaging {field_name}: {governance_path}")
+            for raw_path in raw_paths:
+                _canonical_packaging_relpath(
+                    raw_path,
+                    artifact_path=governance_path,
+                    label=f"package {field_name[:-1]}",
+                )
+
+    raw_manifests = raw_packaging.get("manifests")
+    if raw_manifests is None:
         return
-    for file_path in sorted(path for path in source.rglob("*") if path.is_file()):
-        installed_relpath = file_path.relative_to(source_root).as_posix()
-        if "__pycache__" in file_path.parts or file_path.suffix == ".pyc":
-            continue
-        if installed_relpath in PACKAGE_EXCLUDED_FILES:
-            continue
-        if _is_package_development_test(installed_relpath):
-            continue
-        _copy_file(file_path, install_root / installed_relpath)
+    manifest_paths: list[object] = []
+    if isinstance(raw_manifests, list):
+        for raw_manifest in raw_manifests:
+            if not isinstance(raw_manifest, dict):
+                raise RuntimeError(f"Invalid runtime packaging manifest: {governance_path}")
+            manifest_paths.append(raw_manifest.get("path"))
+    elif isinstance(raw_manifests, dict):
+        for raw_manifest in raw_manifests.values():
+            manifest_paths.append(
+                raw_manifest.get("path") if isinstance(raw_manifest, dict) else raw_manifest
+            )
+    else:
+        raise RuntimeError(f"Invalid runtime packaging manifests: {governance_path}")
+
+    for raw_path in manifest_paths:
+        manifest_relpath = _canonical_packaging_relpath(
+            raw_path,
+            artifact_path=governance_path,
+            label="package manifest",
+        )
+        manifest_path = source_root.joinpath(*PurePosixPath(manifest_relpath).parts)
+        _assert_source_path_is_local(source_root, manifest_path)
 
 
 def runtime_surface_relpaths(source_root: Path) -> list[str]:
     governance_path = source_root / "config" / "version-governance.json"
+    _assert_source_path_is_local(source_root, governance_path)
     if not governance_path.is_file():
         raise RuntimeError(f"Missing runtime governance contract: {governance_path}")
 
-    packaging = resolve_packaging_contract(load_json_file(governance_path), source_root)
+    try:
+        governance = load_json_file(governance_path)
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(f"Unreadable runtime packaging contract: {governance_path}") from exc
+    if not isinstance(governance, dict):
+        raise RuntimeError(f"Expected JSON object: {governance_path}")
+    _validate_packaging_paths(
+        governance,
+        source_root=source_root,
+        governance_path=governance_path,
+    )
+    try:
+        packaging = resolve_packaging_contract(governance, source_root)
+        mirror = packaging["mirror"]
+        files = mirror["files"]
+        directories = mirror["directories"]
+    except (AttributeError, KeyError, OSError, TypeError, ValueError) as exc:
+        raise RuntimeError(f"Invalid runtime packaging contract: {governance_path}") from exc
+    if not isinstance(files, list) or not isinstance(directories, list):
+        raise RuntimeError(f"Invalid runtime packaging contract: {governance_path}")
+
     relpaths: set[str] = set()
-    for relpath in packaging["mirror"]["files"]:
+    for relpath in files:
+        if not isinstance(relpath, str):
+            raise RuntimeError(f"Invalid package file path in runtime contract: {governance_path}")
         normalized = Path(relpath).as_posix()
+        _canonical_owned_relpath(normalized, artifact_path=governance_path, label="package")
         source = source_root / normalized
+        _assert_source_path_is_local(source_root, source)
         if source.is_file() and _should_copy_runtime_surface_file(normalized):
             relpaths.add(normalized)
 
-    for relpath in packaging["mirror"]["directories"]:
+    for relpath in directories:
+        if not isinstance(relpath, str):
+            raise RuntimeError(f"Invalid package directory path in runtime contract: {governance_path}")
+        _canonical_owned_relpath(relpath, artifact_path=governance_path, label="package")
         source = source_root / relpath
+        _assert_source_path_is_local(source_root, source)
         if not source.exists():
             continue
         for file_path in sorted(path for path in source.rglob("*") if path.is_file()):
+            _assert_source_path_is_local(source_root, file_path)
             installed_relpath = file_path.relative_to(source_root).as_posix()
             if _should_copy_runtime_surface_file(installed_relpath):
                 relpaths.add(installed_relpath)
@@ -141,37 +547,1134 @@ def _package_file_relpaths(source_root: Path) -> list[str]:
     relpaths: list[str] = []
     for relpath in runtime_surface_relpaths(source_root):
         source = source_root / relpath
+        _assert_source_path_is_local(source_root, source)
         if not source.exists():
             continue
         relpaths.append(relpath)
     return sorted(set(relpaths))
 
 
-def _copy_package_files(source_root: Path, install_root: Path, relpaths: list[str]) -> None:
-    for relpath in relpaths:
-        _copy_file(source_root / relpath, install_root / relpath)
+def _prepare_install_file_changes(
+    source_root: Path,
+    install_root: Path,
+    relpaths: list[str],
+    *,
+    retired_relpaths: set[str],
+    transaction_id: str,
+) -> list[_InstallFileChange]:
+    changes: list[_InstallFileChange] = []
+    try:
+        for relpath in relpaths:
+            source = source_root / relpath
+            _assert_source_path_is_local(source_root, source)
+            if not source.is_file():
+                raise RuntimeError(f"Package source file is missing: {source}")
+            destination = _owned_file_path(install_root, relpath)
+            destination_is_link = _path_is_link_or_reparse_point(destination)
+            destination_existed = destination.is_file() and not destination_is_link
+            if destination_is_link or (destination.exists() and not destination_existed):
+                raise RuntimeError(f"Install path is not a regular file: {destination}")
+            change = _InstallFileChange(
+                relpath=relpath,
+                destination=destination,
+                staged_path=_stage_file_copy(
+                    source,
+                    destination,
+                    transaction_id=transaction_id,
+                ),
+                destination_existed=destination_existed,
+            )
+            changes.append(change)
+            change.new_sha256 = _sha256_file(cast(Path, change.staged_path))
+            if destination_existed:
+                change.backup_path = _stage_file_copy(
+                    destination,
+                    destination,
+                    transaction_id=transaction_id,
+                )
+                change.old_sha256 = _sha256_file(change.backup_path)
+
+        for relpath in sorted(retired_relpaths, reverse=True):
+            destination = _owned_file_path(install_root, relpath)
+            destination_is_link = _path_is_link_or_reparse_point(destination)
+            if not destination.exists() and not destination_is_link:
+                continue
+            if destination_is_link or not destination.is_file():
+                raise RuntimeError(f"Retired install path is not a regular file: {destination}")
+            change = _InstallFileChange(
+                relpath=relpath,
+                destination=destination,
+                staged_path=None,
+                destination_existed=True,
+            )
+            changes.append(change)
+            change.backup_path = _stage_file_copy(
+                destination,
+                destination,
+                transaction_id=transaction_id,
+            )
+            change.old_sha256 = _sha256_file(change.backup_path)
+    except BaseException:
+        cleanup_failures = _discard_install_file_changes(
+            changes,
+        )
+        if cleanup_failures:
+            _raise_install_operation_failures(
+                "Failed to prepare Vibe install transaction and remove temporary files",
+                cleanup_failures,
+            )
+        raise
+    return changes
 
 
-def _installed_files(install_root: Path, relpaths: list[str]) -> list[dict[str, str]]:
-    files: list[dict[str, str]] = []
-    for relpath in relpaths:
-        file_path = install_root / relpath
-        if not file_path.is_file():
+def _apply_install_file_changes(changes: list[_InstallFileChange]) -> None:
+    for change in changes:
+        if change.staged_path is None:
+            change.destination.unlink()
+        else:
+            os.replace(change.staged_path, change.destination)
+            change.staged_path = None
+
+
+def _discard_install_file_changes(
+    changes: list[_InstallFileChange],
+) -> list[_InstallOperationFailure]:
+    failures: list[_InstallOperationFailure] = []
+    for change in changes:
+        for temporary_path in (change.staged_path, change.backup_path):
+            if temporary_path is None:
+                continue
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError as exc:
+                failures.append(
+                    _InstallOperationFailure(
+                        detail=f"{temporary_path}: {exc}",
+                        error=exc,
+                    )
+                )
+    return failures
+
+
+def _assert_source_path_is_local(source_root: Path, source: Path) -> None:
+    try:
+        resolved_root = source_root.resolve(strict=False)
+        resolved_source = source.resolve(strict=False)
+        resolved_source.relative_to(resolved_root)
+    except ValueError as exc:
+        raise RuntimeError(f"Package path escapes the source root: {source}") from exc
+
+
+def _canonical_owned_relpath(
+    value: object,
+    *,
+    artifact_path: Path,
+    label: str = "owned file",
+) -> str:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"Invalid {label} path in {artifact_path}")
+    if "\\" in value or "\x00" in value:
+        raise RuntimeError(f"Non-canonical {label} path in {artifact_path}: {value}")
+
+    posix_path = PurePosixPath(value)
+    windows_path = PureWindowsPath(value)
+    if (
+        posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or bool(windows_path.drive)
+        or not posix_path.parts
+        or ".." in posix_path.parts
+        or posix_path.as_posix() != value
+        or posix_path.parts[0].casefold() == ".vibeskills"
+        or any(part.rstrip(" .") != part for part in posix_path.parts)
+        or any(PureWindowsPath(part).is_reserved() for part in posix_path.parts)
+        or ":" in value
+    ):
+        raise RuntimeError(f"Unsafe {label} path in {artifact_path}: {value}")
+    return value
+
+
+def _canonical_packaging_relpath(
+    value: object,
+    *,
+    artifact_path: Path,
+    label: str,
+) -> str:
+    if not isinstance(value, str):
+        raise RuntimeError(f"Invalid {label} path in {artifact_path}")
+    return _canonical_owned_relpath(
+        value.replace("\\", "/"),
+        artifact_path=artifact_path,
+        label=label,
+    )
+
+
+def _assert_install_root_is_local(skills_dir: Path, install_root: Path) -> None:
+    expected_install_root = skills_dir.resolve(strict=False) / "vibe"
+    if install_root.absolute() != expected_install_root:
+        raise RuntimeError(f"Vibe install root is outside the Skills directory: {install_root}")
+    if install_root.resolve(strict=False) != expected_install_root:
+        raise RuntimeError(
+            f"Vibe install root must not be a symbolic link or junction: {install_root}"
+        )
+
+
+def _assert_local_destination(
+    install_root: Path,
+    destination: Path,
+    *,
+    reject_destination_symlink: bool,
+    root_label: str = "Vibe install root",
+    path_label: str = "Install path",
+) -> None:
+    if install_root.is_symlink():
+        raise RuntimeError(f"{root_label} must not be a symbolic link: {install_root}")
+
+    try:
+        resolved_root = install_root.resolve(strict=False)
+        if reject_destination_symlink:
+            resolved_destination = destination.resolve(strict=False)
+        else:
+            resolved_destination = destination.parent.resolve(strict=False) / destination.name
+        resolved_destination.relative_to(resolved_root)
+    except ValueError as exc:
+        raise RuntimeError(f"{path_label} escapes the {root_label}: {destination}") from exc
+
+    if reject_destination_symlink and _path_is_link_or_reparse_point(destination):
+        raise RuntimeError(f"{path_label} traverses a link or junction: {destination}")
+
+    current = destination.parent
+    while current != install_root:
+        if current.is_symlink() or current.resolve(strict=False) != current:
+            raise RuntimeError(f"{path_label} traverses a link or junction: {destination}")
+        parent = current.parent
+        if parent == current:
+            raise RuntimeError(f"{path_label} escapes the {root_label}: {destination}")
+        current = parent
+
+
+def _assert_install_destination_is_local(install_root: Path, destination: Path) -> None:
+    _assert_local_destination(
+        install_root,
+        destination,
+        reject_destination_symlink=True,
+    )
+
+
+def _owned_file_path(install_root: Path, relpath: str) -> Path:
+    destination = install_root.joinpath(*PurePosixPath(relpath).parts)
+    _assert_local_destination(
+        install_root,
+        destination,
+        reject_destination_symlink=False,
+    )
+    metadata_root = (install_root / ".vibeskills").absolute()
+    try:
+        destination.absolute().relative_to(metadata_root)
+    except ValueError:
+        pass
+    else:
+        raise RuntimeError(f"Install path targets Vibe installer metadata: {destination}")
+    return destination
+
+
+def _destination_key(destination: Path) -> str:
+    local_destination = destination.parent.resolve(strict=False) / destination.name
+    return os.path.normcase(str(local_destination))
+
+
+def _is_link_or_reparse_point(file_status: os.stat_result) -> bool:
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    file_attributes = getattr(file_status, "st_file_attributes", 0)
+    return stat.S_ISLNK(file_status.st_mode) or bool(file_attributes & reparse_flag)
+
+
+def _path_is_link_or_reparse_point(path: Path) -> bool:
+    try:
+        file_status = path.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        return False
+    return _is_link_or_reparse_point(file_status)
+
+
+def _install_tree_entries(install_root: Path) -> Iterator[_InstallTreeEntry]:
+    pending_directories = [install_root]
+    while pending_directories:
+        directory = pending_directories.pop()
+        with os.scandir(directory) as scanner:
+            raw_entries = sorted(scanner, key=lambda entry: entry.name)
+
+        child_directories: list[Path] = []
+        for raw_entry in raw_entries:
+            file_status = raw_entry.stat(follow_symlinks=False)
+            is_link = _is_link_or_reparse_point(file_status)
+            is_directory = stat.S_ISDIR(file_status.st_mode) and not is_link
+            path = Path(raw_entry.path)
+            yield _InstallTreeEntry(
+                path=path,
+                is_directory=is_directory,
+                is_link=is_link,
+            )
+            if is_directory:
+                child_directories.append(path)
+        pending_directories.extend(reversed(child_directories))
+
+
+def _relpaths_by_destination(
+    install_root: Path,
+    relpaths: list[str] | set[str],
+    *,
+    artifact_path: Path,
+    label: str,
+) -> dict[str, str]:
+    relpaths_by_destination: dict[str, str] = {}
+    for relpath in sorted(relpaths):
+        destination = _owned_file_path(install_root, relpath)
+        destination_key = _destination_key(destination)
+        previous = relpaths_by_destination.get(destination_key)
+        if previous is not None:
+            raise RuntimeError(
+                f"Duplicate {label} paths target the same install file in {artifact_path}: "
+                f"{previous}, {relpath}"
+            )
+        relpaths_by_destination[destination_key] = relpath
+    return relpaths_by_destination
+
+
+def _validated_file_entries(
+    payload: dict[str, object],
+    *,
+    artifact_path: Path,
+    install_root: Path,
+) -> list[dict[str, str]]:
+    raw_entries = payload.get("files")
+    if not isinstance(raw_entries, list) or not raw_entries:
+        raise RuntimeError(f"Invalid Vibe owned-files list: {artifact_path}")
+
+    entries: list[dict[str, str]] = []
+    destinations: set[str] = set()
+    for raw_entry in raw_entries:
+        if not isinstance(raw_entry, dict):
+            raise RuntimeError(f"Invalid Vibe owned-file entry: {artifact_path}")
+        relpath = _canonical_owned_relpath(raw_entry.get("path"), artifact_path=artifact_path)
+        expected_sha = raw_entry.get("sha256")
+        if not isinstance(expected_sha, str) or not expected_sha:
+            raise RuntimeError(f"Invalid Vibe owned-file hash for {relpath}: {artifact_path}")
+        expected_sha = expected_sha.lower()
+        destination = _owned_file_path(install_root, relpath)
+        destination_key = _destination_key(destination)
+        if destination_key in destinations:
+            raise RuntimeError(f"Duplicate Vibe owned-file path: {relpath}")
+        destinations.add(destination_key)
+        entries.append({"path": relpath, "sha256": expected_sha})
+    return entries
+
+
+def _file_entry_paths(entries: list[dict[str, str]]) -> set[str]:
+    return {entry["path"] for entry in entries}
+
+
+def _recorded_path_matches(value: object, expected: Path) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        recorded = Path(value)
+        return recorded.is_absolute() and recorded.resolve(strict=False) == expected.resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _operation_lock_path(skills_dir: Path) -> Path:
+    resolved_skills_dir = skills_dir.resolve()
+    lock_path = resolved_skills_dir.joinpath(*PurePosixPath(OPERATION_LOCK_RELPATH).parts)
+    _assert_local_destination(
+        resolved_skills_dir,
+        lock_path,
+        reject_destination_symlink=True,
+        root_label="Skills directory",
+        path_label="Vibe operation lock path",
+    )
+    return lock_path
+
+
+def _is_platform_lock_contention(exc: OSError) -> bool:
+    if exc.errno in {errno.EACCES, errno.EAGAIN}:
+        return True
+    return os.name == "nt" and getattr(exc, "winerror", None) in {32, 33}
+
+
+def _acquire_platform_file_lock(file_descriptor: int, lock_path: Path) -> None:
+    deadline = time.monotonic() + OPERATION_LOCK_TIMEOUT_SECONDS
+    while True:
+        try:
+            os.lseek(file_descriptor, 0, os.SEEK_SET)
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(file_descriptor, msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(file_descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return
+        except OSError as exc:
+            if not _is_platform_lock_contention(exc):
+                raise
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Timed out waiting for another Vibe lifecycle operation: {lock_path}"
+                ) from exc
+            time.sleep(0.05)
+
+
+def _release_platform_file_lock(file_descriptor: int) -> None:
+    os.lseek(file_descriptor, 0, os.SEEK_SET)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(file_descriptor, msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(file_descriptor, fcntl.LOCK_UN)
+
+
+@contextmanager
+def _cross_process_operation_lock(lock_path: Path) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = _operation_lock_path(lock_path.parent.parent)
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    file_descriptor = os.open(lock_path, flags, 0o600)
+    acquired = False
+    try:
+        file_status = os.fstat(file_descriptor)
+        if not stat.S_ISREG(file_status.st_mode):
+            raise RuntimeError(f"Vibe operation lock is not a regular file: {lock_path}")
+        if file_status.st_nlink != 1:
+            raise RuntimeError(f"Vibe operation lock must not be a hard link: {lock_path}")
+        if file_status.st_size == 0:
+            os.write(file_descriptor, b"\0")
+            os.fsync(file_descriptor)
+        _acquire_platform_file_lock(file_descriptor, lock_path)
+        acquired = True
+        yield
+    finally:
+        try:
+            if acquired:
+                _release_platform_file_lock(file_descriptor)
+        finally:
+            os.close(file_descriptor)
+
+
+@contextmanager
+def _vibe_operation_lock(skills_dir: Path) -> Iterator[None]:
+    global _PROCESS_OPERATION_LOCK_DEPTH
+    global _PROCESS_OPERATION_LOCK_PATH
+
+    lock_path = _operation_lock_path(skills_dir)
+    with _PROCESS_OPERATION_LOCK:
+        if _PROCESS_OPERATION_LOCK_DEPTH:
+            if _PROCESS_OPERATION_LOCK_PATH != lock_path:
+                raise RuntimeError("Nested Vibe lifecycle operations use different Skills directories")
+            _PROCESS_OPERATION_LOCK_DEPTH += 1
+            try:
+                yield
+            finally:
+                _PROCESS_OPERATION_LOCK_DEPTH -= 1
+            return
+
+        with _cross_process_operation_lock(lock_path):
+            _PROCESS_OPERATION_LOCK_PATH = lock_path
+            _PROCESS_OPERATION_LOCK_DEPTH = 1
+            try:
+                yield
+            finally:
+                _PROCESS_OPERATION_LOCK_DEPTH = 0
+                _PROCESS_OPERATION_LOCK_PATH = None
+
+
+def _locked_vibe_operation(function: Callable[_P, _R]) -> Callable[_P, _R]:
+    @wraps(function)
+    def locked(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        raw_skills_dir = kwargs.get("skills_dir")
+        if raw_skills_dir is None:
+            raise TypeError("Vibe lifecycle operation requires skills_dir")
+        with _vibe_operation_lock(cast(Path, raw_skills_dir)):
+            return function(*args, **kwargs)
+
+    return locked
+
+
+def _read_install_receipt(
+    receipt_path: Path,
+    *,
+    skills_dir: Path,
+    install_root: Path,
+) -> dict[str, object]:
+    try:
+        receipt = _read_json(receipt_path)
+    except ValueError as exc:
+        raise RuntimeError(f"Unreadable Vibe install receipt: {receipt_path}") from exc
+
+    if receipt.get("schema_version") != 1:
+        raise RuntimeError(f"Unsupported Vibe install receipt schema: {receipt_path}")
+    if receipt.get("receipt_kind") != "vibe-skill-install" or receipt.get("skill_id") != "vibe":
+        raise RuntimeError(f"Invalid Vibe install receipt: {receipt_path}")
+    if not _recorded_path_matches(receipt.get("skills_dir"), skills_dir):
+        raise RuntimeError(f"Vibe install receipt Skills directory mismatch: {receipt_path}")
+    if not _recorded_path_matches(receipt.get("install_root"), install_root):
+        raise RuntimeError(f"Vibe install receipt install root mismatch: {receipt_path}")
+
+    receipt["files"] = _validated_file_entries(
+        receipt,
+        artifact_path=receipt_path,
+        install_root=install_root,
+    )
+    return receipt
+
+
+def _install_state_path(skills_dir: Path) -> Path:
+    resolved_skills_dir = skills_dir.resolve()
+    state_path = resolved_skills_dir.joinpath(*PurePosixPath(INSTALL_STATE_RELPATH).parts)
+    _assert_local_destination(
+        resolved_skills_dir,
+        state_path,
+        reject_destination_symlink=True,
+        root_label="Skills directory",
+        path_label="Vibe install state path",
+    )
+    return state_path
+
+
+def _validated_transaction_id(value: object, *, state_path: Path) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 32
+        or value != value.lower()
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise RuntimeError(f"Invalid transaction ID in Vibe install state: {state_path}")
+    return value
+
+
+def _validate_install_state_header(
+    state: dict[str, object],
+    *,
+    state_path: Path,
+    skills_dir: Path,
+    install_root: Path,
+) -> tuple[str, str]:
+    if state.get("schema_version") != 1:
+        raise RuntimeError(f"Unsupported Vibe install state schema: {state_path}")
+    if state.get("state_kind") != INSTALL_STATE_KIND or state.get("skill_id") != "vibe":
+        raise RuntimeError(f"Invalid Vibe install state: {state_path}")
+    status = state.get("status")
+    if status not in {INSTALL_STATE_PREPARING, INSTALL_STATE_PREPARED}:
+        raise RuntimeError(f"Invalid Vibe install state status: {state_path}")
+    if not _recorded_path_matches(state.get("skills_dir"), skills_dir):
+        raise RuntimeError(f"Vibe install state Skills directory mismatch: {state_path}")
+    if not _recorded_path_matches(state.get("install_root"), install_root):
+        raise RuntimeError(f"Vibe install state install root mismatch: {state_path}")
+    transaction_id = _validated_transaction_id(
+        state.get("transaction_id"),
+        state_path=state_path,
+    )
+    return cast(str, status), transaction_id
+
+
+def _validated_transaction_sha256(
+    value: object,
+    *,
+    state_path: Path,
+    label: str,
+    required: bool,
+) -> str:
+    if value is None and not required:
+        return ""
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or value != value.lower()
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise RuntimeError(f"Invalid {label} hash in Vibe install state: {state_path}")
+    return value
+
+
+def _validated_transaction_temp_path(
+    value: object,
+    *,
+    state_path: Path,
+    install_root: Path,
+    destination: Path,
+    transaction_id: str,
+    label: str,
+) -> Path:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"Invalid {label} path in Vibe install state: {state_path}")
+    temporary_path = Path(value)
+    if not temporary_path.is_absolute():
+        raise RuntimeError(f"Relative {label} path in Vibe install state: {state_path}")
+    _assert_local_destination(
+        install_root,
+        temporary_path,
+        reject_destination_symlink=True,
+        path_label=f"Vibe install transaction {label} path",
+    )
+    if _destination_key(temporary_path.parent) != _destination_key(destination.parent):
+        raise RuntimeError(f"Misplaced {label} path in Vibe install state: {state_path}")
+    expected_prefix = _temporary_file_prefix(destination, transaction_id)
+    if (
+        not temporary_path.name.startswith(expected_prefix)
+        or not temporary_path.name.endswith(".tmp")
+        or len(temporary_path.name) <= len(expected_prefix) + len(".tmp")
+    ):
+        raise RuntimeError(f"Unexpected {label} name in Vibe install state: {state_path}")
+    if (temporary_path.exists() or temporary_path.is_symlink()) and not temporary_path.is_file():
+        raise RuntimeError(f"Vibe install transaction {label} is not a file: {temporary_path}")
+    return temporary_path
+
+
+def _build_preparing_install_state(
+    *,
+    skills_dir: Path,
+    install_root: Path,
+    transaction_id: str,
+    receipt_existed: bool,
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "state_kind": INSTALL_STATE_KIND,
+        "skill_id": "vibe",
+        "skills_dir": str(skills_dir.resolve()),
+        "install_root": str(install_root.resolve(strict=False)),
+        "transaction_id": transaction_id,
+        "status": INSTALL_STATE_PREPARING,
+        "receipt_existed": receipt_existed,
+    }
+
+
+def _build_install_state(
+    *,
+    skills_dir: Path,
+    install_root: Path,
+    transaction_id: str,
+    changes: list[_InstallFileChange],
+) -> dict[str, object]:
+    receipt_change = changes[-1]
+    if receipt_change.relpath != RECEIPT_RELPATH or not receipt_change.new_sha256:
+        raise RuntimeError("Vibe install transaction has no receipt commit marker")
+    return {
+        "schema_version": 1,
+        "state_kind": INSTALL_STATE_KIND,
+        "skill_id": "vibe",
+        "skills_dir": str(skills_dir.resolve()),
+        "install_root": str(install_root.resolve()),
+        "transaction_id": transaction_id,
+        "status": INSTALL_STATE_PREPARED,
+        "receipt_sha256": receipt_change.new_sha256,
+        "changes": [
+            {
+                "relpath": change.relpath,
+                "destination": str(change.destination.resolve(strict=False)),
+                "staged_path": (
+                    str(change.staged_path.resolve(strict=False))
+                    if change.staged_path is not None
+                    else None
+                ),
+                "backup_path": (
+                    str(change.backup_path.resolve(strict=False))
+                    if change.backup_path is not None
+                    else None
+                ),
+                "destination_existed": change.destination_existed,
+                "old_sha256": change.old_sha256 or None,
+                "new_sha256": change.new_sha256 or None,
+            }
+            for change in changes
+        ],
+    }
+
+
+def _read_install_state(
+    state_path: Path,
+    *,
+    skills_dir: Path,
+    install_root: Path,
+    state: dict[str, object] | None = None,
+) -> list[_InstallFileChange]:
+    if state is None:
+        try:
+            state = _read_json(state_path)
+        except ValueError as exc:
+            raise RuntimeError(f"Unreadable Vibe install state: {state_path}") from exc
+    status, transaction_id = _validate_install_state_header(
+        state,
+        state_path=state_path,
+        skills_dir=skills_dir,
+        install_root=install_root,
+    )
+    if status != INSTALL_STATE_PREPARED:
+        raise RuntimeError(f"Invalid Vibe install state status: {state_path}")
+
+    raw_changes = state.get("changes")
+    if not isinstance(raw_changes, list) or not raw_changes:
+        raise RuntimeError(f"Invalid Vibe install changes list: {state_path}")
+
+    changes: list[_InstallFileChange] = []
+    destination_keys: set[str] = set()
+    temporary_keys: set[str] = set()
+    receipt_count = 0
+    for raw_change in raw_changes:
+        if not isinstance(raw_change, dict):
+            raise RuntimeError(f"Invalid Vibe install change entry: {state_path}")
+        relpath_value = raw_change.get("relpath")
+        is_receipt = relpath_value == RECEIPT_RELPATH
+        if is_receipt:
+            receipt_count += 1
+            relpath = RECEIPT_RELPATH
+            destination = install_root.joinpath(*PurePosixPath(RECEIPT_RELPATH).parts)
+            _assert_install_destination_is_local(install_root, destination)
+        else:
+            relpath = _canonical_owned_relpath(
+                relpath_value,
+                artifact_path=state_path,
+                label="install transaction",
+            )
+            destination = _owned_file_path(install_root, relpath)
+
+        if not _recorded_path_matches(raw_change.get("destination"), destination):
+            raise RuntimeError(
+                f"Vibe install state destination mismatch for {relpath}: {state_path}"
+            )
+        destination_key = _destination_key(destination)
+        if destination_key in destination_keys or destination_key in temporary_keys:
+            raise RuntimeError(f"Duplicate Vibe install transaction destination: {state_path}")
+        destination_keys.add(destination_key)
+
+        destination_existed = raw_change.get("destination_existed")
+        if type(destination_existed) is not bool:
+            raise RuntimeError(f"Invalid destination state for {relpath}: {state_path}")
+        old_sha256 = _validated_transaction_sha256(
+            raw_change.get("old_sha256"),
+            state_path=state_path,
+            label=f"old {relpath}",
+            required=destination_existed,
+        )
+        if not destination_existed and raw_change.get("old_sha256") is not None:
+            raise RuntimeError(f"Unexpected old hash for {relpath}: {state_path}")
+
+        raw_staged_path = raw_change.get("staged_path")
+        has_staged_path = raw_staged_path is not None
+        if is_receipt and not has_staged_path:
+            raise RuntimeError(f"Missing staged receipt in Vibe install state: {state_path}")
+        new_sha256 = _validated_transaction_sha256(
+            raw_change.get("new_sha256"),
+            state_path=state_path,
+            label=f"new {relpath}",
+            required=has_staged_path,
+        )
+        if not has_staged_path and raw_change.get("new_sha256") is not None:
+            raise RuntimeError(f"Unexpected new hash for {relpath}: {state_path}")
+
+        staged_path = None
+        if has_staged_path:
+            staged_path = _validated_transaction_temp_path(
+                raw_staged_path,
+                state_path=state_path,
+                install_root=install_root,
+                destination=destination,
+                transaction_id=transaction_id,
+                label="staged file",
+            )
+        raw_backup_path = raw_change.get("backup_path")
+        if destination_existed:
+            backup_path = _validated_transaction_temp_path(
+                raw_backup_path,
+                state_path=state_path,
+                install_root=install_root,
+                destination=destination,
+                transaction_id=transaction_id,
+                label="backup file",
+            )
+        else:
+            if raw_backup_path is not None:
+                raise RuntimeError(f"Unexpected backup path for {relpath}: {state_path}")
+            backup_path = None
+
+        for temporary_path in (staged_path, backup_path):
+            if temporary_path is None:
+                continue
+            temporary_key = _destination_key(temporary_path)
+            if temporary_key in temporary_keys or temporary_key in destination_keys:
+                raise RuntimeError(f"Duplicate Vibe install transaction path: {state_path}")
+            temporary_keys.add(temporary_key)
+
+        changes.append(
+            _InstallFileChange(
+                relpath=relpath,
+                destination=destination,
+                staged_path=staged_path,
+                backup_path=backup_path,
+                destination_existed=destination_existed,
+                old_sha256=old_sha256,
+                new_sha256=new_sha256,
+            )
+        )
+
+    if receipt_count != 1 or changes[-1].relpath != RECEIPT_RELPATH:
+        raise RuntimeError(f"Vibe install state receipt must be the final change: {state_path}")
+    receipt_sha256 = _validated_transaction_sha256(
+        state.get("receipt_sha256"),
+        state_path=state_path,
+        label="receipt commit marker",
+        required=True,
+    )
+    if receipt_sha256 != changes[-1].new_sha256:
+        raise RuntimeError(f"Vibe install state receipt marker mismatch: {state_path}")
+    return changes
+
+
+def _current_install_file_sha256(path: Path, *, relpath: str) -> str | None:
+    if _path_is_link_or_reparse_point(path):
+        raise RuntimeError(f"Vibe install transaction path became a link or junction: {relpath}")
+    if not path.exists():
+        return None
+    if not path.is_file():
+        raise RuntimeError(f"Vibe install transaction path is not a file: {relpath}")
+    return _sha256_file(path)
+
+
+def _install_change_state(change: _InstallFileChange) -> str:
+    current_sha256 = _current_install_file_sha256(
+        change.destination,
+        relpath=change.relpath,
+    )
+    if change.new_sha256 and current_sha256 == change.new_sha256:
+        return "new"
+    if change.destination_existed and current_sha256 == change.old_sha256:
+        return "old"
+    if current_sha256 is None:
+        if not change.new_sha256:
+            return "new"
+        if not change.destination_existed:
+            return "old"
+    raise RuntimeError(
+        f"Vibe install transaction destination drifted during recovery: {change.relpath}"
+    )
+
+
+def _validated_existing_transaction_file(
+    path: Path,
+    *,
+    expected_sha256: str,
+    label: str,
+) -> bool:
+    if _path_is_link_or_reparse_point(path):
+        raise RuntimeError(f"Vibe install transaction {label} became a link or junction: {path}")
+    if not path.exists():
+        return False
+    if not path.is_file():
+        raise RuntimeError(f"Vibe install transaction {label} is not a file: {path}")
+    if _sha256_file(path) != expected_sha256:
+        raise RuntimeError(f"Vibe install transaction {label} hash mismatch: {path}")
+    return True
+
+
+def _cleanup_install_transaction_files(
+    changes: list[_InstallFileChange],
+) -> list[_InstallOperationFailure]:
+    failures: list[_InstallOperationFailure] = []
+    for change in changes:
+        temporary_files = (
+            (change.staged_path, change.new_sha256, "staged file"),
+            (change.backup_path, change.old_sha256, "backup file"),
+        )
+        for temporary_path, expected_sha256, label in temporary_files:
+            if temporary_path is None:
+                continue
+            try:
+                exists = _validated_existing_transaction_file(
+                    temporary_path,
+                    expected_sha256=expected_sha256,
+                    label=label,
+                )
+                if exists:
+                    temporary_path.unlink()
+            except (OSError, RuntimeError) as exc:
+                failures.append(
+                    _InstallOperationFailure(
+                        detail=(
+                            f"{temporary_path}: {exc}"
+                            if isinstance(exc, OSError)
+                            else str(exc)
+                        ),
+                        error=exc,
+                    )
+                )
+    return failures
+
+
+def _rollback_persisted_install_changes(
+    changes: list[_InstallFileChange],
+) -> list[_InstallOperationFailure]:
+    try:
+        change_states = [_install_change_state(change) for change in changes]
+        for change, change_state in zip(changes, change_states):
+            if change_state != "new" or not change.destination_existed:
+                continue
+            if change.old_sha256 == change.new_sha256:
+                continue
+            if change.backup_path is None or not _validated_existing_transaction_file(
+                change.backup_path,
+                expected_sha256=change.old_sha256,
+                label="rollback backup",
+            ):
+                raise RuntimeError(f"Missing Vibe install rollback backup: {change.relpath}")
+    except (OSError, RuntimeError) as exc:
+        return [_InstallOperationFailure(detail=str(exc), error=exc)]
+
+    failures: list[_InstallOperationFailure] = []
+    for change, change_state in reversed(list(zip(changes, change_states))):
+        if change_state != "new" or change.old_sha256 == change.new_sha256:
             continue
-        files.append({"path": relpath, "sha256": _sha256_file(file_path)})
-    return files
+        try:
+            if change.destination_existed:
+                if change.backup_path is None:
+                    raise RuntimeError(f"Missing rollback backup for {change.destination}")
+                os.replace(change.backup_path, change.destination)
+            else:
+                change.destination.unlink()
+            if _install_change_state(change) != "old":
+                raise RuntimeError(f"Rollback verification failed for {change.destination}")
+        except (OSError, RuntimeError) as exc:
+            failures.append(
+                _InstallOperationFailure(
+                    detail=f"{change.destination}: {exc}",
+                    error=exc,
+                )
+            )
+    return failures
 
 
-def _receipt_file_paths(receipt: dict[str, object]) -> set[str]:
-    owned: set[str] = set()
-    for entry in receipt.get("files") or []:
-        if isinstance(entry, dict):
-            owned.add(str(entry["path"]))
-    return owned
+def _remove_install_state_file(
+    state_path: Path,
+    *,
+    failure_summary: str,
+) -> None:
+    try:
+        state_path.unlink()
+    except OSError as exc:
+        _raise_install_operation_failures(
+            failure_summary,
+            [
+                _InstallOperationFailure(
+                    detail=f"recovery journal retained at {state_path}; {state_path}: {exc}",
+                    error=exc,
+                )
+            ],
+        )
+
+
+def _cleanup_preparing_install_transaction(
+    *,
+    install_root: Path,
+    transaction_id: str,
+) -> list[_InstallOperationFailure]:
+    if not install_root.exists():
+        return []
+    marker = f".{transaction_id}."
+    failures: list[_InstallOperationFailure] = []
+    try:
+        candidates = [
+            entry.path
+            for entry in _install_tree_entries(install_root)
+            if not entry.is_directory
+            and not entry.is_link
+            and entry.path.name.endswith(".tmp")
+        ]
+    except OSError as exc:
+        return [
+            _InstallOperationFailure(
+                detail=f"{install_root}: {exc}",
+                error=exc,
+            )
+        ]
+    for candidate in candidates:
+        if marker not in candidate.name:
+            continue
+        try:
+            _assert_local_destination(
+                install_root,
+                candidate,
+                reject_destination_symlink=True,
+                path_label="Vibe preparing transaction temporary path",
+            )
+            if not candidate.is_file():
+                raise RuntimeError(
+                    f"Vibe preparing transaction temporary path is not a file: {candidate}"
+                )
+            candidate.unlink()
+        except (OSError, RuntimeError) as exc:
+            failures.append(
+                _InstallOperationFailure(
+                    detail=f"{candidate}: {exc}",
+                    error=exc,
+                )
+            )
+    return failures
+
+
+def _recover_install_transaction(
+    *,
+    state_path: Path,
+    skills_dir: Path,
+    install_root: Path,
+) -> _InstallRecovery:
+    try:
+        state = _read_json(state_path)
+    except ValueError as exc:
+        raise RuntimeError(f"Unreadable Vibe install state: {state_path}") from exc
+    status, transaction_id = _validate_install_state_header(
+        state,
+        state_path=state_path,
+        skills_dir=skills_dir,
+        install_root=install_root,
+    )
+    if status == INSTALL_STATE_PREPARING:
+        receipt_existed = state.get("receipt_existed")
+        if type(receipt_existed) is not bool:
+            raise RuntimeError(f"Invalid preparing Vibe install state: {state_path}")
+        cleanup_failures = _cleanup_preparing_install_transaction(
+            install_root=install_root,
+            transaction_id=transaction_id,
+        )
+        if cleanup_failures:
+            _raise_install_operation_failures(
+                "Vibe install preparation cleanup was incomplete; "
+                f"recovery journal retained at {state_path}; "
+                "cleanup failures",
+                cleanup_failures,
+            )
+        _remove_install_state_file(
+            state_path,
+            failure_summary="Vibe install preparation journal cleanup was incomplete",
+        )
+        return _InstallRecovery(
+            disposition=INSTALL_RECOVERY_ROLLED_BACK,
+            receipt_existed=receipt_existed,
+        )
+
+    changes = _read_install_state(
+        state_path,
+        skills_dir=skills_dir,
+        install_root=install_root,
+        state=state,
+    )
+    receipt_change = changes[-1]
+    receipt_state = _install_change_state(receipt_change)
+    if receipt_state == "new":
+        for change in changes:
+            if _install_change_state(change) != "new":
+                raise RuntimeError(
+                    "Vibe install receipt was committed before every payload change completed; "
+                    f"recovery journal retained at {state_path}"
+                )
+        cleanup_failures = _cleanup_install_transaction_files(changes)
+        if cleanup_failures:
+            _raise_install_operation_failures(
+                "Vibe install transaction cleanup was incomplete; "
+                f"recovery journal retained at {state_path}; "
+                "cleanup failures",
+                cleanup_failures,
+            )
+        _remove_install_state_file(
+            state_path,
+            failure_summary="Vibe install transaction cleanup was incomplete",
+        )
+        return _InstallRecovery(
+            disposition=INSTALL_RECOVERY_COMMITTED,
+            receipt_existed=receipt_change.destination_existed,
+        )
+
+    rollback_failures = _rollback_persisted_install_changes(changes)
+    if rollback_failures:
+        retained_backups = sorted(
+            str(change.backup_path)
+            for change in changes
+            if change.backup_path is not None and change.backup_path.exists()
+        )
+        backup_detail = ", ".join(retained_backups) or "none"
+        _raise_install_operation_failures(
+            "Vibe install failed and rollback was incomplete; "
+            f"recovery journal retained at {state_path}; "
+            f"recovery backups retained at: {backup_detail}; rollback failures",
+            rollback_failures,
+        )
+
+    cleanup_failures = _cleanup_install_transaction_files(changes)
+    if cleanup_failures:
+        _raise_install_operation_failures(
+            "Vibe install rollback completed and temporary-file cleanup was incomplete; "
+            f"recovery journal retained at {state_path}; "
+            "cleanup failures",
+            cleanup_failures,
+        )
+    _remove_install_state_file(
+        state_path,
+        failure_summary="Vibe install rollback completed and journal cleanup was incomplete",
+    )
+    return _InstallRecovery(
+        disposition=INSTALL_RECOVERY_ROLLED_BACK,
+        receipt_existed=receipt_change.destination_existed,
+    )
+
+
+def _recover_pending_install_transaction(
+    *,
+    skills_dir: Path,
+    install_root: Path,
+) -> _InstallRecovery | None:
+    state_path = _install_state_path(skills_dir)
+    if not state_path.exists() and not state_path.is_symlink():
+        return None
+    if not state_path.is_file():
+        raise RuntimeError(f"Vibe install state is not a regular file: {state_path}")
+    return _recover_install_transaction(
+        state_path=state_path,
+        skills_dir=skills_dir,
+        install_root=install_root,
+    )
 
 
 def _uninstall_state_path(skills_dir: Path) -> Path:
-    return skills_dir.resolve() / "vibe" / UNINSTALL_STATE_RELPATH
+    resolved_skills_dir = skills_dir.resolve()
+    state_path = resolved_skills_dir.joinpath(*PurePosixPath(UNINSTALL_STATE_RELPATH).parts)
+    _assert_local_destination(
+        resolved_skills_dir,
+        state_path,
+        reject_destination_symlink=True,
+        root_label="Skills directory",
+        path_label="Vibe uninstall state path",
+    )
+    return state_path
+
+
+def _uninstall_completion_path(skills_dir: Path) -> Path:
+    resolved_skills_dir = skills_dir.resolve()
+    completion_path = resolved_skills_dir.joinpath(
+        *PurePosixPath(UNINSTALL_COMPLETE_RELPATH).parts
+    )
+    _assert_local_destination(
+        resolved_skills_dir,
+        completion_path,
+        reject_destination_symlink=True,
+        root_label="Skills directory",
+        path_label="Vibe uninstall completion path",
+    )
+    return completion_path
 
 
 def _read_uninstall_state(
@@ -180,89 +1683,163 @@ def _read_uninstall_state(
     skills_dir: Path,
     install_root: Path,
 ) -> dict[str, object]:
-    state = _read_json(state_path)
+    try:
+        state = _read_json(state_path)
+    except ValueError as exc:
+        raise RuntimeError(f"Unreadable Vibe uninstall state: {state_path}") from exc
     expected_skills_dir = skills_dir.resolve()
     expected_install_root = install_root.resolve()
     if state.get("schema_version") != 1:
         raise RuntimeError(f"Unsupported Vibe uninstall state schema: {state_path}")
     if state.get("state_kind") != UNINSTALL_STATE_KIND or state.get("skill_id") != "vibe":
         raise RuntimeError(f"Invalid Vibe uninstall state: {state_path}")
-    if Path(str(state.get("skills_dir") or "")).resolve() != expected_skills_dir:
+    if not _recorded_path_matches(state.get("skills_dir"), expected_skills_dir):
         raise RuntimeError(f"Vibe uninstall state Skills directory mismatch: {state_path}")
-    if Path(str(state.get("install_root") or "")).resolve() != expected_install_root:
+    if not _recorded_path_matches(state.get("install_root"), expected_install_root):
         raise RuntimeError(f"Vibe uninstall state install root mismatch: {state_path}")
-    if state.get("status") != "managed_files_removed":
+    if state.get("status") != UNINSTALL_STATE_MANAGED_FILES_REMOVED:
         raise RuntimeError(f"Invalid Vibe uninstall state status: {state_path}")
     return state
+
+
+def _read_uninstall_completion(
+    completion_path: Path,
+    *,
+    skills_dir: Path,
+    install_root: Path,
+) -> dict[str, object]:
+    try:
+        completion = _read_json(completion_path)
+    except ValueError as exc:
+        raise RuntimeError(f"Unreadable Vibe uninstall completion: {completion_path}") from exc
+    if completion.get("schema_version") != 1:
+        raise RuntimeError(f"Unsupported Vibe uninstall completion schema: {completion_path}")
+    if (
+        completion.get("completion_kind") != UNINSTALL_COMPLETE_KIND
+        or completion.get("skill_id") != "vibe"
+    ):
+        raise RuntimeError(f"Invalid Vibe uninstall completion: {completion_path}")
+    if not _recorded_path_matches(completion.get("skills_dir"), skills_dir):
+        raise RuntimeError(f"Vibe uninstall completion Skills directory mismatch: {completion_path}")
+    if not _recorded_path_matches(completion.get("install_root"), install_root):
+        raise RuntimeError(f"Vibe uninstall completion install root mismatch: {completion_path}")
+    if completion.get("status") != UNINSTALL_COMPLETE_STATUS:
+        raise RuntimeError(f"Invalid Vibe uninstall completion status: {completion_path}")
+    return completion
+
+
+def _validate_uninstall_completion(
+    completion_path: Path,
+    *,
+    skills_dir: Path,
+    install_root: Path,
+) -> bool:
+    if not completion_path.exists() and not completion_path.is_symlink():
+        return False
+    if not completion_path.is_file():
+        raise RuntimeError(f"Vibe uninstall completion is not a regular file: {completion_path}")
+    _read_uninstall_completion(
+        completion_path,
+        skills_dir=skills_dir,
+        install_root=install_root,
+    )
+    return True
+
+
+def _clear_uninstall_completion(
+    completion_path: Path,
+    *,
+    skills_dir: Path,
+    install_root: Path,
+) -> None:
+    if not _validate_uninstall_completion(
+        completion_path,
+        skills_dir=skills_dir,
+        install_root=install_root,
+    ):
+        return
+    completion_path.unlink()
 
 
 def _is_recoverable_empty_install_root(install_root: Path) -> bool:
     if not install_root.is_dir() or install_root.is_symlink():
         return False
     try:
-        entries = list(install_root.rglob("*"))
+        entries = list(_install_tree_entries(install_root))
     except OSError:
         return False
     for entry in entries:
-        if entry.is_symlink() or not entry.is_dir():
-            return False
-        if entry.relative_to(install_root).as_posix() != ".vibeskills":
+        if not entry.is_directory:
             return False
     return True
 
 
-def _assert_install_destination_is_local(install_root: Path, destination: Path) -> None:
-    if install_root.is_symlink():
-        raise RuntimeError(f"Install root must not be a symbolic link: {install_root}")
-    current = destination.parent
-    while current != install_root.parent:
-        if current.is_symlink():
-            raise RuntimeError(f"Install path traverses a symbolic link: {destination}")
-        if current == install_root:
-            return
-        current = current.parent
-    raise RuntimeError(f"Install path escapes the Vibe install root: {destination}")
-
-
 def _preserved_file_relpaths(install_root: Path, *, owned_files: set[str]) -> list[str]:
-    internal_files = {RECEIPT_RELPATH, UNINSTALL_STATE_RELPATH}
+    internal_files = {RECEIPT_RELPATH}
     preserved: list[str] = []
-    for path in install_root.rglob("*"):
-        if not path.is_file() and not path.is_symlink():
+    for entry in _install_tree_entries(install_root):
+        if entry.is_directory:
             continue
+        path = entry.path
         relpath = path.relative_to(install_root).as_posix()
         if relpath not in internal_files and relpath not in owned_files:
             preserved.append(relpath)
     return sorted(set(preserved))
 
 
-def _prune_empty_directories(install_root: Path) -> list[str]:
+def _prune_empty_directories(
+    install_root: Path,
+) -> tuple[list[str], list[str], list[str]]:
     metadata_dir = install_root / ".vibeskills"
     try:
         directories = sorted(
-            (path for path in install_root.rglob("*") if path.is_dir()),
+            (
+                entry.path
+                for entry in _install_tree_entries(install_root)
+                if entry.is_directory
+            ),
             key=lambda path: len(path.parts),
             reverse=True,
         )
-    except OSError:
-        return ["."]
+    except OSError as exc:
+        permission_denied = ["."] if isinstance(exc, PermissionError) else []
+        unavailable = ["."] if isinstance(exc, TimeoutError) else []
+        return ["."], permission_denied, unavailable
 
     failed: list[str] = []
+    permission_denied: list[str] = []
+    unavailable: list[str] = []
     for directory in directories:
         if directory == metadata_dir or metadata_dir in directory.parents:
             continue
         try:
             directory.rmdir()
+        except TimeoutError:
+            relpath = directory.relative_to(install_root).as_posix()
+            failed.append(relpath)
+            unavailable.append(relpath)
         except PermissionError:
-            failed.append(directory.relative_to(install_root).as_posix())
+            relpath = directory.relative_to(install_root).as_posix()
+            failed.append(relpath)
+            permission_denied.append(relpath)
         except OSError:
             try:
                 is_empty = next(directory.iterdir(), None) is None
+            except TimeoutError:
+                is_empty = True
+                unavailable.append(directory.relative_to(install_root).as_posix())
+            except PermissionError:
+                is_empty = True
+                permission_denied.append(directory.relative_to(install_root).as_posix())
             except OSError:
                 is_empty = True
             if is_empty:
                 failed.append(directory.relative_to(install_root).as_posix())
-    return sorted(set(failed))
+    return (
+        sorted(set(failed)),
+        sorted(set(permission_denied)),
+        sorted(set(unavailable)),
+    )
 
 
 def _uninstall_result(
@@ -272,6 +1849,10 @@ def _uninstall_result(
     removed_files: list[str],
     failed_files: list[str] | None = None,
     failed_directories: list[str] | None = None,
+    permission_denied_files: list[str] | None = None,
+    permission_denied_directories: list[str] | None = None,
+    unavailable_files: list[str] | None = None,
+    unavailable_directories: list[str] | None = None,
     preserved_files: list[str] | None = None,
     recovery_state: str = "",
 ) -> dict[str, object]:
@@ -281,20 +1862,85 @@ def _uninstall_result(
         "removed_files": sorted(set(removed_files)),
         "failed_files": sorted(set(failed_files or [])),
         "failed_directories": sorted(set(failed_directories or [])),
+        "permission_denied_files": sorted(set(permission_denied_files or [])),
+        "permission_denied_directories": sorted(set(permission_denied_directories or [])),
+        "unavailable_files": sorted(set(unavailable_files or [])),
+        "unavailable_directories": sorted(set(unavailable_directories or [])),
         "preserved_files": sorted(set(preserved_files or [])),
         "recovery_state": recovery_state,
     }
 
 
-def _remove_retired_owned_files(install_root: Path, *, old_owned: set[str], next_owned: set[str]) -> None:
-    for relpath in sorted(old_owned - next_owned, reverse=True):
-        file_path = install_root / relpath
-        if file_path.is_file():
-            file_path.unlink()
+def _build_recovery_state(
+    *,
+    skills_dir: Path,
+    install_root: Path,
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "state_kind": UNINSTALL_STATE_KIND,
+        "skill_id": "vibe",
+        "skills_dir": str(skills_dir.resolve()),
+        "install_root": str(install_root.resolve()),
+        "status": UNINSTALL_STATE_MANAGED_FILES_REMOVED,
+    }
 
 
-def _receipt_path(skills_dir: Path) -> Path:
-    return skills_dir.resolve() / "vibe" / RECEIPT_RELPATH
+def _remove_uninstall_state_file(state_path: Path) -> None:
+    state_path.unlink(missing_ok=True)
+
+
+def _commit_uninstall_completion(
+    *,
+    state_path: Path,
+    state: dict[str, object],
+) -> _UninstallCompletionCommitFailure | None:
+    completion_path = _uninstall_completion_path(state_path.parent.parent)
+    completion = {
+        "schema_version": 1,
+        "completion_kind": UNINSTALL_COMPLETE_KIND,
+        "skill_id": "vibe",
+        "skills_dir": state["skills_dir"],
+        "install_root": state["install_root"],
+        "status": UNINSTALL_COMPLETE_STATUS,
+    }
+    try:
+        _write_json(completion_path, completion)
+    except OSError as exc:
+        return _UninstallCompletionCommitFailure(
+            relpath=UNINSTALL_COMPLETE_RELPATH,
+            error=exc,
+        )
+    try:
+        state_path.unlink()
+    except OSError as exc:
+        return _UninstallCompletionCommitFailure(
+            relpath=UNINSTALL_STATE_RELPATH,
+            error=exc,
+        )
+    return None
+
+
+def _uninstall_completion_commit_failure_result(
+    failure: _UninstallCompletionCommitFailure,
+    *,
+    removed_files: list[str],
+) -> dict[str, object]:
+    permission_denied_files = (
+        [failure.relpath] if isinstance(failure.error, PermissionError) else []
+    )
+    unavailable_files = (
+        [failure.relpath] if isinstance(failure.error, TimeoutError) else []
+    )
+    return _uninstall_result(
+        ok=False,
+        status="partial_failure",
+        removed_files=removed_files,
+        failed_files=[failure.relpath],
+        permission_denied_files=permission_denied_files,
+        unavailable_files=unavailable_files,
+        recovery_state=UNINSTALL_STATE_RELPATH,
+    )
 
 
 def _scoped_check_result(payload: dict[str, object]) -> dict[str, object]:
@@ -317,6 +1963,7 @@ def _scoped_check_result(payload: dict[str, object]) -> dict[str, object]:
     }
 
 
+@_locked_vibe_operation
 def install_vibe_skill(
     *,
     repo_root: Path,
@@ -335,9 +1982,35 @@ def install_vibe_skill(
     resolved_skills_dir = skills_dir.resolve()
     install_root = resolved_skills_dir / "vibe"
     receipt_path = install_root / RECEIPT_RELPATH
-    uninstall_state_path = install_root / UNINSTALL_STATE_RELPATH
-    if install_root.exists() and install_root.is_symlink():
-        raise RuntimeError(f"Install root must not be a symbolic link: {install_root}")
+    install_state_path = _install_state_path(resolved_skills_dir)
+    uninstall_state_path = _uninstall_state_path(resolved_skills_dir)
+    uninstall_completion_path = _uninstall_completion_path(resolved_skills_dir)
+    _assert_install_root_is_local(resolved_skills_dir, install_root)
+    _assert_install_destination_is_local(install_root, receipt_path)
+    _recover_pending_install_transaction(
+        skills_dir=resolved_skills_dir,
+        install_root=install_root,
+    )
+    _validate_uninstall_completion(
+        uninstall_completion_path,
+        skills_dir=resolved_skills_dir,
+        install_root=install_root,
+    )
+
+    normalized_source_kind = str(source_kind or "").strip() or "developer_repo"
+    release_payload: dict[str, object] | None = None
+    if normalized_source_kind == "public_release":
+        version = str(release_version or "").strip()
+        asset_name = str(release_asset_name or "").strip()
+        if not version or not asset_name:
+            raise RuntimeError("Public release install requires release version and asset name.")
+        release_payload = {
+            "version": version,
+            "asset_name": asset_name,
+        }
+        digest = str(release_asset_digest or "").strip()
+        if digest:
+            release_payload["asset_digest_sha256"] = digest
 
     has_receipt = receipt_path.is_file()
     has_uninstall_state = uninstall_state_path.is_file()
@@ -356,26 +2029,92 @@ def install_vibe_skill(
         raise RuntimeError(f"Install root already exists without a Vibe install receipt: {install_root}")
 
     install_root.mkdir(parents=True, exist_ok=True)
-    next_owned = _package_file_relpaths(source_root)
-    old_owned: set[str] = set()
-    if has_receipt:
-        old_owned = _receipt_file_paths(_read_json(receipt_path))
-    for relpath in next_owned:
+    governance_path = source_root / "config" / "version-governance.json"
+    next_owned: list[str] = []
+    for relpath in _package_file_relpaths(source_root):
         destination = install_root / relpath
         _assert_install_destination_is_local(install_root, destination)
-        if (destination.exists() or destination.is_symlink()) and relpath not in old_owned:
+        next_owned.append(_canonical_owned_relpath(relpath, artifact_path=governance_path, label="package"))
+    if not next_owned:
+        raise RuntimeError(f"Runtime packaging contract selects no installable files: {governance_path}")
+    next_owned_by_destination = _relpaths_by_destination(
+        install_root,
+        next_owned,
+        artifact_path=governance_path,
+        label="package",
+    )
+    old_owned: set[str] = set()
+    old_owned_by_destination: dict[str, str] = {}
+    if has_receipt:
+        receipt = _read_install_receipt(
+            receipt_path,
+            skills_dir=resolved_skills_dir,
+            install_root=install_root,
+        )
+        old_owned = _file_entry_paths(cast(list[dict[str, str]], receipt["files"]))
+        old_owned_by_destination = _relpaths_by_destination(
+            install_root,
+            old_owned,
+            artifact_path=receipt_path,
+            label="receipt-owned",
+        )
+    for destination_key, relpath in next_owned_by_destination.items():
+        destination = _owned_file_path(install_root, relpath)
+        if (
+            destination.exists() or destination.is_symlink()
+        ) and destination_key not in old_owned_by_destination:
             raise RuntimeError(f"Install path exists but is not owned by the Vibe receipt: {destination}")
-    _remove_retired_owned_files(install_root, old_owned=old_owned, next_owned=set(next_owned))
 
-    _copy_package_files(source_root, install_root, next_owned)
+    transaction_id = secrets.token_hex(16)
+    preparing_state = _build_preparing_install_state(
+        skills_dir=resolved_skills_dir,
+        install_root=install_root,
+        transaction_id=transaction_id,
+        receipt_existed=has_receipt,
+    )
+    if install_state_path.exists() or install_state_path.is_symlink():
+        raise RuntimeError(f"Vibe install transaction already exists: {install_state_path}")
+    _write_json(install_state_path, preparing_state)
 
-    files = _installed_files(install_root, next_owned)
-    package_digest = hashlib.sha256(json.dumps(files, sort_keys=True).encode("utf-8")).hexdigest()
+    try:
+        payload_changes = _prepare_install_file_changes(
+            source_root,
+            install_root,
+            next_owned,
+            retired_relpaths={
+                relpath
+                for destination_key, relpath in old_owned_by_destination.items()
+                if destination_key not in next_owned_by_destination
+            },
+            transaction_id=transaction_id,
+        )
+    except BaseException:
+        _recover_install_transaction(
+            state_path=install_state_path,
+            skills_dir=resolved_skills_dir,
+            install_root=install_root,
+        )
+        raise
+    payload_changes_by_relpath = {
+        change.relpath: change
+        for change in payload_changes
+        if change.new_sha256
+    }
+    files = [
+        {
+            "path": relpath,
+            "sha256": payload_changes_by_relpath[relpath].new_sha256,
+        }
+        for relpath in next_owned
+    ]
+    package_digest = hashlib.sha256(
+        json.dumps(files, sort_keys=True).encode("utf-8")
+    ).hexdigest()
     receipt: dict[str, object] = {
         "schema_version": 1,
         "receipt_kind": "vibe-skill-install",
         "skill_id": "vibe",
-        "source_kind": str(source_kind or "").strip() or "developer_repo",
+        "source_kind": normalized_source_kind,
         "skills_dir": str(resolved_skills_dir),
         "install_root": str(install_root.resolve()),
         "installed_at_utc": installed_at_utc,
@@ -384,58 +2123,129 @@ def install_vibe_skill(
         "package_digest_sha256": package_digest,
         "files": files,
     }
-    if receipt["source_kind"] == "public_release":
-        version = str(release_version or "").strip()
-        asset_name = str(release_asset_name or "").strip()
-        if not version or not asset_name:
-            raise RuntimeError("Public release install requires release version and asset name.")
-        release_payload: dict[str, object] = {
-            "version": version,
-            "asset_name": asset_name,
-        }
-        digest = str(release_asset_digest or "").strip()
-        if digest:
-            release_payload["asset_digest_sha256"] = digest
+    if release_payload is not None:
         receipt["release"] = release_payload
     else:
         receipt["source_path"] = str(source_root)
         receipt["source_git_commit"] = source_git_commit
         receipt["source_git_dirty"] = bool(source_git_dirty)
-    _write_json(receipt_path, receipt)
+    receipt_content = _json_content(receipt)
+    receipt_change = _InstallFileChange(
+        relpath=RECEIPT_RELPATH,
+        destination=receipt_path,
+        staged_path=None,
+        destination_existed=has_receipt,
+        new_sha256=_sha256_text(receipt_content),
+    )
+    try:
+        if has_receipt:
+            receipt_change.backup_path = _stage_file_copy(
+                receipt_path,
+                receipt_path,
+                transaction_id=transaction_id,
+            )
+            receipt_change.old_sha256 = _sha256_file(receipt_change.backup_path)
+        receipt_change.staged_path = _stage_text_file(
+            receipt_content,
+            receipt_path,
+            transaction_id=transaction_id,
+        )
+    except BaseException:
+        _recover_install_transaction(
+            state_path=install_state_path,
+            skills_dir=resolved_skills_dir,
+            install_root=install_root,
+        )
+        raise
+    changes = [*payload_changes, receipt_change]
+
+    try:
+        install_state = _build_install_state(
+            skills_dir=resolved_skills_dir,
+            install_root=install_root,
+            transaction_id=transaction_id,
+            changes=changes,
+        )
+        _write_json(install_state_path, install_state)
+    except BaseException:
+        _recover_install_transaction(
+            state_path=install_state_path,
+            skills_dir=resolved_skills_dir,
+            install_root=install_root,
+        )
+        raise
+
+    try:
+        _apply_install_file_changes(changes)
+    except BaseException:
+        recovery = _recover_install_transaction(
+            state_path=install_state_path,
+            skills_dir=resolved_skills_dir,
+            install_root=install_root,
+        )
+        if recovery.disposition != INSTALL_RECOVERY_COMMITTED:
+            raise
+    else:
+        recovery = _recover_install_transaction(
+            state_path=install_state_path,
+            skills_dir=resolved_skills_dir,
+            install_root=install_root,
+        )
+        if recovery.disposition != INSTALL_RECOVERY_COMMITTED:
+            raise RuntimeError("Vibe install receipt did not commit")
+
     if uninstall_state_path.is_file():
-        uninstall_state_path.unlink()
+        _remove_uninstall_state_file(uninstall_state_path)
+    _clear_uninstall_completion(
+        uninstall_completion_path,
+        skills_dir=resolved_skills_dir,
+        install_root=install_root,
+    )
     return receipt
 
 
 def check_vibe_skill(*, skills_dir: Path) -> dict[str, object]:
-    receipt_path = _receipt_path(skills_dir)
+    resolved_skills_dir = skills_dir.resolve()
+    install_root = resolved_skills_dir / "vibe"
+    receipt_path = install_root / RECEIPT_RELPATH
+    _assert_install_root_is_local(resolved_skills_dir, install_root)
+    _assert_install_destination_is_local(install_root, receipt_path)
     if not receipt_path.is_file():
         return _scoped_check_result({"ok": False, "missing_receipt": str(receipt_path)})
 
-    receipt = _read_json(receipt_path)
-    install_root = Path(str(receipt["install_root"]))
+    receipt = _read_install_receipt(
+        receipt_path,
+        skills_dir=resolved_skills_dir,
+        install_root=install_root,
+    )
+    entries = cast(list[dict[str, str]], receipt["files"])
     missing_files: list[str] = []
     drifted_files: list[str] = []
     receipt_files: set[str] = set()
-    for entry in receipt.get("files") or []:
-        if not isinstance(entry, dict):
-            continue
-        relpath = str(entry["path"])
+    for entry in entries:
+        relpath = entry["path"]
         receipt_files.add(relpath)
-        expected_sha = str(entry["sha256"])
-        file_path = install_root / relpath
+        expected_sha = entry["sha256"]
+        file_path = _owned_file_path(install_root, relpath)
+        if _path_is_link_or_reparse_point(file_path):
+            drifted_files.append(relpath)
+            continue
         if not file_path.is_file():
             missing_files.append(relpath)
             continue
-        if _sha256_file(file_path) != expected_sha:
+        try:
+            actual_sha = _sha256_file(file_path)
+        except _FileChangedDuringReadError:
+            drifted_files.append(relpath)
+            continue
+        if actual_sha != expected_sha:
             drifted_files.append(relpath)
 
     actual_files = {
-        path.relative_to(install_root).as_posix()
-        for path in install_root.rglob("*")
-        if path.is_file()
-        and path.relative_to(install_root).as_posix()
-        not in {RECEIPT_RELPATH, UNINSTALL_STATE_RELPATH}
+        entry.path.relative_to(install_root).as_posix()
+        for entry in _install_tree_entries(install_root)
+        if not entry.is_directory
+        and entry.path.relative_to(install_root).as_posix() != RECEIPT_RELPATH
     }
     extra_files = sorted(actual_files - receipt_files)
 
@@ -447,6 +2257,7 @@ def check_vibe_skill(*, skills_dir: Path) -> dict[str, object]:
     })
 
 
+@_locked_vibe_operation
 def update_vibe_skill(
     *,
     repo_root: Path,
@@ -460,7 +2271,14 @@ def update_vibe_skill(
     release_asset_digest: str = "",
     installer_version: str = "0.1.0",
     package_version: str = "0.1.0",
-    ) -> dict[str, object]:
+) -> dict[str, object]:
+    resolved_skills_dir = skills_dir.resolve()
+    install_root = resolved_skills_dir / "vibe"
+    _assert_install_root_is_local(resolved_skills_dir, install_root)
+    _recover_pending_install_transaction(
+        skills_dir=resolved_skills_dir,
+        install_root=install_root,
+    )
     check_result = check_vibe_skill(skills_dir=skills_dir)
     if not check_result.get("ok"):
         raise RuntimeError(f"Refusing to update drifted Vibe install: {check_result}")
@@ -479,23 +2297,40 @@ def update_vibe_skill(
     )
 
 
-def _build_uninstall_state(
-    *,
-    receipt: dict[str, object],
-    skills_dir: Path,
+def _remove_owned_files(
     install_root: Path,
-    preserved_files: list[str],
-) -> dict[str, object]:
-    return {
-        "schema_version": 1,
-        "state_kind": UNINSTALL_STATE_KIND,
-        "skill_id": "vibe",
-        "skills_dir": str(skills_dir.resolve()),
-        "install_root": str(install_root.resolve()),
-        "status": "managed_files_removed",
-        "previous_package_digest_sha256": str(receipt.get("package_digest_sha256") or ""),
-        "preserved_files": sorted(set(preserved_files)),
-    }
+    entries: list[dict[str, str]],
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    removed_files: list[str] = []
+    failed_files: list[str] = []
+    permission_denied_files: list[str] = []
+    unavailable_files: list[str] = []
+    for entry in entries:
+        relpath = entry["path"]
+        file_path = _owned_file_path(install_root, relpath)
+        try:
+            file_status = file_path.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            continue
+        is_link = _is_link_or_reparse_point(file_status)
+        if not is_link and not stat.S_ISREG(file_status.st_mode):
+            continue
+        try:
+            if is_link and stat.S_ISDIR(file_status.st_mode) and not stat.S_ISLNK(
+                file_status.st_mode
+            ):
+                file_path.rmdir()
+            else:
+                file_path.unlink()
+        except OSError as exc:
+            failed_files.append(relpath)
+            if isinstance(exc, PermissionError):
+                permission_denied_files.append(relpath)
+            if isinstance(exc, TimeoutError):
+                unavailable_files.append(relpath)
+        else:
+            removed_files.append(relpath)
+    return removed_files, failed_files, permission_denied_files, unavailable_files
 
 
 def _finalize_uninstall_state(
@@ -505,7 +2340,30 @@ def _finalize_uninstall_state(
     state: dict[str, object],
     removed_files: list[str],
 ) -> dict[str, object]:
-    failed_directories = _prune_empty_directories(install_root)
+    if state.get("status") != UNINSTALL_STATE_MANAGED_FILES_REMOVED:
+        raise RuntimeError(f"Invalid Vibe uninstall state status: {state_path}")
+
+    if not install_root.exists():
+        commit_failure = _commit_uninstall_completion(
+            state_path=state_path,
+            state=state,
+        )
+        if commit_failure is not None:
+            return _uninstall_completion_commit_failure_result(
+                commit_failure,
+                removed_files=removed_files,
+            )
+        return _uninstall_result(
+            ok=True,
+            status="uninstalled",
+            removed_files=removed_files,
+        )
+
+    (
+        failed_directories,
+        permission_denied_directories,
+        unavailable_directories,
+    ) = _prune_empty_directories(install_root)
     preserved_files = _preserved_file_relpaths(install_root, owned_files=set())
     if failed_directories:
         return _uninstall_result(
@@ -513,6 +2371,8 @@ def _finalize_uninstall_state(
             status="partial_failure",
             removed_files=removed_files,
             failed_directories=failed_directories,
+            permission_denied_directories=permission_denied_directories,
+            unavailable_directories=unavailable_directories,
             preserved_files=preserved_files,
             recovery_state=UNINSTALL_STATE_RELPATH,
         )
@@ -525,41 +2385,65 @@ def _finalize_uninstall_state(
             recovery_state=UNINSTALL_STATE_RELPATH,
         )
 
-    try:
-        state_path.unlink()
-    except OSError:
-        return _uninstall_result(
-            ok=False,
-            status="partial_failure",
-            removed_files=removed_files,
-            failed_files=[UNINSTALL_STATE_RELPATH],
-            recovery_state=UNINSTALL_STATE_RELPATH,
-        )
-
-    metadata_dir = state_path.parent
-    try:
-        metadata_dir.rmdir()
-    except OSError:
-        _write_json(state_path, state)
-        return _uninstall_result(
-            ok=False,
-            status="partial_failure",
-            removed_files=removed_files,
-            failed_directories=[metadata_dir.relative_to(install_root).as_posix()],
-            recovery_state=UNINSTALL_STATE_RELPATH,
-        )
+    metadata_dir = install_root / ".vibeskills"
+    if metadata_dir.exists():
+        try:
+            metadata_dir.rmdir()
+        except OSError as exc:
+            preserved_files = _preserved_file_relpaths(install_root, owned_files=set())
+            if preserved_files:
+                return _uninstall_result(
+                    ok=True,
+                    status="uninstalled_with_preserved_files",
+                    removed_files=removed_files,
+                    preserved_files=preserved_files,
+                    recovery_state=UNINSTALL_STATE_RELPATH,
+                )
+            relpath = metadata_dir.relative_to(install_root).as_posix()
+            permission_denied = [relpath] if isinstance(exc, PermissionError) else []
+            unavailable = [relpath] if isinstance(exc, TimeoutError) else []
+            return _uninstall_result(
+                ok=False,
+                status="partial_failure",
+                removed_files=removed_files,
+                failed_directories=[relpath],
+                permission_denied_directories=permission_denied,
+                unavailable_directories=unavailable,
+                recovery_state=UNINSTALL_STATE_RELPATH,
+            )
 
     try:
         install_root.rmdir()
-    except OSError:
-        _write_json(state_path, state)
+    except OSError as exc:
+        preserved_files = _preserved_file_relpaths(install_root, owned_files=set())
+        if preserved_files:
+            return _uninstall_result(
+                ok=True,
+                status="uninstalled_with_preserved_files",
+                removed_files=removed_files,
+                preserved_files=preserved_files,
+                recovery_state=UNINSTALL_STATE_RELPATH,
+            )
+        permission_denied = ["."] if isinstance(exc, PermissionError) else []
+        unavailable = ["."] if isinstance(exc, TimeoutError) else []
         return _uninstall_result(
             ok=False,
             status="partial_failure",
             removed_files=removed_files,
             failed_directories=["."],
-            preserved_files=_preserved_file_relpaths(install_root, owned_files=set()),
+            permission_denied_directories=permission_denied,
+            unavailable_directories=unavailable,
             recovery_state=UNINSTALL_STATE_RELPATH,
+        )
+
+    commit_failure = _commit_uninstall_completion(
+        state_path=state_path,
+        state=state,
+    )
+    if commit_failure is not None:
+        return _uninstall_completion_commit_failure_result(
+            commit_failure,
+            removed_files=removed_files,
         )
 
     return _uninstall_result(
@@ -569,15 +2453,92 @@ def _finalize_uninstall_state(
     )
 
 
+def _finalize_interrupted_new_install(install_root: Path) -> dict[str, object]:
+    if not install_root.exists():
+        return _uninstall_result(
+            ok=True,
+            status="uninstalled",
+            removed_files=[],
+        )
+
+    (
+        failed_directories,
+        permission_denied_directories,
+        unavailable_directories,
+    ) = _prune_empty_directories(install_root)
+    preserved_files = _preserved_file_relpaths(install_root, owned_files=set())
+    if failed_directories:
+        return _uninstall_result(
+            ok=False,
+            status="partial_failure",
+            removed_files=[],
+            failed_directories=failed_directories,
+            permission_denied_directories=permission_denied_directories,
+            unavailable_directories=unavailable_directories,
+            preserved_files=preserved_files,
+        )
+    if preserved_files:
+        return _uninstall_result(
+            ok=True,
+            status="uninstalled_with_preserved_files",
+            removed_files=[],
+            preserved_files=preserved_files,
+        )
+
+    metadata_dir = install_root / ".vibeskills"
+    if metadata_dir.exists():
+        try:
+            metadata_dir.rmdir()
+        except OSError as exc:
+            relpath = metadata_dir.relative_to(install_root).as_posix()
+            permission_denied = [relpath] if isinstance(exc, PermissionError) else []
+            unavailable = [relpath] if isinstance(exc, TimeoutError) else []
+            return _uninstall_result(
+                ok=False,
+                status="partial_failure",
+                removed_files=[],
+                failed_directories=[relpath],
+                permission_denied_directories=permission_denied,
+                unavailable_directories=unavailable,
+            )
+    try:
+        install_root.rmdir()
+    except OSError as exc:
+        permission_denied = ["."] if isinstance(exc, PermissionError) else []
+        unavailable = ["."] if isinstance(exc, TimeoutError) else []
+        return _uninstall_result(
+            ok=False,
+            status="partial_failure",
+            removed_files=[],
+            failed_directories=["."],
+            permission_denied_directories=permission_denied,
+            unavailable_directories=unavailable,
+        )
+    return _uninstall_result(
+        ok=True,
+        status="uninstalled",
+        removed_files=[],
+    )
+
+
+@_locked_vibe_operation
 def uninstall_vibe_skill(*, skills_dir: Path) -> dict[str, object]:
-    receipt_path = _receipt_path(skills_dir)
-    state_path = _uninstall_state_path(skills_dir)
+    resolved_skills_dir = skills_dir.resolve()
+    install_root = resolved_skills_dir / "vibe"
+    receipt_path = install_root / RECEIPT_RELPATH
+    state_path = _uninstall_state_path(resolved_skills_dir)
+    completion_path = _uninstall_completion_path(resolved_skills_dir)
+    _assert_install_root_is_local(resolved_skills_dir, install_root)
+    _assert_install_destination_is_local(install_root, receipt_path)
+    install_recovery = _recover_pending_install_transaction(
+        skills_dir=resolved_skills_dir,
+        install_root=install_root,
+    )
     if not receipt_path.is_file():
         if state_path.is_file():
-            install_root = skills_dir.resolve() / "vibe"
             state = _read_uninstall_state(
                 state_path,
-                skills_dir=skills_dir,
+                skills_dir=resolved_skills_dir,
                 install_root=install_root,
             )
             return _finalize_uninstall_state(
@@ -586,25 +2547,55 @@ def uninstall_vibe_skill(*, skills_dir: Path) -> dict[str, object]:
                 state=state,
                 removed_files=[],
             )
+        if completion_path.exists() or completion_path.is_symlink():
+            if not completion_path.is_file():
+                raise RuntimeError(
+                    f"Vibe uninstall completion is not a regular file: {completion_path}"
+                )
+            _read_uninstall_completion(
+                completion_path,
+                skills_dir=resolved_skills_dir,
+                install_root=install_root,
+            )
+            preserved_files = (
+                _preserved_file_relpaths(install_root, owned_files=set())
+                if install_root.exists()
+                else []
+            )
+            return _uninstall_result(
+                ok=True,
+                status=(
+                    "uninstalled_with_preserved_files"
+                    if preserved_files
+                    else "uninstalled"
+                ),
+                removed_files=[],
+                preserved_files=preserved_files,
+            )
+        if (
+            install_recovery is not None
+            and install_recovery.disposition == INSTALL_RECOVERY_ROLLED_BACK
+            and not install_recovery.receipt_existed
+        ):
+            return _finalize_interrupted_new_install(install_root)
         raise RuntimeError(f"Vibe install receipt is missing: {receipt_path}")
 
-    receipt = _read_json(receipt_path)
-    install_root = Path(str(receipt["install_root"]))
-    owned_files = _receipt_file_paths(receipt)
-    removed_files: list[str] = []
-    failed_files: list[str] = []
-    for entry in receipt.get("files") or []:
-        if not isinstance(entry, dict):
-            continue
-        relpath = str(entry["path"])
-        file_path = install_root / relpath
-        if file_path.is_file():
-            try:
-                file_path.unlink()
-            except OSError:
-                failed_files.append(relpath)
-            else:
-                removed_files.append(relpath)
+    receipt = _read_install_receipt(
+        receipt_path,
+        skills_dir=resolved_skills_dir,
+        install_root=install_root,
+    )
+    entries = cast(list[dict[str, str]], receipt["files"])
+    owned_files = _file_entry_paths(entries)
+    (
+        removed_files,
+        failed_files,
+        permission_denied_files,
+        unavailable_files,
+    ) = _remove_owned_files(
+        install_root,
+        entries,
+    )
 
     preserved_files = _preserved_file_relpaths(install_root, owned_files=owned_files)
     if failed_files:
@@ -613,34 +2604,44 @@ def uninstall_vibe_skill(*, skills_dir: Path) -> dict[str, object]:
             status="partial_failure",
             removed_files=removed_files,
             failed_files=failed_files,
+            permission_denied_files=permission_denied_files,
+            unavailable_files=unavailable_files,
             preserved_files=preserved_files,
         )
 
-    failed_directories = _prune_empty_directories(install_root)
+    (
+        failed_directories,
+        permission_denied_directories,
+        unavailable_directories,
+    ) = _prune_empty_directories(install_root)
     if failed_directories:
         return _uninstall_result(
             ok=False,
             status="partial_failure",
             removed_files=removed_files,
             failed_directories=failed_directories,
+            permission_denied_directories=permission_denied_directories,
+            unavailable_directories=unavailable_directories,
             preserved_files=preserved_files,
         )
 
-    state = _build_uninstall_state(
-        receipt=receipt,
-        skills_dir=skills_dir,
+    state = _build_recovery_state(
+        skills_dir=resolved_skills_dir,
         install_root=install_root,
-        preserved_files=preserved_files,
     )
     _write_json(state_path, state)
     try:
         receipt_path.unlink()
-    except OSError:
+    except OSError as exc:
+        permission_denied_files = [RECEIPT_RELPATH] if isinstance(exc, PermissionError) else []
+        unavailable_files = [RECEIPT_RELPATH] if isinstance(exc, TimeoutError) else []
         return _uninstall_result(
             ok=False,
             status="partial_failure",
             removed_files=removed_files,
             failed_files=[RECEIPT_RELPATH],
+            permission_denied_files=permission_denied_files,
+            unavailable_files=unavailable_files,
             preserved_files=preserved_files,
             recovery_state=UNINSTALL_STATE_RELPATH,
         )

--- a/packages/installer-core/src/vgo_installer/simple_skill_installer.py
+++ b/packages/installer-core/src/vgo_installer/simple_skill_installer.py
@@ -40,6 +40,8 @@ PACKAGE_RUNTIME_TEST_ENTRYPOINTS = {
     "packages/verification-core/src/vgo_verify/test_baseline_audit.py",
 }
 RECEIPT_RELPATH = ".vibeskills/install-receipt.json"
+UNINSTALL_STATE_RELPATH = ".vibeskills/uninstall-state.json"
+UNINSTALL_STATE_KIND = "vibe-skill-uninstall-state"
 
 
 def _sha256_file(path: Path) -> str:
@@ -168,6 +170,122 @@ def _receipt_file_paths(receipt: dict[str, object]) -> set[str]:
     return owned
 
 
+def _uninstall_state_path(skills_dir: Path) -> Path:
+    return skills_dir.resolve() / "vibe" / UNINSTALL_STATE_RELPATH
+
+
+def _read_uninstall_state(
+    state_path: Path,
+    *,
+    skills_dir: Path,
+    install_root: Path,
+) -> dict[str, object]:
+    state = _read_json(state_path)
+    expected_skills_dir = skills_dir.resolve()
+    expected_install_root = install_root.resolve()
+    if state.get("schema_version") != 1:
+        raise RuntimeError(f"Unsupported Vibe uninstall state schema: {state_path}")
+    if state.get("state_kind") != UNINSTALL_STATE_KIND or state.get("skill_id") != "vibe":
+        raise RuntimeError(f"Invalid Vibe uninstall state: {state_path}")
+    if Path(str(state.get("skills_dir") or "")).resolve() != expected_skills_dir:
+        raise RuntimeError(f"Vibe uninstall state Skills directory mismatch: {state_path}")
+    if Path(str(state.get("install_root") or "")).resolve() != expected_install_root:
+        raise RuntimeError(f"Vibe uninstall state install root mismatch: {state_path}")
+    if state.get("status") != "managed_files_removed":
+        raise RuntimeError(f"Invalid Vibe uninstall state status: {state_path}")
+    return state
+
+
+def _is_recoverable_empty_install_root(install_root: Path) -> bool:
+    if not install_root.is_dir() or install_root.is_symlink():
+        return False
+    try:
+        entries = list(install_root.rglob("*"))
+    except OSError:
+        return False
+    for entry in entries:
+        if entry.is_symlink() or not entry.is_dir():
+            return False
+        if entry.relative_to(install_root).as_posix() != ".vibeskills":
+            return False
+    return True
+
+
+def _assert_install_destination_is_local(install_root: Path, destination: Path) -> None:
+    if install_root.is_symlink():
+        raise RuntimeError(f"Install root must not be a symbolic link: {install_root}")
+    current = destination.parent
+    while current != install_root.parent:
+        if current.is_symlink():
+            raise RuntimeError(f"Install path traverses a symbolic link: {destination}")
+        if current == install_root:
+            return
+        current = current.parent
+    raise RuntimeError(f"Install path escapes the Vibe install root: {destination}")
+
+
+def _preserved_file_relpaths(install_root: Path, *, owned_files: set[str]) -> list[str]:
+    internal_files = {RECEIPT_RELPATH, UNINSTALL_STATE_RELPATH}
+    preserved: list[str] = []
+    for path in install_root.rglob("*"):
+        if not path.is_file() and not path.is_symlink():
+            continue
+        relpath = path.relative_to(install_root).as_posix()
+        if relpath not in internal_files and relpath not in owned_files:
+            preserved.append(relpath)
+    return sorted(set(preserved))
+
+
+def _prune_empty_directories(install_root: Path) -> list[str]:
+    metadata_dir = install_root / ".vibeskills"
+    try:
+        directories = sorted(
+            (path for path in install_root.rglob("*") if path.is_dir()),
+            key=lambda path: len(path.parts),
+            reverse=True,
+        )
+    except OSError:
+        return ["."]
+
+    failed: list[str] = []
+    for directory in directories:
+        if directory == metadata_dir or metadata_dir in directory.parents:
+            continue
+        try:
+            directory.rmdir()
+        except PermissionError:
+            failed.append(directory.relative_to(install_root).as_posix())
+        except OSError:
+            try:
+                is_empty = next(directory.iterdir(), None) is None
+            except OSError:
+                is_empty = True
+            if is_empty:
+                failed.append(directory.relative_to(install_root).as_posix())
+    return sorted(set(failed))
+
+
+def _uninstall_result(
+    *,
+    ok: bool,
+    status: str,
+    removed_files: list[str],
+    failed_files: list[str] | None = None,
+    failed_directories: list[str] | None = None,
+    preserved_files: list[str] | None = None,
+    recovery_state: str = "",
+) -> dict[str, object]:
+    return {
+        "ok": ok,
+        "status": status,
+        "removed_files": sorted(set(removed_files)),
+        "failed_files": sorted(set(failed_files or [])),
+        "failed_directories": sorted(set(failed_directories or [])),
+        "preserved_files": sorted(set(preserved_files or [])),
+        "recovery_state": recovery_state,
+    }
+
+
 def _remove_retired_owned_files(install_root: Path, *, old_owned: set[str], next_owned: set[str]) -> None:
     for relpath in sorted(old_owned - next_owned, reverse=True):
         file_path = install_root / relpath
@@ -217,17 +335,35 @@ def install_vibe_skill(
     resolved_skills_dir = skills_dir.resolve()
     install_root = resolved_skills_dir / "vibe"
     receipt_path = install_root / RECEIPT_RELPATH
-    if install_root.exists() and not receipt_path.is_file():
+    uninstall_state_path = install_root / UNINSTALL_STATE_RELPATH
+    if install_root.exists() and install_root.is_symlink():
+        raise RuntimeError(f"Install root must not be a symbolic link: {install_root}")
+
+    has_receipt = receipt_path.is_file()
+    has_uninstall_state = uninstall_state_path.is_file()
+    if has_uninstall_state and not has_receipt:
+        _read_uninstall_state(
+            uninstall_state_path,
+            skills_dir=resolved_skills_dir,
+            install_root=install_root,
+        )
+    if (
+        install_root.exists()
+        and not has_receipt
+        and not has_uninstall_state
+        and not _is_recoverable_empty_install_root(install_root)
+    ):
         raise RuntimeError(f"Install root already exists without a Vibe install receipt: {install_root}")
 
     install_root.mkdir(parents=True, exist_ok=True)
     next_owned = _package_file_relpaths(source_root)
     old_owned: set[str] = set()
-    if receipt_path.is_file():
+    if has_receipt:
         old_owned = _receipt_file_paths(_read_json(receipt_path))
     for relpath in next_owned:
         destination = install_root / relpath
-        if destination.exists() and relpath not in old_owned:
+        _assert_install_destination_is_local(install_root, destination)
+        if (destination.exists() or destination.is_symlink()) and relpath not in old_owned:
             raise RuntimeError(f"Install path exists but is not owned by the Vibe receipt: {destination}")
     _remove_retired_owned_files(install_root, old_owned=old_owned, next_owned=set(next_owned))
 
@@ -266,6 +402,8 @@ def install_vibe_skill(
         receipt["source_git_commit"] = source_git_commit
         receipt["source_git_dirty"] = bool(source_git_dirty)
     _write_json(receipt_path, receipt)
+    if uninstall_state_path.is_file():
+        uninstall_state_path.unlink()
     return receipt
 
 
@@ -295,7 +433,9 @@ def check_vibe_skill(*, skills_dir: Path) -> dict[str, object]:
     actual_files = {
         path.relative_to(install_root).as_posix()
         for path in install_root.rglob("*")
-        if path.is_file() and path.relative_to(install_root).as_posix() != RECEIPT_RELPATH
+        if path.is_file()
+        and path.relative_to(install_root).as_posix()
+        not in {RECEIPT_RELPATH, UNINSTALL_STATE_RELPATH}
     }
     extra_files = sorted(actual_files - receipt_files)
 
@@ -339,35 +479,178 @@ def update_vibe_skill(
     )
 
 
+def _build_uninstall_state(
+    *,
+    receipt: dict[str, object],
+    skills_dir: Path,
+    install_root: Path,
+    preserved_files: list[str],
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "state_kind": UNINSTALL_STATE_KIND,
+        "skill_id": "vibe",
+        "skills_dir": str(skills_dir.resolve()),
+        "install_root": str(install_root.resolve()),
+        "status": "managed_files_removed",
+        "previous_package_digest_sha256": str(receipt.get("package_digest_sha256") or ""),
+        "preserved_files": sorted(set(preserved_files)),
+    }
+
+
+def _finalize_uninstall_state(
+    *,
+    install_root: Path,
+    state_path: Path,
+    state: dict[str, object],
+    removed_files: list[str],
+) -> dict[str, object]:
+    failed_directories = _prune_empty_directories(install_root)
+    preserved_files = _preserved_file_relpaths(install_root, owned_files=set())
+    if failed_directories:
+        return _uninstall_result(
+            ok=False,
+            status="partial_failure",
+            removed_files=removed_files,
+            failed_directories=failed_directories,
+            preserved_files=preserved_files,
+            recovery_state=UNINSTALL_STATE_RELPATH,
+        )
+    if preserved_files:
+        return _uninstall_result(
+            ok=True,
+            status="uninstalled_with_preserved_files",
+            removed_files=removed_files,
+            preserved_files=preserved_files,
+            recovery_state=UNINSTALL_STATE_RELPATH,
+        )
+
+    try:
+        state_path.unlink()
+    except OSError:
+        return _uninstall_result(
+            ok=False,
+            status="partial_failure",
+            removed_files=removed_files,
+            failed_files=[UNINSTALL_STATE_RELPATH],
+            recovery_state=UNINSTALL_STATE_RELPATH,
+        )
+
+    metadata_dir = state_path.parent
+    try:
+        metadata_dir.rmdir()
+    except OSError:
+        _write_json(state_path, state)
+        return _uninstall_result(
+            ok=False,
+            status="partial_failure",
+            removed_files=removed_files,
+            failed_directories=[metadata_dir.relative_to(install_root).as_posix()],
+            recovery_state=UNINSTALL_STATE_RELPATH,
+        )
+
+    try:
+        install_root.rmdir()
+    except OSError:
+        _write_json(state_path, state)
+        return _uninstall_result(
+            ok=False,
+            status="partial_failure",
+            removed_files=removed_files,
+            failed_directories=["."],
+            preserved_files=_preserved_file_relpaths(install_root, owned_files=set()),
+            recovery_state=UNINSTALL_STATE_RELPATH,
+        )
+
+    return _uninstall_result(
+        ok=True,
+        status="uninstalled",
+        removed_files=removed_files,
+    )
+
+
 def uninstall_vibe_skill(*, skills_dir: Path) -> dict[str, object]:
     receipt_path = _receipt_path(skills_dir)
+    state_path = _uninstall_state_path(skills_dir)
     if not receipt_path.is_file():
+        if state_path.is_file():
+            install_root = skills_dir.resolve() / "vibe"
+            state = _read_uninstall_state(
+                state_path,
+                skills_dir=skills_dir,
+                install_root=install_root,
+            )
+            return _finalize_uninstall_state(
+                install_root=install_root,
+                state_path=state_path,
+                state=state,
+                removed_files=[],
+            )
         raise RuntimeError(f"Vibe install receipt is missing: {receipt_path}")
 
     receipt = _read_json(receipt_path)
     install_root = Path(str(receipt["install_root"]))
+    owned_files = _receipt_file_paths(receipt)
     removed_files: list[str] = []
+    failed_files: list[str] = []
     for entry in receipt.get("files") or []:
         if not isinstance(entry, dict):
             continue
         relpath = str(entry["path"])
         file_path = install_root / relpath
         if file_path.is_file():
-            file_path.unlink()
-            removed_files.append(relpath)
+            try:
+                file_path.unlink()
+            except OSError:
+                failed_files.append(relpath)
+            else:
+                removed_files.append(relpath)
 
-    receipt_path.unlink()
-    for directory in sorted((path for path in install_root.rglob("*") if path.is_dir()), reverse=True):
-        try:
-            directory.rmdir()
-        except OSError:
-            pass
+    preserved_files = _preserved_file_relpaths(install_root, owned_files=owned_files)
+    if failed_files:
+        return _uninstall_result(
+            ok=False,
+            status="partial_failure",
+            removed_files=removed_files,
+            failed_files=failed_files,
+            preserved_files=preserved_files,
+        )
+
+    failed_directories = _prune_empty_directories(install_root)
+    if failed_directories:
+        return _uninstall_result(
+            ok=False,
+            status="partial_failure",
+            removed_files=removed_files,
+            failed_directories=failed_directories,
+            preserved_files=preserved_files,
+        )
+
+    state = _build_uninstall_state(
+        receipt=receipt,
+        skills_dir=skills_dir,
+        install_root=install_root,
+        preserved_files=preserved_files,
+    )
+    _write_json(state_path, state)
     try:
-        install_root.rmdir()
+        receipt_path.unlink()
     except OSError:
-        pass
+        return _uninstall_result(
+            ok=False,
+            status="partial_failure",
+            removed_files=removed_files,
+            failed_files=[RECEIPT_RELPATH],
+            preserved_files=preserved_files,
+            recovery_state=UNINSTALL_STATE_RELPATH,
+        )
 
-    return {"removed_files": sorted(removed_files)}
+    return _finalize_uninstall_state(
+        install_root=install_root,
+        state_path=state_path,
+        state=state,
+        removed_files=removed_files,
+    )
 
 
 __all__ = [

--- a/tests/unit/test_simple_skill_installer.py
+++ b/tests/unit/test_simple_skill_installer.py
@@ -4,6 +4,7 @@ import errno
 import json
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 import textwrap
@@ -118,6 +119,7 @@ def _run_install_until_process_exit(
         text=True,
         env=environment,
         check=False,
+        timeout=10,
     )
     assert result.returncode == 91, result.stderr
 
@@ -165,6 +167,7 @@ def _run_install_until_staging_exit(*, repo_root: Path, skills_dir: Path) -> Non
         text=True,
         env=environment,
         check=False,
+        timeout=10,
     )
     assert result.returncode == 92, result.stderr
 
@@ -207,6 +210,7 @@ def _run_uninstall_until_state_delete_exit(*, skills_dir: Path) -> None:
         text=True,
         env=environment,
         check=False,
+        timeout=10,
     )
     assert result.returncode == 93, result.stderr
 
@@ -462,7 +466,11 @@ def test_install_rejects_packaging_source_that_escapes_repo_root(tmp_path: Path)
         config_files=("config/../../escaped.txt",),
     )
 
-    with pytest.raises(RuntimeError, match="Unsafe package path|Package path escapes the source root"):
+    expected_error = (
+        f"Unsafe package path in {repo_root / 'config' / 'version-governance.json'}: "
+        "config/../../escaped.txt"
+    )
+    with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         install_vibe_skill(
             repo_root=repo_root,
             skills_dir=skills_dir,
@@ -698,7 +706,8 @@ def test_transaction_hash_rejects_file_replaced_by_symlink_after_precheck(
         swap_after_link_check,
     )
 
-    with pytest.raises(RuntimeError, match="link|identity|type"):
+    expected_error = f"File changed to a symbolic link before hashing: {destination}"
+    with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         simple_skill_installer._current_install_file_sha256(
             destination,
             relpath="installed.txt",
@@ -744,7 +753,10 @@ def test_transaction_hash_rejects_junction_replacement_after_precheck(
 
     monkeypatch.setattr(Path, "is_file", report_raced_path_as_file)
 
-    with pytest.raises(RuntimeError, match="link|junction|non-file|identity|type"):
+    expected_error = (
+        f"File changed to a link, junction, or non-file before hashing: {destination}"
+    )
+    with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         simple_skill_installer._current_install_file_sha256(
             destination,
             relpath="installed.txt",
@@ -929,7 +941,8 @@ def test_uninstall_rejects_owned_path_through_parent_symlink(tmp_path: Path) -> 
     installed_file.parent.rmdir()
     _symlink_or_skip(installed_file.parent, external_root)
 
-    with pytest.raises(RuntimeError, match="escapes|traverses a link or junction"):
+    expected_error = f"Install path escapes the Vibe install root: {installed_file}"
+    with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         uninstall_vibe_skill(skills_dir=skills_dir)
 
     assert external_file.read_text(encoding="utf-8") == "keep me\n"

--- a/tests/unit/test_simple_skill_installer.py
+++ b/tests/unit/test_simple_skill_installer.py
@@ -351,3 +351,224 @@ def test_uninstall_removes_owned_files_but_keeps_user_files(tmp_path: Path) -> N
     assert "config/runtime-script-manifest.json" in removed_files
     assert user_file.read_text(encoding="utf-8") == "keep me\n"
     assert (skills_dir / "vibe").is_dir()
+
+
+def test_uninstall_collects_file_failures_and_keeps_receipt_for_retry(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+        source_git_commit="abc123",
+        source_git_dirty=False,
+    )
+    install_root = skills_dir / "vibe"
+    receipt_path = install_root / ".vibeskills" / "install-receipt.json"
+    locked_file = install_root / "SKILL.md"
+    original_unlink = Path.unlink
+
+    def fail_locked_file(path: Path, *args, **kwargs) -> None:
+        if path == locked_file:
+            raise PermissionError(f"locked: {path}")
+        original_unlink(path, *args, **kwargs)
+
+    with monkeypatch.context() as context:
+        context.setattr(Path, "unlink", fail_locked_file)
+        result = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert result["ok"] is False
+    assert result["status"] == "partial_failure"
+    assert result["failed_files"] == ["SKILL.md"]
+    assert receipt_path.is_file()
+
+    retry = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert retry["ok"] is True
+    assert not install_root.exists()
+
+
+def test_uninstall_reports_empty_directory_cleanup_failure_before_dropping_receipt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+        source_git_commit="abc123",
+        source_git_dirty=False,
+    )
+    install_root = skills_dir / "vibe"
+    receipt_path = install_root / ".vibeskills" / "install-receipt.json"
+    locked_directory = install_root / "config"
+    original_rmdir = Path.rmdir
+
+    def fail_locked_directory(path: Path, *args, **kwargs) -> None:
+        if path == locked_directory:
+            raise PermissionError(f"locked: {path}")
+        original_rmdir(path, *args, **kwargs)
+
+    with monkeypatch.context() as context:
+        context.setattr(Path, "rmdir", fail_locked_directory)
+        result = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert result["ok"] is False
+    assert result["status"] == "partial_failure"
+    assert result["failed_directories"] == ["config"]
+    assert receipt_path.is_file()
+
+    retry = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert retry["ok"] is True
+    assert not install_root.exists()
+
+
+def test_uninstall_final_root_cleanup_failure_keeps_resumable_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+        source_git_commit="abc123",
+        source_git_dirty=False,
+    )
+    install_root = skills_dir / "vibe"
+    receipt_path = install_root / ".vibeskills" / "install-receipt.json"
+    recovery_path = install_root / ".vibeskills" / "uninstall-state.json"
+    original_rmdir = Path.rmdir
+
+    def fail_install_root(path: Path, *args, **kwargs) -> None:
+        if path == install_root:
+            raise PermissionError(f"locked: {path}")
+        original_rmdir(path, *args, **kwargs)
+
+    with monkeypatch.context() as context:
+        context.setattr(Path, "rmdir", fail_install_root)
+        result = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert result["ok"] is False
+    assert result["status"] == "partial_failure"
+    assert result["failed_directories"] == ["."]
+    assert not receipt_path.exists()
+    assert recovery_path.is_file()
+
+    retry = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert retry["ok"] is True
+    assert not install_root.exists()
+
+
+def test_reinstall_uses_uninstall_state_without_overwriting_user_files(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+        source_git_commit="abc123",
+        source_git_dirty=False,
+    )
+    install_root = skills_dir / "vibe"
+    user_file = install_root / "notes.md"
+    user_file.write_text("keep me\n", encoding="utf-8")
+
+    result = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    recovery_path = install_root / ".vibeskills" / "uninstall-state.json"
+    assert result["ok"] is True
+    assert result["status"] == "uninstalled_with_preserved_files"
+    assert result["preserved_files"] == ["notes.md"]
+    assert recovery_path.is_file()
+
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T09:00:00Z",
+        source_git_commit="def456",
+        source_git_dirty=False,
+    )
+
+    assert user_file.read_text(encoding="utf-8") == "keep me\n"
+    assert (install_root / ".vibeskills" / "install-receipt.json").is_file()
+    assert not recovery_path.exists()
+    assert check_vibe_skill(skills_dir=skills_dir)["extra_files"] == ["notes.md"]
+
+
+def test_reinstall_with_receipt_ignores_incomplete_uninstall_state(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+        source_git_commit="abc123",
+        source_git_dirty=False,
+    )
+    install_root = skills_dir / "vibe"
+    recovery_path = install_root / ".vibeskills" / "uninstall-state.json"
+    recovery_path.write_text("{\n", encoding="utf-8")
+
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T09:00:00Z",
+        source_git_commit="def456",
+        source_git_dirty=False,
+    )
+
+    assert (install_root / ".vibeskills" / "install-receipt.json").is_file()
+    assert not recovery_path.exists()
+
+
+def test_reinstall_from_uninstall_state_rejects_new_package_path_collision(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+        source_git_commit="abc123",
+        source_git_dirty=False,
+    )
+    install_root = skills_dir / "vibe"
+    (install_root / "notes.md").write_text("keep me\n", encoding="utf-8")
+    uninstall_vibe_skill(skills_dir=skills_dir)
+    user_collision = install_root / "SKILL.md"
+    user_collision.write_text("# user-owned\n", encoding="utf-8")
+
+    try:
+        install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T09:00:00Z",
+            source_git_commit="def456",
+            source_git_dirty=False,
+        )
+    except RuntimeError as exc:
+        assert "Install path exists but is not owned" in str(exc)
+    else:
+        raise AssertionError("reinstall should reject a new user-owned package path")
+
+    assert user_collision.read_text(encoding="utf-8") == "# user-owned\n"

--- a/tests/unit/test_simple_skill_installer.py
+++ b/tests/unit/test_simple_skill_installer.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import errno
 import json
+import os
 from pathlib import Path
+import subprocess
 import sys
+import textwrap
+import time
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -18,11 +25,190 @@ from vgo_installer.simple_skill_installer import (
     uninstall_vibe_skill,
     update_vibe_skill,
 )
+import vgo_installer.simple_skill_installer as simple_skill_installer
 
 
 def _write(path: Path, text: str = "x\n") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    link.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        link.symlink_to(target, target_is_directory=target.is_dir())
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symbolic links are unavailable: {exc}")
+
+
+def _junction_or_skip(link: Path, target: Path) -> None:
+    if os.name != "nt":
+        pytest.skip("directory junctions are Windows-only")
+    target.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        ["cmd.exe", "/d", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"directory junctions are unavailable: {result.stderr.strip()}")
+
+
+def _file_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def _run_install_until_process_exit(
+    *,
+    repo_root: Path,
+    skills_dir: Path,
+    exit_after_destination: Path,
+) -> None:
+    script = textwrap.dedent(
+        """
+        import os
+        from pathlib import Path
+        import sys
+
+        import vgo_installer.simple_skill_installer as installer
+
+        repo_root = Path(sys.argv[1])
+        skills_dir = Path(sys.argv[2])
+        exit_after_destination = Path(sys.argv[3]).resolve(strict=False)
+        original_replace = installer.os.replace
+
+        def replace_then_exit(source, destination):
+            original_replace(source, destination)
+            if Path(destination).resolve(strict=False) == exit_after_destination:
+                os._exit(91)
+
+        installer.os.replace = replace_then_exit
+        installer.install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T09:00:00Z",
+        )
+        """
+    )
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = os.pathsep.join(
+        path
+        for path in (
+            str(CONTRACTS_SRC),
+            str(INSTALLER_SRC),
+            environment.get("PYTHONPATH", ""),
+        )
+        if path
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            script,
+            str(repo_root),
+            str(skills_dir),
+            str(exit_after_destination),
+        ],
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=False,
+    )
+    assert result.returncode == 91, result.stderr
+
+
+def _run_install_until_staging_exit(*, repo_root: Path, skills_dir: Path) -> None:
+    script = textwrap.dedent(
+        """
+        import os
+        from pathlib import Path
+        import sys
+
+        import vgo_installer.simple_skill_installer as installer
+
+        repo_root = Path(sys.argv[1])
+        skills_dir = Path(sys.argv[2])
+        original_copy = installer.shutil.copy2
+
+        def copy_then_exit(source, destination):
+            result = original_copy(source, destination)
+            if Path(source).name == "SKILL.md":
+                os._exit(92)
+            return result
+
+        installer.shutil.copy2 = copy_then_exit
+        installer.install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T09:00:00Z",
+        )
+        """
+    )
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = os.pathsep.join(
+        path
+        for path in (
+            str(CONTRACTS_SRC),
+            str(INSTALLER_SRC),
+            environment.get("PYTHONPATH", ""),
+        )
+        if path
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(repo_root), str(skills_dir)],
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=False,
+    )
+    assert result.returncode == 92, result.stderr
+
+
+def _run_uninstall_until_state_delete_exit(*, skills_dir: Path) -> None:
+    script = textwrap.dedent(
+        """
+        import os
+        from pathlib import Path
+        import sys
+
+        import vgo_installer.simple_skill_installer as installer
+
+        skills_dir = Path(sys.argv[1])
+        state_path = skills_dir / ".vibeskills" / "vibe-uninstall-state.json"
+        original_unlink = Path.unlink
+
+        def unlink_then_exit(path, *, missing_ok=False):
+            original_unlink(path, missing_ok=missing_ok)
+            if path == state_path:
+                os._exit(93)
+
+        Path.unlink = unlink_then_exit
+        installer.uninstall_vibe_skill(skills_dir=skills_dir)
+        """
+    )
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = os.pathsep.join(
+        path
+        for path in (
+            str(CONTRACTS_SRC),
+            str(INSTALLER_SRC),
+            environment.get("PYTHONPATH", ""),
+        )
+        if path
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(skills_dir)],
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=False,
+    )
+    assert result.returncode == 93, result.stderr
 
 
 def _seed_runtime_contract(
@@ -190,6 +376,214 @@ def test_install_public_release_writes_release_identity_not_git_fields(tmp_path:
     assert "source_git_dirty" not in receipt
 
 
+def test_invalid_public_release_identity_does_not_create_install_root(tmp_path: Path) -> None:
+    repo_root = tmp_path / "release-root"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+
+    with pytest.raises(RuntimeError, match="requires release version and asset name"):
+        install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-08T08:00:00Z",
+            source_kind="public_release",
+            release_version="",
+            release_asset_name="",
+        )
+
+    assert not (skills_dir / "vibe").exists()
+
+
+def test_install_rejects_packaging_path_that_escapes_install_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+
+    def escaping_relpaths(source_root: Path) -> list[str]:
+        assert source_root == repo_root.resolve()
+        return ["config/../../escaped.txt"]
+
+    monkeypatch.setattr(
+        simple_skill_installer,
+        "_package_file_relpaths",
+        escaping_relpaths,
+    )
+
+    with pytest.raises(RuntimeError, match="Install path escapes the Vibe install root"):
+        install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T08:00:00Z",
+            source_git_commit="abc123",
+            source_git_dirty=False,
+        )
+
+    assert not (skills_dir / "escaped.txt").exists()
+
+
+def test_install_rejects_junction_install_root_that_targets_outside_skills_dir(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    outside_root = tmp_path / "outside"
+    install_root = skills_dir / "vibe"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    skills_dir.mkdir(parents=True)
+    _junction_or_skip(install_root, outside_root)
+
+    try:
+        with pytest.raises(RuntimeError, match="symbolic link or junction"):
+            install_vibe_skill(
+                repo_root=repo_root,
+                skills_dir=skills_dir,
+                installed_at_utc="2026-07-02T08:00:00Z",
+            )
+
+        assert not list(outside_root.iterdir())
+    finally:
+        if install_root.exists():
+            install_root.rmdir()
+
+
+def test_install_rejects_packaging_source_that_escapes_repo_root(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _write(tmp_path / "escaped.txt", "outside source\n")
+    _seed_runtime_contract(
+        repo_root,
+        config_files=("config/../../escaped.txt",),
+    )
+
+    with pytest.raises(RuntimeError, match="Unsafe package path|Package path escapes the source root"):
+        install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T08:00:00Z",
+            source_git_commit="abc123",
+            source_git_dirty=False,
+        )
+
+    assert not (skills_dir / "escaped.txt").exists()
+
+
+def test_install_accepts_windows_style_packaging_paths(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _write(repo_root / "config" / "runtime.json", '{"ok": true}\n')
+    _seed_runtime_contract(repo_root, config_files=("config/runtime.json",))
+    governance_path = repo_root / "config" / "version-governance.json"
+    governance = json.loads(governance_path.read_text(encoding="utf-8"))
+    packaging = governance["packaging"]
+    runtime_payload = packaging["runtime_payload"]
+    runtime_payload["files"] = [path.replace("/", "\\") for path in runtime_payload["files"]]
+    runtime_payload["directories"] = [
+        path.replace("/", "\\") for path in runtime_payload["directories"]
+    ]
+    for manifest in packaging["manifests"]:
+        manifest["path"] = manifest["path"].replace("/", "\\")
+    _write(governance_path, json.dumps(governance, indent=2) + "\n")
+
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+
+    assert (skills_dir / "vibe" / "config" / "runtime.json").is_file()
+
+
+def test_install_allows_source_symlink_that_resolves_inside_repo(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    linked_source = repo_root / "shared" / "runtime.json"
+    package_path = repo_root / "config" / "linked-runtime.json"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _write(linked_source, '{"safe": true}\n')
+    _seed_runtime_contract(repo_root, config_files=("config/linked-runtime.json",))
+    _symlink_or_skip(package_path, linked_source)
+
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+
+    assert (skills_dir / "vibe" / "config" / "linked-runtime.json").read_text(
+        encoding="utf-8"
+    ) == '{"safe": true}\n'
+
+
+def test_install_rejects_source_symlink_that_escapes_repo(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    outside_source = tmp_path / "outside.json"
+    package_path = repo_root / "config" / "linked-runtime.json"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _write(outside_source, '{"unsafe": true}\n')
+    _seed_runtime_contract(repo_root, config_files=("config/linked-runtime.json",))
+    _symlink_or_skip(package_path, outside_source)
+
+    with pytest.raises(RuntimeError, match="Package path escapes the source root"):
+        install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T08:00:00Z",
+        )
+
+    assert not (skills_dir / "vibe" / "config" / "linked-runtime.json").exists()
+
+
+def test_install_rejects_packaging_manifest_that_escapes_repo_root(tmp_path: Path) -> None:
+    repo_root = tmp_path / "nested" / "repo"
+    skills_dir = tmp_path / "skills"
+    outside_manifest = tmp_path / "outside.json"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _write(outside_manifest, json.dumps({"files": ["SKILL.md"]}) + "\n")
+    _write(
+        repo_root / "config" / "version-governance.json",
+        json.dumps(
+            {
+                "packaging": {
+                    "runtime_payload": {"files": ["SKILL.md"], "directories": []},
+                    "manifests": [{"id": "outside", "path": "../../outside.json"}],
+                }
+            }
+        )
+        + "\n",
+    )
+
+    with pytest.raises(RuntimeError, match="Unsafe package manifest path"):
+        install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T08:00:00Z",
+        )
+
+    assert outside_manifest.read_text(encoding="utf-8") == '{"files": ["SKILL.md"]}\n'
+
+
+def test_install_rejects_non_object_runtime_governance(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "config" / "version-governance.json", "[]\n")
+
+    with pytest.raises(RuntimeError, match="Expected JSON object"):
+        install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T08:00:00Z",
+        )
+
+
 def test_check_reports_drift_when_receipt_owned_file_changes(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     skills_dir = tmp_path / "skills"
@@ -211,6 +605,392 @@ def test_check_reports_drift_when_receipt_owned_file_changes(tmp_path: Path) -> 
 
     assert result["ok"] is False
     assert result["drifted_files"] == ["SKILL.md"]
+
+
+def test_check_reports_owned_leaf_symlink_as_drift(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    external_file = tmp_path / "external-skill.md"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _write(external_file, "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    installed_skill = skills_dir / "vibe" / "SKILL.md"
+    installed_skill.unlink()
+    _symlink_or_skip(installed_skill, external_file)
+
+    result = check_vibe_skill(skills_dir=skills_dir)
+
+    assert result["ok"] is False
+    assert result["drifted_files"] == ["SKILL.md"]
+    assert external_file.read_text(encoding="utf-8") == "# vibe\n"
+
+
+def test_check_detects_owned_file_replaced_by_symlink_before_hash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    external_file = tmp_path / "external-skill.md"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _write(external_file, "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    installed_skill = skills_dir / "vibe" / "SKILL.md"
+    original_link_check = simple_skill_installer._path_is_link_or_reparse_point
+    swapped = False
+
+    def swap_after_link_check(path: Path) -> bool:
+        nonlocal swapped
+        result = original_link_check(path)
+        if path == installed_skill and not swapped:
+            installed_skill.unlink()
+            _symlink_or_skip(installed_skill, external_file)
+            swapped = True
+        return result
+
+    monkeypatch.setattr(
+        simple_skill_installer,
+        "_path_is_link_or_reparse_point",
+        swap_after_link_check,
+    )
+
+    result = check_vibe_skill(skills_dir=skills_dir)
+
+    assert result["ok"] is False
+    assert result["drifted_files"] == ["SKILL.md"]
+    assert installed_skill.is_symlink()
+    assert external_file.read_text(encoding="utf-8") == "# vibe\n"
+
+
+def test_transaction_hash_rejects_file_replaced_by_symlink_after_precheck(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "installed.txt"
+    external_file = tmp_path / "external.txt"
+    _write(destination, "same contents\n")
+    _write(external_file, "same contents\n")
+    original_link_check = simple_skill_installer._path_is_link_or_reparse_point
+    swapped = False
+
+    def swap_after_link_check(path: Path) -> bool:
+        nonlocal swapped
+        result = original_link_check(path)
+        if path == destination and not swapped:
+            destination.unlink()
+            _symlink_or_skip(destination, external_file)
+            swapped = True
+        return result
+
+    monkeypatch.setattr(
+        simple_skill_installer,
+        "_path_is_link_or_reparse_point",
+        swap_after_link_check,
+    )
+
+    with pytest.raises(RuntimeError, match="link|identity|type"):
+        simple_skill_installer._current_install_file_sha256(
+            destination,
+            relpath="installed.txt",
+        )
+
+    assert destination.is_symlink()
+    assert external_file.read_text(encoding="utf-8") == "same contents\n"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="directory junctions are Windows-only")
+def test_transaction_hash_rejects_junction_replacement_after_precheck(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "installed.txt"
+    external_root = tmp_path / "external"
+    external_file = external_root / "keep.txt"
+    _write(destination, "managed contents\n")
+    _write(external_file, "keep me\n")
+    original_link_check = simple_skill_installer._path_is_link_or_reparse_point
+    original_is_file = Path.is_file
+    swapped = False
+
+    def swap_after_link_check(path: Path) -> bool:
+        nonlocal swapped
+        result = original_link_check(path)
+        if path == destination and not swapped:
+            destination.unlink()
+            _junction_or_skip(destination, external_root)
+            swapped = True
+        return result
+
+    monkeypatch.setattr(
+        simple_skill_installer,
+        "_path_is_link_or_reparse_point",
+        swap_after_link_check,
+    )
+
+    def report_raced_path_as_file(path: Path) -> bool:
+        if path == destination and swapped:
+            return True
+        return original_is_file(path)
+
+    monkeypatch.setattr(Path, "is_file", report_raced_path_as_file)
+
+    with pytest.raises(RuntimeError, match="link|junction|non-file|identity|type"):
+        simple_skill_installer._current_install_file_sha256(
+            destination,
+            relpath="installed.txt",
+        )
+
+    assert destination.is_dir()
+    assert external_file.read_text(encoding="utf-8") == "keep me\n"
+    destination.rmdir()
+
+
+def test_check_missing_install_does_not_create_skills_directory(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "missing-skills"
+
+    result = check_vibe_skill(skills_dir=skills_dir)
+
+    assert result["ok"] is False
+    assert Path(str(result["missing_receipt"])) == (
+        skills_dir.resolve() / "vibe" / ".vibeskills" / "install-receipt.json"
+    )
+    assert not skills_dir.exists()
+
+
+def test_operation_lock_rejects_hardlink_without_mutating_external_file(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    external_file = tmp_path / "external-lock"
+    lock_path = skills_dir / ".vibeskills" / "vibe-operation.lock"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    external_file.touch()
+    lock_path.parent.mkdir(parents=True)
+    try:
+        os.link(external_file, lock_path)
+    except OSError as exc:
+        pytest.skip(f"hard links are unavailable: {exc}")
+
+    with pytest.raises(RuntimeError, match="operation lock must not be a hard link"):
+        install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T08:00:00Z",
+        )
+
+    assert external_file.read_bytes() == b""
+
+
+def test_platform_file_lock_propagates_non_contention_error_without_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock_path = tmp_path / "operation.lock"
+    lock_path.write_bytes(b"\0")
+    failure = OSError(errno.EIO, "lock I/O failure")
+
+    def fail_lock(*args: object) -> None:
+        raise failure
+
+    if os.name == "nt":
+        import msvcrt
+
+        monkeypatch.setattr(msvcrt, "locking", fail_lock)
+    else:
+        import fcntl
+
+        monkeypatch.setattr(fcntl, "flock", fail_lock)
+
+    def fail_sleep(seconds: float) -> None:
+        pytest.fail(f"non-contention lock failure slept for {seconds} seconds")
+
+    monkeypatch.setattr(simple_skill_installer.time, "sleep", fail_sleep)
+    with lock_path.open("r+b") as handle:
+        with pytest.raises(OSError) as error:
+            simple_skill_installer._acquire_platform_file_lock(
+                handle.fileno(),
+                lock_path,
+            )
+
+    assert error.value is failure
+
+
+def test_platform_file_lock_times_out_for_contention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock_path = tmp_path / "operation.lock"
+    lock_path.write_bytes(b"\0")
+
+    def fail_lock(*args: object) -> None:
+        raise PermissionError(errno.EACCES, "lock is held")
+
+    if os.name == "nt":
+        import msvcrt
+
+        monkeypatch.setattr(msvcrt, "locking", fail_lock)
+    else:
+        import fcntl
+
+        monkeypatch.setattr(fcntl, "flock", fail_lock)
+
+    monkeypatch.setattr(simple_skill_installer, "OPERATION_LOCK_TIMEOUT_SECONDS", 0.0)
+    with lock_path.open("r+b") as handle:
+        with pytest.raises(TimeoutError, match="Timed out waiting"):
+            simple_skill_installer._acquire_platform_file_lock(
+                handle.fileno(),
+                lock_path,
+            )
+
+
+def test_uninstall_rejects_receipt_root_mismatch_without_deleting_external_file(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    outside_root = tmp_path / "outside"
+    victim = outside_root / "victim.txt"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _write(victim, "keep me\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+        source_git_commit="abc123",
+        source_git_dirty=False,
+    )
+    receipt_path = skills_dir / "vibe" / ".vibeskills" / "install-receipt.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["install_root"] = str(outside_root.resolve())
+    receipt["files"] = [{"path": "victim.txt", "sha256": "fixture"}]
+    _write(receipt_path, json.dumps(receipt, indent=2) + "\n")
+
+    with pytest.raises(RuntimeError, match="install root mismatch"):
+        uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert victim.read_text(encoding="utf-8") == "keep me\n"
+    assert receipt_path.is_file()
+
+
+def test_uninstall_rejects_parent_path_in_receipt_without_deleting_external_file(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    victim = tmp_path / "victim.txt"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _write(victim, "keep me\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+        source_git_commit="abc123",
+        source_git_dirty=False,
+    )
+    receipt_path = skills_dir / "vibe" / ".vibeskills" / "install-receipt.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["files"] = [{"path": "../../victim.txt", "sha256": "fixture"}]
+    _write(receipt_path, json.dumps(receipt, indent=2) + "\n")
+
+    with pytest.raises(RuntimeError, match="Unsafe owned file path"):
+        uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert victim.read_text(encoding="utf-8") == "keep me\n"
+    assert receipt_path.is_file()
+
+
+def test_uninstall_rejects_owned_path_through_parent_symlink(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    install_root = skills_dir / "vibe"
+    external_root = tmp_path / "external"
+    external_file = external_root / "owned.txt"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _write(repo_root / "config" / "nested" / "owned.txt", "managed\n")
+    _write(external_file, "keep me\n")
+    _seed_runtime_contract(repo_root, config_files=("config/nested/owned.txt",))
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    installed_file = install_root / "config" / "nested" / "owned.txt"
+    installed_file.unlink()
+    installed_file.parent.rmdir()
+    _symlink_or_skip(installed_file.parent, external_root)
+
+    with pytest.raises(RuntimeError, match="escapes|traverses a link or junction"):
+        uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert external_file.read_text(encoding="utf-8") == "keep me\n"
+    assert (install_root / ".vibeskills" / "install-receipt.json").is_file()
+
+
+def test_uninstall_removes_owned_leaf_symlink_and_preserves_external_target(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    external_file = tmp_path / "external-skill.md"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _write(external_file, "keep me\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    installed_skill = skills_dir / "vibe" / "SKILL.md"
+    installed_skill.unlink()
+    _symlink_or_skip(installed_skill, external_file)
+
+    result = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert result["status"] == "uninstalled"
+    assert not installed_skill.exists()
+    assert not installed_skill.is_symlink()
+    assert external_file.read_text(encoding="utf-8") == "keep me\n"
+
+
+@pytest.mark.parametrize(
+    "owned_path",
+    [
+        ".vibeskills/install-receipt.json",
+        ".vibeskills./install-receipt.json",
+    ],
+)
+def test_uninstall_rejects_receipt_path_inside_installer_metadata(
+    tmp_path: Path,
+    owned_path: str,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    receipt_path = skills_dir / "vibe" / ".vibeskills" / "install-receipt.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["files"] = [{"path": owned_path, "sha256": "fixture"}]
+    _write(receipt_path, json.dumps(receipt, indent=2) + "\n")
+
+    with pytest.raises(RuntimeError, match="Unsafe owned file path"):
+        uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert receipt_path.is_file()
 
 
 def test_update_refuses_to_overwrite_drifted_install(tmp_path: Path) -> None:
@@ -275,6 +1055,690 @@ def test_update_preserves_user_added_files(tmp_path: Path) -> None:
     assert (skills_dir / "vibe" / "SKILL.md").read_text(encoding="utf-8") == "# next vibe\n"
     assert user_file.read_text(encoding="utf-8") == "keep me\n"
     assert "notes.md" not in {entry["path"] for entry in receipt["files"]}
+
+
+def test_update_copy_failure_keeps_existing_file_and_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    next_repo_root = tmp_path / "next-repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# old vibe\n")
+    _write(next_repo_root / "SKILL.md", "# next vibe\n")
+    _seed_runtime_contract(repo_root)
+    _seed_runtime_contract(next_repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    install_root = skills_dir / "vibe"
+    receipt_path = install_root / ".vibeskills" / "install-receipt.json"
+    original_receipt = receipt_path.read_bytes()
+    original_copy2 = simple_skill_installer.shutil.copy2
+    copy_attempt = 0
+
+    def fail_after_partial_copy(source: Path, destination: Path) -> str | Path:
+        nonlocal copy_attempt
+        copy_attempt += 1
+        if copy_attempt == 2:
+            destination.write_text("partial\n", encoding="utf-8")
+            raise OSError(f"copy failed: {source}")
+        return original_copy2(source, destination)
+
+    monkeypatch.setattr(simple_skill_installer.shutil, "copy2", fail_after_partial_copy)
+
+    with pytest.raises(OSError, match="copy failed"):
+        update_vibe_skill(
+            repo_root=next_repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T09:00:00Z",
+        )
+
+    assert (install_root / "SKILL.md").read_text(encoding="utf-8") == "# old vibe\n"
+    assert receipt_path.read_bytes() == original_receipt
+    assert not list(install_root.rglob("*.tmp"))
+
+
+def test_update_replace_failure_rolls_back_all_files_and_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    next_repo_root = tmp_path / "next-repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# old vibe\n")
+    _write(repo_root / "config" / "retired.json", '{"old": true}\n')
+    _write(next_repo_root / "SKILL.md", "# next vibe\n")
+    _write(next_repo_root / "config" / "replacement.json", '{"new": true}\n')
+    _seed_runtime_contract(repo_root, config_files=("config/retired.json",))
+    _seed_runtime_contract(next_repo_root, config_files=("config/replacement.json",))
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    install_root = skills_dir / "vibe"
+    receipt_path = install_root / ".vibeskills" / "install-receipt.json"
+    original_snapshot = _file_snapshot(install_root)
+    original_replace = simple_skill_installer.os.replace
+    payload_replacements = 0
+
+    def fail_second_payload_replace(source: Path, destination: Path) -> None:
+        nonlocal payload_replacements
+        destination_path = Path(destination)
+        if install_root in destination_path.parents and destination_path != receipt_path:
+            payload_replacements += 1
+            if payload_replacements == 2:
+                raise OSError(f"replace failed: {destination_path}")
+        original_replace(source, destination)
+
+    with monkeypatch.context() as context:
+        context.setattr(simple_skill_installer.os, "replace", fail_second_payload_replace)
+        with pytest.raises(OSError, match="replace failed"):
+            update_vibe_skill(
+                repo_root=next_repo_root,
+                skills_dir=skills_dir,
+                installed_at_utc="2026-07-02T09:00:00Z",
+            )
+
+    assert _file_snapshot(install_root) == original_snapshot
+    assert check_vibe_skill(skills_dir=skills_dir)["ok"] is True
+    assert not list(install_root.rglob("*.tmp"))
+
+    update_vibe_skill(
+        repo_root=next_repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T09:00:00Z",
+    )
+
+    assert (install_root / "config" / "replacement.json").is_file()
+    assert not (install_root / "config" / "retired.json").exists()
+
+
+def test_update_reports_retained_backup_when_rollback_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    next_repo_root = tmp_path / "next-repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# old vibe\n")
+    _write(next_repo_root / "SKILL.md", "# next vibe\n")
+    _seed_runtime_contract(repo_root)
+    _seed_runtime_contract(next_repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    install_root = skills_dir / "vibe"
+    installed_skill = install_root / "SKILL.md"
+    original_replace = simple_skill_installer.os.replace
+    payload_replacements = 0
+    apply_failed = False
+
+    def fail_apply_and_rollback(source: Path, destination: Path) -> None:
+        nonlocal apply_failed, payload_replacements
+        destination_path = Path(destination)
+        if install_root in destination_path.parents:
+            if not apply_failed:
+                payload_replacements += 1
+                if payload_replacements == 2:
+                    apply_failed = True
+                    raise OSError(f"apply failed: {destination_path}")
+            elif destination_path == installed_skill:
+                raise OSError(f"rollback failed: {destination_path}")
+        original_replace(source, destination)
+
+    with monkeypatch.context() as context:
+        context.setattr(simple_skill_installer.os, "replace", fail_apply_and_rollback)
+        with pytest.raises(OSError, match="rollback was incomplete") as error:
+            update_vibe_skill(
+                repo_root=next_repo_root,
+                skills_dir=skills_dir,
+                installed_at_utc="2026-07-02T09:00:00Z",
+            )
+
+    retained_backups = list(install_root.glob(".SKILL.md.*.tmp"))
+    assert len(retained_backups) == 1
+    assert str(retained_backups[0]) in str(error.value)
+    assert retained_backups[0].read_text(encoding="utf-8") == "# old vibe\n"
+
+
+def test_update_receipt_commit_failure_rolls_back_payload_and_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    next_repo_root = tmp_path / "next-repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# old vibe\n")
+    _write(next_repo_root / "SKILL.md", "# next vibe\n")
+    _seed_runtime_contract(repo_root)
+    _seed_runtime_contract(next_repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    install_root = skills_dir / "vibe"
+    receipt_path = install_root / ".vibeskills" / "install-receipt.json"
+    original_snapshot = _file_snapshot(install_root)
+    original_replace = simple_skill_installer.os.replace
+    receipt_commit_failed = False
+
+    def fail_receipt_commit_once(source: Path, destination: Path) -> None:
+        nonlocal receipt_commit_failed
+        if Path(destination) == receipt_path and not receipt_commit_failed:
+            receipt_commit_failed = True
+            raise OSError(f"receipt commit failed: {destination}")
+        original_replace(source, destination)
+
+    with monkeypatch.context() as context:
+        context.setattr(simple_skill_installer.os, "replace", fail_receipt_commit_once)
+        with pytest.raises(OSError, match="receipt commit failed"):
+            update_vibe_skill(
+                repo_root=next_repo_root,
+                skills_dir=skills_dir,
+                installed_at_utc="2026-07-02T09:00:00Z",
+            )
+
+    assert _file_snapshot(install_root) == original_snapshot
+    assert check_vibe_skill(skills_dir=skills_dir)["ok"] is True
+    assert not list(install_root.rglob("*.tmp"))
+
+    update_vibe_skill(
+        repo_root=next_repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T09:00:00Z",
+    )
+    assert (install_root / "SKILL.md").read_text(encoding="utf-8") == "# next vibe\n"
+
+
+def test_new_install_receipt_commit_failure_leaves_retryable_empty_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    install_root = skills_dir / "vibe"
+    receipt_path = install_root / ".vibeskills" / "install-receipt.json"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    original_replace = simple_skill_installer.os.replace
+    receipt_commit_failed = False
+
+    def fail_receipt_commit_once(source: Path, destination: Path) -> None:
+        nonlocal receipt_commit_failed
+        if Path(destination) == receipt_path and not receipt_commit_failed:
+            receipt_commit_failed = True
+            raise OSError(f"receipt commit failed: {destination}")
+        original_replace(source, destination)
+
+    with monkeypatch.context() as context:
+        context.setattr(simple_skill_installer.os, "replace", fail_receipt_commit_once)
+        with pytest.raises(OSError, match="receipt commit failed"):
+            install_vibe_skill(
+                repo_root=repo_root,
+                skills_dir=skills_dir,
+                installed_at_utc="2026-07-02T08:00:00Z",
+            )
+
+    assert install_root.is_dir()
+    assert all(path.is_dir() for path in install_root.rglob("*"))
+    assert not list(skills_dir.rglob("*.tmp"))
+
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T09:00:00Z",
+    )
+    assert check_vibe_skill(skills_dir=skills_dir)["ok"] is True
+
+
+def test_install_recovers_process_exit_before_receipt_commit(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    install_root = skills_dir / "vibe"
+    install_state_path = skills_dir / ".vibeskills" / "vibe-install-state.json"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+
+    _run_install_until_process_exit(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        exit_after_destination=install_root / "SKILL.md",
+    )
+
+    assert install_state_path.is_file()
+    assert (install_root / "SKILL.md").read_text(encoding="utf-8") == "# vibe\n"
+    assert not (install_root / ".vibeskills" / "install-receipt.json").exists()
+
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T10:00:00Z",
+    )
+
+    assert check_vibe_skill(skills_dir=skills_dir)["ok"] is True
+    assert not install_state_path.exists()
+    assert not list(skills_dir.rglob("*.tmp"))
+
+
+def test_install_recovers_process_exit_during_staging(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    install_root = skills_dir / "vibe"
+    install_state_path = skills_dir / ".vibeskills" / "vibe-install-state.json"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+
+    _run_install_until_staging_exit(repo_root=repo_root, skills_dir=skills_dir)
+
+    state = json.loads(install_state_path.read_text(encoding="utf-8"))
+    assert state["status"] == "preparing"
+    assert list(install_root.rglob("*.tmp"))
+    assert not (install_root / "SKILL.md").exists()
+
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T10:00:00Z",
+    )
+
+    assert check_vibe_skill(skills_dir=skills_dir)["ok"] is True
+    assert not install_state_path.exists()
+    assert not list(skills_dir.rglob("*.tmp"))
+
+
+def test_update_recovers_process_exit_before_receipt_commit(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    next_repo_root = tmp_path / "next-repo"
+    skills_dir = tmp_path / "skills"
+    install_root = skills_dir / "vibe"
+    install_state_path = skills_dir / ".vibeskills" / "vibe-install-state.json"
+    _write(repo_root / "SKILL.md", "# old vibe\n")
+    _write(next_repo_root / "SKILL.md", "# next vibe\n")
+    _seed_runtime_contract(repo_root)
+    _seed_runtime_contract(next_repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+
+    _run_install_until_process_exit(
+        repo_root=next_repo_root,
+        skills_dir=skills_dir,
+        exit_after_destination=install_root / "SKILL.md",
+    )
+
+    assert install_state_path.is_file()
+    assert (install_root / "SKILL.md").read_text(encoding="utf-8") == "# next vibe\n"
+
+    update_vibe_skill(
+        repo_root=next_repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T10:00:00Z",
+    )
+
+    assert (install_root / "SKILL.md").read_text(encoding="utf-8") == "# next vibe\n"
+    assert check_vibe_skill(skills_dir=skills_dir)["ok"] is True
+    assert not install_state_path.exists()
+    assert not list(skills_dir.rglob("*.tmp"))
+
+
+def test_concurrent_install_waits_for_active_transaction(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    marker_path = tmp_path / "apply-started"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    script = textwrap.dedent(
+        """
+        from pathlib import Path
+        import sys
+        import time
+
+        import vgo_installer.simple_skill_installer as installer
+
+        repo_root = Path(sys.argv[1])
+        skills_dir = Path(sys.argv[2])
+        marker_path = Path(sys.argv[3])
+        original_apply = installer._apply_install_file_changes
+
+        def slow_apply(changes):
+            marker_path.write_text("started\\n", encoding="utf-8")
+            time.sleep(1.0)
+            original_apply(changes)
+
+        installer._apply_install_file_changes = slow_apply
+        installer.install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T09:00:00Z",
+        )
+        """
+    )
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = os.pathsep.join(
+        path
+        for path in (
+            str(CONTRACTS_SRC),
+            str(INSTALLER_SRC),
+            environment.get("PYTHONPATH", ""),
+        )
+        if path
+    )
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            script,
+            str(repo_root),
+            str(skills_dir),
+            str(marker_path),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=environment,
+    )
+    deadline = time.monotonic() + 10.0
+    while not marker_path.is_file() and process.poll() is None:
+        if time.monotonic() >= deadline:
+            process.kill()
+            raise AssertionError("concurrent install did not reach apply")
+        time.sleep(0.02)
+
+    receipt = install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T10:00:00Z",
+    )
+    stdout, stderr = process.communicate(timeout=10)
+
+    assert process.returncode == 0, stdout + stderr
+    assert receipt["installed_at_utc"] == "2026-07-02T10:00:00Z"
+    assert check_vibe_skill(skills_dir=skills_dir)["ok"] is True
+    assert not (skills_dir / ".vibeskills" / "vibe-install-state.json").exists()
+    assert not list(skills_dir.rglob("*.tmp"))
+
+
+def test_uninstall_converges_interrupted_new_install(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    install_root = skills_dir / "vibe"
+    install_state_path = skills_dir / ".vibeskills" / "vibe-install-state.json"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+
+    _run_install_until_process_exit(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        exit_after_destination=install_root / "SKILL.md",
+    )
+
+    result = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert result["ok"] is True
+    assert result["status"] == "uninstalled"
+    assert not install_root.exists()
+    assert not install_state_path.exists()
+    assert not list(skills_dir.rglob("*.tmp"))
+
+
+def test_uninstall_recovers_committed_receipt_before_cleanup(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    install_root = skills_dir / "vibe"
+    receipt_path = install_root / ".vibeskills" / "install-receipt.json"
+    install_state_path = skills_dir / ".vibeskills" / "vibe-install-state.json"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+
+    _run_install_until_process_exit(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        exit_after_destination=receipt_path,
+    )
+
+    assert receipt_path.is_file()
+    assert install_state_path.is_file()
+    assert check_vibe_skill(skills_dir=skills_dir)["ok"] is True
+
+    result = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert result["ok"] is True
+    assert not install_root.exists()
+    assert not install_state_path.exists()
+    assert not list(skills_dir.rglob("*.tmp"))
+
+
+def test_committed_install_keeps_journal_when_backup_cleanup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    next_repo_root = tmp_path / "next-repo"
+    skills_dir = tmp_path / "skills"
+    install_root = skills_dir / "vibe"
+    install_state_path = skills_dir / ".vibeskills" / "vibe-install-state.json"
+    _write(repo_root / "SKILL.md", "# old vibe\n")
+    _write(next_repo_root / "SKILL.md", "# next vibe\n")
+    _seed_runtime_contract(repo_root)
+    _seed_runtime_contract(next_repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    original_unlink = Path.unlink
+
+    def fail_skill_backup_delete(path: Path, *, missing_ok: bool = False) -> None:
+        if path.parent == install_root and path.name.startswith(".SKILL.md."):
+            raise PermissionError(f"locked backup: {path}")
+        original_unlink(path, missing_ok=missing_ok)
+
+    with monkeypatch.context() as context:
+        context.setattr(Path, "unlink", fail_skill_backup_delete)
+        with pytest.raises(PermissionError, match="cleanup was incomplete"):
+            update_vibe_skill(
+                repo_root=next_repo_root,
+                skills_dir=skills_dir,
+                installed_at_utc="2026-07-02T09:00:00Z",
+            )
+
+    assert (install_root / "SKILL.md").read_text(encoding="utf-8") == "# next vibe\n"
+    assert install_state_path.is_file()
+    assert len(list(install_root.glob(".SKILL.md.*.tmp"))) == 1
+
+    update_vibe_skill(
+        repo_root=next_repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T10:00:00Z",
+    )
+
+    assert check_vibe_skill(skills_dir=skills_dir)["ok"] is True
+    assert not install_state_path.exists()
+    assert not list(skills_dir.rglob("*.tmp"))
+
+
+def test_committed_install_retries_journal_delete_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    install_root = skills_dir / "vibe"
+    install_state_path = skills_dir / ".vibeskills" / "vibe-install-state.json"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    original_unlink = Path.unlink
+
+    def fail_install_state_delete(path: Path, *, missing_ok: bool = False) -> None:
+        if path == install_state_path:
+            raise PermissionError(f"locked state: {path}")
+        original_unlink(path, missing_ok=missing_ok)
+
+    with monkeypatch.context() as context:
+        context.setattr(Path, "unlink", fail_install_state_delete)
+        with pytest.raises(PermissionError, match="cleanup was incomplete"):
+            install_vibe_skill(
+                repo_root=repo_root,
+                skills_dir=skills_dir,
+                installed_at_utc="2026-07-02T09:00:00Z",
+            )
+
+    assert (install_root / ".vibeskills" / "install-receipt.json").is_file()
+    assert install_state_path.is_file()
+    assert not list(install_root.rglob("*.tmp"))
+
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T10:00:00Z",
+    )
+
+    assert check_vibe_skill(skills_dir=skills_dir)["ok"] is True
+    assert not install_state_path.exists()
+    assert not list(skills_dir.rglob("*.tmp"))
+
+
+def test_install_recovery_rejects_journal_temp_path_outside_install_root(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    install_root = skills_dir / "vibe"
+    install_state_path = skills_dir / ".vibeskills" / "vibe-install-state.json"
+    outside_file = tmp_path / ".SKILL.md.outside.tmp"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    _write(outside_file, "outside\n")
+    _run_install_until_process_exit(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        exit_after_destination=install_root / "SKILL.md",
+    )
+    state = json.loads(install_state_path.read_text(encoding="utf-8"))
+    state["changes"][0]["staged_path"] = str(outside_file.resolve())
+    _write(install_state_path, json.dumps(state, indent=2) + "\n")
+
+    with pytest.raises(RuntimeError, match="escapes the Vibe install root"):
+        install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T10:00:00Z",
+        )
+
+    assert outside_file.read_text(encoding="utf-8") == "outside\n"
+    assert install_state_path.is_file()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows path aliases are Windows-only")
+def test_install_rejects_case_alias_package_destinations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _write(repo_root / "config" / "Foo.json", "{}\n")
+    _seed_runtime_contract(repo_root)
+    monkeypatch.setattr(
+        simple_skill_installer,
+        "_package_file_relpaths",
+        lambda source_root: ["config/Foo.json", "config/foo.json"],
+    )
+
+    with pytest.raises(RuntimeError, match="target the same install file"):
+        install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T08:00:00Z",
+        )
+
+    assert not (skills_dir / "vibe" / ".vibeskills" / "install-receipt.json").exists()
+    assert not (skills_dir / ".vibeskills" / "vibe-install-state.json").exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows path aliases are Windows-only")
+def test_update_accepts_owned_path_case_change(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    next_repo_root = tmp_path / "next-repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# old vibe\n")
+    _write(repo_root / "config" / "Foo.json", "{\"version\": 1}\n")
+    _write(next_repo_root / "SKILL.md", "# next vibe\n")
+    _write(next_repo_root / "config" / "foo.json", "{\"version\": 2}\n")
+    _seed_runtime_contract(repo_root, config_files=("config/Foo.json",))
+    _seed_runtime_contract(next_repo_root, config_files=("config/foo.json",))
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+
+    receipt = update_vibe_skill(
+        repo_root=next_repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T09:00:00Z",
+    )
+
+    paths = {entry["path"] for entry in receipt["files"]}
+    assert "config/foo.json" in paths
+    assert "config/Foo.json" not in paths
+    assert (skills_dir / "vibe" / "config" / "foo.json").read_text(encoding="utf-8") == (
+        "{\"version\": 2}\n"
+    )
+    assert check_vibe_skill(skills_dir=skills_dir)["ok"] is True
+
+
+def test_update_replaces_hardlinks_without_mutating_external_files(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    next_repo_root = tmp_path / "next-repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# old vibe\n")
+    _write(next_repo_root / "SKILL.md", "# next vibe\n")
+    _seed_runtime_contract(repo_root)
+    _seed_runtime_contract(next_repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    install_root = skills_dir / "vibe"
+    installed_skill = install_root / "SKILL.md"
+    receipt_path = install_root / ".vibeskills" / "install-receipt.json"
+    external_skill = tmp_path / "external-skill.md"
+    external_receipt = tmp_path / "external-receipt.json"
+    external_skill.write_bytes(installed_skill.read_bytes())
+    external_receipt.write_bytes(receipt_path.read_bytes())
+    installed_skill.unlink()
+    receipt_path.unlink()
+    try:
+        os.link(external_skill, installed_skill)
+        os.link(external_receipt, receipt_path)
+    except OSError as exc:
+        pytest.skip(f"hard links are unavailable: {exc}")
+
+    update_vibe_skill(
+        repo_root=next_repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T09:00:00Z",
+    )
+
+    assert installed_skill.read_text(encoding="utf-8") == "# next vibe\n"
+    assert external_skill.read_text(encoding="utf-8") == "# old vibe\n"
+    assert json.loads(receipt_path.read_text(encoding="utf-8"))["installed_at_utc"] == (
+        "2026-07-02T09:00:00Z"
+    )
+    assert json.loads(external_receipt.read_text(encoding="utf-8"))["installed_at_utc"] == (
+        "2026-07-02T08:00:00Z"
+    )
 
 
 def test_install_rerun_preserves_user_added_files(tmp_path: Path) -> None:
@@ -353,9 +1817,46 @@ def test_uninstall_removes_owned_files_but_keeps_user_files(tmp_path: Path) -> N
     assert (skills_dir / "vibe").is_dir()
 
 
+def test_uninstall_preserves_junction_and_external_target_tree(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    external_root = tmp_path / "external"
+    external_empty_directory = external_root / "empty"
+    external_file = external_root / "data.txt"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    install_root = skills_dir / "vibe"
+    junction = install_root / "user-junction"
+    external_empty_directory.mkdir(parents=True)
+    _write(external_file, "keep me\n")
+    _junction_or_skip(junction, external_root)
+
+    result = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert result["ok"] is True
+    assert result["status"] == "uninstalled_with_preserved_files"
+    assert result["preserved_files"] == ["user-junction"]
+    assert junction.is_dir()
+    assert external_empty_directory.is_dir()
+    assert external_file.read_text(encoding="utf-8") == "keep me\n"
+
+    junction.rmdir()
+    retry = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert retry["ok"] is True
+    assert retry["status"] == "uninstalled"
+    assert external_empty_directory.is_dir()
+    assert external_file.read_text(encoding="utf-8") == "keep me\n"
+
+
 def test_uninstall_collects_file_failures_and_keeps_receipt_for_retry(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo_root = tmp_path / "repo"
     skills_dir = tmp_path / "skills"
@@ -373,10 +1874,10 @@ def test_uninstall_collects_file_failures_and_keeps_receipt_for_retry(
     locked_file = install_root / "SKILL.md"
     original_unlink = Path.unlink
 
-    def fail_locked_file(path: Path, *args, **kwargs) -> None:
+    def fail_locked_file(path: Path, *, missing_ok: bool = False) -> None:
         if path == locked_file:
             raise PermissionError(f"locked: {path}")
-        original_unlink(path, *args, **kwargs)
+        original_unlink(path, missing_ok=missing_ok)
 
     with monkeypatch.context() as context:
         context.setattr(Path, "unlink", fail_locked_file)
@@ -385,6 +1886,7 @@ def test_uninstall_collects_file_failures_and_keeps_receipt_for_retry(
     assert result["ok"] is False
     assert result["status"] == "partial_failure"
     assert result["failed_files"] == ["SKILL.md"]
+    assert result["permission_denied_files"] == ["SKILL.md"]
     assert receipt_path.is_file()
 
     retry = uninstall_vibe_skill(skills_dir=skills_dir)
@@ -395,7 +1897,7 @@ def test_uninstall_collects_file_failures_and_keeps_receipt_for_retry(
 
 def test_uninstall_reports_empty_directory_cleanup_failure_before_dropping_receipt(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo_root = tmp_path / "repo"
     skills_dir = tmp_path / "skills"
@@ -413,10 +1915,10 @@ def test_uninstall_reports_empty_directory_cleanup_failure_before_dropping_recei
     locked_directory = install_root / "config"
     original_rmdir = Path.rmdir
 
-    def fail_locked_directory(path: Path, *args, **kwargs) -> None:
+    def fail_locked_directory(path: Path) -> None:
         if path == locked_directory:
             raise PermissionError(f"locked: {path}")
-        original_rmdir(path, *args, **kwargs)
+        original_rmdir(path)
 
     with monkeypatch.context() as context:
         context.setattr(Path, "rmdir", fail_locked_directory)
@@ -425,6 +1927,7 @@ def test_uninstall_reports_empty_directory_cleanup_failure_before_dropping_recei
     assert result["ok"] is False
     assert result["status"] == "partial_failure"
     assert result["failed_directories"] == ["config"]
+    assert result["permission_denied_directories"] == ["config"]
     assert receipt_path.is_file()
 
     retry = uninstall_vibe_skill(skills_dir=skills_dir)
@@ -435,7 +1938,7 @@ def test_uninstall_reports_empty_directory_cleanup_failure_before_dropping_recei
 
 def test_uninstall_final_root_cleanup_failure_keeps_resumable_state(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     repo_root = tmp_path / "repo"
     skills_dir = tmp_path / "skills"
@@ -450,13 +1953,13 @@ def test_uninstall_final_root_cleanup_failure_keeps_resumable_state(
     )
     install_root = skills_dir / "vibe"
     receipt_path = install_root / ".vibeskills" / "install-receipt.json"
-    recovery_path = install_root / ".vibeskills" / "uninstall-state.json"
+    recovery_path = skills_dir / ".vibeskills" / "vibe-uninstall-state.json"
     original_rmdir = Path.rmdir
 
-    def fail_install_root(path: Path, *args, **kwargs) -> None:
+    def fail_install_root(path: Path) -> None:
         if path == install_root:
             raise PermissionError(f"locked: {path}")
-        original_rmdir(path, *args, **kwargs)
+        original_rmdir(path)
 
     with monkeypatch.context() as context:
         context.setattr(Path, "rmdir", fail_install_root)
@@ -465,6 +1968,7 @@ def test_uninstall_final_root_cleanup_failure_keeps_resumable_state(
     assert result["ok"] is False
     assert result["status"] == "partial_failure"
     assert result["failed_directories"] == ["."]
+    assert result["permission_denied_directories"] == ["."]
     assert not receipt_path.exists()
     assert recovery_path.is_file()
 
@@ -472,6 +1976,191 @@ def test_uninstall_final_root_cleanup_failure_keeps_resumable_state(
 
     assert retry["ok"] is True
     assert not install_root.exists()
+
+
+def test_uninstall_state_delete_failure_is_retryable_after_root_removal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    install_root = skills_dir / "vibe"
+    recovery_path = skills_dir / ".vibeskills" / "vibe-uninstall-state.json"
+    original_unlink = Path.unlink
+
+    def fail_recovery_state_delete(path: Path, *, missing_ok: bool = False) -> None:
+        if path == recovery_path:
+            raise PermissionError(f"locked: {path}")
+        original_unlink(path, missing_ok=missing_ok)
+
+    with monkeypatch.context() as context:
+        context.setattr(Path, "unlink", fail_recovery_state_delete)
+        result = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert result["ok"] is False
+    assert result["failed_files"] == [".vibeskills/vibe-uninstall-state.json"]
+    assert result["permission_denied_files"] == [".vibeskills/vibe-uninstall-state.json"]
+    assert not install_root.exists()
+    assert recovery_path.is_file()
+
+    retry = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert retry["ok"] is True
+    assert not recovery_path.exists()
+
+
+def test_uninstall_completion_survives_process_exit_after_state_delete(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    install_root = skills_dir / "vibe"
+    recovery_path = skills_dir / ".vibeskills" / "vibe-uninstall-state.json"
+    completion_path = skills_dir / ".vibeskills" / "vibe-uninstall-complete.json"
+
+    _run_uninstall_until_state_delete_exit(skills_dir=skills_dir)
+
+    assert not install_root.exists()
+    assert not recovery_path.exists()
+    assert completion_path.is_file()
+
+    retry = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert retry["ok"] is True
+    assert retry["status"] == "uninstalled"
+    assert completion_path.is_file()
+
+
+def test_uninstall_completion_write_failure_is_visible_and_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    install_root = skills_dir / "vibe"
+    recovery_path = skills_dir / ".vibeskills" / "vibe-uninstall-state.json"
+    completion_path = skills_dir / ".vibeskills" / "vibe-uninstall-complete.json"
+    original_replace = simple_skill_installer.os.replace
+
+    def fail_completion_write(source: Path, destination: Path) -> None:
+        if Path(destination) == completion_path:
+            raise PermissionError(f"locked: {destination}")
+        original_replace(source, destination)
+
+    with monkeypatch.context() as context:
+        context.setattr(simple_skill_installer.os, "replace", fail_completion_write)
+        result = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert result["ok"] is False
+    assert result["status"] == "partial_failure"
+    assert result["failed_files"] == [".vibeskills/vibe-uninstall-complete.json"]
+    assert result["permission_denied_files"] == [
+        ".vibeskills/vibe-uninstall-complete.json"
+    ]
+    assert not install_root.exists()
+    assert recovery_path.is_file()
+    assert not completion_path.exists()
+    assert not list(skills_dir.rglob("*.tmp"))
+
+    retry = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert retry["ok"] is True
+    assert not recovery_path.exists()
+    assert completion_path.is_file()
+
+
+def test_invalid_reinstall_preserves_uninstall_completion(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    assert uninstall_vibe_skill(skills_dir=skills_dir)["ok"] is True
+    completion_path = skills_dir / ".vibeskills" / "vibe-uninstall-complete.json"
+    assert completion_path.is_file()
+
+    with pytest.raises(RuntimeError, match="requires release version and asset name"):
+        install_vibe_skill(
+            repo_root=repo_root,
+            skills_dir=skills_dir,
+            installed_at_utc="2026-07-02T09:00:00Z",
+            source_kind="public_release",
+        )
+
+    assert completion_path.is_file()
+    retry = uninstall_vibe_skill(skills_dir=skills_dir)
+    assert retry["ok"] is True
+    assert retry["status"] == "uninstalled"
+
+
+def test_successful_reinstall_clears_uninstall_completion(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    assert uninstall_vibe_skill(skills_dir=skills_dir)["ok"] is True
+    completion_path = skills_dir / ".vibeskills" / "vibe-uninstall-complete.json"
+    assert completion_path.is_file()
+
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T09:00:00Z",
+    )
+
+    assert (skills_dir / "vibe" / ".vibeskills" / "install-receipt.json").is_file()
+    assert not completion_path.exists()
+
+
+def test_uninstall_keeps_other_skills_metadata_when_removing_recovery_state(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    _write(repo_root / "SKILL.md", "# vibe\n")
+    _seed_runtime_contract(repo_root)
+    install_vibe_skill(
+        repo_root=repo_root,
+        skills_dir=skills_dir,
+        installed_at_utc="2026-07-02T08:00:00Z",
+    )
+    metadata_file = skills_dir / ".vibeskills" / "other-state.json"
+    _write(metadata_file, "{}\n")
+
+    result = uninstall_vibe_skill(skills_dir=skills_dir)
+
+    assert result["ok"] is True
+    assert metadata_file.read_text(encoding="utf-8") == "{}\n"
+    assert not (metadata_file.parent / "vibe-uninstall-state.json").exists()
+    assert not list(skills_dir.rglob("*.tmp"))
 
 
 def test_reinstall_uses_uninstall_state_without_overwriting_user_files(tmp_path: Path) -> None:
@@ -492,7 +2181,7 @@ def test_reinstall_uses_uninstall_state_without_overwriting_user_files(tmp_path:
 
     result = uninstall_vibe_skill(skills_dir=skills_dir)
 
-    recovery_path = install_root / ".vibeskills" / "uninstall-state.json"
+    recovery_path = skills_dir / ".vibeskills" / "vibe-uninstall-state.json"
     assert result["ok"] is True
     assert result["status"] == "uninstalled_with_preserved_files"
     assert result["preserved_files"] == ["notes.md"]
@@ -525,8 +2214,8 @@ def test_reinstall_with_receipt_ignores_incomplete_uninstall_state(tmp_path: Pat
         source_git_dirty=False,
     )
     install_root = skills_dir / "vibe"
-    recovery_path = install_root / ".vibeskills" / "uninstall-state.json"
-    recovery_path.write_text("{\n", encoding="utf-8")
+    recovery_path = skills_dir / ".vibeskills" / "vibe-uninstall-state.json"
+    _write(recovery_path, "{\n")
 
     install_vibe_skill(
         repo_root=repo_root,

--- a/tests/unit/test_vgo_cli_commands.py
+++ b/tests/unit/test_vgo_cli_commands.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -15,7 +16,16 @@ if str(CLI_SRC) not in sys.path:
     sys.path.insert(0, str(CLI_SRC))
 
 from vgo_cli.commands import canonical_entry_command, check_command, compatibility_exit_command, index_command, inspect_run_command, install_command, locate_entry_command, route_command, run_command, runtime_command, uninstall_command, update_command, upgrade_command, verify_command
-from vgo_cli.errors import CliError
+from vgo_cli.errors import (
+    CliError,
+    CliExitCode,
+    CliIoError,
+    CliMissingResourceError,
+    CliPermissionError,
+    CliStateError,
+    CliUnavailableError,
+)
+import vgo_cli.main as cli_main
 from vgo_cli.main import build_parser
 from vgo_cli.output import parse_json_output, print_json_payload
 
@@ -31,6 +41,122 @@ def test_parse_json_output_rejects_invalid_json() -> None:
 
     with pytest.raises(CliError, match='Invalid JSON output from core command'):
         parse_json_output(result)
+
+
+def test_main_returns_the_specific_cli_error_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class CannotCreateError(CliError):
+        exit_code = 73
+
+    class FailingParser:
+        @staticmethod
+        def parse_args(argv: list[str] | None) -> argparse.Namespace:
+            def fail(args: argparse.Namespace) -> int:
+                raise CannotCreateError("target cannot be created")
+
+            return argparse.Namespace(handler=fail)
+
+    monkeypatch.setattr(cli_main, "build_parser", FailingParser)
+
+    assert cli_main.main([]) == 73
+    assert capsys.readouterr().err == "[FAIL] target cannot be created\n"
+
+
+def test_cli_exit_code_values_are_stable() -> None:
+    assert {member.name: int(member) for member in CliExitCode} == {
+        "FAILURE": 1,
+        "USAGE": 2,
+        "INVALID_STATE": 3,
+        "MISSING_RESOURCE": 4,
+        "PERMISSION_DENIED": 5,
+        "UNAVAILABLE": 6,
+        "IO_ERROR": 7,
+    }
+
+
+@pytest.mark.parametrize(
+    ("error_type", "expected_exit_code"),
+    [
+        (CliError, 1),
+        (CliStateError, 3),
+        (CliMissingResourceError, 4),
+        (CliPermissionError, 5),
+        (CliUnavailableError, 6),
+        (CliIoError, 7),
+    ],
+)
+def test_cli_error_types_have_stable_exit_codes(
+    error_type: type[CliError],
+    expected_exit_code: int,
+) -> None:
+    assert int(error_type.exit_code) == expected_exit_code
+
+
+def test_uninstall_missing_receipt_uses_state_exit_code_without_traceback(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join(
+        value for value in (str(CLI_SRC), existing_pythonpath) if value
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vgo_cli.main",
+            "uninstall",
+            "--repo-root",
+            str(REPO_ROOT),
+            "--skills-dir",
+            str(tmp_path / "missing-skills"),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 3
+    assert "[FAIL] Vibe install receipt is missing" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_partial_uninstall_returns_io_exit_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    skills_dir = tmp_path / "skills"
+    args = argparse.Namespace(repo_root=str(REPO_ROOT), skills_dir=str(skills_dir))
+    assert install_command(args) == 0
+    capsys.readouterr()
+
+    locked_directory = skills_dir / "vibe" / "config"
+    original_rmdir = Path.rmdir
+
+    def fail_locked_directory(path: Path, *args, **kwargs) -> None:
+        if path == locked_directory:
+            raise PermissionError(f"locked: {path}")
+        original_rmdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "rmdir", fail_locked_directory)
+
+    exit_code = cli_main.main(
+        [
+            "uninstall",
+            "--repo-root",
+            str(REPO_ROOT),
+            "--skills-dir",
+            str(skills_dir),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == CliExitCode.IO_ERROR
+    assert json.loads(captured.out)["failed_directories"] == ["config"]
+    assert "retry after resolving the reported failures" in captured.err
 
 
 def test_route_command_delegates_to_runtime_core_bridge(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/test_vgo_cli_commands.py
+++ b/tests/unit/test_vgo_cli_commands.py
@@ -94,6 +94,25 @@ def test_cli_error_types_have_stable_exit_codes(
     assert int(error_type.exit_code) == expected_exit_code
 
 
+@pytest.mark.parametrize(
+    ("error", "expected_type"),
+    [
+        (PermissionError("denied"), CliPermissionError),
+        (FileNotFoundError("missing"), CliMissingResourceError),
+        (TimeoutError("busy"), CliUnavailableError),
+        (OSError("failed"), CliIoError),
+        (RuntimeError("invalid"), CliStateError),
+    ],
+)
+def test_installer_errors_map_to_specific_cli_error_types(
+    error: RuntimeError | OSError,
+    expected_type: type[CliError],
+) -> None:
+    import vgo_cli.commands as cli_commands
+
+    assert isinstance(cli_commands._installer_cli_error(error), expected_type)
+
+
 def test_uninstall_missing_receipt_uses_state_exit_code_without_traceback(tmp_path: Path) -> None:
     env = os.environ.copy()
     existing_pythonpath = env.get("PYTHONPATH", "")
@@ -123,10 +142,60 @@ def test_uninstall_missing_receipt_uses_state_exit_code_without_traceback(tmp_pa
     assert "Traceback" not in result.stderr
 
 
-def test_partial_uninstall_returns_io_exit_code(
+def test_uninstall_malformed_recovery_state_uses_state_exit_code_without_traceback(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    recovery_path = skills_dir / ".vibeskills" / "vibe-uninstall-state.json"
+    recovery_path.parent.mkdir(parents=True)
+    recovery_path.write_text("{\n", encoding="utf-8")
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join(
+        value for value in (str(CLI_SRC), existing_pythonpath) if value
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vgo_cli.main",
+            "uninstall",
+            "--repo-root",
+            str(REPO_ROOT),
+            "--skills-dir",
+            str(skills_dir),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 3
+    assert "[FAIL] Unreadable Vibe uninstall state" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    (
+        "failure_type",
+        "expected_exit_code",
+        "permission_denied",
+        "unavailable",
+    ),
+    [
+        (PermissionError, CliExitCode.PERMISSION_DENIED, True, False),
+        (TimeoutError, CliExitCode.UNAVAILABLE, False, True),
+        (OSError, CliExitCode.IO_ERROR, False, False),
+    ],
+)
+def test_partial_uninstall_uses_specific_exit_code(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    failure_type: type[OSError],
+    expected_exit_code: CliExitCode,
+    permission_denied: bool,
+    unavailable: bool,
 ) -> None:
     skills_dir = tmp_path / "skills"
     args = argparse.Namespace(repo_root=str(REPO_ROOT), skills_dir=str(skills_dir))
@@ -136,10 +205,10 @@ def test_partial_uninstall_returns_io_exit_code(
     locked_directory = skills_dir / "vibe" / "config"
     original_rmdir = Path.rmdir
 
-    def fail_locked_directory(path: Path, *args, **kwargs) -> None:
+    def fail_locked_directory(path: Path) -> None:
         if path == locked_directory:
-            raise PermissionError(f"locked: {path}")
-        original_rmdir(path, *args, **kwargs)
+            raise failure_type(f"locked: {path}")
+        original_rmdir(path)
 
     monkeypatch.setattr(Path, "rmdir", fail_locked_directory)
 
@@ -154,8 +223,11 @@ def test_partial_uninstall_returns_io_exit_code(
     )
 
     captured = capsys.readouterr()
-    assert exit_code == CliExitCode.IO_ERROR
-    assert json.loads(captured.out)["failed_directories"] == ["config"]
+    assert exit_code == expected_exit_code
+    payload = json.loads(captured.out)
+    assert payload["failed_directories"] == ["config"]
+    assert bool(payload["permission_denied_directories"]) is permission_denied
+    assert bool(payload["unavailable_directories"]) is unavailable
     assert "retry after resolving the reported failures" in captured.err
 
 
@@ -727,6 +799,57 @@ def test_install_command_uses_public_release_bundle_metadata_when_present(
     assert '"source_git_dirty"' not in output
 
 
+def test_install_malformed_public_release_bundle_uses_state_exit_code(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    release_root = tmp_path / 'release-root'
+    _write_minimal_install_source(release_root)
+    (release_root / 'release-bundle.json').write_text('{\n', encoding='utf-8')
+
+    exit_code = cli_main.main(
+        [
+            'install',
+            '--repo-root',
+            str(release_root),
+            '--skills-dir',
+            str(tmp_path / 'skills'),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == CliExitCode.INVALID_STATE
+    assert '[FAIL] Unreadable public release bundle' in captured.err
+    assert 'Traceback' not in captured.err
+
+
+def test_install_malformed_public_release_bundle_shape_uses_state_exit_code(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    release_root = tmp_path / 'release-root'
+    _write_minimal_install_source(release_root)
+    (release_root / 'release-bundle.json').write_text(
+        json.dumps({'public_install': []}),
+        encoding='utf-8',
+    )
+
+    exit_code = cli_main.main(
+        [
+            'install',
+            '--repo-root',
+            str(release_root),
+            '--skills-dir',
+            str(tmp_path / 'skills'),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == CliExitCode.INVALID_STATE
+    assert "field 'public_install' must be an object" in captured.err
+    assert 'Traceback' not in captured.err
+
+
 def test_uninstall_command_uses_simplified_skills_dir_uninstall(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -753,6 +876,52 @@ def test_update_command_uses_simplified_skills_dir_update(
 
     assert (skills_dir / 'vibe' / '.vibeskills' / 'install-receipt.json').is_file()
     assert '"receipt_kind": "vibe-skill-install"' in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("failure_type", "expected_exit_code"),
+    [
+        (PermissionError, CliExitCode.PERMISSION_DENIED),
+        (TimeoutError, CliExitCode.UNAVAILABLE),
+        (OSError, CliExitCode.IO_ERROR),
+    ],
+)
+def test_update_transaction_cleanup_uses_specific_exit_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    failure_type: type[OSError],
+    expected_exit_code: CliExitCode,
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_dir = tmp_path / "skills"
+    install_root = skills_dir / "vibe"
+    _write_minimal_install_source(repo_root)
+    args = argparse.Namespace(repo_root=str(repo_root), skills_dir=str(skills_dir))
+    assert install_command(args) == 0
+    capsys.readouterr()
+    original_unlink = Path.unlink
+
+    def fail_backup_cleanup(path: Path, *, missing_ok: bool = False) -> None:
+        if path.parent == install_root and path.name.startswith(".SKILL.md."):
+            raise failure_type(f"locked backup: {path}")
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", fail_backup_cleanup)
+    exit_code = cli_main.main(
+        [
+            "update",
+            "--repo-root",
+            str(repo_root),
+            "--skills-dir",
+            str(skills_dir),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == expected_exit_code
+    assert "Vibe install transaction cleanup was incomplete" in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_check_command_uses_simplified_skills_dir_check(

--- a/tests/unit/test_vgo_cli_infra_split.py
+++ b/tests/unit/test_vgo_cli_infra_split.py
@@ -12,7 +12,7 @@ CLI_SRC = REPO_ROOT / 'apps' / 'vgo-cli' / 'src'
 if str(CLI_SRC) not in sys.path:
     sys.path.insert(0, str(CLI_SRC))
 
-from vgo_cli.errors import CliError
+from vgo_cli.errors import CliUnavailableError
 import vgo_cli.hosts as cli_hosts
 from vgo_cli.hosts import (
     install_mode_for_host,
@@ -27,6 +27,40 @@ def test_normalize_host_id_supports_aliases_and_defaults_unknown_to_registry_def
     assert normalize_host_id('claude') == 'claude-code'
     assert normalize_host_id('codex') == 'codex'
     assert normalize_host_id('unknown-host') == 'codex'
+
+
+def test_missing_default_host_registry_entry_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class MissingRegistryModule:
+        @staticmethod
+        def normalize_adapter_host_id(
+            requested_host: str,
+            registry: dict[str, object],
+        ) -> str:
+            return requested_host
+
+        @staticmethod
+        def resolve_adapter_entry(
+            registry: dict[str, object],
+            host_id: str,
+        ) -> dict[str, object]:
+            raise ValueError(host_id)
+
+    monkeypatch.setattr(
+        cli_hosts,
+        '_load_registry',
+        lambda: (
+            tmp_path,
+            {'default_adapter_id': 'codex'},
+            MissingRegistryModule,
+            object(),
+        ),
+    )
+
+    with pytest.raises(CliUnavailableError, match='Unable to resolve host registry entry'):
+        cli_hosts._resolve_host_entry('unknown-host')
 
 
 def test_workspace_repo_root_resolution_no_longer_requires_installer_core(
@@ -164,7 +198,7 @@ def test_run_powershell_file_error_includes_script_and_resolution_details(monkey
 
     monkeypatch.setattr(cli_process, 'choose_powershell', fake_choose_powershell)
 
-    with pytest.raises(CliError) as excinfo:
+    with pytest.raises(CliUnavailableError) as excinfo:
         run_powershell_file(script_path, '-TargetRoot', '/tmp/out')
 
     message = str(excinfo.value)


### PR DESCRIPTION
## Summary

- preserve receipt-backed ownership across partial uninstall failures and process termination
- recover interrupted install/update transactions with a persistent journal and bounded cross-process lock
- validate receipt, manifest, metadata, symlink, junction, hardlink, and Windows path-alias boundaries
- hash managed files through no-follow handles and report leaf links as drift while safely unlinking them during uninstall
- expose stable typed CLI exit codes for state, missing-resource, permission, timeout/unavailable, and I/O failures
- retain detailed failed, permission-denied, and unavailable file/directory results for retry

## Surfaces touched

- `packages/installer-core/src/vgo_installer/simple_skill_installer.py`
- `apps/vgo-cli/src/vgo_cli/{commands,errors,hosts,main,process}.py`
- focused installer, CLI, infrastructure, integration, and runtime-neutral tests

No Z0, mirror, vendor, or generated output surfaces are changed.

## Proof

- Command: `py -3 -m pytest tests/unit/test_simple_skill_installer.py tests/unit/test_vgo_cli_commands.py tests/unit/test_vgo_cli_infra_split.py -q`
  - Output: `125 passed, 7 skipped in 60.39s`
  - Claim: focused recovery, path-boundary, exit-code, host, and process behavior passes on Windows.
- Command: targeted 17-file CLI, installer, wrapper, integration, and runtime-neutral suite
  - Output: `203 passed, 7 skipped in 74.87s`
  - Claim: the related lifecycle and compatibility matrix passes on Windows.
- Command: `wsl.exe bash -lc "... python3 -m pytest tests/unit/test_simple_skill_installer.py -q"`
  - Output: `56 passed, 5 skipped in 14.97s`
  - Claim: Linux behavior passes, including symlink drift, safe unlink, and no-follow hashing coverage.
- Command: five-file install/check/uninstall lifecycle suite
  - Output: `36 passed in 128.82s`
  - Claim: cross-module wrapper lifecycle behavior passes.
- Command: `pwsh -File scripts/verify/vibe-version-packaging-gate.ps1`
  - Output: `9 passed, 0 failed; Gate Result: PASS`
  - Claim: canonical runtime packaging remains coherent.
- Command: `pwsh -File scripts/verify/vibe-repo-cleanliness-gate.ps1`
  - Output: all three assertions passed; eight intended managed-workset paths reported before commit.
  - Claim: no scratch, generated, or uncategorized paths are included.
- Command: isolated `install.ps1` -> freshness gate -> `check.ps1` -> `uninstall.ps1`
  - Output: 276 receipt files verified; `ok=true`; 276 files removed; zero failures; no recovery state remained.
  - Claim: the packaged dirty worktree completes a real wrapper lifecycle.
- Commands: `py -3 -m py_compile ...` and `git diff --check`
  - Output: both passed.
  - Claim: changed Python files compile and the patch has no whitespace errors.

## Known repository baseline failures

- `py -3 -m pytest -q -x` stops at `test_clean_architecture_roots_exist` because `docs/architecture` is absent on `origin/main`.
- `vibe-release-install-runtime-coherence-gate.ps1` reaches and passes the changed wrapper/receipt checks, then reports six governance-document assertions for files already absent on `origin/main`.
- Ruff reports the repository's existing path-bootstrap `E402` imports on the touched modules and tests.

Closes #304
Closes #305
Related: #306 duplicates #305.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added distinct CLI exit codes for invalid state, missing resources, permission issues, unavailable services, and I/O failures.
  * Interrupted or partial installs and uninstalls can recover and resume safely.
  * User-managed files are preserved during uninstall, with failed items reported for retry.
  * Concurrent installation operations are coordinated to prevent conflicts.

* **Bug Fixes**
  * Improved validation prevents unsafe installation, update, and reinstallation paths.
  * Installer commands now provide more specific errors instead of generic failures.
  * Successful reinstalls clear stale uninstall data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->